### PR TITLE
refactor(runs): derive the terminal run-status set from RunStatus (#613)

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -30,7 +30,7 @@ from brain.app.api.routers.cortex._helpers import (
     _row_to_dict,
 )
 from brain.app.api.routers.cortex._router import router
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES, TERMINAL_RUN_STATUS_VALUES
 from brain.systems.runs.events import run_event
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore as _AgentRunStore
@@ -923,7 +923,7 @@ async def idea_audit_analysis_result(
         if failure is not None:
             result["failure"] = dict(failure)
 
-        if public_status in ("completed", "failed", "canceled", "expired"):
+        if public_status in TERMINAL_RUN_STATUS_VALUES:
             msg = (
                 await uow.session.scalars(
                     select(IdeaThread)

--- a/brain/contracts/statuses.py
+++ b/brain/contracts/statuses.py
@@ -87,6 +87,12 @@ OPEN_RUN_STATUS_VALUES = (
     RunStatus.QUEUED.value,
     *ACTIVE_RUN_STATUS_VALUES,
 )
+TERMINAL_RUN_STATUS_VALUES = (
+    RunStatus.COMPLETED.value,
+    RunStatus.FAILED.value,
+    RunStatus.CANCELED.value,
+    RunStatus.EXPIRED.value,
+)
 PROCESSING_RUN_STATUS_VALUES = (
     RunStatus.STARTING.value,
     RunStatus.RUNNING.value,

--- a/brain/systems/runs/status.py
+++ b/brain/systems/runs/status.py
@@ -12,17 +12,15 @@ from brain.contracts.statuses import (
     RUN_FAILED_STATUS_VALUE,
     RUN_STATUS_ALIASES,
     RUN_STATUS_VALUES,
+    TERMINAL_RUN_STATUS_VALUES,
     RunStatus,
     project_run_status_value,
 )
 
 
-TERMINAL_RUN_STATUSES = frozenset({
-    RunStatus.COMPLETED,
-    RunStatus.FAILED,
-    RunStatus.CANCELED,
-    RunStatus.EXPIRED,
-})
+TERMINAL_RUN_STATUSES = frozenset(
+    RunStatus(status) for status in TERMINAL_RUN_STATUS_VALUES
+)
 
 ACTIVE_RUN_STATUSES = frozenset({
     RunStatus.STARTING,
@@ -44,6 +42,9 @@ assert ACTIVE_RUN_STATUS_VALUES == tuple(
     status.value for status in RunStatus if status in ACTIVE_RUN_STATUSES
 )
 assert OPEN_RUN_STATUS_VALUES == tuple(status.value for status in RunStatus if status in OPEN_RUN_STATUSES)
+assert TERMINAL_RUN_STATUS_VALUES == tuple(
+    status.value for status in RunStatus if status in TERMINAL_RUN_STATUSES
+)
 assert PROCESSING_RUN_STATUS_VALUES == tuple(
     status.value for status in RunStatus if status in PROCESSING_RUN_STATUSES
 )
@@ -148,6 +149,7 @@ __all__ = [
     "RunTransitionError",
     "RUN_STATUS_VALUES",
     "TERMINAL_RUN_STATUSES",
+    "TERMINAL_RUN_STATUS_VALUES",
     "coerce_run_status",
     "ensure_run_transition",
     "project_run_status_value",

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -19,8 +19,15 @@ from sqlalchemy.schema import CreateTable
 
 from brain.systems.runs.domain import AgentRunRequest as _AgentRunRequest, RunRecipe
 from brain.systems.runs.engine import AsyncAgentRunEngine, RunRecipeResult, RunRuntime, StaticAnswerRecipe
+from brain.contracts.statuses import (
+    OPEN_RUN_STATUS_VALUES,
+    RUN_STATUS_VALUES,
+    TERMINAL_RUN_STATUS_VALUES,
+)
+from brain.systems.runs import status as run_status_contract
 from brain.systems.runs.status import (
     ALLOWED_RUN_TRANSITIONS,
+    TERMINAL_RUN_STATUSES,
     RunStatus,
     RunTransitionError,
     ensure_run_transition,
@@ -92,6 +99,29 @@ def test_interrupted_requeue_transition_is_declared_but_scoped(from_status: RunS
     ) == (from_status, RunStatus.QUEUED)
     with pytest.raises(RunTransitionError, match="outside interrupted requeue"):
         ensure_run_transition(from_status, RunStatus.QUEUED)
+
+
+def test_terminal_run_status_contract_preserves_canonical_membership():
+    assert TERMINAL_RUN_STATUS_VALUES == (
+        "completed",
+        "failed",
+        "canceled",
+        "expired",
+    )
+    assert type(TERMINAL_RUN_STATUSES) is frozenset
+    assert TERMINAL_RUN_STATUSES == frozenset(
+        RunStatus(status) for status in TERMINAL_RUN_STATUS_VALUES
+    )
+    assert all(isinstance(status, RunStatus) for status in TERMINAL_RUN_STATUSES)
+    assert "TERMINAL_RUN_STATUSES" in run_status_contract.__all__
+
+
+def test_open_and_terminal_run_statuses_partition_canonical_values():
+    open_statuses = set(OPEN_RUN_STATUS_VALUES)
+    terminal_statuses = set(TERMINAL_RUN_STATUS_VALUES)
+
+    assert set(RUN_STATUS_VALUES) == open_statuses | terminal_statuses
+    assert open_statuses.isdisjoint(terminal_statuses)
 
 
 async def test_concurrent_event_appends_are_sequential_and_leave_session_usable(session_factory):

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -11,11 +11,7 @@ from pathlib import Path
 import pytest
 
 from brain.contracts import worker_lifecycle as worker_lifecycle_contract
-from brain.contracts.statuses import (
-    OPEN_RUN_STATUS_VALUES,
-    RUN_STATUS_VALUES,
-    TERMINAL_RUN_STATUS_VALUES,
-)
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
 from brain.contracts.worker_lifecycle import (
     WorkerContainerState,
     WorkerCoverObservation,
@@ -30,9 +26,6 @@ from brain.contracts.worker_swap import (
     worker_swap_rows_sql,
     worker_swap_snapshot,
 )
-from brain.systems.runs import status as run_status_contract
-from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES
-
 
 def _shell_function_body(content: str, name: str) -> str:
     match = re.search(
@@ -506,29 +499,6 @@ def test_worker_swap_snapshot_derives_decision_and_presentation_from_canonical_p
     assert parsed.details == "2327:paused,2330:running,2331:queued"
     for status in OPEN_RUN_STATUS_VALUES:
         assert repr(status) in worker_swap_rows_sql()
-
-
-def test_terminal_run_status_contract_preserves_canonical_membership():
-    assert TERMINAL_RUN_STATUS_VALUES == (
-        "completed",
-        "failed",
-        "canceled",
-        "expired",
-    )
-    assert type(TERMINAL_RUN_STATUSES) is frozenset
-    assert TERMINAL_RUN_STATUSES == frozenset(
-        RunStatus(status) for status in TERMINAL_RUN_STATUS_VALUES
-    )
-    assert all(isinstance(status, RunStatus) for status in TERMINAL_RUN_STATUSES)
-    assert "TERMINAL_RUN_STATUSES" in run_status_contract.__all__
-
-
-def test_open_and_terminal_run_statuses_partition_canonical_values():
-    open_statuses = set(OPEN_RUN_STATUS_VALUES)
-    terminal_statuses = set(TERMINAL_RUN_STATUS_VALUES)
-
-    assert set(RUN_STATUS_VALUES) == open_statuses | terminal_statuses
-    assert open_statuses.isdisjoint(terminal_statuses)
 
 
 def test_worker_lifecycle_phase_is_published_outside_the_worker_process(

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -11,7 +11,11 @@ from pathlib import Path
 import pytest
 
 from brain.contracts import worker_lifecycle as worker_lifecycle_contract
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.contracts.statuses import (
+    OPEN_RUN_STATUS_VALUES,
+    RUN_STATUS_VALUES,
+    TERMINAL_RUN_STATUS_VALUES,
+)
 from brain.contracts.worker_lifecycle import (
     WorkerContainerState,
     WorkerCoverObservation,
@@ -26,6 +30,8 @@ from brain.contracts.worker_swap import (
     worker_swap_rows_sql,
     worker_swap_snapshot,
 )
+from brain.systems.runs import status as run_status_contract
+from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES
 
 
 def _shell_function_body(content: str, name: str) -> str:
@@ -500,6 +506,29 @@ def test_worker_swap_snapshot_derives_decision_and_presentation_from_canonical_p
     assert parsed.details == "2327:paused,2330:running,2331:queued"
     for status in OPEN_RUN_STATUS_VALUES:
         assert repr(status) in worker_swap_rows_sql()
+
+
+def test_terminal_run_status_contract_preserves_canonical_membership():
+    assert TERMINAL_RUN_STATUS_VALUES == (
+        "completed",
+        "failed",
+        "canceled",
+        "expired",
+    )
+    assert type(TERMINAL_RUN_STATUSES) is frozenset
+    assert TERMINAL_RUN_STATUSES == frozenset(
+        RunStatus(status) for status in TERMINAL_RUN_STATUS_VALUES
+    )
+    assert all(isinstance(status, RunStatus) for status in TERMINAL_RUN_STATUSES)
+    assert "TERMINAL_RUN_STATUSES" in run_status_contract.__all__
+
+
+def test_open_and_terminal_run_statuses_partition_canonical_values():
+    open_statuses = set(OPEN_RUN_STATUS_VALUES)
+    terminal_statuses = set(TERMINAL_RUN_STATUS_VALUES)
+
+    assert set(RUN_STATUS_VALUES) == open_statuses | terminal_statuses
+    assert open_statuses.isdisjoint(terminal_statuses)
 
 
 def test_worker_lifecycle_phase_is_published_outside_the_worker_process(


### PR DESCRIPTION
Closes #613.

`brain/contracts/statuses.py` derives every run-status subset from the `RunStatus`
enum — `RUN_STATUS_VALUES`, `ACTIVE_`, `OPEN_`, `PROCESSING_` — with one exception.
**Terminal** had no canonical constant, so callers hand-listed it. Adding a member to
`RunStatus` updated none of the copies, and nothing failed: a run in the new state
would quietly read as non-terminal.

This is a pure de-duplication. **No behavior change anywhere.**

## What changed (4 files, +46 / −9)

- `brain/contracts/statuses.py` — adds `TERMINAL_RUN_STATUS_VALUES`, derived from
  `RunStatus`, in the same style as the constants around it.
- `brain/systems/runs/status.py` — `TERMINAL_RUN_STATUSES` is now built from that
  tuple instead of re-declaring its four members, and joins the file's existing
  `assert`-pairing pattern. It keeps its exact name, type (`frozenset[RunStatus]`)
  and export, so **none of its ~25 consumers** — `store.py`, `engine.py`, `runner.py`,
  `cancel.py`, `evidence_health.py`, `chantier_continuation.py`, `reconciliation.py`,
  `external_agents/service.py`, `detached_agent_runs.py`, the cortex routers — needed
  a single edit.
- `brain/app/api/routers/cortex/_misc.py:926` — the bare literal
  `("completed", "failed", "canceled", "expired")` now reads the contract.
- `tests/test_agent_run_state_machine.py` — two new guards.

## Why the `_misc.py` swap is safe

`public_status` is `project_run_status(d.status)` (line 913), so it has already been
through `RUN_STATUS_ALIASES` before the comparison — legacy `"cancelled"` has become
`"canceled"`, and `"error"` / `"blocked"` / `"timeout"` have become `"failed"`. The
canonical four values are therefore exactly the literal being replaced.

## The guard that makes this stick

The issue asked for a test proving a new terminal member reaches every consumer, which
isn't directly expressible. The honest equivalent shipped instead — a **partition
invariant**:

```python
assert set(RUN_STATUS_VALUES) == set(OPEN_RUN_STATUS_VALUES) | set(TERMINAL_RUN_STATUS_VALUES)
assert set(OPEN_RUN_STATUS_VALUES).isdisjoint(set(TERMINAL_RUN_STATUS_VALUES))
```

This holds exactly today (9 = 5 + 4, no overlap). Adding a member to `RunStatus` without
classifying it as open or terminal now fails a test loudly, instead of silently reading
as non-terminal — which is the actual defect.

**Known trade-off, stated deliberately:** the companion membership test pins the four
values literally. That is the "provably identical value set" proof, and it means adding
a terminal status touches exactly two places — the contract, and the pin that guards it.
That is the design, not a gap.

## Sets deliberately NOT folded

A sweep found seven nearby frozensets. Folding them would have been a behavior change,
not a de-duplication, so all seven are untouched:

- `cycles/service.py:84` — `TERMINAL_RUN_STATUSES` for **Cycle** runs: the same name in a
  different domain. (Worth its own look someday; it shadows this one.)
- `cycles/service.py:918` — cycle finalization, deliberately omits `canceled`.
- `inbound/admin.py:1252`, `runs/cortex/read_models.py:22`, `runs/ui_events.py:38`,
  `runs/cortex/recording.py:102`, `tool_catalog/handlers/workspace_data.py:504` — these
  are **failure** sets (terminal *minus* `completed`), several also carrying the legacy
  `"cancelled"` spelling. "Failed" and "terminal" are different predicates.

## Left for a follow-up

The issue names a third site: `_TERMINAL_RUN_STATUSES` in the #578 knowledge-recall
harvester. **That file doesn't exist on `main`** — it lives only on PR #614's branch, so
it can't be routed through a constant that isn't merged yet. Whichever of #613/#614 lands
second, R3 routes it then. The acceptance criterion holds as "no hand-listed terminal set
remains on `main`."

## Verification

- Full suite on the branch, **outside** the Codex sandbox: **4548 passed, 92 skipped,
  0 failed**. That reconciles exactly against the measured `main` baseline of 4546, +2
  new tests.
- The worker's in-sandbox run showed 6 non-passes; all six were `socket.bind()`
  `PermissionError` and all six pass outside the sandbox. Re-run independently rather
  than taken on trust.
- No migration. No API change. Rebased check: `main@7cc782e8` has touched none of these
  files.

## Reviewer note

I moved both new tests out of `tests/test_safe_deploy.py`, where the worker put them,
into `tests/test_agent_run_state_machine.py`. `test_safe_deploy.py` is a deploy-script /
worker-lifecycle file that merely imports `OPEN_RUN_STATUS_VALUES` for a pre-swap check;
`test_agent_run_state_machine.py` is where `brain/systems/runs/status.py`'s contract tests
already live. A guard nobody can find when they add a status is not a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
