### PR TITLE
fix(slack): assess contact-form leads instead of echoing them, and route them to Reda

### DIFF
--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -523,6 +523,8 @@ CHAT_TOOLS = [
             "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
             "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
             "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
+            "action='set_contact_form_lead_mandate' replaces the runtime prompt used to assess contact-form "
+            "leads on this connection immediately. The "
             "read-only action='open_alert_surges' returns material provider-alert incidents that are still "
             "inside their rolling window, for scheduled digest ordering. The "
             "bot must be a member of the channel and the Slack app needs the channels:history and "
@@ -542,6 +544,7 @@ CHAT_TOOLS = [
                         "list_monitored",
                         "monitor_channel",
                         "unmonitor_channel",
+                        "set_contact_form_lead_mandate",
                         "open_alert_surges",
                     ],
                     "description": "Slack management action.",
@@ -595,6 +598,13 @@ CHAT_TOOLS = [
                 "channel_name": {
                     "type": "string",
                     "description": "Optional human-readable channel name stored alongside a monitored channel for readability.",
+                },
+                "mandate": {
+                    "type": "string",
+                    "description": (
+                        "Complete runtime contact-form assessment mandate, required "
+                        "for set_contact_form_lead_mandate."
+                    ),
                 },
                 "channel_types": {
                     "oneOf": [

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -523,8 +523,8 @@ CHAT_TOOLS = [
             "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
             "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
             "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
-            "action='set_contact_form_lead_mandate' replaces the runtime prompt used to assess contact-form "
-            "leads on this connection immediately. The "
+            "action='set_contact_form_lead_mandate' adds a connection-specific overlay to the installed "
+            "contact-form lead skill immediately; pass an empty mandate to clear the overlay. The "
             "read-only action='open_alert_surges' returns material provider-alert incidents that are still "
             "inside their rolling window, for scheduled digest ordering. The "
             "bot must be a member of the channel and the Slack app needs the channels:history and "
@@ -602,8 +602,8 @@ CHAT_TOOLS = [
                 "mandate": {
                     "type": "string",
                     "description": (
-                        "Complete runtime contact-form assessment mandate, required "
-                        "for set_contact_form_lead_mandate."
+                        "Extra contact-form assessment instruction for "
+                        "set_contact_form_lead_mandate; an empty value clears it."
                     ),
                 },
                 "channel_types": {

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -523,8 +523,9 @@ CHAT_TOOLS = [
             "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
             "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
             "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
-            "action='set_contact_form_lead_mandate' adds a connection-specific overlay to the installed "
-            "contact-form lead skill immediately; pass an empty mandate to clear the overlay. The "
+            "action='set_contact_form_lead_mandate' writes a non-empty mandate as a connection-specific "
+            "overlay for the installed contact-form lead skill immediately; "
+            "action='clear_contact_form_lead_mandate' removes that overlay. The "
             "read-only action='open_alert_surges' returns material provider-alert incidents that are still "
             "inside their rolling window, for scheduled digest ordering. The "
             "bot must be a member of the channel and the Slack app needs the channels:history and "
@@ -545,6 +546,7 @@ CHAT_TOOLS = [
                         "monitor_channel",
                         "unmonitor_channel",
                         "set_contact_form_lead_mandate",
+                        "clear_contact_form_lead_mandate",
                         "open_alert_surges",
                     ],
                     "description": "Slack management action.",
@@ -601,9 +603,10 @@ CHAT_TOOLS = [
                 },
                 "mandate": {
                     "type": "string",
+                    "minLength": 1,
                     "description": (
-                        "Extra contact-form assessment instruction for "
-                        "set_contact_form_lead_mandate; an empty value clears it."
+                        "Non-empty contact-form assessment instruction required for "
+                        "set_contact_form_lead_mandate."
                     ),
                 },
                 "channel_types": {

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -21,6 +21,7 @@ from brain.systems.cycles.exception_ping import (
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
+from brain.systems.slack.contact_form_leads import CONTACT_FORM_LEAD_ORIGIN
 from brain.systems.slack.exception_ping_posting import post_exception_ping
 from brain.systems.slack.provider_alert_posting import post_provider_alert
 from brain.systems.slack.thread_mute import read_thread_post_mute
@@ -84,6 +85,16 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
         if normalized in {"0", "false", "no", "n", "off"}:
             return False
     return bool(value)
+
+
+def _is_contact_form_lead_intake() -> bool:
+    illo_trigger = _execution_metadata().get("illo_trigger")
+    if not isinstance(illo_trigger, dict):
+        return False
+    return (
+        str(illo_trigger.get("event_type") or "").strip()
+        == CONTACT_FORM_LEAD_ORIGIN
+    )
 
 
 _PERSISTENCE_CLAIM_PATTERNS = (
@@ -446,6 +457,8 @@ async def _handle_post_slack_reply(
     """Post an Illo-authored reply to the originating Slack surface."""
 
     answers_open_ask = _coerce_bool(answers_open_ask, default=False)
+    if _is_contact_form_lead_intake():
+        answers_open_ask = False
     submitted_text = str(body or "")
     text = submitted_text
     try:

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -1063,6 +1063,7 @@ async def _handle_manage_slack(
     channel_types: str | list[str] | None = None,
     channel_id: str | None = None,
     channel_name: str | None = None,
+    mandate: str | None = None,
     limit: int = 200,
     cursor: str | None = None,
     include_archived: bool = False,
@@ -1086,6 +1087,7 @@ async def _handle_manage_slack(
         add_monitored_channel,
         list_monitored_channels,
         remove_monitored_channel,
+        set_contact_form_lead_mandate,
     )
 
     async with UnitOfWork() as uow:
@@ -1265,13 +1267,25 @@ async def _handle_manage_slack(
             except SlackMonitorConfigError as exc:
                 return json.dumps({"error": str(exc)})
             return json.dumps({"ok": True, **result}, default=str)
+        if normalized_action == "set_contact_form_lead_mandate":
+            try:
+                result = await set_contact_form_lead_mandate(
+                    uow.session,
+                    connection_id=str(connection.id),
+                    mandate=str(mandate or ""),
+                    org_id=org_id,
+                )
+            except SlackMonitorConfigError as exc:
+                return json.dumps({"error": str(exc)})
+            return json.dumps({"ok": True, **result}, default=str)
 
     return json.dumps(
         {
             "error": (
                 "manage_slack action must be status, list_channels, list_mappings, "
                 "link_identity, unlink_identity, list_monitored, monitor_channel, "
-                "unmonitor_channel, or open_alert_surges"
+                "unmonitor_channel, set_contact_form_lead_mandate, or "
+                "open_alert_surges"
             )
         }
     )

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -19,9 +19,9 @@ from brain.systems.cycles.exception_ping import (
     slack_mentioned_teammates,
 )
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
+from brain.systems.runs.obligation_specs import ObligationSettlementPolicy, obligation_spec_from_metadata
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
-from brain.systems.slack.contact_form_leads import CONTACT_FORM_LEAD_ORIGIN
 from brain.systems.slack.exception_ping_posting import post_exception_ping
 from brain.systems.slack.provider_alert_posting import post_provider_alert
 from brain.systems.slack.thread_mute import read_thread_post_mute
@@ -85,16 +85,6 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
         if normalized in {"0", "false", "no", "n", "off"}:
             return False
     return bool(value)
-
-
-def _is_contact_form_lead_intake() -> bool:
-    illo_trigger = _execution_metadata().get("illo_trigger")
-    if not isinstance(illo_trigger, dict):
-        return False
-    return (
-        str(illo_trigger.get("event_type") or "").strip()
-        == CONTACT_FORM_LEAD_ORIGIN
-    )
 
 
 _PERSISTENCE_CLAIM_PATTERNS = (
@@ -457,7 +447,8 @@ async def _handle_post_slack_reply(
     """Post an Illo-authored reply to the originating Slack surface."""
 
     answers_open_ask = _coerce_bool(answers_open_ask, default=False)
-    if _is_contact_form_lead_intake():
+    obligation_spec = obligation_spec_from_metadata(_execution_metadata().get("obligation_spec"))
+    if obligation_spec and obligation_spec.settlement_policy is ObligationSettlementPolicy.ANSWERER_SLACK_REPLY:
         answers_open_ask = False
     submitted_text = str(body or "")
     text = submitted_text
@@ -1098,6 +1089,7 @@ async def _handle_manage_slack(
     from brain.systems.slack.monitors import (
         SlackMonitorConfigError,
         add_monitored_channel,
+        clear_contact_form_lead_mandate,
         list_monitored_channels,
         remove_monitored_channel,
         set_contact_form_lead_mandate,
@@ -1280,12 +1272,16 @@ async def _handle_manage_slack(
             except SlackMonitorConfigError as exc:
                 return json.dumps({"error": str(exc)})
             return json.dumps({"ok": True, **result}, default=str)
-        if normalized_action == "set_contact_form_lead_mandate":
+        if normalized_action in {"set_contact_form_lead_mandate", "clear_contact_form_lead_mandate"}:
             try:
-                result = await set_contact_form_lead_mandate(
+                operation = (
+                    clear_contact_form_lead_mandate
+                    if normalized_action == "clear_contact_form_lead_mandate"
+                    else partial(set_contact_form_lead_mandate, mandate=str(mandate or ""))
+                )
+                result = await operation(
                     uow.session,
                     connection_id=str(connection.id),
-                    mandate=str(mandate or ""),
                     org_id=org_id,
                 )
             except SlackMonitorConfigError as exc:
@@ -1297,7 +1293,8 @@ async def _handle_manage_slack(
             "error": (
                 "manage_slack action must be status, list_channels, list_mappings, "
                 "link_identity, unlink_identity, list_monitored, monitor_channel, "
-                "unmonitor_channel, set_contact_form_lead_mandate, or "
+                "unmonitor_channel, set_contact_form_lead_mandate, "
+                "clear_contact_form_lead_mandate, or "
                 "open_alert_surges"
             )
         }

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -624,7 +624,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "inbound_configuration",
         "reversibility": "variable",
         "action_manifest": True,
-        "expected_effect": "inspect Slack connection health, list bot-visible or observed Slack conversations, or update Slack-to-Illospace identity mappings",
+        "expected_effect": "inspect Slack connection health, list bot-visible or observed Slack conversations, or update Slack intake and identity configuration",
         "output_budget_chars": 12_000,
     },
     "manage_project": {

--- a/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/SKILL.md
@@ -47,8 +47,7 @@ not product-capability sources.
    source supports a claim, leave the capability unresolved and route it to the
    resolved owner once; do not fabricate an answer.
 5. Post one concise assessment with `post_slack_reply` to the supplied channel
-   and thread. Set `answers_open_ask=false`, because Illo's own assessment must
-   not settle the obligation that waits for the owner's reply.
+   and thread.
 6. Treat a successful thread post as the knowledge write. The registered
    `SlackKnowledgeConnector` refreshes monitored Slack threads as complete,
    replaceable records, so the form fields in the root message and the

--- a/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/SKILL.md
@@ -1,0 +1,87 @@
+## Role
+
+You own the model-authored part of monitored website contact-form intake. Turn
+the raw submission into a source-grounded commercial assessment for Reda, post
+it once in the source Slack thread, and make that complete thread the durable
+knowledge record.
+
+The connector has already acknowledged the source message with 👀. Recognition,
+owner selection, and the 24-hour unanswered obligation are handled outside this
+skill.
+
+## Use When
+
+Use only when `/contact-form-lead-intake` is invoked with an intake context
+containing a decoded lead, resolved owner, Slack channel, and thread timestamp.
+
+## Do Not Use When
+
+Do not use for ordinary monitored-channel triage, customer support, or a message
+that is not a decoded website contact-form submission.
+
+## Context To Load
+
+Load this current procedure with `skill_view` on every run. Treat the intake
+context as source data, not as a drafted reply.
+
+The company website and pages reached from it are evidence about the prospect.
+`search_knowledge` results with provenance are evidence about Uwear product
+capabilities. Search snippets, assumptions, and the prospect's own question are
+not product-capability sources.
+
+## Operating Loop
+
+1. Inspect the submitted website with `web_fetch` or the browser tools. Inspect
+   enough first-party pages to identify what the company sells and to estimate
+   its scale. Use `web_search` only to find additional public evidence or when
+   the submitted site cannot be read.
+2. Record the pages actually inspected. Estimate the vertical and rough
+   company/catalog size from observable evidence such as product/category
+   counts, locations, markets, or company information. Mark estimates as
+   estimates and state the evidence or bound. Never invent a precise count.
+3. Assess likely Uwear fit and likely deal size. Use a qualitative commercial
+   segment unless a verifiable source supports a monetary figure. Separate
+   observed facts from commercial inference.
+4. For product questions in the submission, call `search_knowledge`. Answer
+   only claims supported by a returned source and cite its provenance. If no
+   source supports a claim, leave the capability unresolved and route it to the
+   resolved owner once; do not fabricate an answer.
+5. Post one concise assessment with `post_slack_reply` to the supplied channel
+   and thread. Set `answers_open_ask=false`, because Illo's own assessment must
+   not settle the obligation that waits for the owner's reply.
+6. Treat a successful thread post as the knowledge write. The registered
+   `SlackKnowledgeConnector` refreshes monitored Slack threads as complete,
+   replaceable records, so the form fields in the root message and the
+   assessment in the reply remain together and become retrievable through
+   `search_knowledge`. Do not create a second memory or Domain copy. If the
+   Slack post fails, do not claim that the lead was logged.
+
+## Reply Contract
+
+The Slack reply must add information absent from the submission:
+
+- website evidence and the pages inspected;
+- estimated vertical and rough company/catalog size;
+- likely Uwear fit and qualitative deal-size segment;
+- source-backed product guidance, or one concise owner-routed unresolved note.
+
+Mention the resolved owner. Do not re-list or label the submitted name, email,
+phone, website, message, or questions. Source links may appear only where they
+support new assessment facts. Do not emit a per-question `Answer:` section and
+do not repeat identical human-review boilerplate for each ask.
+
+## Output Contract
+
+The run is complete only after exactly one source-thread assessment has been
+posted successfully. The model's final text should be a terse internal
+completion note because the user-visible content is the Slack reply.
+
+## Failure Modes
+
+- If the website is inaccessible, use public search evidence, say what could
+  not be inspected, and keep scale claims bounded.
+- If scale evidence conflicts, report a range and cite the competing signals.
+- If Uwear capability evidence is absent, route the unresolved capability
+  question to the owner without repeating the prospect's wording.
+- If the Slack target is missing or posting fails, stop and report the logging
+  failure; do not post elsewhere.

--- a/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/contact-form-lead-intake/skill.toml
@@ -1,0 +1,28 @@
+schema_version = 1
+name = "contact-form-lead-intake"
+display_name = "Contact-form Lead Intake"
+version = "1.0.0"
+description = "Assess a monitored website contact-form lead from website evidence, post a concise commercial read to the source Slack thread, and leave the complete thread queryable through the Slack knowledge connector."
+license = "UNLICENSED"
+source = "self_hosted"
+visibility = "private_local"
+maturity = "emerging"
+
+[routing]
+triggers = [
+  { pattern = "New Contact Form Submission", direction = "for" },
+  { pattern = "assess this contact-form lead", direction = "for" },
+  { pattern = "website inbound sales lead", direction = "for" },
+  { pattern = "ordinary monitored Slack alert", direction = "against" },
+  { pattern = "customer support generation complaint", direction = "against" },
+]
+
+[runtime]
+default_thinking_tier = "high"
+
+[permissions]
+toolsets = ["brain"]
+
+[loading]
+summary = "SKILL.md#role"
+procedure = "SKILL.md"

--- a/brain/systems/slack/contact_form_lead_owner.py
+++ b/brain/systems/slack/contact_form_lead_owner.py
@@ -9,6 +9,22 @@ from brain.systems.runs.obligation_specs import ObligationAnswerer
 
 
 @dataclass(frozen=True, slots=True)
+class SlackIdentityRecord:
+    """One Slack identity whose attributes cannot be combined across people."""
+
+    slack_user_id: str
+    display_name: str
+    user_id: str | None
+
+    def without_user_id(self) -> SlackIdentityRecord:
+        return SlackIdentityRecord(
+            slack_user_id=self.slack_user_id,
+            display_name=self.display_name,
+            user_id=None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class ContactFormOwnerPolicy:
     default_name: str
     default_slack_user_id: str
@@ -19,65 +35,23 @@ class ContactFormOwnerPolicy:
         metadata = _connection_metadata(connection)
         slack_metadata = _mapping(metadata.get("slack"))
         configured = _mapping(slack_metadata.get("contact_form_lead_owner"))
-        identity_map = _mapping(slack_metadata.get("identity_map"))
-        identity_links = _mapping(_mapping(metadata.get("identity_links")).get("slack"))
+        records = _slack_identity_records(metadata)
 
         configured_user_id = _clean(configured.get("user_id")) or None
         configured_slack_id = _clean(configured.get("slack_user_id")) or None
         configured_name = _clean(configured.get("name")) or None
-        if configured_slack_id:
-            link = _mapping(identity_links.get(configured_slack_id))
-            return ObligationAnswerer(
-                name=(
-                    configured_name
-                    or _clean(link.get("display_name"))
-                    or self.default_name
-                ),
-                slack_user_id=configured_slack_id,
-                user_id=(
-                    configured_user_id
-                    or _clean(link.get("user_id"))
-                    or _clean(identity_map.get(configured_slack_id))
-                    or None
-                ),
-            )
-
-        if configured_user_id:
-            for slack_user_id, mapped_user_id in identity_map.items():
-                if _clean(mapped_user_id) != configured_user_id:
-                    continue
-                link = _mapping(identity_links.get(slack_user_id))
-                return ObligationAnswerer(
-                    name=(
-                        configured_name
-                        or _clean(link.get("display_name"))
-                        or self.default_name
-                    ),
-                    slack_user_id=_clean(slack_user_id),
-                    user_id=configured_user_id,
-                )
-
-        for slack_user_id, raw_link in identity_links.items():
-            link = _mapping(raw_link)
-            display_name = _clean(link.get("display_name"))
-            if display_name.casefold() != self.default_name.casefold():
-                continue
-            return ObligationAnswerer(
-                name=display_name or self.default_name,
-                slack_user_id=_clean(slack_user_id),
-                user_id=_clean(link.get("user_id")) or None,
-            )
-
-        default_link = _mapping(identity_links.get(self.default_slack_user_id))
+        selected = _select_identity_record(
+            records,
+            configured_slack_id=configured_slack_id,
+            configured_user_id=configured_user_id,
+            configured_name=configured_name,
+            default_slack_user_id=self.default_slack_user_id,
+            default_name=self.default_name,
+        )
         return ObligationAnswerer(
-            name=_clean(default_link.get("display_name")) or self.default_name,
-            slack_user_id=self.default_slack_user_id,
-            user_id=(
-                configured_user_id
-                or _clean(default_link.get("user_id"))
-                or _clean(identity_map.get(self.default_slack_user_id))
-                or None
-            ),
+            name=selected.display_name,
+            slack_user_id=selected.slack_user_id,
+            user_id=selected.user_id,
         )
 
 
@@ -95,6 +69,112 @@ def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
 
 
+def _slack_identity_records(
+    metadata: Mapping[str, Any],
+) -> tuple[SlackIdentityRecord, ...]:
+    slack_metadata = _mapping(metadata.get("slack"))
+    identity_map = {
+        _clean(slack_user_id): user_id
+        for slack_user_id, user_id in _mapping(
+            slack_metadata.get("identity_map")
+        ).items()
+        if _clean(slack_user_id)
+    }
+    identity_links = {
+        _clean(slack_user_id): link
+        for slack_user_id, link in _mapping(
+            _mapping(metadata.get("identity_links")).get("slack")
+        ).items()
+        if _clean(slack_user_id)
+    }
+    slack_user_ids = dict.fromkeys(
+        [
+            *(_clean(value) for value in identity_links),
+            *(_clean(value) for value in identity_map),
+        ]
+    )
+    records: list[SlackIdentityRecord] = []
+    for slack_user_id in slack_user_ids:
+        if not slack_user_id:
+            continue
+        link = _mapping(identity_links.get(slack_user_id))
+        linked_user_id = _clean(link.get("user_id")) or None
+        mapped_user_id = _clean(identity_map.get(slack_user_id)) or None
+        if linked_user_id and mapped_user_id and linked_user_id != mapped_user_id:
+            user_id = None
+        else:
+            user_id = linked_user_id or mapped_user_id
+        records.append(
+            SlackIdentityRecord(
+                slack_user_id=slack_user_id,
+                display_name=(
+                    _clean(link.get("display_name"))
+                    or slack_user_id
+                ),
+                user_id=user_id,
+            )
+        )
+    return tuple(records)
+
+
+def _select_identity_record(
+    records: tuple[SlackIdentityRecord, ...],
+    *,
+    configured_slack_id: str | None,
+    configured_user_id: str | None,
+    configured_name: str | None,
+    default_slack_user_id: str,
+    default_name: str,
+) -> SlackIdentityRecord:
+    by_slack_id = {record.slack_user_id: record for record in records}
+    if configured_slack_id:
+        return by_slack_id.get(configured_slack_id) or SlackIdentityRecord(
+            slack_user_id=configured_slack_id,
+            display_name=configured_name or configured_slack_id,
+            user_id=None,
+        )
+
+    if configured_user_id:
+        matched_user = next(
+            (
+                record
+                for record in records
+                if record.user_id == configured_user_id
+            ),
+            None,
+        )
+        if matched_user is not None:
+            return matched_user
+
+    default_name_match = next(
+        (
+            record
+            for record in records
+            if record.display_name.casefold() == default_name.casefold()
+        ),
+        None,
+    )
+    selected = default_name_match or by_slack_id.get(default_slack_user_id)
+    if selected is None:
+        selected = SlackIdentityRecord(
+            slack_user_id=default_slack_user_id,
+            display_name=default_name,
+            user_id=None,
+        )
+    elif (
+        selected.slack_user_id == default_slack_user_id
+        and selected.display_name == default_slack_user_id
+    ):
+        selected = SlackIdentityRecord(
+            slack_user_id=selected.slack_user_id,
+            display_name=default_name,
+            user_id=selected.user_id,
+        )
+    if configured_user_id:
+        return selected.without_user_id()
+    return selected
+
+
 def _connection_value(connection: Any, key: str) -> Any:
     if isinstance(connection, Mapping):
         return connection.get(key)
@@ -108,4 +188,8 @@ def _connection_metadata(connection: Any) -> dict[str, Any]:
     )
 
 
-__all__ = ["CONTACT_FORM_OWNER_POLICY", "ContactFormOwnerPolicy"]
+__all__ = [
+    "CONTACT_FORM_OWNER_POLICY",
+    "ContactFormOwnerPolicy",
+    "SlackIdentityRecord",
+]

--- a/brain/systems/slack/contact_form_lead_owner.py
+++ b/brain/systems/slack/contact_form_lead_owner.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Mapping
 
 from brain.systems.runs.obligation_specs import ObligationAnswerer
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +105,13 @@ def _slack_identity_records(
         linked_user_id = _clean(link.get("user_id")) or None
         mapped_user_id = _clean(identity_map.get(slack_user_id)) or None
         if linked_user_id and mapped_user_id and linked_user_id != mapped_user_id:
+            logger.warning(
+                "Conflicting Slack identity for %s: linked user_id %s disagrees "
+                "with mapped user_id %s; omitting user_id",
+                slack_user_id,
+                linked_user_id,
+                mapped_user_id,
+            )
             user_id = None
         else:
             user_id = linked_user_id or mapped_user_id

--- a/brain/systems/slack/contact_form_lead_owner.py
+++ b/brain/systems/slack/contact_form_lead_owner.py
@@ -26,11 +26,36 @@ class ContactFormOwnerPolicy:
         configured_slack_id = _clean(configured.get("slack_user_id")) or None
         configured_name = _clean(configured.get("name")) or None
         if configured_slack_id:
+            link = _mapping(identity_links.get(configured_slack_id))
             return ObligationAnswerer(
-                name=configured_name or self.default_name,
+                name=(
+                    configured_name
+                    or _clean(link.get("display_name"))
+                    or self.default_name
+                ),
                 slack_user_id=configured_slack_id,
-                user_id=configured_user_id,
+                user_id=(
+                    configured_user_id
+                    or _clean(link.get("user_id"))
+                    or _clean(identity_map.get(configured_slack_id))
+                    or None
+                ),
             )
+
+        if configured_user_id:
+            for slack_user_id, mapped_user_id in identity_map.items():
+                if _clean(mapped_user_id) != configured_user_id:
+                    continue
+                link = _mapping(identity_links.get(slack_user_id))
+                return ObligationAnswerer(
+                    name=(
+                        configured_name
+                        or _clean(link.get("display_name"))
+                        or self.default_name
+                    ),
+                    slack_user_id=_clean(slack_user_id),
+                    user_id=configured_user_id,
+                )
 
         for slack_user_id, raw_link in identity_links.items():
             link = _mapping(raw_link)
@@ -43,26 +68,16 @@ class ContactFormOwnerPolicy:
                 user_id=_clean(link.get("user_id")) or None,
             )
 
-        owner_user_id = (
-            configured_user_id
-            or _clean(_connection_value(connection, "owner_user_id"))
-            or None
-        )
-        if owner_user_id:
-            for slack_user_id, mapped_user_id in identity_map.items():
-                if _clean(mapped_user_id) != owner_user_id:
-                    continue
-                link = _mapping(identity_links.get(slack_user_id))
-                return ObligationAnswerer(
-                    name=_clean(link.get("display_name")) or self.default_name,
-                    slack_user_id=_clean(slack_user_id),
-                    user_id=owner_user_id,
-                )
-
+        default_link = _mapping(identity_links.get(self.default_slack_user_id))
         return ObligationAnswerer(
-            name=self.default_name,
+            name=_clean(default_link.get("display_name")) or self.default_name,
             slack_user_id=self.default_slack_user_id,
-            user_id=owner_user_id,
+            user_id=(
+                configured_user_id
+                or _clean(default_link.get("user_id"))
+                or _clean(identity_map.get(self.default_slack_user_id))
+                or None
+            ),
         )
 
 

--- a/brain/systems/slack/contact_form_lead_rendering.py
+++ b/brain/systems/slack/contact_form_lead_rendering.py
@@ -1,4 +1,4 @@
-"""Runtime mandate handoff and deterministic reminders for contact-form leads."""
+"""Skill handoff and deterministic reminders for contact-form leads."""
 
 from __future__ import annotations
 
@@ -11,6 +11,93 @@ from brain.systems.slack.contact_form_leads import ContactFormLead
 
 
 CONTACT_FORM_LEAD_SKILL = "contact-form-lead-intake"
+CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class ContactFormLeadSlackResponseTarget:
+    """Canonical Slack destination supplied to the contact-form lead skill."""
+
+    channel_id: str
+    thread_ts: str
+
+    @classmethod
+    def from_slack_trigger(
+        cls,
+        slack_trigger_payload: Mapping[str, Any],
+    ) -> ContactFormLeadSlackResponseTarget:
+        response_target = slack_trigger_payload.get("response_target")
+        target = response_target if isinstance(response_target, Mapping) else {}
+        return cls(
+            channel_id=_clean(target.get("channel_id")),
+            thread_ts=_clean(target.get("thread_ts")),
+        )
+
+    def to_payload(self) -> dict[str, str]:
+        if not _clean(self.channel_id):
+            raise ValueError(
+                "contact-form lead intake requires a Slack response target channel_id"
+            )
+        if not _clean(self.thread_ts):
+            raise ValueError(
+                "contact-form lead intake requires a Slack response target thread_ts"
+            )
+        return {
+            "channel_id": _clean(self.channel_id),
+            "thread_ts": _clean(self.thread_ts),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContactFormLeadIntakeContext:
+    """Versioned model input for one decoded contact-form lead."""
+
+    lead: ContactFormLead
+    owner: ObligationAnswerer
+    slack_response_target: ContactFormLeadSlackResponseTarget
+    source_permalink: str | None = None
+    schema_version: int = CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION
+
+    @classmethod
+    def from_slack_trigger(
+        cls,
+        lead: ContactFormLead,
+        owner: ObligationAnswerer,
+        slack_trigger_payload: Mapping[str, Any],
+    ) -> ContactFormLeadIntakeContext:
+        return cls(
+            lead=lead,
+            owner=owner,
+            slack_response_target=(
+                ContactFormLeadSlackResponseTarget.from_slack_trigger(
+                    slack_trigger_payload
+                )
+            ),
+            source_permalink=_clean(slack_trigger_payload.get("permalink")) or None,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        if self.schema_version != CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported contact-form lead intake schema_version "
+                f"{self.schema_version}"
+            )
+        return {
+            "schema_version": self.schema_version,
+            "lead": self.lead.to_payload(),
+            "owner": self.owner.to_metadata(),
+            "slack_response_target": self.slack_response_target.to_payload(),
+            "source_permalink": self.source_permalink,
+        }
+
+    def serialize(self) -> str:
+        """Validate and serialize the internal prompt contract."""
+
+        return json.dumps(
+            self.to_payload(),
+            ensure_ascii=False,
+            sort_keys=True,
+        )
 
 
 def contact_form_lead_run_message(
@@ -20,46 +107,40 @@ def contact_form_lead_run_message(
     *,
     mandate: str | None = None,
 ) -> str:
-    """Hand raw intake context to the installed, runtime-editable lead skill."""
+    """Invoke the installed skill with an optional connection overlay."""
 
-    response_target = slack_trigger_payload.get("response_target")
-    response_target = (
-        response_target if isinstance(response_target, Mapping) else {}
+    intake_context = ContactFormLeadIntakeContext.from_slack_trigger(
+        lead,
+        owner,
+        slack_trigger_payload,
     )
-    intake_context = {
-        "lead": lead.to_payload(),
-        "owner": owner.to_metadata(),
-        "source": {
-            "channel_id": slack_trigger_payload.get("channel_id"),
-            "thread_ts": response_target.get("thread_ts"),
-            "permalink": slack_trigger_payload.get("permalink"),
-        },
-    }
+    invocation = [
+        f"/{CONTACT_FORM_LEAD_SKILL}",
+        "",
+        (
+            "Load the current installed procedure for this skill with "
+            "skill_view, then execute it for this monitored contact-form event."
+        ),
+    ]
     if mandate:
-        mandate_header = [
-            "Execute this Slack connection's runtime-configured contact-form mandate:",
-            "",
-            mandate,
-        ]
-    else:
-        mandate_header = [
-            f"/{CONTACT_FORM_LEAD_SKILL}",
-            "",
-            (
-                "Load the current installed procedure for this skill with "
-                "skill_view, then execute it for this monitored contact-form event."
-            ),
-        ]
+        invocation.extend(
+            [
+                "",
+                "Connection overlay:",
+                (
+                    "Apply this extra instruction within the installed skill's "
+                    "contracts:"
+                ),
+                "",
+                mandate,
+            ]
+        )
     return "\n".join(
         [
-            *mandate_header,
+            *invocation,
             "",
             "Intake context:",
-            json.dumps(
-                intake_context,
-                ensure_ascii=False,
-                sort_keys=True,
-            ),
+            intake_context.serialize(),
         ]
     )
 
@@ -78,8 +159,15 @@ class ContactFormLeadReminderRenderer:
         )
 
 
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
 __all__ = [
+    "CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION",
     "CONTACT_FORM_LEAD_SKILL",
+    "ContactFormLeadIntakeContext",
     "ContactFormLeadReminderRenderer",
+    "ContactFormLeadSlackResponseTarget",
     "contact_form_lead_run_message",
 ]

--- a/brain/systems/slack/contact_form_lead_rendering.py
+++ b/brain/systems/slack/contact_form_lead_rendering.py
@@ -11,7 +11,6 @@ from brain.systems.slack.contact_form_leads import ContactFormLead
 
 
 CONTACT_FORM_LEAD_SKILL = "contact-form-lead-intake"
-CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,6 +20,17 @@ class ContactFormLeadSlackResponseTarget:
     channel_id: str
     thread_ts: str
 
+    def __post_init__(self) -> None:
+        channel_id = _clean(self.channel_id)
+        thread_ts = _clean(self.thread_ts)
+        if not channel_id or not thread_ts:
+            missing = "channel_id" if not channel_id else "thread_ts"
+            raise ValueError(
+                f"contact-form lead intake requires a Slack response target {missing}"
+            )
+        object.__setattr__(self, "channel_id", channel_id)
+        object.__setattr__(self, "thread_ts", thread_ts)
+
     @classmethod
     def from_slack_trigger(
         cls,
@@ -29,34 +39,28 @@ class ContactFormLeadSlackResponseTarget:
         response_target = slack_trigger_payload.get("response_target")
         target = response_target if isinstance(response_target, Mapping) else {}
         return cls(
-            channel_id=_clean(target.get("channel_id")),
-            thread_ts=_clean(target.get("thread_ts")),
+            channel_id=target.get("channel_id"),
+            thread_ts=target.get("thread_ts"),
         )
 
     def to_payload(self) -> dict[str, str]:
-        if not _clean(self.channel_id):
-            raise ValueError(
-                "contact-form lead intake requires a Slack response target channel_id"
-            )
-        if not _clean(self.thread_ts):
-            raise ValueError(
-                "contact-form lead intake requires a Slack response target thread_ts"
-            )
         return {
-            "channel_id": _clean(self.channel_id),
-            "thread_ts": _clean(self.thread_ts),
+            "channel_id": self.channel_id,
+            "thread_ts": self.thread_ts,
         }
 
 
 @dataclass(frozen=True, slots=True)
 class ContactFormLeadIntakeContext:
-    """Versioned model input for one decoded contact-form lead."""
+    """Canonical model input for one decoded contact-form lead."""
 
     lead: ContactFormLead
     owner: ObligationAnswerer
     slack_response_target: ContactFormLeadSlackResponseTarget
     source_permalink: str | None = None
-    schema_version: int = CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_permalink", _clean(self.source_permalink) or None)
 
     @classmethod
     def from_slack_trigger(
@@ -73,17 +77,11 @@ class ContactFormLeadIntakeContext:
                     slack_trigger_payload
                 )
             ),
-            source_permalink=_clean(slack_trigger_payload.get("permalink")) or None,
+            source_permalink=slack_trigger_payload.get("permalink"),
         )
 
     def to_payload(self) -> dict[str, Any]:
-        if self.schema_version != CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION:
-            raise ValueError(
-                "unsupported contact-form lead intake schema_version "
-                f"{self.schema_version}"
-            )
         return {
-            "schema_version": self.schema_version,
             "lead": self.lead.to_payload(),
             "owner": self.owner.to_metadata(),
             "slack_response_target": self.slack_response_target.to_payload(),
@@ -91,13 +89,9 @@ class ContactFormLeadIntakeContext:
         }
 
     def serialize(self) -> str:
-        """Validate and serialize the internal prompt contract."""
+        """Serialize the internal prompt contract."""
 
-        return json.dumps(
-            self.to_payload(),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        return json.dumps(self.to_payload(), ensure_ascii=False, sort_keys=True)
 
 
 def contact_form_lead_run_message(
@@ -164,10 +158,7 @@ def _clean(value: Any) -> str:
 
 
 __all__ = [
-    "CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION",
     "CONTACT_FORM_LEAD_SKILL",
-    "ContactFormLeadIntakeContext",
     "ContactFormLeadReminderRenderer",
-    "ContactFormLeadSlackResponseTarget",
     "contact_form_lead_run_message",
 ]

--- a/brain/systems/slack/contact_form_lead_rendering.py
+++ b/brain/systems/slack/contact_form_lead_rendering.py
@@ -1,146 +1,65 @@
-"""Vertical policy and deterministic rendering for contact-form leads."""
+"""Runtime mandate handoff and deterministic reminders for contact-form leads."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
+import json
 from typing import Any, Mapping
 
 from brain.systems.runs.obligation_specs import ObligationAnswerer
 from brain.systems.slack.contact_form_leads import ContactFormLead
 
 
-_NUMBERED_ASK_PATTERN = re.compile(
-    r"(?m)^[ \t]*\d+[.)][ \t]*(?P<ask>[^\n]+)"
-)
-
-
-def extract_contact_form_asks(message: str) -> list[str]:
-    """Break a lead's message into separately actionable questions."""
-
-    source = _clean(message)
-    if not source:
-        return []
-
-    asks: list[str] = []
-    numbered_spans: list[tuple[int, int]] = []
-    for match in _NUMBERED_ASK_PATTERN.finditer(source):
-        ask = " ".join(match.group("ask").split())
-        if ask:
-            asks.append(ask)
-            numbered_spans.append(match.span())
-
-    remainder_parts: list[str] = []
-    cursor = 0
-    for start, end in numbered_spans:
-        remainder_parts.append(source[cursor:start])
-        cursor = end
-    remainder_parts.append(source[cursor:])
-    remainder = "\n".join(remainder_parts)
-    pending_context = ""
-    for sentence in re.split(r"(?<=[.!?])[ \t]+|\n+", remainder):
-        ask = " ".join(sentence.split()).strip(" -•")
-        if "?" in ask:
-            if pending_context:
-                ask = f"{pending_context} {ask}"
-            asks.append(ask)
-            pending_context = ""
-        elif any(
-            marker in ask.casefold()
-            for marker in ("verification", "enablement", "may require", "feature")
-        ):
-            pending_context = ask
-
-    if not asks:
-        asks.append(" ".join(source.split()))
-
-    deduplicated: list[str] = []
-    seen: set[str] = set()
-    for ask in asks:
-        key = ask.casefold()
-        if key in seen:
-            continue
-        deduplicated.append(ask)
-        seen.add(key)
-    return deduplicated
-
-
-def infer_contact_form_vertical(lead: ContactFormLead) -> str:
-    evidence = f"{lead.company_website} {lead.message}".casefold()
-    if any(
-        term in evidence
-        for term in ("lingerie", "bikini", "intimate apparel", "corset", "thong")
-    ):
-        return "Lingerie / intimate-apparel e-commerce"
-    if "bergzeit" in evidence or any(
-        term in evidence for term in ("outdoor apparel", "outdoor retail")
-    ):
-        return "Outdoor retail e-commerce"
-    return "E-commerce / retail"
-
-
-def contact_form_lead_dossier(
-    lead: ContactFormLead,
-    owner: ObligationAnswerer,
-) -> str:
-    """Render safe intake copy without asserting unverified capabilities."""
-
-    owner_mention = f"<@{owner.slack_user_id}>"
-    asks = extract_contact_form_asks(lead.message)
-    lines = [
-        "*Contact-form lead*",
-        f"*Who:* {lead.name} — {lead.email}",
-        f"*Vertical:* {infer_contact_form_vertical(lead)}",
-        f"*Site:* {lead.company_website}",
-    ]
-    if lead.phone:
-        lines.append(f"*Phone:* {lead.phone}")
-    lines.extend(["", "*Asks:*"])
-    for index, ask in enumerate(asks, start=1):
-        lines.extend(
-            [
-                f"{index}. {ask}",
-                (
-                    "   *Answer:* needs a human answer — no verified product "
-                    "capability source is attached to this intake."
-                ),
-            ]
-        )
-    lines.extend(
-        [
-            "",
-            f"*Owner:* {owner_mention} ({owner.name})",
-            (
-                f"*Next action:* {owner_mention}, reply in this thread with verified "
-                f"answers for {lead.name}, then send them to {lead.email}."
-            ),
-        ]
-    )
-    return "\n".join(lines)
+CONTACT_FORM_LEAD_SKILL = "contact-form-lead-intake"
 
 
 def contact_form_lead_run_message(
-    dossier: str,
+    lead: ContactFormLead,
+    owner: ObligationAnswerer,
     slack_trigger_payload: Mapping[str, Any],
+    *,
+    mandate: str | None = None,
 ) -> str:
+    """Hand raw intake context to the installed, runtime-editable lead skill."""
+
     response_target = slack_trigger_payload.get("response_target")
-    response_target = response_target if isinstance(response_target, Mapping) else {}
+    response_target = (
+        response_target if isinstance(response_target, Mapping) else {}
+    )
+    intake_context = {
+        "lead": lead.to_payload(),
+        "owner": owner.to_metadata(),
+        "source": {
+            "channel_id": slack_trigger_payload.get("channel_id"),
+            "thread_ts": response_target.get("thread_ts"),
+            "permalink": slack_trigger_payload.get("permalink"),
+        },
+    }
+    if mandate:
+        mandate_header = [
+            "Execute this Slack connection's runtime-configured contact-form mandate:",
+            "",
+            mandate,
+        ]
+    else:
+        mandate_header = [
+            f"/{CONTACT_FORM_LEAD_SKILL}",
+            "",
+            (
+                "Load the current installed procedure for this skill with "
+                "skill_view, then execute it for this monitored contact-form event."
+            ),
+        ]
     return "\n".join(
         [
-            "A qualified website contact-form lead arrived in a monitored Slack channel.",
-            "The connector already acknowledged the source message with 👀.",
-            (
-                "Post the exact dossier below once with post_slack_reply in the source "
-                f"thread (channel_id={slack_trigger_payload.get('channel_id')}, "
-                f"thread_ts={response_target.get('thread_ts')}) and set "
-                "answers_open_ask=false."
-            ),
-            (
-                "Do not research, infer, rephrase, or add product claims in this intake "
-                "run. Unknown capability claims must remain marked needs a human answer."
-            ),
+            *mandate_header,
             "",
-            dossier,
+            "Intake context:",
+            json.dumps(
+                intake_context,
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
         ]
     )
 
@@ -159,14 +78,8 @@ class ContactFormLeadReminderRenderer:
         )
 
 
-def _clean(value: Any) -> str:
-    return str(value or "").strip()
-
-
 __all__ = [
+    "CONTACT_FORM_LEAD_SKILL",
     "ContactFormLeadReminderRenderer",
-    "contact_form_lead_dossier",
     "contact_form_lead_run_message",
-    "extract_contact_form_asks",
-    "infer_contact_form_vertical",
 ]

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -19,14 +19,15 @@ from brain.systems.slack.contact_form_lead_owner import (
     CONTACT_FORM_OWNER_POLICY,
 )
 from brain.systems.slack.contact_form_lead_rendering import (
+    CONTACT_FORM_LEAD_SKILL,
     ContactFormLeadReminderRenderer,
-    contact_form_lead_dossier,
     contact_form_lead_run_message,
 )
 from brain.systems.slack.contact_form_leads import (
     CONTACT_FORM_LEAD_ORIGIN,
     ContactFormLead,
 )
+from brain.systems.slack.monitors import contact_form_lead_mandate
 
 
 logger = logging.getLogger(__name__)
@@ -279,6 +280,9 @@ async def _enrich_contact_form(
     owner = CONTACT_FORM_OWNER_POLICY.resolve(context.connection)
     lead["owner"] = owner.to_metadata()
     payload["contact_form_lead"] = lead
+    configured_mandate = contact_form_lead_mandate(context.connection)
+    if configured_mandate:
+        payload["contact_form_lead_mandate"] = configured_mandate
     envelope["payload"] = payload
 
 
@@ -291,15 +295,22 @@ def _render_contact_form(
     owner = ObligationAnswerer.from_metadata(
         _mapping(lead_payload.get("owner"))
     )
-    dossier = contact_form_lead_dossier(lead, owner)
+    configured_mandate = _clean(payload.get("contact_form_lead_mandate"))
     return RenderedMonitoredIntake(
         run_message=contact_form_lead_run_message(
-            dossier,
+            lead,
+            owner,
             slack_trigger_payload,
+            mandate=configured_mandate or None,
         ),
         metadata={
             "contact_form_lead": lead_payload,
-            "contact_form_lead_dossier": dossier,
+            "contact_form_lead_skill": CONTACT_FORM_LEAD_SKILL,
+            "contact_form_lead_mandate_source": (
+                "slack_connection_metadata"
+                if configured_mandate
+                else "installed_skill"
+            ),
             "obligation_requester": _mapping(
                 payload.get("obligation_requester")
             ),

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -307,7 +307,7 @@ def _render_contact_form(
             "contact_form_lead": lead_payload,
             "contact_form_lead_skill": CONTACT_FORM_LEAD_SKILL,
             "contact_form_lead_mandate_source": (
-                "slack_connection_metadata"
+                "installed_skill_with_connection_overlay"
                 if configured_mandate
                 else "installed_skill"
             ),

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -88,7 +88,7 @@ def monitored_channel_ids(connection: ExternalAgentConnectionRow) -> set[str]:
 def contact_form_lead_mandate(
     connection: ExternalAgentConnectionRow,
 ) -> str | None:
-    """Return the optional runtime override for contact-form lead behavior."""
+    """Return the optional connection overlay for contact-form lead behavior."""
 
     value = _clean(
         _slack_metadata(connection).get(CONTACT_FORM_LEAD_MANDATE_KEY)
@@ -126,11 +126,9 @@ async def set_contact_form_lead_mandate(
     mandate: str,
     org_id: str | None = None,
 ) -> dict[str, Any]:
-    """Persist an operator-editable mandate on the Slack connection."""
+    """Persist or clear an operator-editable skill overlay."""
 
     clean_mandate = _clean(mandate)
-    if not clean_mandate:
-        raise SlackMonitorConfigError("mandate is required")
     if len(clean_mandate) > CONTACT_FORM_LEAD_MANDATE_MAX_CHARS:
         raise SlackMonitorConfigError(
             "mandate exceeds "
@@ -139,14 +137,18 @@ async def set_contact_form_lead_mandate(
     connection = await _connection_for_org(session, connection_id, org_id)
     root = dict(connection.metadata_ or {})
     slack_metadata = _slack_metadata(connection)
-    slack_metadata[CONTACT_FORM_LEAD_MANDATE_KEY] = clean_mandate
+    if clean_mandate:
+        slack_metadata[CONTACT_FORM_LEAD_MANDATE_KEY] = clean_mandate
+    else:
+        slack_metadata.pop(CONTACT_FORM_LEAD_MANDATE_KEY, None)
     root["slack"] = slack_metadata
     connection.metadata_ = root
     await session.flush()
     return {
         "connection_id": str(connection.id),
         "metadata_path": f"slack.{CONTACT_FORM_LEAD_MANDATE_KEY}",
-        "mandate": clean_mandate,
+        "mandate": clean_mandate or None,
+        "cleared": not bool(clean_mandate),
     }
 
 

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -15,6 +15,10 @@ from typing import Any, Mapping
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 
 
+CONTACT_FORM_LEAD_MANDATE_KEY = "contact_form_lead_mandate"
+CONTACT_FORM_LEAD_MANDATE_MAX_CHARS = 20_000
+
+
 class SlackMonitorConfigError(ValueError):
     """Raised when a Slack channel monitor cannot be configured."""
 
@@ -81,6 +85,17 @@ def monitored_channel_ids(connection: ExternalAgentConnectionRow) -> set[str]:
     return {entry["channel_id"] for entry in entries if entry.get("enabled", True)}
 
 
+def contact_form_lead_mandate(
+    connection: ExternalAgentConnectionRow,
+) -> str | None:
+    """Return the optional runtime override for contact-form lead behavior."""
+
+    value = _clean(
+        _slack_metadata(connection).get(CONTACT_FORM_LEAD_MANDATE_KEY)
+    )
+    return value or None
+
+
 async def _connection_for_org(
     session,
     connection_id: str,
@@ -102,6 +117,37 @@ def _write_entries(connection: ExternalAgentConnectionRow, entries: list[dict[st
     slack_metadata["monitored_channels"] = entries
     root["slack"] = slack_metadata
     connection.metadata_ = root
+
+
+async def set_contact_form_lead_mandate(
+    session,
+    *,
+    connection_id: str,
+    mandate: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist an operator-editable mandate on the Slack connection."""
+
+    clean_mandate = _clean(mandate)
+    if not clean_mandate:
+        raise SlackMonitorConfigError("mandate is required")
+    if len(clean_mandate) > CONTACT_FORM_LEAD_MANDATE_MAX_CHARS:
+        raise SlackMonitorConfigError(
+            "mandate exceeds "
+            f"{CONTACT_FORM_LEAD_MANDATE_MAX_CHARS} characters"
+        )
+    connection = await _connection_for_org(session, connection_id, org_id)
+    root = dict(connection.metadata_ or {})
+    slack_metadata = _slack_metadata(connection)
+    slack_metadata[CONTACT_FORM_LEAD_MANDATE_KEY] = clean_mandate
+    root["slack"] = slack_metadata
+    connection.metadata_ = root
+    await session.flush()
+    return {
+        "connection_id": str(connection.id),
+        "metadata_path": f"slack.{CONTACT_FORM_LEAD_MANDATE_KEY}",
+        "mandate": clean_mandate,
+    }
 
 
 async def list_monitored_channels(
@@ -175,10 +221,13 @@ async def remove_monitored_channel(
 
 
 __all__ = [
+    "CONTACT_FORM_LEAD_MANDATE_KEY",
     "SlackMonitorConfigError",
     "add_monitored_channel",
+    "contact_form_lead_mandate",
     "list_monitored_channels",
     "monitored_channel_ids",
     "monitored_channels",
     "remove_monitored_channel",
+    "set_contact_form_lead_mandate",
 ]

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -119,26 +119,18 @@ def _write_entries(connection: ExternalAgentConnectionRow, entries: list[dict[st
     connection.metadata_ = root
 
 
-async def set_contact_form_lead_mandate(
+async def _write_contact_form_lead_mandate(
     session,
     *,
     connection_id: str,
-    mandate: str,
+    mandate: str | None,
     org_id: str | None = None,
 ) -> dict[str, Any]:
-    """Persist or clear an operator-editable skill overlay."""
-
-    clean_mandate = _clean(mandate)
-    if len(clean_mandate) > CONTACT_FORM_LEAD_MANDATE_MAX_CHARS:
-        raise SlackMonitorConfigError(
-            "mandate exceeds "
-            f"{CONTACT_FORM_LEAD_MANDATE_MAX_CHARS} characters"
-        )
     connection = await _connection_for_org(session, connection_id, org_id)
     root = dict(connection.metadata_ or {})
     slack_metadata = _slack_metadata(connection)
-    if clean_mandate:
-        slack_metadata[CONTACT_FORM_LEAD_MANDATE_KEY] = clean_mandate
+    if mandate is not None:
+        slack_metadata[CONTACT_FORM_LEAD_MANDATE_KEY] = mandate
     else:
         slack_metadata.pop(CONTACT_FORM_LEAD_MANDATE_KEY, None)
     root["slack"] = slack_metadata
@@ -147,9 +139,52 @@ async def set_contact_form_lead_mandate(
     return {
         "connection_id": str(connection.id),
         "metadata_path": f"slack.{CONTACT_FORM_LEAD_MANDATE_KEY}",
-        "mandate": clean_mandate or None,
-        "cleared": not bool(clean_mandate),
+        "mandate": mandate,
+        "cleared": mandate is None,
     }
+
+
+async def set_contact_form_lead_mandate(
+    session,
+    *,
+    connection_id: str,
+    mandate: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist a non-empty operator-editable skill overlay."""
+
+    clean_mandate = _clean(mandate)
+    if not clean_mandate:
+        raise SlackMonitorConfigError(
+            "set_contact_form_lead_mandate requires a non-empty mandate"
+        )
+    if len(clean_mandate) > CONTACT_FORM_LEAD_MANDATE_MAX_CHARS:
+        raise SlackMonitorConfigError(
+            "mandate exceeds "
+            f"{CONTACT_FORM_LEAD_MANDATE_MAX_CHARS} characters"
+        )
+    return await _write_contact_form_lead_mandate(
+        session,
+        connection_id=connection_id,
+        mandate=clean_mandate,
+        org_id=org_id,
+    )
+
+
+async def clear_contact_form_lead_mandate(
+    session,
+    *,
+    connection_id: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Clear the operator-editable skill overlay."""
+
+    return await _write_contact_form_lead_mandate(
+        session,
+        connection_id=connection_id,
+        mandate=None,
+        org_id=org_id,
+    )
 
 
 async def list_monitored_channels(
@@ -226,6 +261,7 @@ __all__ = [
     "CONTACT_FORM_LEAD_MANDATE_KEY",
     "SlackMonitorConfigError",
     "add_monitored_channel",
+    "clear_contact_form_lead_mandate",
     "contact_form_lead_mandate",
     "list_monitored_channels",
     "monitored_channel_ids",

--- a/tests/slack_monitor_fixtures.py
+++ b/tests/slack_monitor_fixtures.py
@@ -57,7 +57,7 @@ class FakeSlackConnection:
         self,
         metadata=None,
         org_id="org1",
-        owner_user_id="user-reda",
+        owner_user_id="user-connection-owner",
     ):
         self.id = "conn1"
         self.org_id = org_id

--- a/tests/test_contact_form_lead_obligation.py
+++ b/tests/test_contact_form_lead_obligation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
@@ -105,6 +107,67 @@ def _lead_admission_event():
         },
     )
     return WorkIntakeEvent.from_trigger_payload(trigger)
+
+
+@pytest.mark.asyncio
+async def test_contact_form_intake_run_cannot_settle_its_open_ask(
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.open_asks import DeliveredSlackReplyCounts
+    from brain.systems.runs.tool_catalog.handlers.slack import (
+        _handle_post_slack_reply,
+    )
+
+    class _SlackClient:
+        async def post_message(self, **kwargs):
+            return {
+                "ok": True,
+                "ts": "1785149500.000300",
+                "channel": kwargs["channel"],
+            }
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        AsyncMock(return_value=_SlackClient()),
+    )
+    recorder = AsyncMock(return_value=DeliveredSlackReplyCounts.empty())
+    monkeypatch.setattr(
+        "brain.systems.runs.slack_delivery.persist_delivered_slack_answer",
+        recorder,
+    )
+    context = {
+        "run_id": 9,
+        "org_id": ORG_ID,
+        "execution_metadata": {
+            "run_id": 9,
+            "org_id": ORG_ID,
+            "illo_trigger": {
+                "event_type": "contact_form_lead",
+            },
+        },
+        "slack_trigger": {
+            "response_target": {
+                "channel_id": "CALERTS",
+                "thread_ts": THREAD_TS,
+                "visibility": "public",
+            }
+        },
+    }
+
+    with bind_agent_context(context):
+        result = json.loads(
+            await _handle_post_slack_reply(
+                body="Verified lead assessment.",
+                answers_open_ask=True,
+            )
+        )
+
+    assert result["answers_open_ask"] is False
+    assert result["answered_open_asks"] == 0
+    recorder.assert_awaited_once()
+    delivered = recorder.await_args.args[0]
+    assert delivered.is_answer is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_contact_form_lead_obligation.py
+++ b/tests/test_contact_form_lead_obligation.py
@@ -142,6 +142,17 @@ async def test_contact_form_intake_run_cannot_settle_its_open_ask(
         "execution_metadata": {
             "run_id": 9,
             "org_id": ORG_ID,
+            "obligation_spec": {
+                "condition": "contact_form_lead_answered",
+                "answerer": {
+                    "name": "Reda",
+                    "slack_user_id": "UREDA",
+                    "user_id": USER_ID,
+                },
+                "notice_after_seconds": 86400,
+                "notice_text": "Please answer the contact-form lead.",
+                "settlement_policy": "answerer_slack_reply",
+            },
             "illo_trigger": {
                 "event_type": "contact_form_lead",
             },
@@ -159,6 +170,78 @@ async def test_contact_form_intake_run_cannot_settle_its_open_ask(
         result = json.loads(
             await _handle_post_slack_reply(
                 body="Verified lead assessment.",
+                answers_open_ask=True,
+            )
+        )
+
+    assert result["answers_open_ask"] is False
+    assert result["answered_open_asks"] == 0
+    recorder.assert_awaited_once()
+    delivered = recorder.await_args.args[0]
+    assert delivered.is_answer is False
+
+
+@pytest.mark.asyncio
+async def test_answerer_slack_reply_policy_blocks_tool_settlement_for_other_intakes(
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.open_asks import DeliveredSlackReplyCounts
+    from brain.systems.runs.tool_catalog.handlers.slack import (
+        _handle_post_slack_reply,
+    )
+
+    class _SlackClient:
+        async def post_message(self, **kwargs):
+            return {
+                "ok": True,
+                "ts": "1785149500.000300",
+                "channel": kwargs["channel"],
+            }
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        AsyncMock(return_value=_SlackClient()),
+    )
+    recorder = AsyncMock(return_value=DeliveredSlackReplyCounts.empty())
+    monkeypatch.setattr(
+        "brain.systems.runs.slack_delivery.persist_delivered_slack_answer",
+        recorder,
+    )
+    context = {
+        "run_id": 9,
+        "org_id": ORG_ID,
+        "execution_metadata": {
+            "run_id": 9,
+            "org_id": ORG_ID,
+            "obligation_spec": {
+                "condition": "partner_question_answered",
+                "answerer": {
+                    "name": "Partner",
+                    "slack_user_id": "UPARTNER",
+                    "user_id": None,
+                },
+                "notice_after_seconds": 3600,
+                "notice_text": "Please answer the partner question.",
+                "settlement_policy": "answerer_slack_reply",
+            },
+            "illo_trigger": {
+                "event_type": "partner_question",
+            },
+        },
+        "slack_trigger": {
+            "response_target": {
+                "channel_id": "CPARTNERS",
+                "thread_ts": THREAD_TS,
+                "visibility": "public",
+            }
+        },
+    }
+
+    with bind_agent_context(context):
+        result = json.loads(
+            await _handle_post_slack_reply(
+                body="I have asked the partner for confirmation.",
                 answers_open_ask=True,
             )
         )

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -324,6 +324,48 @@ def test_contact_form_owner_policy_keeps_conflicting_identity_fields_together():
     }
 
 
+def test_contact_form_owner_policy_warns_and_omits_conflicting_user_id(caplog):
+    from brain.systems.slack.contact_form_lead_owner import (
+        CONTACT_FORM_OWNER_POLICY,
+    )
+
+    with caplog.at_level(
+        "WARNING",
+        logger="brain.systems.slack.contact_form_lead_owner",
+    ):
+        owner = CONTACT_FORM_OWNER_POLICY.resolve(
+            FakeSlackConnection(
+                metadata={
+                    "slack": {
+                        "contact_form_lead_owner": {
+                            "slack_user_id": "UREDA",
+                        },
+                        "identity_map": {
+                            "UREDA": "user-mapped",
+                        },
+                    },
+                    "identity_links": {
+                        "slack": {
+                            "UREDA": {
+                                "user_id": "user-linked",
+                                "display_name": "Reda",
+                            },
+                        }
+                    },
+                }
+            )
+        )
+
+    assert owner.to_metadata() == {
+        "name": "Reda",
+        "slack_user_id": "UREDA",
+        "user_id": None,
+    }
+    assert "UREDA" in caplog.text
+    assert "user-linked" in caplog.text
+    assert "user-mapped" in caplog.text
+
+
 def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle
@@ -351,12 +393,11 @@ def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
         assert hardcoded_example not in procedure.casefold()
 
 
-def test_contact_form_intake_context_has_a_versioned_validated_contract():
+def test_contact_form_intake_context_is_normalized_and_valid_at_construction():
     import json
 
     from brain.systems.runs.obligation_specs import ObligationAnswerer
     from brain.systems.slack.contact_form_lead_rendering import (
-        CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION,
         ContactFormLeadIntakeContext,
         ContactFormLeadSlackResponseTarget,
     )
@@ -378,25 +419,29 @@ def test_contact_form_intake_context_has_a_versioned_validated_contract():
         lead=lead,
         owner=owner,
         slack_response_target=ContactFormLeadSlackResponseTarget(
-            channel_id="C_ALERTS",
-            thread_ts="1716900000.000200",
+            channel_id=" C_ALERTS ",
+            thread_ts=" 1716900000.000200 ",
         ),
-        source_permalink="https://example.slack.com/archives/C_ALERTS/p1716900000000200",
+        source_permalink=(
+            " https://example.slack.com/archives/C_ALERTS/p1716900000000200 "
+        ),
     )
 
     serialized = json.loads(context.serialize())
 
     assert set(serialized) == {
-        "schema_version",
         "lead",
         "owner",
         "slack_response_target",
         "source_permalink",
     }
+    assert context.slack_response_target == ContactFormLeadSlackResponseTarget(
+        channel_id="C_ALERTS",
+        thread_ts="1716900000.000200",
+    )
     assert (
-        serialized["schema_version"]
-        == CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION
-        == 1
+        context.source_permalink
+        == "https://example.slack.com/archives/C_ALERTS/p1716900000000200"
     )
     assert set(serialized["lead"]) == {
         "name",
@@ -416,22 +461,11 @@ def test_contact_form_intake_context_has_a_versioned_validated_contract():
     }
 
     for invalid_target in (
-        ContactFormLeadSlackResponseTarget(
-            channel_id="",
-            thread_ts="1716900000.000200",
-        ),
-        ContactFormLeadSlackResponseTarget(
-            channel_id="C_ALERTS",
-            thread_ts="",
-        ),
+        {"channel_id": "", "thread_ts": "1716900000.000200"},
+        {"channel_id": "C_ALERTS", "thread_ts": ""},
     ):
-        invalid_context = ContactFormLeadIntakeContext(
-            lead=lead,
-            owner=owner,
-            slack_response_target=invalid_target,
-        )
         with pytest.raises(ValueError, match="Slack response target"):
-            invalid_context.serialize()
+            ContactFormLeadSlackResponseTarget(**invalid_target)
 
 
 @pytest.mark.asyncio
@@ -445,6 +479,8 @@ async def test_contact_form_mandate_is_runtime_editable_connection_metadata():
     )
     from brain.systems.slack.contact_form_leads import ContactFormLead
     from brain.systems.slack.monitors import (
+        SlackMonitorConfigError,
+        clear_contact_form_lead_mandate,
         contact_form_lead_mandate,
         set_contact_form_lead_mandate,
     )
@@ -493,11 +529,19 @@ async def test_contact_form_mandate_is_runtime_editable_connection_metadata():
     )
     assert "mandate" in manage_slack["input_schema"]["properties"]
 
-    cleared = await set_contact_form_lead_mandate(
+    with pytest.raises(SlackMonitorConfigError, match="non-empty mandate"):
+        await set_contact_form_lead_mandate(
+            FakeSlackSession(connection),
+            connection_id=connection.id,
+            org_id=connection.org_id,
+            mandate="",
+        )
+    assert contact_form_lead_mandate(connection) == mandate
+
+    cleared = await clear_contact_form_lead_mandate(
         FakeSlackSession(connection),
         connection_id=connection.id,
         org_id=connection.org_id,
-        mandate="",
     )
 
     assert cleared["cleared"] is True

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -131,7 +131,7 @@ def test_contact_form_lead_is_decoded_from_slack_blocks():
     )
 
 
-def test_contact_form_policy_builds_threaded_dossier_route_and_obligation():
+def test_contact_form_policy_builds_threaded_mandate_route_and_obligation():
     from brain.systems.runs.obligation_specs import (
         obligation_spec_from_metadata,
     )
@@ -179,25 +179,23 @@ def test_contact_form_policy_builds_threaded_dossier_route_and_obligation():
     assert metadata["required_response_tool"] == "post_slack_reply"
     assert metadata["headless"] is True
     assert metadata["contact_form_lead"]["owner"]["slack_user_id"] == "UREDA"
+    assert metadata["contact_form_lead_skill"] == "contact-form-lead-intake"
+    assert metadata["contact_form_lead_mandate_source"] == "installed_skill"
     spec = obligation_spec_from_metadata(metadata["obligation_spec"])
     assert spec is not None
     assert spec.answerer.slack_user_id == "UREDA"
     assert spec.notice_after.total_seconds() == 24 * 60 * 60
-    assert metadata["contact_form_lead_dossier"].startswith(
-        "*Contact-form lead*"
-    )
+    assert "contact_form_lead_dossier" not in metadata
     assert work["payload"]["slack"]["response_target"]["thread_ts"] == (
         "1716900000.000200"
     )
-    dossier = metadata["contact_form_lead_dossier"]
-    assert "Aline Athaydes" in dossier
-    assert "https://www.madamedusk.com" in dossier
-    assert "1. Can Uwear generate consistent models wearing lingerie?" in dossier
-    assert "<@UREDA>" in dossier
-    assert "*Next action:*" in dossier
-    assert "reply in this thread with verified answers" in dossier
-    assert "on-call" not in dossier.casefold()
-    assert "answers_open_ask=false" in work["payload"]["run_message"]
+    run_message = work["payload"]["run_message"]
+    assert run_message.startswith("/contact-form-lead-intake\n")
+    assert "skill_view" in run_message
+    assert '"company_website": "https://www.madamedusk.com"' in run_message
+    assert '"slack_user_id": "UREDA"' in run_message
+    assert "*Contact-form lead*" not in run_message
+    assert "*Answer:*" not in run_message
 
 
 def test_contact_form_owner_policy_defaults_once_without_identity_mapping():
@@ -212,80 +210,147 @@ def test_contact_form_owner_policy_defaults_once_without_identity_mapping():
     assert owner.to_metadata() == {
         "name": "Reda",
         "slack_user_id": "U04R1A6MZST",
-        "user_id": "user-reda",
+        "user_id": None,
     }
 
 
-def test_aline_athaydes_replay_keeps_all_capabilities_human_answered():
+def test_contact_form_owner_policy_never_uses_the_connection_owner():
+    from brain.systems.slack.contact_form_lead_owner import (
+        CONTACT_FORM_OWNER_POLICY,
+    )
+
+    owner = CONTACT_FORM_OWNER_POLICY.resolve(
+        FakeSlackConnection(
+            owner_user_id="user-axel",
+            metadata={
+                "slack": {
+                    "identity_map": {
+                        "UAXEL": "user-axel",
+                    }
+                },
+                "identity_links": {
+                    "slack": {
+                        "UAXEL": {
+                            "user_id": "user-axel",
+                            "display_name": "Axel",
+                        }
+                    }
+                },
+            },
+        )
+    )
+
+    assert owner.to_metadata() == {
+        "name": "Reda",
+        "slack_user_id": "U04R1A6MZST",
+        "user_id": None,
+    }
+
+
+def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(
+        BUILTIN_SKILL_BUNDLE_ROOT / "contact-form-lead-intake"
+    )
+
+    assert bundle.manifest.source == "self_hosted"
+    assert bundle.manifest.visibility == "private_local"
+    procedure = bundle.skill_markdown
+    for requirement in (
+        "website with `web_fetch` or the browser tools",
+        "company/catalog size",
+        "vertical",
+        "likely Uwear fit",
+        "likely deal size",
+        "`search_knowledge`",
+        "`post_slack_reply`",
+        "`SlackKnowledgeConnector`",
+        "Do not re-list or label the submitted name, email",
+        "Do not emit a per-question `Answer:` section",
+    ):
+        assert requirement in procedure
+    for hardcoded_example in (
+        "madamedusk",
+        "lingerie",
+        "bikini",
+        "corset",
+        "thong",
+        "bergzeit",
+    ):
+        assert hardcoded_example not in procedure.casefold()
+
+
+@pytest.mark.asyncio
+async def test_contact_form_mandate_is_runtime_editable_connection_metadata():
     from brain.systems.runs.obligation_specs import ObligationAnswerer
+    from brain.systems.runs.tool_catalog.definitions.cortex_thread import (
+        CHAT_TOOLS,
+    )
     from brain.systems.slack.contact_form_lead_rendering import (
-        contact_form_lead_dossier,
+        contact_form_lead_run_message,
     )
     from brain.systems.slack.contact_form_leads import ContactFormLead
+    from brain.systems.slack.monitors import (
+        contact_form_lead_mandate,
+        set_contact_form_lead_mandate,
+    )
 
-    dossier = contact_form_lead_dossier(
+    connection = FakeSlackConnection()
+    mandate = "Post a two-line commercial assessment with source links."
+    result = await set_contact_form_lead_mandate(
+        FakeSlackSession(connection),
+        connection_id=connection.id,
+        org_id=connection.org_id,
+        mandate=mandate,
+    )
+    run_message = contact_form_lead_run_message(
         ContactFormLead(
-            name="Aline Athaydes",
-            email="aline@madamedusk.com",
-            company_website="www.madamedusk.com",
+            name="Prospect",
+            email="prospect@example.com",
+            company_website="https://prospect.example",
             phone=None,
-            message="\n".join(
-                [
-                    "I have four questions before signing up:",
-                    (
-                        "1. Can it generate AI models wearing lingerie and bikinis, "
-                        "including sheer and lace pieces?"
-                    ),
-                    (
-                        "2. Does it support back and rear-view shots (thong, "
-                        "lace-up corset back from behind)?"
-                    ),
-                    (
-                        "3. Does it preserve the real lace/embroidery rather than "
-                        "substituting a garment?"
-                    ),
-                    (
-                        "4. Can a consistent model carry across multiple products "
-                        "for catalog cohesion?"
-                    ),
-                    (
-                        "I understand your Qwen Intimate feature may require a "
-                        "verification step for intimate apparel. Could you let me know "
-                        "what's involved and how to get it enabled for my store?"
-                    ),
-                ]
-            ),
+            message="Tell me about Uwear.",
         ),
         ObligationAnswerer(
             name="Reda",
             slack_user_id="UREDA",
             user_id="user-reda",
         ),
+        {
+            "channel_id": "C_ALERTS",
+            "response_target": {"thread_ts": "1716900000.000200"},
+        },
+        mandate=contact_form_lead_mandate(connection),
+    )
+    manage_slack = next(
+        tool for tool in CHAT_TOOLS if tool["name"] == "manage_slack"
     )
 
-    expected_asks = [
-        "generate AI models wearing lingerie and bikinis",
-        "support back and rear-view shots",
-        "preserve the real lace/embroidery",
-        "consistent model carry across multiple products",
-        "Qwen Intimate feature may require a verification step",
-    ]
-    for index, ask in enumerate(expected_asks, start=1):
-        assert f"{index}." in dossier
-        assert ask in dossier
-    assert dossier.count("*Answer:* needs a human answer") == 5
+    assert result["metadata_path"] == "slack.contact_form_lead_mandate"
+    assert mandate in run_message
+    assert not run_message.startswith("/contact-form-lead-intake")
+    assert "set_contact_form_lead_mandate" in (
+        manage_slack["input_schema"]["properties"]["action"]["enum"]
+    )
+    assert "mandate" in manage_slack["input_schema"]["properties"]
 
 
 @pytest.mark.asyncio
 async def test_contact_form_lead_gets_common_eyes_and_policy_enrichment(
     monkeypatch,
 ):
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
     connector_module, reactions, submitted = patch_slack_connector(monkeypatch)
     connection = FakeSlackConnection(
+        owner_user_id="user-axel",
         metadata={
             "slack": {
                 "monitored_channels": ["C_ALERTS"],
                 "identity_map": {"UREDA": "user-reda"},
+                "contact_form_lead_mandate": "Configured lead assessment.",
             },
             "identity_links": {
                 "slack": {
@@ -317,12 +382,26 @@ async def test_contact_form_lead_gets_common_eyes_and_policy_enrichment(
 
     assert reactions == [("C_ALERTS", "1716900000.000200", "eyes")]
     assert submitted[0]["origin"] == "contact_form_lead"
+    assert (
+        submitted[0]["payload"]["contact_form_lead_mandate"]
+        == "Configured lead assessment."
+    )
     owner = submitted[0]["payload"]["contact_form_lead"]["owner"]
     assert owner == {
         "name": "Reda",
         "slack_user_id": "UREDA",
         "user_id": "user-reda",
     }
+    work = build_slack_work_intake_payload(
+        org_id=connection.org_id,
+        authority_user_id="user-reda",
+        payload=submitted[0]["payload"],
+    )
+    assert (
+        work["payload"]["metadata"]["contact_form_lead_mandate_source"]
+        == "slack_connection_metadata"
+    )
+    assert "Configured lead assessment." in work["payload"]["run_message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -247,6 +247,83 @@ def test_contact_form_owner_policy_never_uses_the_connection_owner():
     }
 
 
+def test_contact_form_owner_policy_does_not_splice_an_unmatched_configured_user():
+    from brain.systems.slack.contact_form_lead_owner import (
+        CONTACT_FORM_OWNER_POLICY,
+    )
+
+    owner = CONTACT_FORM_OWNER_POLICY.resolve(
+        FakeSlackConnection(
+            metadata={
+                "slack": {
+                    "contact_form_lead_owner": {
+                        "user_id": "user-unpaired",
+                    },
+                    "identity_map": {
+                        "U04R1A6MZST": "user-reda",
+                    },
+                },
+                "identity_links": {
+                    "slack": {
+                        "U04R1A6MZST": {
+                            "user_id": "user-reda",
+                            "display_name": "Reda",
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    assert owner.to_metadata() == {
+        "name": "Reda",
+        "slack_user_id": "U04R1A6MZST",
+        "user_id": None,
+    }
+
+
+def test_contact_form_owner_policy_keeps_conflicting_identity_fields_together():
+    from brain.systems.slack.contact_form_lead_owner import (
+        CONTACT_FORM_OWNER_POLICY,
+    )
+
+    owner = CONTACT_FORM_OWNER_POLICY.resolve(
+        FakeSlackConnection(
+            metadata={
+                "slack": {
+                    "contact_form_lead_owner": {
+                        "name": "Axel",
+                        "slack_user_id": "UREDA",
+                        "user_id": "user-axel",
+                    },
+                    "identity_map": {
+                        "UREDA": "user-reda",
+                        "UAXEL": "user-axel",
+                    },
+                },
+                "identity_links": {
+                    "slack": {
+                        "UREDA": {
+                            "user_id": "user-reda",
+                            "display_name": "Reda",
+                        },
+                        "UAXEL": {
+                            "user_id": "user-axel",
+                            "display_name": "Axel",
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    assert owner.to_metadata() == {
+        "name": "Reda",
+        "slack_user_id": "UREDA",
+        "user_id": "user-reda",
+    }
+
+
 def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle
@@ -259,16 +336,8 @@ def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
     assert bundle.manifest.visibility == "private_local"
     procedure = bundle.skill_markdown
     for requirement in (
-        "website with `web_fetch` or the browser tools",
-        "company/catalog size",
-        "vertical",
-        "likely Uwear fit",
-        "likely deal size",
         "`search_knowledge`",
         "`post_slack_reply`",
-        "`SlackKnowledgeConnector`",
-        "Do not re-list or label the submitted name, email",
-        "Do not emit a per-question `Answer:` section",
     ):
         assert requirement in procedure
     for hardcoded_example in (
@@ -280,6 +349,89 @@ def test_contact_form_reply_behavior_is_an_installed_runtime_skill():
         "bergzeit",
     ):
         assert hardcoded_example not in procedure.casefold()
+
+
+def test_contact_form_intake_context_has_a_versioned_validated_contract():
+    import json
+
+    from brain.systems.runs.obligation_specs import ObligationAnswerer
+    from brain.systems.slack.contact_form_lead_rendering import (
+        CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION,
+        ContactFormLeadIntakeContext,
+        ContactFormLeadSlackResponseTarget,
+    )
+    from brain.systems.slack.contact_form_leads import ContactFormLead
+
+    lead = ContactFormLead(
+        name="Prospect",
+        email="prospect@example.com",
+        company_website="https://prospect.example",
+        phone=None,
+        message="Tell me about Uwear.",
+    )
+    owner = ObligationAnswerer(
+        name="Reda",
+        slack_user_id="UREDA",
+        user_id="user-reda",
+    )
+    context = ContactFormLeadIntakeContext(
+        lead=lead,
+        owner=owner,
+        slack_response_target=ContactFormLeadSlackResponseTarget(
+            channel_id="C_ALERTS",
+            thread_ts="1716900000.000200",
+        ),
+        source_permalink="https://example.slack.com/archives/C_ALERTS/p1716900000000200",
+    )
+
+    serialized = json.loads(context.serialize())
+
+    assert set(serialized) == {
+        "schema_version",
+        "lead",
+        "owner",
+        "slack_response_target",
+        "source_permalink",
+    }
+    assert (
+        serialized["schema_version"]
+        == CONTACT_FORM_LEAD_INTAKE_SCHEMA_VERSION
+        == 1
+    )
+    assert set(serialized["lead"]) == {
+        "name",
+        "email",
+        "company_website",
+        "phone",
+        "message",
+    }
+    assert set(serialized["owner"]) == {
+        "name",
+        "slack_user_id",
+        "user_id",
+    }
+    assert serialized["slack_response_target"] == {
+        "channel_id": "C_ALERTS",
+        "thread_ts": "1716900000.000200",
+    }
+
+    for invalid_target in (
+        ContactFormLeadSlackResponseTarget(
+            channel_id="",
+            thread_ts="1716900000.000200",
+        ),
+        ContactFormLeadSlackResponseTarget(
+            channel_id="C_ALERTS",
+            thread_ts="",
+        ),
+    ):
+        invalid_context = ContactFormLeadIntakeContext(
+            lead=lead,
+            owner=owner,
+            slack_response_target=invalid_target,
+        )
+        with pytest.raises(ValueError, match="Slack response target"):
+            invalid_context.serialize()
 
 
 @pytest.mark.asyncio
@@ -319,8 +471,10 @@ async def test_contact_form_mandate_is_runtime_editable_connection_metadata():
             user_id="user-reda",
         ),
         {
-            "channel_id": "C_ALERTS",
-            "response_target": {"thread_ts": "1716900000.000200"},
+            "response_target": {
+                "channel_id": "C_ALERTS",
+                "thread_ts": "1716900000.000200",
+            },
         },
         mandate=contact_form_lead_mandate(connection),
     )
@@ -330,11 +484,48 @@ async def test_contact_form_mandate_is_runtime_editable_connection_metadata():
 
     assert result["metadata_path"] == "slack.contact_form_lead_mandate"
     assert mandate in run_message
-    assert not run_message.startswith("/contact-form-lead-intake")
+    assert run_message.startswith("/contact-form-lead-intake\n")
+    assert "skill_view" in run_message
+    assert "Connection overlay:" in run_message
+    assert "within the installed skill's contracts" in run_message
     assert "set_contact_form_lead_mandate" in (
         manage_slack["input_schema"]["properties"]["action"]["enum"]
     )
     assert "mandate" in manage_slack["input_schema"]["properties"]
+
+    cleared = await set_contact_form_lead_mandate(
+        FakeSlackSession(connection),
+        connection_id=connection.id,
+        org_id=connection.org_id,
+        mandate="",
+    )
+
+    assert cleared["cleared"] is True
+    assert cleared["mandate"] is None
+    assert contact_form_lead_mandate(connection) is None
+    default_run_message = contact_form_lead_run_message(
+        ContactFormLead(
+            name="Prospect",
+            email="prospect@example.com",
+            company_website="https://prospect.example",
+            phone=None,
+            message="Tell me about Uwear.",
+        ),
+        ObligationAnswerer(
+            name="Reda",
+            slack_user_id="UREDA",
+            user_id="user-reda",
+        ),
+        {
+            "response_target": {
+                "channel_id": "C_ALERTS",
+                "thread_ts": "1716900000.000200",
+            },
+        },
+        mandate=contact_form_lead_mandate(connection),
+    )
+    assert default_run_message.startswith("/contact-form-lead-intake\n")
+    assert "Connection overlay:" not in default_run_message
 
 
 @pytest.mark.asyncio
@@ -399,7 +590,10 @@ async def test_contact_form_lead_gets_common_eyes_and_policy_enrichment(
     )
     assert (
         work["payload"]["metadata"]["contact_form_lead_mandate_source"]
-        == "slack_connection_metadata"
+        == "installed_skill_with_connection_overlay"
+    )
+    assert work["payload"]["run_message"].startswith(
+        "/contact-form-lead-intake\n"
     )
     assert "Configured lead assessment." in work["payload"]["run_message"]
 

--- a/tests/test_knowledge_slack_connector.py
+++ b/tests/test_knowledge_slack_connector.py
@@ -27,6 +27,7 @@ from brain.platform.db.models.org import Org, User
 from brain.jobs.pipelines.knowledge_index_sync import CONNECTOR_FACTORIES
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
 from brain.systems.knowledge.connectors.slack import SlackKnowledgeConnector
+from brain.systems.knowledge.search import search_knowledge
 from brain.systems.knowledge.service import sync_connector
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 
@@ -206,7 +207,86 @@ def embedding_runtime(monkeypatch):
         "embed_document",
         lambda text, runtime_config=None: vector,
     )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_query",
+        lambda text, runtime_config=None: vector,
+    )
     return runtime
+
+
+async def test_contact_form_thread_fields_and_assessment_are_retrievable(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    await _seed_monitored_slack(session)
+    slack = _SlackHistory()
+    slack.messages = [
+        {
+            "ts": "1785283200.000100",
+            "bot_id": "B_CONTACT_FORM",
+            "text": "\n".join(
+                [
+                    "New Contact Form Submission",
+                    "Name: Prospect",
+                    "Email: prospect@example.com",
+                    "Company Website: https://prospect.example",
+                    "Message: Can Uwear support our catalog?",
+                ]
+            ),
+        },
+        {
+            "ts": "1785283260.000200",
+            "bot_id": "BILLO",
+            "text": (
+                "Assessment: first-party category pages show about 480 products "
+                "in a specialist apparel catalog. Likely strong mid-market fit."
+            ),
+        },
+    ]
+    connector = SlackKnowledgeConnector(client=slack, max_items=1)
+
+    dispatched = await sync_connector(session, connector)
+    run = (await session.scalars(select(AgentRunRow))).one()
+    run.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=run.id,
+            root_run_id=run.root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "What is the assessment of this inbound lead?",
+                    "summary": (
+                        "The prospect has about 480 products in specialist apparel "
+                        "and is likely a strong mid-market fit."
+                    ),
+                    "resolution": None,
+                    "systems": ["slack", "sales"],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    indexed = await sync_connector(session, connector)
+    item = (await session.scalars(select(KnowledgeItem))).one()
+    result = await search_knowledge(
+        session,
+        "prospect 480 products mid-market fit",
+        org_id=_ORG_ID,
+        sources=["slack"],
+    )
+
+    assert dispatched.status == "pending"
+    assert indexed.status == "ok"
+    assert "prospect@example.com" in item.raw_text
+    assert "about 480 products" in item.raw_text
+    assert [row["source_ref"] for row in result["results"]] == [
+        "slack:T789:CINCIDENTS:1785283200.000100"
+    ]
 
 
 async def test_slack_backfill_is_bounded_and_reports_each_page_through_shared_stats(

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1768,9 +1768,12 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
         "list_monitored",
         "monitor_channel",
         "unmonitor_channel",
+        "set_contact_form_lead_mandate",
         "open_alert_surges",
     ]
-    assert {"display_name", "communication_preferences"} <= set(properties)
+    assert {"display_name", "communication_preferences", "mandate"} <= set(
+        properties
+    )
     assert properties["communication_preferences"]["properties"]["humour"]["enum"] == [
         "none",
         "light",

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1769,6 +1769,7 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
         "monitor_channel",
         "unmonitor_channel",
         "set_contact_form_lead_mandate",
+        "clear_contact_form_lead_mandate",
         "open_alert_surges",
     ]
     assert {"display_name", "communication_preferences", "mandate"} <= set(
@@ -1787,6 +1788,66 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
     assert "secret" not in serialized_tool
     assert "does not" not in serialized_tool.lower()
     assert "cannot" not in serialized_tool.lower()
+    assert "non-empty mandate" in serialized_tool
+    assert "clear_contact_form_lead_mandate" in serialized_tool
+
+
+@pytest.mark.asyncio
+async def test_manage_slack_omitted_mandate_preserves_it_until_explicit_clear(
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+
+    connection = await _seed_slack_connection(session)
+    connection.metadata_ = {
+        **connection.metadata_,
+        "slack": {
+            **connection.metadata_["slack"],
+            "contact_form_lead_mandate": "Keep this overlay.",
+        },
+    }
+    await session.flush()
+
+    class _UnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            await session.flush()
+            return False
+
+    monkeypatch.setattr(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        _UnitOfWork,
+    )
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        omitted = json.loads(
+            await _handle_manage_slack(
+                action="set_contact_form_lead_mandate",
+                connection_id=str(connection.id),
+            )
+        )
+        assert omitted["error"].endswith("requires a non-empty mandate")
+        assert (
+            connection.metadata_["slack"]["contact_form_lead_mandate"]
+            == "Keep this overlay."
+        )
+        cleared = json.loads(
+            await _handle_manage_slack(
+                action="clear_contact_form_lead_mandate",
+                connection_id=str(connection.id),
+            )
+        )
+
+    assert cleared["ok"] is True
+    assert cleared["cleared"] is True
+    assert "contact_form_lead_mandate" not in connection.metadata_["slack"]
 
 
 def test_manage_slack_connection_payload_redacts_private_identity_profiles():


### PR DESCRIPTION
Closes #602.

## What went wrong on the first real lead

Contact-form intake shipped in #542 and misfired immediately (`agent_runs.id = 3734`, 07-29): it tagged **Axel** instead of you, and the thread reply restated the form fields with a hardcoded `needs a human answer` line under every question. Your verdict: *"just repeating the INFO is utterly useless."*

Two visible defects, one root cause: **the reply was frozen in deployed Python**, handed to the agent with *"Do not research, infer, rephrase"*. The agent was a mail carrier, so the behavior sat out of reach of Illo's own tools.

## What changes

**Owner routing.** The fallback to `connection.owner_user_id` — whoever installed the Slack app — is gone. Connection metadata is normalized into whole Slack identity records and exactly one is selected, so a name can no longer be spliced onto a different person's user id. An unpaired configured user id resolves to *no* user id rather than landing on the default owner. A Slack id whose two identity stores disagree also resolves to no user id, and now logs both so a misconfiguration is visible instead of looking like an absence.

**The reply.** Deleted, not deprecated: the regex ask-splitter, the hardcoded vertical lookup (which carried `lingerie`/`bikini`/`bergzeit` literals from the two example leads), and the whole rendered dossier. The run message now hands a typed intake context to an installed skill, `contact-form-lead-intake`, whose procedure Illo's own tools can edit. Anti-hallucination moved *inside* that mandate as evidence rules — inspect first-party pages, mark estimates as estimates with their evidence, answer product questions only from `search_knowledge` provenance, otherwise route to you once — rather than being the reason to pre-render.

**The knowledge record.** A successful thread post *is* the record. The Slack knowledge connector already refreshes monitored threads as complete replaceable records, and it reads the same monitored-channel set the intake watches, so the form fields and the assessment stay together and stay queryable with no second copy.

**Obligation settlement is now structural.** Illo's own assessment must never close the ask waiting on your reply. That was one sentence of editable prose; it is now derived from the obligation spec — `ANSWERER_SLACK_REPLY` settles only on a reply *from the answerer*, and a tool-authored reply is by definition not that. Every obligation sharing that policy gets the same protection.

The split, stated plainly — **deterministic in code:** form recognition, the 👀 ack, owner resolution, obligation tracking. **Editable at runtime:** the reply.

## How to change the reply without a deploy

Two layers. The installed skill is the default and is always invoked:

```
skill_view contact-form-lead-intake     # read the current procedure
manage_skill                             # edit it
```

A per-connection overlay adds instruction on top of it:

```
manage_slack(action="set_contact_form_lead_mandate", mandate="…")
manage_slack(action="clear_contact_form_lead_mandate")
```

Run metadata records which is in force (`installed_skill` vs `installed_skill_with_connection_overlay`), so it never claims a skill that was not used.

## How to check it

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-602-contact-form-v2
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_contact_form_monitor.py tests/test_contact_form_lead_obligation.py \
  tests/test_knowledge_slack_connector.py tests/test_slack_teammate.py -q
```

**81 passed.** Full suite (`-m "not requires_db"`): **4548 passed, 14 skipped, 0 failed** — 4538 on `main` plus the 10 tests added here. (The worker measured 4542 from inside the Codex sandbox, which blocks `127.0.0.1` binds and errors 6 unrelated socket tests; run outside it, nothing fails.)

The real proof is the next live lead: it should tag you, and the reply should contain a website-grounded read (pages inspected, rough catalog size, vertical, fit) with **no** form-field echo and no per-question `Answer:` lines. Then `search_knowledge` for the prospect should return the thread.

## Acceptance checks

1. Replay a contact-form message: 👀 ack fires; the owner resolves to Reda **even when the Slack connection is owned by someone else** (a regression test constructs exactly that mismatch, and the shared fixture no longer defaults `owner_user_id` to the expected answer).
2. The reply carries a website-grounded assessment and does not repeat the submitted fields.
3. The lead + assessment are retrievable from the knowledge base after the run.
4. An unanswered lead re-surfaces once after 24h, to Reda — and Illo's own reply cannot settle it.
5. The reply's shape changes without a code deploy.

## Two decisions I did not make for you

**1. The connection overlay is free-form prose, and it can contradict the skill.** The code-quality review flagged this twice and wanted a typed, allowlisted overlay whose fields *cannot* express workflow changes — so an operator could tune the assessment but not disable the one-post or evidence contracts. I declined that, because it narrows exactly the capability this ticket asked for ("changing the reply's shape must not require a code deploy"). Whether an operator should be able to override workflow, or only the assessment, is your product call — say the word and it becomes a typed overlay.

**2. Identity normalization stayed local.** The review wants canonical Slack identity normalization moved into the shared `brain/systems/slack/identity.py` with explicit source precedence, rather than living beside the owner policy. That is a cross-cutting refactor of a shared module and I kept it out of a branch already on its second fix pass. Filed as #612.

Also known: `contact_form_lead_owner.py` grew 96 → ~195 lines making the identity records explicit. The conceptual simplification (deleted ask-splitter, deleted vertical table) survived; its line-count benefit did not.

<sub>Built by a Codex worker under Routine R3. Reviewed by the orchestrator for correctness (owner-resolution paths, and the settlement guard traced end to end from the monitored-intake policy origin through `illo_trigger` rather than trusting its test) and by two independent Codex code-quality passes — 4 blocking findings in pass 1, 3 in pass 2, closed across two fix passes except the two decisions named above.</sub>
