### PR TITLE
refactor(slack): centralize identity normalization in identity.py (#612)

### DIFF
--- a/brain/app/api/routers/agent_mcp_identity.py
+++ b/brain/app/api/routers/agent_mcp_identity.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User, UserCodexConnection
 from brain.systems.external_agents import service as external_agents
+from brain.systems.slack.identity import normalize_slack_identities
 
 
 def _clean(value: Any) -> str:
@@ -67,6 +68,8 @@ def _connection_identity_links(connection: ExternalAgentConnectionRow) -> list[d
     identities: list[dict[str, Any]] = []
     links = _links_root(connection)
     for provider, provider_links in links.items():
+        if _provider(provider) == "slack":
+            continue
         if not isinstance(provider_links, Mapping):
             continue
         for external_user_id, raw_link in provider_links.items():
@@ -87,19 +90,43 @@ def _connection_identity_links(connection: ExternalAgentConnectionRow) -> list[d
                 )
             )
 
-    slack_metadata = _metadata(_metadata(connection.metadata_).get("slack"))
-    slack_map = slack_metadata.get("identity_map")
-    if isinstance(slack_map, Mapping):
-        for slack_user_id, user_id in slack_map.items():
-            clean_slack_user_id = _clean(slack_user_id)
-            clean_user_id = _clean(user_id)
-            if not clean_slack_user_id or not clean_user_id:
-                continue
+    connection_metadata = _metadata(connection.metadata_)
+    slack_metadata = _metadata(connection_metadata.get("slack"))
+    slack_map = {
+        _clean(slack_user_id): user_id
+        for slack_user_id, user_id in _metadata(
+            slack_metadata.get("identity_map")
+        ).items()
+        if _clean(slack_user_id)
+    }
+    slack_links = {
+        _clean(slack_user_id): raw_link
+        for slack_user_id, raw_link in _metadata(links.get("slack")).items()
+        if _clean(slack_user_id)
+    }
+    normalization = normalize_slack_identities(connection_metadata)
+    for record in normalization.records:
+        if record.user_id is None:
+            continue
+        raw_link = _metadata(slack_links.get(record.slack_user_id))
+        if _clean(raw_link.get("user_id")):
             identities.append(
                 _identity_payload(
                     provider="slack",
-                    external_user_id=clean_slack_user_id,
-                    user_id=clean_user_id,
+                    external_user_id=record.slack_user_id,
+                    user_id=record.user_id,
+                    display_name=_clean(raw_link.get("display_name")) or None,
+                    metadata=_metadata(raw_link.get("metadata")),
+                    source="external_connection.identity_links",
+                    connection=connection,
+                )
+            )
+        if _clean(slack_map.get(record.slack_user_id)):
+            identities.append(
+                _identity_payload(
+                    provider="slack",
+                    external_user_id=record.slack_user_id,
+                    user_id=record.user_id,
                     source="external_connection.slack.identity_map",
                     connection=connection,
                     metadata={

--- a/brain/app/api/routers/agent_mcp_identity.py
+++ b/brain/app/api/routers/agent_mcp_identity.py
@@ -11,7 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User, UserCodexConnection
 from brain.systems.external_agents import service as external_agents
-from brain.systems.slack.identity import normalize_slack_identities
+from brain.systems.slack.identity import (
+    SlackIdentitySource,
+    link_slack_identity,
+    normalize_slack_identities,
+    unlink_slack_identity,
+)
 
 
 def _clean(value: Any) -> str:
@@ -90,49 +95,34 @@ def _connection_identity_links(connection: ExternalAgentConnectionRow) -> list[d
                 )
             )
 
-    connection_metadata = _metadata(connection.metadata_)
-    slack_metadata = _metadata(connection_metadata.get("slack"))
-    slack_map = {
-        _clean(slack_user_id): user_id
-        for slack_user_id, user_id in _metadata(
-            slack_metadata.get("identity_map")
-        ).items()
-        if _clean(slack_user_id)
-    }
-    slack_links = {
-        _clean(slack_user_id): raw_link
-        for slack_user_id, raw_link in _metadata(links.get("slack")).items()
-        if _clean(slack_user_id)
-    }
-    normalization = normalize_slack_identities(connection_metadata)
-    for record in normalization.records:
+    records, _conflicts = normalize_slack_identities(
+        _metadata(connection.metadata_)
+    )
+    for record in records.values():
         if record.user_id is None:
             continue
-        raw_link = _metadata(slack_links.get(record.slack_user_id))
-        if _clean(raw_link.get("user_id")):
+        user_id = record.user_id
+        if SlackIdentitySource.LINK in record.sources and record.linked_user_id:
             identities.append(
                 _identity_payload(
                     provider="slack",
                     external_user_id=record.slack_user_id,
-                    user_id=record.user_id,
-                    display_name=_clean(raw_link.get("display_name")) or None,
-                    metadata=_metadata(raw_link.get("metadata")),
-                    source="external_connection.identity_links",
+                    user_id=user_id,
+                    display_name=record.link_display_name,
+                    metadata=record.link_metadata,
+                    source=SlackIdentitySource.LINK.value,
                     connection=connection,
                 )
             )
-        if _clean(slack_map.get(record.slack_user_id)):
+        if SlackIdentitySource.MAP in record.sources and record.mapped_user_id:
             identities.append(
                 _identity_payload(
                     provider="slack",
                     external_user_id=record.slack_user_id,
-                    user_id=record.user_id,
-                    source="external_connection.slack.identity_map",
+                    user_id=user_id,
+                    source=SlackIdentitySource.MAP.value,
                     connection=connection,
-                    metadata={
-                        "team_id": slack_metadata.get("team_id"),
-                        "bot_user_id": slack_metadata.get("bot_user_id"),
-                    },
+                    metadata=record.map_metadata,
                 )
             )
     return identities
@@ -318,41 +308,63 @@ async def manage_identity(
     if connection is None or str(connection.org_id) != principal.org_id:
         raise ValueError("External source connection not found")
 
-    links = _links_root(connection)
-    provider_links = dict(links.get(provider) or {})
     removed = False
-    if action == "unlink":
-        removed = external_user_id in provider_links
-        provider_links.pop(external_user_id, None)
-    else:
+    is_slack_connection = provider == "slack" and connection.agent_kind == "slack"
+    if is_slack_connection and action == "unlink":
+        records, _conflicts = normalize_slack_identities(
+            _metadata(connection.metadata_)
+        )
+        record = records.get(external_user_id)
+        removed = bool(
+            record is not None
+            and SlackIdentitySource.LINK in record.sources
+        )
+        await unlink_slack_identity(
+            db,
+            connection_id=connection_id,
+            slack_user_id=external_user_id,
+            org_id=principal.org_id,
+        )
+    elif is_slack_connection:
         user_id = _clean(arguments.get("user_id"))
         if not user_id:
             raise ValueError("identity.manage action link requires user_id")
         user = await db.get(User, user_id)
         if user is None or str(user.org_id) != principal.org_id:
             raise ValueError("Illospace user not found")
-        provider_links[external_user_id] = {
-            "user_id": user_id,
-            "display_name": _clean(arguments.get("display_name")) or None,
-            "metadata": _metadata(arguments.get("metadata")),
-        }
-    if provider_links:
-        links[provider] = provider_links
+        await link_slack_identity(
+            db,
+            connection_id=connection_id,
+            slack_user_id=external_user_id,
+            user_id=user_id,
+            org_id=principal.org_id,
+            display_name=_clean(arguments.get("display_name")) or None,
+            link_metadata=_metadata(arguments.get("metadata")),
+            replace_profile=True,
+        )
     else:
-        links.pop(provider, None)
-    _set_links_root(connection, links)
-
-    if provider == "slack" and connection.agent_kind == "slack":
-        metadata = _metadata(connection.metadata_)
-        slack_metadata = _metadata(metadata.get("slack"))
-        identity_map = dict(slack_metadata.get("identity_map") or {})
+        links = _links_root(connection)
+        provider_links = dict(links.get(provider) or {})
         if action == "unlink":
-            identity_map.pop(external_user_id, None)
+            removed = external_user_id in provider_links
+            provider_links.pop(external_user_id, None)
         else:
-            identity_map[external_user_id] = _clean(arguments.get("user_id"))
-        slack_metadata["identity_map"] = identity_map
-        metadata["slack"] = slack_metadata
-        connection.metadata_ = metadata
+            user_id = _clean(arguments.get("user_id"))
+            if not user_id:
+                raise ValueError("identity.manage action link requires user_id")
+            user = await db.get(User, user_id)
+            if user is None or str(user.org_id) != principal.org_id:
+                raise ValueError("Illospace user not found")
+            provider_links[external_user_id] = {
+                "user_id": user_id,
+                "display_name": _clean(arguments.get("display_name")) or None,
+                "metadata": _metadata(arguments.get("metadata")),
+            }
+        if provider_links:
+            links[provider] = provider_links
+        else:
+            links.pop(provider, None)
+        _set_links_root(connection, links)
 
     await db.flush()
     return {

--- a/brain/systems/slack/contact_form_lead_owner.py
+++ b/brain/systems/slack/contact_form_lead_owner.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Mapping
 
+from brain.kernel.common.coercion import as_mapping, optional_text
 from brain.systems.runs.obligation_specs import ObligationAnswerer
 from brain.systems.slack.identity import (
+    SlackIdentityRecord,
     normalize_slack_identities,
-    select_slack_identity_record,
 )
 
 
@@ -21,26 +22,76 @@ class ContactFormOwnerPolicy:
         """Resolve the owner once; downstream consumers receive a complete value."""
 
         metadata = _connection_metadata(connection)
-        slack_metadata = _mapping(metadata.get("slack"))
-        configured = _mapping(slack_metadata.get("contact_form_lead_owner"))
-        normalization = normalize_slack_identities(metadata)
+        slack_metadata = as_mapping(metadata.get("slack"))
+        configured = as_mapping(slack_metadata.get("contact_form_lead_owner"))
+        records, _conflicts = normalize_slack_identities(metadata)
 
-        configured_user_id = _clean(configured.get("user_id")) or None
-        configured_slack_id = _clean(configured.get("slack_user_id")) or None
-        configured_name = _clean(configured.get("name")) or None
-        selected = select_slack_identity_record(
-            normalization.records,
-            configured_slack_id=configured_slack_id,
-            configured_user_id=configured_user_id,
-            configured_name=configured_name,
-            default_slack_user_id=self.default_slack_user_id,
-            default_name=self.default_name,
+        selected = self._select_identity_record(
+            records,
+            configured_slack_id=_configured_text(
+                configured.get("slack_user_id")
+            ),
+            configured_user_id=_configured_text(configured.get("user_id")),
+            configured_name=_configured_text(configured.get("name")),
         )
         return ObligationAnswerer(
             name=selected.display_name,
             slack_user_id=selected.slack_user_id,
             user_id=selected.user_id,
         )
+
+    def _select_identity_record(
+        self,
+        records: Mapping[str, SlackIdentityRecord],
+        *,
+        configured_slack_id: str | None,
+        configured_user_id: str | None,
+        configured_name: str | None,
+    ) -> SlackIdentityRecord:
+        """Select one whole record from configured and default owner candidates."""
+
+        if configured_slack_id:
+            return records.get(configured_slack_id) or SlackIdentityRecord(
+                slack_user_id=configured_slack_id,
+                display_name=configured_name or configured_slack_id,
+                user_id=None,
+            )
+
+        if configured_user_id:
+            matched_user = next(
+                (
+                    record
+                    for record in records.values()
+                    if record.user_id == configured_user_id
+                ),
+                None,
+            )
+            if matched_user is not None:
+                return matched_user
+
+        default_name_match = next(
+            (
+                record
+                for record in records.values()
+                if record.display_name.casefold() == self.default_name.casefold()
+            ),
+            None,
+        )
+        selected = default_name_match or records.get(self.default_slack_user_id)
+        if selected is None:
+            selected = SlackIdentityRecord(
+                slack_user_id=self.default_slack_user_id,
+                display_name=self.default_name,
+                user_id=None,
+            )
+        elif (
+            selected.slack_user_id == self.default_slack_user_id
+            and selected.display_name == self.default_slack_user_id
+        ):
+            selected = replace(selected, display_name=self.default_name)
+        if configured_user_id:
+            return replace(selected, user_id=None)
+        return selected
 
 
 CONTACT_FORM_OWNER_POLICY = ContactFormOwnerPolicy(
@@ -49,12 +100,8 @@ CONTACT_FORM_OWNER_POLICY = ContactFormOwnerPolicy(
 )
 
 
-def _clean(value: Any) -> str:
-    return str(value or "").strip()
-
-
-def _mapping(value: Any) -> dict[str, Any]:
-    return dict(value) if isinstance(value, Mapping) else {}
+def _configured_text(value: Any) -> str | None:
+    return optional_text(value) if value else None
 
 
 def _connection_value(connection: Any, key: str) -> Any:
@@ -64,7 +111,7 @@ def _connection_value(connection: Any, key: str) -> Any:
 
 
 def _connection_metadata(connection: Any) -> dict[str, Any]:
-    return _mapping(
+    return as_mapping(
         _connection_value(connection, "metadata_")
         or _connection_value(connection, "metadata")
     )

--- a/brain/systems/slack/contact_form_lead_owner.py
+++ b/brain/systems/slack/contact_form_lead_owner.py
@@ -3,29 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
 from typing import Any, Mapping
 
 from brain.systems.runs.obligation_specs import ObligationAnswerer
-
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class SlackIdentityRecord:
-    """One Slack identity whose attributes cannot be combined across people."""
-
-    slack_user_id: str
-    display_name: str
-    user_id: str | None
-
-    def without_user_id(self) -> SlackIdentityRecord:
-        return SlackIdentityRecord(
-            slack_user_id=self.slack_user_id,
-            display_name=self.display_name,
-            user_id=None,
-        )
+from brain.systems.slack.identity import (
+    normalize_slack_identities,
+    select_slack_identity_record,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,13 +23,13 @@ class ContactFormOwnerPolicy:
         metadata = _connection_metadata(connection)
         slack_metadata = _mapping(metadata.get("slack"))
         configured = _mapping(slack_metadata.get("contact_form_lead_owner"))
-        records = _slack_identity_records(metadata)
+        normalization = normalize_slack_identities(metadata)
 
         configured_user_id = _clean(configured.get("user_id")) or None
         configured_slack_id = _clean(configured.get("slack_user_id")) or None
         configured_name = _clean(configured.get("name")) or None
-        selected = _select_identity_record(
-            records,
+        selected = select_slack_identity_record(
+            normalization.records,
             configured_slack_id=configured_slack_id,
             configured_user_id=configured_user_id,
             configured_name=configured_name,
@@ -73,119 +57,6 @@ def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
 
 
-def _slack_identity_records(
-    metadata: Mapping[str, Any],
-) -> tuple[SlackIdentityRecord, ...]:
-    slack_metadata = _mapping(metadata.get("slack"))
-    identity_map = {
-        _clean(slack_user_id): user_id
-        for slack_user_id, user_id in _mapping(
-            slack_metadata.get("identity_map")
-        ).items()
-        if _clean(slack_user_id)
-    }
-    identity_links = {
-        _clean(slack_user_id): link
-        for slack_user_id, link in _mapping(
-            _mapping(metadata.get("identity_links")).get("slack")
-        ).items()
-        if _clean(slack_user_id)
-    }
-    slack_user_ids = dict.fromkeys(
-        [
-            *(_clean(value) for value in identity_links),
-            *(_clean(value) for value in identity_map),
-        ]
-    )
-    records: list[SlackIdentityRecord] = []
-    for slack_user_id in slack_user_ids:
-        if not slack_user_id:
-            continue
-        link = _mapping(identity_links.get(slack_user_id))
-        linked_user_id = _clean(link.get("user_id")) or None
-        mapped_user_id = _clean(identity_map.get(slack_user_id)) or None
-        if linked_user_id and mapped_user_id and linked_user_id != mapped_user_id:
-            logger.warning(
-                "Conflicting Slack identity for %s: linked user_id %s disagrees "
-                "with mapped user_id %s; omitting user_id",
-                slack_user_id,
-                linked_user_id,
-                mapped_user_id,
-            )
-            user_id = None
-        else:
-            user_id = linked_user_id or mapped_user_id
-        records.append(
-            SlackIdentityRecord(
-                slack_user_id=slack_user_id,
-                display_name=(
-                    _clean(link.get("display_name"))
-                    or slack_user_id
-                ),
-                user_id=user_id,
-            )
-        )
-    return tuple(records)
-
-
-def _select_identity_record(
-    records: tuple[SlackIdentityRecord, ...],
-    *,
-    configured_slack_id: str | None,
-    configured_user_id: str | None,
-    configured_name: str | None,
-    default_slack_user_id: str,
-    default_name: str,
-) -> SlackIdentityRecord:
-    by_slack_id = {record.slack_user_id: record for record in records}
-    if configured_slack_id:
-        return by_slack_id.get(configured_slack_id) or SlackIdentityRecord(
-            slack_user_id=configured_slack_id,
-            display_name=configured_name or configured_slack_id,
-            user_id=None,
-        )
-
-    if configured_user_id:
-        matched_user = next(
-            (
-                record
-                for record in records
-                if record.user_id == configured_user_id
-            ),
-            None,
-        )
-        if matched_user is not None:
-            return matched_user
-
-    default_name_match = next(
-        (
-            record
-            for record in records
-            if record.display_name.casefold() == default_name.casefold()
-        ),
-        None,
-    )
-    selected = default_name_match or by_slack_id.get(default_slack_user_id)
-    if selected is None:
-        selected = SlackIdentityRecord(
-            slack_user_id=default_slack_user_id,
-            display_name=default_name,
-            user_id=None,
-        )
-    elif (
-        selected.slack_user_id == default_slack_user_id
-        and selected.display_name == default_slack_user_id
-    ):
-        selected = SlackIdentityRecord(
-            slack_user_id=selected.slack_user_id,
-            display_name=default_name,
-            user_id=selected.user_id,
-        )
-    if configured_user_id:
-        return selected.without_user_id()
-    return selected
-
-
 def _connection_value(connection: Any, key: str) -> Any:
     if isinstance(connection, Mapping):
         return connection.get(key)
@@ -202,5 +73,4 @@ def _connection_metadata(connection: Any) -> dict[str, Any]:
 __all__ = [
     "CONTACT_FORM_OWNER_POLICY",
     "ContactFormOwnerPolicy",
-    "SlackIdentityRecord",
 ]

--- a/brain/systems/slack/identity.py
+++ b/brain/systems/slack/identity.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 import logging
 from typing import Any, Mapping
 
 from sqlalchemy import select
 
+from brain.kernel.common.coercion import as_mapping
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User
 from brain.systems.personality.person_context import normalize_communication_preferences
@@ -17,214 +19,134 @@ logger = logging.getLogger(__name__)
 
 
 class SlackIdentityMappingError(ValueError):
-    """A typed Slack identity mapping failure or non-raising diagnostic."""
+    """Raised when a Slack identity mapping cannot be applied."""
 
-    def __init__(
-        self,
-        message: str,
-        *,
-        code: str = "mapping_error",
-        slack_user_id: str | None = None,
-        linked_user_id: str | None = None,
-        mapped_user_id: str | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.code = code
-        self.slack_user_id = slack_user_id
-        self.linked_user_id = linked_user_id
-        self.mapped_user_id = mapped_user_id
 
-    @classmethod
-    def conflicting_user_ids(
-        cls,
-        *,
-        slack_user_id: str,
-        linked_user_id: str,
-        mapped_user_id: str,
-    ) -> SlackIdentityMappingError:
-        return cls(
-            (
-                f"Conflicting Slack identity for {slack_user_id}: linked user_id "
-                f"{linked_user_id} disagrees with mapped user_id {mapped_user_id}; "
-                "omitting user_id"
-            ),
-            code="linked_mapped_user_id_conflict",
-            slack_user_id=slack_user_id,
-            linked_user_id=linked_user_id,
-            mapped_user_id=mapped_user_id,
+class SlackIdentitySource(StrEnum):
+    """Persisted source that contributed to a canonical Slack identity."""
+
+    LINK = "external_connection.identity_links"
+    MAP = "external_connection.slack.identity_map"
+
+
+@dataclass(frozen=True, slots=True)
+class SlackIdentityConflict:
+    """A recoverable disagreement between the two Slack identity stores."""
+
+    slack_user_id: str
+    linked_user_id: str
+    mapped_user_id: str
+    code: str = field(
+        default="linked_mapped_user_id_conflict",
+        init=False,
+    )
+
+    def __str__(self) -> str:
+        return (
+            f"Conflicting Slack identity for {self.slack_user_id}: linked user_id "
+            f"{self.linked_user_id} disagrees with mapped user_id "
+            f"{self.mapped_user_id}; omitting user_id"
         )
 
 
 @dataclass(frozen=True, slots=True)
 class SlackIdentityRecord:
-    """One Slack identity whose attributes cannot be combined across people."""
+    """One reconciled Slack identity plus normalized source provenance."""
 
     slack_user_id: str
     display_name: str
     user_id: str | None
-
-    def without_user_id(self) -> SlackIdentityRecord:
-        return SlackIdentityRecord(
-            slack_user_id=self.slack_user_id,
-            display_name=self.display_name,
-            user_id=None,
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class SlackIdentityNormalization:
-    """Canonical Slack records plus diagnostics that were safe to recover from."""
-
-    records: tuple[SlackIdentityRecord, ...]
-    diagnostics: tuple[SlackIdentityMappingError, ...]
-
-    def record_for_slack_user_id(
-        self,
-        slack_user_id: str,
-    ) -> SlackIdentityRecord | None:
-        clean_slack_user_id = _clean(slack_user_id)
-        return next(
-            (
-                record
-                for record in self.records
-                if record.slack_user_id == clean_slack_user_id
-            ),
-            None,
-        )
+    sources: frozenset[SlackIdentitySource] = frozenset()
+    linked_user_id: str | None = None
+    mapped_user_id: str | None = None
+    link_display_name: str | None = None
+    link_metadata: Mapping[str, Any] = field(default_factory=dict)
+    map_metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
 def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
-def _mapping(value: Any) -> dict[str, Any]:
-    return dict(value) if isinstance(value, Mapping) else {}
-
-
 def normalize_slack_identities(
     metadata: Mapping[str, Any],
-) -> SlackIdentityNormalization:
+) -> tuple[
+    dict[str, SlackIdentityRecord],
+    tuple[SlackIdentityConflict, ...],
+]:
     """Reconcile both Slack identity stores without ever splicing identities.
 
     Source precedence is explicit. ``identity_links.slack`` supplies display
     names. For ``user_id``, a populated value from whichever store has one is
     used; matching values collapse to one record. If both stores have populated
-    values and they disagree, neither takes precedence: the record gets
-    ``user_id=None`` and a :class:`SlackIdentityMappingError` diagnostic is
-    returned and logged, never raised. Linked records precede map-only records.
+    values and they disagree, neither takes precedence: the record is marked
+    conflicted with ``user_id=None`` and a :class:`SlackIdentityConflict`
+    value is returned and logged, never raised. Linked records precede
+    map-only records.
     """
 
-    metadata = _mapping(metadata)
-    slack_metadata = _mapping(metadata.get("slack"))
+    metadata = as_mapping(metadata)
+    slack_metadata = as_mapping(metadata.get("slack"))
     identity_map = {
-        _clean(slack_user_id): user_id
-        for slack_user_id, user_id in _mapping(
+        clean_slack_user_id: user_id
+        for slack_user_id, user_id in as_mapping(
             slack_metadata.get("identity_map")
         ).items()
-        if _clean(slack_user_id)
+        if (clean_slack_user_id := _clean(slack_user_id))
     }
     identity_links = {
-        _clean(slack_user_id): link
-        for slack_user_id, link in _mapping(
-            _mapping(metadata.get("identity_links")).get("slack")
+        clean_slack_user_id: link
+        for slack_user_id, link in as_mapping(
+            as_mapping(metadata.get("identity_links")).get("slack")
         ).items()
-        if _clean(slack_user_id)
+        if (clean_slack_user_id := _clean(slack_user_id))
     }
     slack_user_ids = dict.fromkeys([*identity_links, *identity_map])
-    records: list[SlackIdentityRecord] = []
-    diagnostics: list[SlackIdentityMappingError] = []
+    records: dict[str, SlackIdentityRecord] = {}
+    conflicts: list[SlackIdentityConflict] = []
     for slack_user_id in slack_user_ids:
-        link = _mapping(identity_links.get(slack_user_id))
+        link = as_mapping(identity_links.get(slack_user_id))
         linked_user_id = _clean(link.get("user_id")) or None
         mapped_user_id = _clean(identity_map.get(slack_user_id)) or None
+        link_display_name = _clean(link.get("display_name")) or None
         if linked_user_id and mapped_user_id and linked_user_id != mapped_user_id:
-            diagnostic = SlackIdentityMappingError.conflicting_user_ids(
+            conflict = SlackIdentityConflict(
                 slack_user_id=slack_user_id,
                 linked_user_id=linked_user_id,
                 mapped_user_id=mapped_user_id,
             )
-            diagnostics.append(diagnostic)
-            logger.warning("%s", diagnostic)
+            conflicts.append(conflict)
+            logger.warning("%s", conflict)
             user_id = None
         else:
             user_id = linked_user_id or mapped_user_id
-        records.append(
-            SlackIdentityRecord(
-                slack_user_id=slack_user_id,
-                display_name=_clean(link.get("display_name")) or slack_user_id,
-                user_id=user_id,
+        sources = frozenset(
+            source
+            for source, source_records in (
+                (SlackIdentitySource.LINK, identity_links),
+                (SlackIdentitySource.MAP, identity_map),
             )
+            if slack_user_id in source_records
         )
-    return SlackIdentityNormalization(
-        records=tuple(records),
-        diagnostics=tuple(diagnostics),
-    )
-
-
-def select_slack_identity_record(
-    records: tuple[SlackIdentityRecord, ...],
-    *,
-    configured_slack_id: str | None,
-    configured_user_id: str | None,
-    configured_name: str | None,
-    default_slack_user_id: str,
-    default_name: str,
-) -> SlackIdentityRecord:
-    """Select one whole record from configured and default identity candidates."""
-
-    by_slack_id = {record.slack_user_id: record for record in records}
-    if configured_slack_id:
-        return by_slack_id.get(configured_slack_id) or SlackIdentityRecord(
-            slack_user_id=configured_slack_id,
-            display_name=configured_name or configured_slack_id,
-            user_id=None,
+        records[slack_user_id] = SlackIdentityRecord(
+            slack_user_id=slack_user_id,
+            display_name=link_display_name or slack_user_id,
+            user_id=user_id,
+            sources=sources,
+            linked_user_id=linked_user_id,
+            mapped_user_id=mapped_user_id,
+            link_display_name=link_display_name,
+            link_metadata=as_mapping(link.get("metadata")),
+            map_metadata={
+                "team_id": slack_metadata.get("team_id"),
+                "bot_user_id": slack_metadata.get("bot_user_id"),
+            },
         )
-
-    if configured_user_id:
-        matched_user = next(
-            (
-                record
-                for record in records
-                if record.user_id == configured_user_id
-            ),
-            None,
-        )
-        if matched_user is not None:
-            return matched_user
-
-    default_name_match = next(
-        (
-            record
-            for record in records
-            if record.display_name.casefold() == default_name.casefold()
-        ),
-        None,
-    )
-    selected = default_name_match or by_slack_id.get(default_slack_user_id)
-    if selected is None:
-        selected = SlackIdentityRecord(
-            slack_user_id=default_slack_user_id,
-            display_name=default_name,
-            user_id=None,
-        )
-    elif (
-        selected.slack_user_id == default_slack_user_id
-        and selected.display_name == default_slack_user_id
-    ):
-        selected = SlackIdentityRecord(
-            slack_user_id=selected.slack_user_id,
-            display_name=default_name,
-            user_id=selected.user_id,
-        )
-    if configured_user_id:
-        return selected.without_user_id()
-    return selected
+    return records, tuple(conflicts)
 
 
 def _slack_metadata(connection: ExternalAgentConnectionRow) -> dict[str, Any]:
-    metadata = dict(connection.metadata_ or {})
-    slack_metadata = metadata.get("slack")
-    return dict(slack_metadata or {}) if isinstance(slack_metadata, Mapping) else {}
+    return as_mapping(as_mapping(connection.metadata_).get("slack"))
 
 
 async def _connection_for_org(session, connection_id: str, org_id: str | None) -> ExternalAgentConnectionRow:
@@ -247,6 +169,8 @@ async def link_slack_identity(
     org_id: str | None = None,
     display_name: str | None = None,
     communication_preferences: Mapping[str, Any] | None = None,
+    link_metadata: Mapping[str, Any] | None = None,
+    replace_profile: bool = False,
 ) -> dict[str, str]:
     """Link a Slack user id to an Illospace user id for one Slack connection."""
 
@@ -272,18 +196,29 @@ async def link_slack_identity(
     slack_links = dict(slack_links) if isinstance(slack_links, Mapping) else {}
     existing_link = slack_links.get(clean_slack_user_id)
     existing_link = dict(existing_link) if isinstance(existing_link, Mapping) else {}
-    if _clean(existing_link.get("user_id")) != clean_user_id:
+    if (
+        replace_profile
+        or _clean(existing_link.get("user_id")) != clean_user_id
+    ):
         existing_link = {}
     existing_metadata = existing_link.get("metadata")
-    link_metadata = dict(existing_metadata) if isinstance(existing_metadata, Mapping) else {}
+    normalized_link_metadata = (
+        as_mapping(link_metadata)
+        if link_metadata is not None
+        else as_mapping(existing_metadata)
+    )
     if communication_preferences is not None:
-        link_metadata["communication_preferences"] = normalize_communication_preferences(
-            communication_preferences
+        normalized_link_metadata["communication_preferences"] = (
+            normalize_communication_preferences(communication_preferences)
         )
     slack_links[clean_slack_user_id] = {
         "user_id": clean_user_id,
-        "display_name": _clean(display_name) or existing_link.get("display_name") or None,
-        "metadata": link_metadata,
+        "display_name": (
+            _clean(display_name)
+            or existing_link.get("display_name")
+            or None
+        ),
+        "metadata": normalized_link_metadata,
     }
     identity_links["slack"] = slack_links
     root["identity_links"] = identity_links
@@ -334,12 +269,12 @@ async def list_slack_identity_mappings(
     org_id: str | None = None,
 ) -> list[dict[str, str | None]]:
     connection = await _connection_for_org(session, connection_id, org_id)
-    normalization = normalize_slack_identities(connection.metadata_ or {})
-    if not normalization.records:
+    records, _conflicts = normalize_slack_identities(connection.metadata_ or {})
+    if not records:
         return []
     user_ids = [
         record.user_id
-        for record in normalization.records
+        for record in records.values()
         if record.user_id is not None
     ]
     users = {}
@@ -362,19 +297,20 @@ async def list_slack_identity_mappings(
             "user_name": getattr(users.get(str(record.user_id)), "name", None),
         }
         for record in sorted(
-            normalization.records,
+            # Operators must see unresolved and conflicted pairs to repair them.
+            records.values(),
             key=lambda value: value.slack_user_id,
         )
     ]
 
 
 __all__ = [
-    "SlackIdentityNormalization",
+    "SlackIdentityConflict",
     "SlackIdentityMappingError",
     "SlackIdentityRecord",
+    "SlackIdentitySource",
     "link_slack_identity",
     "list_slack_identity_mappings",
     "normalize_slack_identities",
-    "select_slack_identity_record",
     "unlink_slack_identity",
 ]

--- a/brain/systems/slack/identity.py
+++ b/brain/systems/slack/identity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import logging
 from typing import Any, Mapping
 
 from sqlalchemy import select
@@ -11,12 +13,212 @@ from brain.platform.db.models.org import User
 from brain.systems.personality.person_context import normalize_communication_preferences
 
 
+logger = logging.getLogger(__name__)
+
+
 class SlackIdentityMappingError(ValueError):
-    """Raised when a Slack identity mapping cannot be applied."""
+    """A typed Slack identity mapping failure or non-raising diagnostic."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "mapping_error",
+        slack_user_id: str | None = None,
+        linked_user_id: str | None = None,
+        mapped_user_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.slack_user_id = slack_user_id
+        self.linked_user_id = linked_user_id
+        self.mapped_user_id = mapped_user_id
+
+    @classmethod
+    def conflicting_user_ids(
+        cls,
+        *,
+        slack_user_id: str,
+        linked_user_id: str,
+        mapped_user_id: str,
+    ) -> SlackIdentityMappingError:
+        return cls(
+            (
+                f"Conflicting Slack identity for {slack_user_id}: linked user_id "
+                f"{linked_user_id} disagrees with mapped user_id {mapped_user_id}; "
+                "omitting user_id"
+            ),
+            code="linked_mapped_user_id_conflict",
+            slack_user_id=slack_user_id,
+            linked_user_id=linked_user_id,
+            mapped_user_id=mapped_user_id,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SlackIdentityRecord:
+    """One Slack identity whose attributes cannot be combined across people."""
+
+    slack_user_id: str
+    display_name: str
+    user_id: str | None
+
+    def without_user_id(self) -> SlackIdentityRecord:
+        return SlackIdentityRecord(
+            slack_user_id=self.slack_user_id,
+            display_name=self.display_name,
+            user_id=None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SlackIdentityNormalization:
+    """Canonical Slack records plus diagnostics that were safe to recover from."""
+
+    records: tuple[SlackIdentityRecord, ...]
+    diagnostics: tuple[SlackIdentityMappingError, ...]
+
+    def record_for_slack_user_id(
+        self,
+        slack_user_id: str,
+    ) -> SlackIdentityRecord | None:
+        clean_slack_user_id = _clean(slack_user_id)
+        return next(
+            (
+                record
+                for record in self.records
+                if record.slack_user_id == clean_slack_user_id
+            ),
+            None,
+        )
 
 
 def _clean(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def normalize_slack_identities(
+    metadata: Mapping[str, Any],
+) -> SlackIdentityNormalization:
+    """Reconcile both Slack identity stores without ever splicing identities.
+
+    Source precedence is explicit. ``identity_links.slack`` supplies display
+    names. For ``user_id``, a populated value from whichever store has one is
+    used; matching values collapse to one record. If both stores have populated
+    values and they disagree, neither takes precedence: the record gets
+    ``user_id=None`` and a :class:`SlackIdentityMappingError` diagnostic is
+    returned and logged, never raised. Linked records precede map-only records.
+    """
+
+    metadata = _mapping(metadata)
+    slack_metadata = _mapping(metadata.get("slack"))
+    identity_map = {
+        _clean(slack_user_id): user_id
+        for slack_user_id, user_id in _mapping(
+            slack_metadata.get("identity_map")
+        ).items()
+        if _clean(slack_user_id)
+    }
+    identity_links = {
+        _clean(slack_user_id): link
+        for slack_user_id, link in _mapping(
+            _mapping(metadata.get("identity_links")).get("slack")
+        ).items()
+        if _clean(slack_user_id)
+    }
+    slack_user_ids = dict.fromkeys([*identity_links, *identity_map])
+    records: list[SlackIdentityRecord] = []
+    diagnostics: list[SlackIdentityMappingError] = []
+    for slack_user_id in slack_user_ids:
+        link = _mapping(identity_links.get(slack_user_id))
+        linked_user_id = _clean(link.get("user_id")) or None
+        mapped_user_id = _clean(identity_map.get(slack_user_id)) or None
+        if linked_user_id and mapped_user_id and linked_user_id != mapped_user_id:
+            diagnostic = SlackIdentityMappingError.conflicting_user_ids(
+                slack_user_id=slack_user_id,
+                linked_user_id=linked_user_id,
+                mapped_user_id=mapped_user_id,
+            )
+            diagnostics.append(diagnostic)
+            logger.warning("%s", diagnostic)
+            user_id = None
+        else:
+            user_id = linked_user_id or mapped_user_id
+        records.append(
+            SlackIdentityRecord(
+                slack_user_id=slack_user_id,
+                display_name=_clean(link.get("display_name")) or slack_user_id,
+                user_id=user_id,
+            )
+        )
+    return SlackIdentityNormalization(
+        records=tuple(records),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def select_slack_identity_record(
+    records: tuple[SlackIdentityRecord, ...],
+    *,
+    configured_slack_id: str | None,
+    configured_user_id: str | None,
+    configured_name: str | None,
+    default_slack_user_id: str,
+    default_name: str,
+) -> SlackIdentityRecord:
+    """Select one whole record from configured and default identity candidates."""
+
+    by_slack_id = {record.slack_user_id: record for record in records}
+    if configured_slack_id:
+        return by_slack_id.get(configured_slack_id) or SlackIdentityRecord(
+            slack_user_id=configured_slack_id,
+            display_name=configured_name or configured_slack_id,
+            user_id=None,
+        )
+
+    if configured_user_id:
+        matched_user = next(
+            (
+                record
+                for record in records
+                if record.user_id == configured_user_id
+            ),
+            None,
+        )
+        if matched_user is not None:
+            return matched_user
+
+    default_name_match = next(
+        (
+            record
+            for record in records
+            if record.display_name.casefold() == default_name.casefold()
+        ),
+        None,
+    )
+    selected = default_name_match or by_slack_id.get(default_slack_user_id)
+    if selected is None:
+        selected = SlackIdentityRecord(
+            slack_user_id=default_slack_user_id,
+            display_name=default_name,
+            user_id=None,
+        )
+    elif (
+        selected.slack_user_id == default_slack_user_id
+        and selected.display_name == default_slack_user_id
+    ):
+        selected = SlackIdentityRecord(
+            slack_user_id=selected.slack_user_id,
+            display_name=default_name,
+            user_id=selected.user_id,
+        )
+    if configured_user_id:
+        return selected.without_user_id()
+    return selected
 
 
 def _slack_metadata(connection: ExternalAgentConnectionRow) -> dict[str, Any]:
@@ -132,34 +334,47 @@ async def list_slack_identity_mappings(
     org_id: str | None = None,
 ) -> list[dict[str, str | None]]:
     connection = await _connection_for_org(session, connection_id, org_id)
-    identity_map = dict(_slack_metadata(connection).get("identity_map") or {})
-    if not identity_map:
+    normalization = normalize_slack_identities(connection.metadata_ or {})
+    if not normalization.records:
         return []
-    user_ids = [str(user_id) for user_id in identity_map.values()]
-    users = {
-        str(user.id): user
-        for user in (
-            await session.scalars(
-                select(User).where(
-                    User.org_id == str(connection.org_id),
-                    User.id.in_(user_ids),
+    user_ids = [
+        record.user_id
+        for record in normalization.records
+        if record.user_id is not None
+    ]
+    users = {}
+    if user_ids:
+        users = {
+            str(user.id): user
+            for user in (
+                await session.scalars(
+                    select(User).where(
+                        User.org_id == str(connection.org_id),
+                        User.id.in_(user_ids),
+                    )
                 )
-            )
-        ).all()
-    }
+            ).all()
+        }
     return [
         {
-            "slack_user_id": str(slack_user_id),
-            "user_id": str(user_id),
-            "user_name": getattr(users.get(str(user_id)), "name", None),
+            "slack_user_id": record.slack_user_id,
+            "user_id": record.user_id,
+            "user_name": getattr(users.get(str(record.user_id)), "name", None),
         }
-        for slack_user_id, user_id in sorted(identity_map.items())
+        for record in sorted(
+            normalization.records,
+            key=lambda value: value.slack_user_id,
+        )
     ]
 
 
 __all__ = [
+    "SlackIdentityNormalization",
     "SlackIdentityMappingError",
+    "SlackIdentityRecord",
     "link_slack_identity",
     "list_slack_identity_mappings",
+    "normalize_slack_identities",
+    "select_slack_identity_record",
     "unlink_slack_identity",
 ]

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -26,6 +26,7 @@ from brain.systems.slack.chantier_declare import (
     apply_chantier_declare_run_contract,
     maybe_declare_chantier_from_slack,
 )
+from brain.systems.slack.identity import normalize_slack_identities
 from brain.systems.slack.triggers import (
     SLACK_MESSAGE_ENVELOPE_KIND,
     build_slack_work_intake_payload,
@@ -180,21 +181,20 @@ async def _slack_run_identity(
         connection = await session.get(ExternalAgentConnectionRow, context.connection_id)
         if connection is not None:
             metadata = dict(connection.metadata_ or {})
-            slack_metadata = metadata.get("slack")
-            if isinstance(slack_metadata, Mapping):
-                identity_map = slack_metadata.get("identity_map")
-                if isinstance(identity_map, Mapping):
-                    mapped_user_id = optional_text(identity_map.get(slack_user_id))
-                    if mapped_user_id:
-                        user = await session.get(User, mapped_user_id)
-                        if user is not None and str(user.org_id) == str(context.org_id):
-                            person_context = _linked_slack_person_context(
-                                metadata,
-                                slack_user_id=slack_user_id,
-                                mapped_user_id=mapped_user_id,
-                                channel_type=payload.get("channel_type"),
-                            )
-                            return mapped_user_id, person_context
+            record = normalize_slack_identities(
+                metadata
+            ).record_for_slack_user_id(slack_user_id)
+            mapped_user_id = record.user_id if record is not None else None
+            if mapped_user_id:
+                user = await session.get(User, mapped_user_id)
+                if user is not None and str(user.org_id) == str(context.org_id):
+                    person_context = _linked_slack_person_context(
+                        metadata,
+                        slack_user_id=slack_user_id,
+                        mapped_user_id=mapped_user_id,
+                        channel_type=payload.get("channel_type"),
+                    )
+                    return mapped_user_id, person_context
     return context.owner_user_id, None
 
 

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.kernel.common.coercion import optional_text
+from brain.kernel.common.coercion import as_mapping, optional_text
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.org import User
@@ -26,7 +26,11 @@ from brain.systems.slack.chantier_declare import (
     apply_chantier_declare_run_contract,
     maybe_declare_chantier_from_slack,
 )
-from brain.systems.slack.identity import normalize_slack_identities
+from brain.systems.slack.identity import (
+    SlackIdentityRecord,
+    SlackIdentitySource,
+    normalize_slack_identities,
+)
 from brain.systems.slack.triggers import (
     SLACK_MESSAGE_ENVELOPE_KIND,
     build_slack_work_intake_payload,
@@ -180,18 +184,16 @@ async def _slack_run_identity(
     if slack_user_id:
         connection = await session.get(ExternalAgentConnectionRow, context.connection_id)
         if connection is not None:
-            metadata = dict(connection.metadata_ or {})
-            record = normalize_slack_identities(
-                metadata
-            ).record_for_slack_user_id(slack_user_id)
+            records, _conflicts = normalize_slack_identities(
+                connection.metadata_ or {}
+            )
+            record = records.get(slack_user_id)
             mapped_user_id = record.user_id if record is not None else None
             if mapped_user_id:
                 user = await session.get(User, mapped_user_id)
                 if user is not None and str(user.org_id) == str(context.org_id):
                     person_context = _linked_slack_person_context(
-                        metadata,
-                        slack_user_id=slack_user_id,
-                        mapped_user_id=mapped_user_id,
+                        record,
                         channel_type=payload.get("channel_type"),
                     )
                     return mapped_user_id, person_context
@@ -199,45 +201,36 @@ async def _slack_run_identity(
 
 
 def _linked_slack_person_context(
-    connection_metadata: Mapping[str, Any],
+    record: SlackIdentityRecord,
     *,
-    slack_user_id: str,
-    mapped_user_id: str,
     channel_type: Any,
 ) -> dict[str, Any] | None:
-    """Read explicit Slack preferences only after authority mapping."""
+    """Use normalized Slack preferences only after authority reconciliation."""
 
-    identity_links = connection_metadata.get("identity_links")
-    if not isinstance(identity_links, Mapping):
-        return None
-    slack_links = identity_links.get("slack")
-    if not isinstance(slack_links, Mapping):
-        return None
-    raw_link = slack_links.get(slack_user_id)
-    if not isinstance(raw_link, Mapping):
-        return None
-    if optional_text(raw_link.get("user_id")) != mapped_user_id:
+    if (
+        SlackIdentitySource.LINK not in record.sources
+        or record.user_id is None
+        or record.linked_user_id != record.user_id
+    ):
         return None
 
-    link_metadata = raw_link.get("metadata")
-    link_metadata = dict(link_metadata) if isinstance(link_metadata, Mapping) else {}
-    raw_preferences = link_metadata.get("communication_preferences")
-    preferences = dict(raw_preferences) if isinstance(raw_preferences, Mapping) else {}
-    if str(channel_type or "").strip().lower() == "im":
-        address_as = optional_text(raw_link.get("display_name"))
-        if address_as:
-            preferences.setdefault("address_as", address_as)
+    preferences = as_mapping(
+        record.link_metadata.get("communication_preferences")
+    )
+    if (optional_text(channel_type) or "").lower() == "im":
+        if record.link_display_name:
+            preferences.setdefault("address_as", record.link_display_name)
     else:
         preferences.pop("address_as", None)
 
     person_context = normalize_person_context(
         {
             "mapping": "verified",
-            "user_id": mapped_user_id,
+            "user_id": record.user_id,
             "source": "slack_identity_link",
             "preferences": preferences,
         },
-        verified_user_id=mapped_user_id,
+        verified_user_id=record.user_id,
     )
     return person_context or None
 

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -331,7 +331,7 @@ def test_contact_form_owner_policy_warns_and_omits_conflicting_user_id(caplog):
 
     with caplog.at_level(
         "WARNING",
-        logger="brain.systems.slack.contact_form_lead_owner",
+        logger="brain.systems.slack.identity",
     ):
         owner = CONTACT_FORM_OWNER_POLICY.resolve(
             FakeSlackConnection(
@@ -640,6 +640,60 @@ async def test_contact_form_lead_gets_common_eyes_and_policy_enrichment(
         "/contact-form-lead-intake\n"
     )
     assert "Configured lead assessment." in work["payload"]["run_message"]
+
+
+@pytest.mark.asyncio
+async def test_contact_form_lead_intake_completes_with_conflicted_owner_identity(
+    monkeypatch,
+):
+    connector_module, reactions, submitted = patch_slack_connector(monkeypatch)
+    connection = FakeSlackConnection(
+        metadata={
+            "slack": {
+                "monitored_channels": ["C_ALERTS"],
+                "contact_form_lead_owner": {
+                    "slack_user_id": "UREDA",
+                },
+                "identity_map": {
+                    "UREDA": "user-mapped",
+                },
+            },
+            "identity_links": {
+                "slack": {
+                    "UREDA": {
+                        "user_id": "user-linked",
+                        "display_name": "Reda",
+                    }
+                }
+            },
+        }
+    )
+    config = connector_module.SlackConnectorConfig(
+        bot_token="xoxb-x",
+        app_token="xapp-x",
+        bot_user_id="BILLO",
+    )
+
+    result = await connector_module.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=socket_mode_channel_message(
+            user="",
+            bot_id="B_CONTACT_FORM",
+            app_id="A_CONTACT_FORM",
+            text=_contact_form_text(),
+        ),
+        config=config,
+    )
+
+    assert result["ignored"] is False
+    assert reactions == [("C_ALERTS", "1716900000.000200", "eyes")]
+    assert len(submitted) == 1
+    assert submitted[0]["payload"]["contact_form_lead"]["owner"] == {
+        "name": "Reda",
+        "slack_user_id": "UREDA",
+        "user_id": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack_identity.py
+++ b/tests/test_slack_identity.py
@@ -1,0 +1,82 @@
+"""Canonical Slack identity normalization contracts."""
+
+from __future__ import annotations
+
+
+def test_normalize_slack_identities_applies_documented_source_precedence():
+    from brain.systems.slack.identity import normalize_slack_identities
+
+    normalization = normalize_slack_identities(
+        {
+            "slack": {
+                "identity_map": {
+                    "UMAP": "user-map",
+                    "UMAPWITHLINK": "user-map-with-link",
+                    "UAGREE": "user-agree",
+                }
+            },
+            "identity_links": {
+                "slack": {
+                    "ULINK": {
+                        "user_id": "user-link",
+                        "display_name": "Linked only",
+                    },
+                    "UAGREE": {
+                        "user_id": "user-agree",
+                        "display_name": "Both agree",
+                    },
+                    "UMAPWITHLINK": {
+                        "user_id": " ",
+                        "display_name": "Linked display",
+                    },
+                }
+            },
+        }
+    )
+
+    assert normalization.diagnostics == ()
+    assert {
+        record.slack_user_id: (record.display_name, record.user_id)
+        for record in normalization.records
+    } == {
+        "ULINK": ("Linked only", "user-link"),
+        "UAGREE": ("Both agree", "user-agree"),
+        "UMAPWITHLINK": ("Linked display", "user-map-with-link"),
+        "UMAP": ("UMAP", "user-map"),
+    }
+
+
+def test_normalize_slack_identities_returns_typed_conflict_without_raising():
+    from brain.systems.slack.identity import (
+        SlackIdentityMappingError,
+        normalize_slack_identities,
+    )
+
+    normalization = normalize_slack_identities(
+        {
+            "slack": {
+                "identity_map": {
+                    "UCONFLICT": "user-mapped",
+                }
+            },
+            "identity_links": {
+                "slack": {
+                    "UCONFLICT": {
+                        "user_id": "user-linked",
+                        "display_name": "Conflicted",
+                    }
+                }
+            },
+        }
+    )
+
+    record = normalization.record_for_slack_user_id("UCONFLICT")
+    assert record is not None
+    assert record.user_id is None
+    assert len(normalization.diagnostics) == 1
+    diagnostic = normalization.diagnostics[0]
+    assert isinstance(diagnostic, SlackIdentityMappingError)
+    assert diagnostic.code == "linked_mapped_user_id_conflict"
+    assert diagnostic.slack_user_id == "UCONFLICT"
+    assert diagnostic.linked_user_id == "user-linked"
+    assert diagnostic.mapped_user_id == "user-mapped"

--- a/tests/test_slack_identity.py
+++ b/tests/test_slack_identity.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 
 def test_normalize_slack_identities_applies_documented_source_precedence():
-    from brain.systems.slack.identity import normalize_slack_identities
+    from brain.systems.slack.identity import (
+        SlackIdentitySource,
+        normalize_slack_identities,
+    )
 
-    normalization = normalize_slack_identities(
+    records, conflicts = normalize_slack_identities(
         {
             "slack": {
+                "team_id": "T123",
+                "bot_user_id": "B123",
                 "identity_map": {
                     "UMAP": "user-map",
                     "UMAPWITHLINK": "user-map-with-link",
@@ -24,6 +29,7 @@ def test_normalize_slack_identities_applies_documented_source_precedence():
                     "UAGREE": {
                         "user_id": "user-agree",
                         "display_name": "Both agree",
+                        "metadata": {"source": "manual"},
                     },
                     "UMAPWITHLINK": {
                         "user_id": " ",
@@ -34,25 +40,38 @@ def test_normalize_slack_identities_applies_documented_source_precedence():
         }
     )
 
-    assert normalization.diagnostics == ()
+    assert conflicts == ()
     assert {
         record.slack_user_id: (record.display_name, record.user_id)
-        for record in normalization.records
+        for record in records.values()
     } == {
         "ULINK": ("Linked only", "user-link"),
         "UAGREE": ("Both agree", "user-agree"),
         "UMAPWITHLINK": ("Linked display", "user-map-with-link"),
         "UMAP": ("UMAP", "user-map"),
     }
+    agreed = records["UAGREE"]
+    assert agreed.sources == {
+        SlackIdentitySource.LINK,
+        SlackIdentitySource.MAP,
+    }
+    assert agreed.linked_user_id == "user-agree"
+    assert agreed.mapped_user_id == "user-agree"
+    assert agreed.link_display_name == "Both agree"
+    assert agreed.link_metadata == {"source": "manual"}
+    assert agreed.map_metadata == {
+        "team_id": "T123",
+        "bot_user_id": "B123",
+    }
 
 
 def test_normalize_slack_identities_returns_typed_conflict_without_raising():
     from brain.systems.slack.identity import (
-        SlackIdentityMappingError,
+        SlackIdentityConflict,
         normalize_slack_identities,
     )
 
-    normalization = normalize_slack_identities(
+    records, conflicts = normalize_slack_identities(
         {
             "slack": {
                 "identity_map": {
@@ -70,13 +89,13 @@ def test_normalize_slack_identities_returns_typed_conflict_without_raising():
         }
     )
 
-    record = normalization.record_for_slack_user_id("UCONFLICT")
-    assert record is not None
+    record = records["UCONFLICT"]
     assert record.user_id is None
-    assert len(normalization.diagnostics) == 1
-    diagnostic = normalization.diagnostics[0]
-    assert isinstance(diagnostic, SlackIdentityMappingError)
-    assert diagnostic.code == "linked_mapped_user_id_conflict"
-    assert diagnostic.slack_user_id == "UCONFLICT"
-    assert diagnostic.linked_user_id == "user-linked"
-    assert diagnostic.mapped_user_id == "user-mapped"
+    assert len(conflicts) == 1
+    conflict = conflicts[0]
+    assert isinstance(conflict, SlackIdentityConflict)
+    assert not isinstance(conflict, Exception)
+    assert conflict.code == "linked_mapped_user_id_conflict"
+    assert conflict.slack_user_id == "UCONFLICT"
+    assert conflict.linked_user_id == "user-linked"
+    assert conflict.mapped_user_id == "user-mapped"

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -2276,6 +2276,63 @@ async def test_slack_identity_mapping_uses_linked_illospace_user_for_run(session
 
 
 @pytest.mark.asyncio
+async def test_slack_identity_conflict_does_not_authorize_either_user_for_run(
+    session,
+):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    connection = await _seed_slack_connection(session)
+    session.add(
+        User(
+            id=MAPPED_USER_ID,
+            org_id=ORG_ID,
+            name="Mapped user",
+            email="mapped@example.com",
+        )
+    )
+    session.add(
+        User(
+            id=OTHER_MAPPED_USER_ID,
+            org_id=ORG_ID,
+            name="Linked user",
+            email="linked@example.com",
+        )
+    )
+    connection.metadata_ = {
+        "slack": {
+            "team_id": "T789",
+            "bot_user_id": "BILLO",
+            "identity_map": {"U123": MAPPED_USER_ID},
+        },
+        "identity_links": {
+            "slack": {
+                "U123": {
+                    "user_id": OTHER_MAPPED_USER_ID,
+                    "display_name": "Conflicted user",
+                }
+            }
+        },
+    }
+    await session.flush()
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_app_mention(),
+        bot_user_id="BILLO",
+    )
+
+    await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=envelope,
+    )
+
+    run = (await session.scalars(select(AgentRunRow))).one()
+    assert run.user_id == USER_ID
+    assert "person_context" not in run.metadata_
+
+
+@pytest.mark.asyncio
 async def test_slack_identity_link_supplies_explicit_dm_communication_preferences(session):
     from brain.systems.inbound.service import submit_inbound_envelope
     from brain.systems.slack.ingress import normalize_slack_socket_event

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -2472,6 +2472,54 @@ async def test_slack_identity_mapping_service_links_user(session):
 
 
 @pytest.mark.asyncio
+async def test_list_slack_identity_mappings_keeps_conflicted_pair_for_operator(
+    session,
+):
+    """A conflict must stay visible at the surface an operator actually uses.
+
+    ``normalize_slack_identities`` resolves a linked-vs-mapped disagreement to
+    ``user_id=None`` so two identities can never be spliced. That is only
+    repairable if the unresolved pair still appears in the mapping listing the
+    Slack tool handler reads -- dropping it would hide the misconfiguration
+    rather than report it.
+    """
+
+    from brain.systems.slack.identity import list_slack_identity_mappings
+
+    connection = await _seed_slack_connection(session)
+    connection.metadata_ = {
+        "slack": {
+            "identity_map": {
+                "UCONFLICT": MAPPED_USER_ID,
+            }
+        },
+        "identity_links": {
+            "slack": {
+                "UCONFLICT": {
+                    "user_id": OTHER_MAPPED_USER_ID,
+                    "display_name": "Conflicted user",
+                }
+            }
+        },
+    }
+    await session.flush()
+
+    mappings = await list_slack_identity_mappings(
+        session,
+        connection_id=str(connection.id),
+        org_id=ORG_ID,
+    )
+
+    assert mappings == [
+        {
+            "slack_user_id": "UCONFLICT",
+            "user_id": None,
+            "user_name": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_slack_identity_relink_clears_previous_person_profile(session):
     from brain.systems.slack.identity import link_slack_identity
 

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -2394,8 +2394,14 @@ async def test_slack_identity_link_supplies_explicit_dm_communication_preference
 
 def test_slack_person_context_rejects_mismatched_identity_link_and_shared_address():
     from brain.systems.slack.inbound import _linked_slack_person_context
+    from brain.systems.slack.identity import normalize_slack_identities
 
     metadata = {
+        "slack": {
+            "identity_map": {
+                "U123": MAPPED_USER_ID,
+            }
+        },
         "identity_links": {
             "slack": {
                 "U123": {
@@ -2406,18 +2412,16 @@ def test_slack_person_context_rejects_mismatched_identity_link_and_shared_addres
             }
         }
     }
+    records, _conflicts = normalize_slack_identities(metadata)
     assert _linked_slack_person_context(
-        metadata,
-        slack_user_id="U123",
-        mapped_user_id=MAPPED_USER_ID,
+        records["U123"],
         channel_type="im",
     ) is None
 
     metadata["identity_links"]["slack"]["U123"]["user_id"] = MAPPED_USER_ID
+    records, _conflicts = normalize_slack_identities(metadata)
     person = _linked_slack_person_context(
-        metadata,
-        slack_user_id="U123",
-        mapped_user_id=MAPPED_USER_ID,
+        records["U123"],
         channel_type="channel",
     )
     assert person["preferences"] == {"tone": "warm"}


### PR DESCRIPTION
Closes #612.

PR #611 fixed a real identity-splicing bug — a Slack display name could be paired with
a different person's `user_id`. The fix was correct; its **placement** was not. It left
~100 lines of generic Slack identity logic inside `contact_form_lead_owner.py`, a
contact-form feature module, which grew 96 → 206 lines.

This moves the normalization to the module that already owns the concept.

## Why `identity.py` is the right owner

`identity.py`'s `link_slack_identity` is what **writes both stores** —
`metadata_["slack"]["identity_map"]` and `metadata_["identity_links"]["slack"]` — in a
single call. The module that establishes the invariant is the module that must own
reconciling it. Until now, the only complete reader lived in a feature policy.

## What changed (7 files, +631 / −267)

- `brain/systems/slack/identity.py` (+203) — `normalize_slack_identities()`, returning a
  `SlackIdentityNormalization` of whole records plus diagnostics. It normalizes; it does
  not choose. Selection is feature policy and stays out.
- `brain/systems/slack/contact_form_lead_owner.py` — **206 → 123 lines**. It is a feature
  policy again: read configured owner, select (`ContactFormOwnerPolicy._select_identity_record`,
  private), build one `ObligationAnswerer`. It defines no identity types and exports no
  compatibility shim.
- `brain/systems/slack/inbound.py`, `brain/app/api/routers/agent_mcp_identity.py` — the
  sweep found these were **already** resolving Slack→`user_id` independently. The ticket
  predicted "a second consumer will duplicate it"; there were three. All now route
  through the shared normalizer.

## Source precedence, now written down

`identity_links.slack` supplies display names. For `user_id`, a populated value from
whichever store has one wins; matching values collapse to one record. **If both stores
are populated and disagree, neither wins**: the record gets `user_id=None` and a
`SlackIdentityConflict` diagnostic is returned and logged — a plain frozen value type,
**never raised**.

`None` is the safe answer; it is exactly what prevents the splice #602 was filed for.

## The constraint that shaped this

A misconfigured identity pair must **never** drop a lead. So the typed diagnostic is a
returned value, not a new exception on the intake path. Verified: the only
`raise SlackIdentityMappingError` sites are the pre-existing ones on the *write* path
(`link_slack_identity` / `_connection_for_org`), untouched.

The conflict itself is carried by a plain `SlackIdentityConflict` value type, so no
exception type does double duty as a returned datum. (The first pass overloaded
`SlackIdentityMappingError` for both; the review caught it — see below.)

## A quality review sent this back once

A Codex maintainability review returned **three blocking findings**, all fixed here
before this left draft:

1. **The canonical record was lossy**, so the MCP route and `inbound.py` still reparsed
   both raw stores to rebuild provenance — the de-dup was half done. Records now carry
   source provenance and normalized link metadata, and consumers read only the record.
2. **`SlackIdentityMappingError` was playing two roles** — raised write-path exception
   *and* returned read-path datum. Now there is a plain `SlackIdentityConflict` value
   type; the error is raise-only again. A test pins it: `assert not isinstance(conflict,
   Exception)`.
3. **Contact-form policy had leaked into the generic module.** `select_slack_identity_record`
   encoded configured-owner precedence and default-name matching yet had one caller; it is
   private to `ContactFormOwnerPolicy` again.

I declined the review's remedy for (2) — it proposed deleting the diagnostics channel
outright, which would have traded a maintainability nit for an unmet acceptance criterion,
since #612 asks that a conflict be reportable rather than log-only.

## Verification

- Full suite **outside** the Codex sandbox: **4565 passed, 92 skipped, 0 failed**, on a
  tree merged with current `main`. Every count on the way reconciled exactly: 4560 after
  the first pass, 4561 with a restored test, 4565 after merging #616's four.
- `main` moved twice while this was in flight (#611, then #616). #616 touched **both**
  test files this branch edits, so the branch went from clean to conflicting mid-fix-pass.
  Resolved by keeping both sides' tests in full — neither was weakened.
- **#602's regression tests are byte-identical to `main`** (`git diff` on
  `tests/test_contact_form_lead_obligation.py` is empty). No test was bent to make the
  refactor pass — which is the check that matters for a "no user-visible change" claim.
- New coverage: the both-present-and-disagreeing case, in `tests/test_slack_identity.py`,
  `tests/test_slack_teammate.py` and `tests/test_contact_form_monitor.py`.
- No migration.
- Re-verified 2026-07-30 19:45Z against today's `main` (`26859554`, includes #618): this
  branch and the three other open drafts (#610, #614, #615) merge clean in one tree —
  **4587 passed / 0 failed / 92 skipped**.

## Reviewer notes

Two things I'd look at, independent of the automated review:

- **The fix pass deleted a test I put back.** It removed
  `test_list_slack_identity_mappings_keeps_conflicted_pair_for_operator` without
  mentioning it. The *behavior* survived — `list_slack_identity_mappings` still returns a
  conflicted pair with `user_id=None`, which is what lets an operator repair it via the
  Slack tool handler — but the only remaining coverage of that function was the happy
  path. Restored unchanged; it passes against the fix-pass code, so the deletion bought
  nothing.
- The conflict diagnostic is returned and logged, and reaches an operator through the
  mapping listing. There is no dedicated alerting surface for it; that's a follow-up if
  you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

