### PR TITLE
feat(slack): runtime per-intake routing policy — disable_intake/enable_intake

### DIFF
--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -523,6 +523,9 @@ CHAT_TOOLS = [
             "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
             "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
             "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
+            "action='disable_intake' pauses a typed intake such as contact_form_lead while preserving other "
+            "routing in its monitored channel; action='enable_intake' resumes it. list_monitored reports "
+            "the currently disabled intakes. The "
             "action='set_contact_form_lead_mandate' writes a non-empty mandate as a connection-specific "
             "overlay for the installed contact-form lead skill immediately; "
             "action='clear_contact_form_lead_mandate' removes that overlay. The "
@@ -545,6 +548,8 @@ CHAT_TOOLS = [
                         "list_monitored",
                         "monitor_channel",
                         "unmonitor_channel",
+                        "disable_intake",
+                        "enable_intake",
                         "set_contact_form_lead_mandate",
                         "clear_contact_form_lead_mandate",
                         "open_alert_surges",
@@ -600,6 +605,13 @@ CHAT_TOOLS = [
                 "channel_name": {
                     "type": "string",
                     "description": "Optional human-readable channel name stored alongside a monitored channel for readability.",
+                },
+                "intake": {
+                    "type": "string",
+                    "description": (
+                        "Typed monitored intake identifier, such as contact_form_lead; "
+                        "required for disable_intake and enable_intake."
+                    ),
                 },
                 "mandate": {
                     "type": "string",

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -1067,6 +1067,7 @@ async def _handle_manage_slack(
     channel_types: str | list[str] | None = None,
     channel_id: str | None = None,
     channel_name: str | None = None,
+    intake: str | None = None,
     mandate: str | None = None,
     limit: int = 200,
     cursor: str | None = None,
@@ -1090,6 +1091,9 @@ async def _handle_manage_slack(
         SlackMonitorConfigError,
         add_monitored_channel,
         clear_contact_form_lead_mandate,
+        disable_intake,
+        disabled_intake_origins,
+        enable_intake,
         list_monitored_channels,
         remove_monitored_channel,
         set_contact_form_lead_mandate,
@@ -1242,6 +1246,9 @@ async def _handle_manage_slack(
                     "ok": True,
                     "connection": _slack_connection_payload(connection),
                     "monitored_channels": channels,
+                    "disabled_intakes": sorted(
+                        disabled_intake_origins(connection)
+                    ),
                 },
                 default=str,
             )
@@ -1272,6 +1279,26 @@ async def _handle_manage_slack(
             except SlackMonitorConfigError as exc:
                 return json.dumps({"error": str(exc)})
             return json.dumps({"ok": True, **result}, default=str)
+        if normalized_action in {"disable_intake", "enable_intake"}:
+            if not str(intake or "").strip():
+                return json.dumps(
+                    {"error": f"{normalized_action} requires: intake"}
+                )
+            try:
+                operation = (
+                    enable_intake
+                    if normalized_action == "enable_intake"
+                    else disable_intake
+                )
+                result = await operation(
+                    uow.session,
+                    connection_id=str(connection.id),
+                    intake=str(intake),
+                    org_id=org_id,
+                )
+            except SlackMonitorConfigError as exc:
+                return json.dumps({"error": str(exc)})
+            return json.dumps({"ok": True, **result}, default=str)
         if normalized_action in {"set_contact_form_lead_mandate", "clear_contact_form_lead_mandate"}:
             try:
                 operation = (
@@ -1293,7 +1320,8 @@ async def _handle_manage_slack(
             "error": (
                 "manage_slack action must be status, list_channels, list_mappings, "
                 "link_identity, unlink_identity, list_monitored, monitor_channel, "
-                "unmonitor_channel, set_contact_form_lead_mandate, "
+                "unmonitor_channel, disable_intake, enable_intake, "
+                "set_contact_form_lead_mandate, "
                 "clear_contact_form_lead_mandate, or "
                 "open_alert_surges"
             )

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -31,7 +31,10 @@ from brain.systems.slack.monitored_intakes import (
     enrich_monitored_intake,
     is_monitored_intake,
 )
-from brain.systems.slack.monitors import monitored_channel_ids
+from brain.systems.slack.monitors import (
+    disabled_intake_origins,
+    monitored_channel_ids,
+)
 
 logger = logging.getLogger(__name__)
 SLACK_PROCESSING_STATUS = "is working on it..."
@@ -321,6 +324,7 @@ async def process_socket_payload(
         socket_payload,
         bot_user_id=config.bot_user_id,
         monitored_channels=monitored_channels,
+        disabled_intakes=disabled_intake_origins(connection),
     )
     if envelope is None:
         return {"ack": ack, "ignored": True}
@@ -430,6 +434,7 @@ async def process_slack_history_message(
         socket_payload,
         bot_user_id=config.bot_user_id,
         monitored_channels=monitored_channel_ids(connection),
+        disabled_intakes=disabled_intake_origins(connection),
     )
     if envelope is None:
         return {"ignored": True, "acked": False}

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Mapping
 
 from brain.systems.slack.monitored_intakes import (
@@ -9,8 +10,11 @@ from brain.systems.slack.monitored_intakes import (
     enrich_monitored_intake_payload,
     recognize_monitored_intake,
     slack_response_thread_ts,
+    typed_monitored_intake_origins,
     visible_slack_content,
 )
+
+logger = logging.getLogger(__name__)
 
 SLACK_MESSAGE_ENVELOPE_KIND = "slack_message"
 MAX_SLACK_TEXT_CHARS = 4000
@@ -148,6 +152,7 @@ def normalize_slack_socket_event(
     *,
     bot_user_id: str | None = None,
     monitored_channels: frozenset[str] | set[str] | list[str] | None = None,
+    disabled_intakes: frozenset[str] | set[str] | list[str] | None = None,
 ) -> dict[str, Any] | None:
     """Return a shared inbound envelope for actionable Slack Socket Mode events.
 
@@ -161,6 +166,11 @@ def normalize_slack_socket_event(
     event = _slack_event(socket_payload)
     visible_content = visible_slack_content(event)
     monitored_intake = recognize_monitored_intake(event, visible_content)
+    disabled = frozenset(
+        str(intake).strip()
+        for intake in (disabled_intakes or ())
+        if str(intake).strip()
+    )
     resolved_bot_user_id = _bot_user_id(socket_payload, bot_user_id)
     api_app_id = str(payload.get("api_app_id") or "").strip() or None
     monitored = frozenset(
@@ -174,6 +184,21 @@ def normalize_slack_socket_event(
         monitored_intake=monitored_intake,
     )
     if origin is None:
+        return None
+    # A disabled intake silences only the passive monitored-channel lane —
+    # explicit mentions and DMs resolve their own origin above and stay
+    # actionable even when their text happens to decode as a typed intake.
+    if (
+        origin == monitored_intake.policy.origin
+        and origin in typed_monitored_intake_origins()
+        and origin in disabled
+    ):
+        logger.info(
+            "slack_monitored_intake_disabled: intake=%s channel_id=%s message_ts=%s",
+            origin,
+            str(event.get("channel") or "").strip(),
+            str(event.get("ts") or event.get("event_ts") or "").strip(),
+        )
         return None
     message_text = (
         monitored_intake.text

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -477,6 +477,16 @@ MONITORED_INTAKE_POLICIES: tuple[MonitoredIntakePolicy, ...] = (
 )
 
 
+def typed_monitored_intake_origins() -> frozenset[str]:
+    """Return registry origins that precede the channel-message fallback."""
+
+    return frozenset(
+        policy.origin
+        for policy in MONITORED_INTAKE_POLICIES
+        if policy.origin != SLACK_CHANNEL_MESSAGE_ORIGIN
+    )
+
+
 def _bounded_text(value: Any, *, limit: int | None = 4000) -> str:
     text = str(value or "")
     return text if limit is None else text[:limit]
@@ -562,5 +572,6 @@ __all__ = [
     "recognize_monitored_intake",
     "route_monitored_intake",
     "slack_response_thread_ts",
+    "typed_monitored_intake_origins",
     "visible_slack_content",
 ]

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -17,6 +17,7 @@ from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 
 CONTACT_FORM_LEAD_MANDATE_KEY = "contact_form_lead_mandate"
 CONTACT_FORM_LEAD_MANDATE_MAX_CHARS = 20_000
+DISABLED_INTAKES_KEY = "disabled_intakes"
 
 
 class SlackMonitorConfigError(ValueError):
@@ -94,6 +95,30 @@ def contact_form_lead_mandate(
         _slack_metadata(connection).get(CONTACT_FORM_LEAD_MANDATE_KEY)
     )
     return value or None
+
+
+def _typed_intake_origins() -> frozenset[str]:
+    from brain.systems.slack.monitored_intakes import (
+        typed_monitored_intake_origins,
+    )
+
+    return typed_monitored_intake_origins()
+
+
+def disabled_intake_origins(
+    connection: ExternalAgentConnectionRow,
+) -> set[str]:
+    """Return disabled typed-intake origins; all typed intakes default enabled."""
+
+    raw = _slack_metadata(connection).get(DISABLED_INTAKES_KEY)
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return set()
+    valid_origins = _typed_intake_origins()
+    return {
+        origin
+        for item in raw
+        if (origin := _clean(item)) in valid_origins
+    }
 
 
 async def _connection_for_org(
@@ -187,6 +212,99 @@ async def clear_contact_form_lead_mandate(
     )
 
 
+def _validated_typed_intake_origin(intake: str) -> str:
+    from brain.systems.slack.monitored_intakes import (
+        SLACK_CHANNEL_MESSAGE_ORIGIN,
+    )
+
+    clean_intake = _clean(intake)
+    if not clean_intake:
+        raise SlackMonitorConfigError("intake is required")
+    if clean_intake == SLACK_CHANNEL_MESSAGE_ORIGIN:
+        raise SlackMonitorConfigError(
+            f"{SLACK_CHANNEL_MESSAGE_ORIGIN} is the fallback intake; "
+            "use unmonitor_channel for channel-level monitoring"
+        )
+    valid_origins = _typed_intake_origins()
+    if clean_intake not in valid_origins:
+        valid = ", ".join(sorted(valid_origins)) or "(none)"
+        raise SlackMonitorConfigError(
+            f"Unknown monitored intake {clean_intake!r}; "
+            f"valid typed intakes: {valid}"
+        )
+    return clean_intake
+
+
+async def _write_intake_enabled(
+    session,
+    *,
+    connection_id: str,
+    intake: str,
+    enabled: bool,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    clean_intake = _validated_typed_intake_origin(intake)
+    connection = await _connection_for_org(session, connection_id, org_id)
+    disabled_intakes = disabled_intake_origins(connection)
+    if enabled:
+        disabled_intakes.discard(clean_intake)
+    else:
+        disabled_intakes.add(clean_intake)
+
+    root = dict(connection.metadata_ or {})
+    slack_metadata = _slack_metadata(connection)
+    if disabled_intakes:
+        slack_metadata[DISABLED_INTAKES_KEY] = sorted(disabled_intakes)
+    else:
+        slack_metadata.pop(DISABLED_INTAKES_KEY, None)
+    root["slack"] = slack_metadata
+    connection.metadata_ = root
+    await session.flush()
+    return {
+        "connection_id": str(connection.id),
+        "metadata_path": f"slack.{DISABLED_INTAKES_KEY}",
+        "intake": clean_intake,
+        "enabled": enabled,
+        "disabled_intakes": sorted(disabled_intakes),
+    }
+
+
+async def disable_intake(
+    session,
+    *,
+    connection_id: str,
+    intake: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Disable one typed monitored intake without unmonitoring its channel."""
+
+    return await _write_intake_enabled(
+        session,
+        connection_id=connection_id,
+        intake=intake,
+        enabled=False,
+        org_id=org_id,
+    )
+
+
+async def enable_intake(
+    session,
+    *,
+    connection_id: str,
+    intake: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Restore the default-enabled routing for one typed monitored intake."""
+
+    return await _write_intake_enabled(
+        session,
+        connection_id=connection_id,
+        intake=intake,
+        enabled=True,
+        org_id=org_id,
+    )
+
+
 async def list_monitored_channels(
     session,
     *,
@@ -259,10 +377,14 @@ async def remove_monitored_channel(
 
 __all__ = [
     "CONTACT_FORM_LEAD_MANDATE_KEY",
+    "DISABLED_INTAKES_KEY",
     "SlackMonitorConfigError",
     "add_monitored_channel",
     "clear_contact_form_lead_mandate",
     "contact_form_lead_mandate",
+    "disable_intake",
+    "disabled_intake_origins",
+    "enable_intake",
     "list_monitored_channels",
     "monitored_channel_ids",
     "monitored_channels",

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -76,6 +76,89 @@ def test_contact_form_lead_is_decoded_once_with_reordered_fields_and_no_phone():
     }
 
 
+def test_disabled_contact_form_is_dropped_without_channel_message_fallback(
+    caplog,
+):
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+    from brain.systems.slack.monitors import disabled_intake_origins
+
+    socket_payload = socket_mode_channel_message(
+        user="",
+        bot_id="B_CONTACT_FORM",
+        app_id="A_CONTACT_FORM",
+        text=_contact_form_text(),
+    )
+
+    assert disabled_intake_origins(FakeSlackConnection()) == set()
+    assert (
+        normalize_slack_socket_event(
+            socket_payload,
+            bot_user_id="BILLO",
+            monitored_channels={"C_ALERTS"},
+        )["origin"]
+        == "contact_form_lead"
+    )
+
+    with caplog.at_level(
+        "INFO",
+        logger="brain.systems.slack.ingress",
+    ):
+        disabled = normalize_slack_socket_event(
+            socket_payload,
+            bot_user_id="BILLO",
+            monitored_channels={"C_ALERTS"},
+            disabled_intakes={"contact_form_lead"},
+        )
+
+    assert disabled is None
+    dropped_records = [
+        record
+        for record in caplog.records
+        if record.name == "brain.systems.slack.ingress"
+        and record.message.startswith("slack_monitored_intake_disabled:")
+    ]
+    assert len(dropped_records) == 1
+    assert "intake=contact_form_lead" in dropped_records[0].message
+
+    fallback = normalize_slack_socket_event(
+        socket_mode_channel_message(),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+        disabled_intakes={"slack.channel_message"},
+    )
+    assert fallback is not None
+    assert fallback["origin"] == "slack.channel_message"
+
+
+def test_disabled_contact_form_leaves_mentions_and_dms_actionable():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    dm = normalize_slack_socket_event(
+        socket_mode_channel_message(
+            text=_contact_form_text(),
+            channel="D_DM",
+            channel_type="im",
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+        disabled_intakes={"contact_form_lead"},
+    )
+    assert dm is not None
+    assert dm["origin"] == "slack.direct_message"
+
+    mention = normalize_slack_socket_event(
+        socket_mode_channel_message(
+            type="app_mention",
+            text=_contact_form_text(),
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+        disabled_intakes={"contact_form_lead"},
+    )
+    assert mention is not None
+    assert mention["origin"] == "slack.app_mention"
+
+
 def test_contact_form_lead_is_decoded_from_slack_blocks():
     from brain.systems.slack.ingress import normalize_slack_socket_event
 
@@ -640,6 +723,40 @@ async def test_contact_form_lead_gets_common_eyes_and_policy_enrichment(
         "/contact-form-lead-intake\n"
     )
     assert "Configured lead assessment." in work["payload"]["run_message"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_contact_form_creates_no_run_or_ack(monkeypatch):
+    connector_module, reactions, submitted = patch_slack_connector(monkeypatch)
+    connection = FakeSlackConnection(
+        metadata={
+            "slack": {
+                "monitored_channels": ["C_ALERTS"],
+                "disabled_intakes": ["contact_form_lead"],
+            }
+        }
+    )
+    config = connector_module.SlackConnectorConfig(
+        bot_token="xoxb-x",
+        app_token="xapp-x",
+        bot_user_id="BILLO",
+    )
+
+    result = await connector_module.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=socket_mode_channel_message(
+            user="",
+            bot_id="B_CONTACT_FORM",
+            app_id="A_CONTACT_FORM",
+            text=_contact_form_text(),
+        ),
+        config=config,
+    )
+
+    assert result["ignored"] is True
+    assert reactions == []
+    assert submitted == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1768,11 +1768,13 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
         "list_monitored",
         "monitor_channel",
         "unmonitor_channel",
+        "disable_intake",
+        "enable_intake",
         "set_contact_form_lead_mandate",
         "clear_contact_form_lead_mandate",
         "open_alert_surges",
     ]
-    assert {"display_name", "communication_preferences", "mandate"} <= set(
+    assert {"display_name", "communication_preferences", "intake", "mandate"} <= set(
         properties
     )
     assert properties["communication_preferences"]["properties"]["humour"]["enum"] == [
@@ -1790,6 +1792,7 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
     assert "cannot" not in serialized_tool.lower()
     assert "non-empty mandate" in serialized_tool
     assert "clear_contact_form_lead_mandate" in serialized_tool
+    assert "contact_form_lead" in properties["intake"]["description"]
 
 
 @pytest.mark.asyncio
@@ -1848,6 +1851,94 @@ async def test_manage_slack_omitted_mandate_preserves_it_until_explicit_clear(
     assert cleared["ok"] is True
     assert cleared["cleared"] is True
     assert "contact_form_lead_mandate" not in connection.metadata_["slack"]
+
+
+@pytest.mark.asyncio
+async def test_manage_slack_runtime_intake_policy_roundtrip_and_validation(
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+
+    connection = await _seed_slack_connection(session)
+
+    class _UnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            await session.flush()
+            return False
+
+    monkeypatch.setattr(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        _UnitOfWork,
+    )
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        initial = json.loads(
+            await _handle_manage_slack(
+                action="list_monitored",
+                connection_id=str(connection.id),
+            )
+        )
+        disabled = json.loads(
+            await _handle_manage_slack(
+                action="disable_intake",
+                connection_id=str(connection.id),
+                intake="contact_form_lead",
+            )
+        )
+        listed = json.loads(
+            await _handle_manage_slack(
+                action="list_monitored",
+                connection_id=str(connection.id),
+            )
+        )
+        unknown = json.loads(
+            await _handle_manage_slack(
+                action="disable_intake",
+                connection_id=str(connection.id),
+                intake="sales_lead",
+            )
+        )
+        fallback = json.loads(
+            await _handle_manage_slack(
+                action="disable_intake",
+                connection_id=str(connection.id),
+                intake="slack.channel_message",
+            )
+        )
+        enabled = json.loads(
+            await _handle_manage_slack(
+                action="enable_intake",
+                connection_id=str(connection.id),
+                intake="contact_form_lead",
+            )
+        )
+
+    assert initial["disabled_intakes"] == []
+    assert disabled == {
+        "ok": True,
+        "connection_id": str(connection.id),
+        "metadata_path": "slack.disabled_intakes",
+        "intake": "contact_form_lead",
+        "enabled": False,
+        "disabled_intakes": ["contact_form_lead"],
+    }
+    assert listed["disabled_intakes"] == ["contact_form_lead"]
+    assert "Unknown monitored intake 'sales_lead'" in unknown["error"]
+    assert "valid typed intakes: contact_form_lead" in unknown["error"]
+    assert "fallback intake" in fallback["error"]
+    assert "unmonitor_channel" in fallback["error"]
+    assert enabled["ok"] is True
+    assert enabled["enabled"] is True
+    assert enabled["disabled_intakes"] == []
+    assert "disabled_intakes" not in connection.metadata_["slack"]
 
 
 def test_manage_slack_connection_payload_redacts_private_identity_profiles():


### PR DESCRIPTION
## Why

When Reda told Illo "stop processing contact forms for now" (2026-07-30), the only runtime switch was channel-level (`unmonitor_channel`), which would also have killed PostHog alert triage. Whether a typed intake spawns a run at all was frozen in code — the same root cause #611 fixed for the reply behavior. This applies #611's mandate-overlay pattern one level up: intake admission becomes runtime-editable connection state Illo can flip with its own tools.

## What

- **`slack.disabled_intakes`** connection-metadata list (default: everything enabled), with reader/writer helpers in `monitors.py` mirroring the mandate overlay.
- **Ingress honors it after origin resolution**: a message admitted via the passive monitored-channel lane whose typed intake is disabled is dropped entirely — no run, no ack, no reply, and no fall-through to `channel_message` (a disabled contact-form lead must never get triaged as a generic alert). One log line per drop.
- **Mentions and DMs stay actionable**: the check gates only the monitored-channel origin, so a human pasting lead-shaped text into a DM or @mention still gets a run while the intake is paused (regression-tested).
- **`manage_slack` gains `disable_intake` / `enable_intake`** with identifier validation against the typed-intake registry (the `slack.channel_message` fallback is rejected — that's what `unmonitor_channel` is for). `list_monitored` now reports `disabled_intakes`, and the tool description documents the new actions so Illo discovers it can pause intakes itself.

## Tests

`test_contact_form_monitor.py`, `test_slack_teammate.py`, `test_slack_channel_monitor.py`, `test_tools.py`, `test_tool_registry.py`, `test_cold_start_reconciliation.py`, `test_knowledge_slack_connector.py` — 208 passed locally. New coverage: disabled → dropped with no fallback and no run/ack; enable/disable roundtrip + validation errors; mention/DM protection while disabled.

Implementation by Codex (gpt-5.6-sol) from a Claude spec; Claude director review moved the disabled check after origin resolution (the original ordering would have silently swallowed mentions/DMs containing lead-shaped text) and added the regression test for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)