### PR TITLE
feat(briefing): retire Slack handoff briefs — the ticket IS the handoff

### DIFF
--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -16,13 +16,14 @@ Load-bearing stances:
 - **Noise gate.** ``create_launch_handoff_with_status`` reuse
   (``created=False``) means this content already went out — mint records
   NO Slack delivery on reuse. Re-triage of unchanged truth is silent.
-- **Post-commit delivery.** Mint never posts to Slack itself: the write
-  phase records a pending ``PacketBriefDelivery`` (one per handoff id)
-  inside its savepoint, and ``brain.systems.briefing.deliver`` posts it
-  strictly after the enclosing transaction commits — a rolled-back mint
-  leaves no Slack message, a crash-retry cannot double-post (the
-  deterministic ``packet-brief:<handoff_id>`` identity plus the
-  thread-read disambiguation own that).
+- **No Slack briefs (Reda, 2026-07-30).** The ticket IS the handoff, so
+  the live lanes record no ``PacketBriefDelivery`` — packets mint silently
+  and their launch URLs are reached from tickets and digests. The
+  ``deliver_to`` mechanism below survives for callers that still owe a
+  post (none today) and for draining legacy outbox rows via
+  ``brain.systems.briefing.deliver``; the post-commit outbox invariants it
+  enforces (rolled-back mint leaves no message, crash-retry cannot
+  double-post) still hold for those.
 - **Supersede, existing vocabulary only.** When the job's truth changes,
   the new revision is a NEW row (new idempotency key); the prior row —
   found via the idea's packet stamp — becomes ``archived`` +
@@ -60,18 +61,15 @@ from brain.systems.briefing.deliver import (
     DeliveryTarget,
     record_brief_delivery,
     refresh_pending_delivery_brief,
-    schedule_post_commit_delivery,
     transfer_pending_delivery,
 )
 from brain.systems.briefing.gather import (
-    PUBLIC_CHANNEL_TYPE,
     DefaultGithubReader,
     DefaultSlackReader,
     GithubReader,
     SlackReader,
     gather_pieces,
     load_inbound_event,
-    slack_provenance,
 )
 from brain.systems.inbound.attribution import durable_work_refs
 from brain.systems.launch_handoffs import (
@@ -594,25 +592,6 @@ def _record_job_ref(attribution: dict[str, Any] | None, idea: Any) -> str:
     return f"idea:{getattr(idea, 'id', '')}"
 
 
-def _delivery_target_for_event(event: Any) -> tuple[DeliveryTarget | None, str]:
-    """Origin-thread delivery target — same provenance and public-only
-    allowlist the deleted in-transaction post used, but resolved at MINT
-    time so the outbox row snapshots channel/thread_ts and delivery never
-    needs the event again. Returns (target, "") or (None, why)."""
-    provenance = slack_provenance(event) if event is not None else None
-    if not provenance:
-        return None, "no_slack_provenance"
-    if provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
-        return None, "non_public"
-    return DeliveryTarget(
-        channel=provenance["channel"],
-        thread_ts=provenance["thread_ts"],
-        # Crash disambiguation trusts only Illo-authored thread messages —
-        # the same identity gather's echo filter already keys on.
-        bot_user_id=str(provenance.get("bot_user_id") or "") or None,
-    ), ""
-
-
 async def _mint_for_idea_and_event(
     session: Any,
     *,
@@ -624,16 +603,19 @@ async def _mint_for_idea_and_event(
     job_ref: str | None = None,
 ) -> MintResult:
     """Shared stage for every inbound-completion lane once the job-home idea
-    is resolved: owner → target → mint → record-delivery-once. Raises upward;
-    the lane-facing wrappers own containment. The Slack reply itself is
-    post-commit: the savepoint records the obligation, the after-commit fast
-    path (or the notify-cycle sweep) sends it."""
+    is resolved: owner → target → mint. Raises upward; the lane-facing
+    wrappers own containment.
+
+    No Slack brief is recorded: the ticket IS the handoff (Reda,
+    2026-07-30 — "we don't need handoffs anymore, the tickets are enough").
+    Packets still mint so their launch URLs stay reachable from tickets and
+    digests; only the origin-thread "→ owner · Launch: …" post is retired.
+    """
     details = dict(getattr(idea, "agent_details", None) or {})
     assignment = dict(details.get("assignment") or {})
     owner_user_id = str(assignment.get("owner_id") or "") or None
     owner_label = await _owner_label(session, owner_user_id)
     target_tool = agent_target_for_member(owner_user_id, _member_targets())
-    deliver_to, delivery_skip = _delivery_target_for_event(event)
     actionable_lane = (
         dict(details.get("inbound_triage") or {}).get("reason")
         == "actionable_run_completion"
@@ -660,19 +642,9 @@ async def _mint_for_idea_and_event(
         source_ref=packet_source_ref,
         readers=readers,
         reader_user_id=str(getattr(event, "authority_user_id", "") or "") or None,
-        deliver_to=deliver_to,
     )
     if result.ok and result.created:
-        if deliver_to is None:
-            result.delivery = f"skipped:{delivery_skip}"
-        elif result.delivery == "recorded":
-            try:
-                schedule_post_commit_delivery(
-                    session, org_id=org_id, handoff_ids=[str(result.handoff.id)]
-                )
-            except Exception as exc:  # noqa: BLE001 — the sweep remains the guaranteed path
-                logger.warning("packet %s minted but fast-path dispatch failed to arm: %s",
-                               getattr(result.handoff, "id", "?"), exc)
+        result.delivery = "skipped:briefs_retired"
     return result
 
 

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -257,7 +257,7 @@ async def test_create_with_status_flags_created_vs_reused():
     assert str(again.id) == str(row.id)
 
 
-async def test_triage_mint_records_one_delivery_and_stamps_idea(posts):
+async def test_triage_mint_is_silent_and_stamps_idea(posts):
     idea = _idea()
     session = FakeSession(ideas=[idea], events=[_event()],
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
@@ -265,17 +265,15 @@ async def test_triage_mint_records_one_delivery_and_stamps_idea(posts):
         session, event=_event(), run_row=SimpleNamespace(id=1), attribution=None,
         readers=_readers(),
     )
-    assert result.ok and result.created and result.delivery == "recorded"
-    assert posts == []  # NOTHING goes to Slack inside the mint transaction
-    assert len(session.deliveries) == 1
-    delivery = session.deliveries[0]
-    assert delivery.state == "pending"
-    assert delivery.channel == "C0PROD" and delivery.thread_ts == "1751964840.0"
-    assert delivery.handoff_id == str(result.handoff.id)
-    assert delivery.idempotency_key == f"packet-brief:{result.handoff.id}"
-    assert "Launch: http" in delivery.brief
-    assert "→ Axel" in delivery.brief
-    assert str(result.handoff.id) in delivery.brief  # the crash-dedup marker
+    assert result.ok and result.created
+    # Briefs retired (Reda, 2026-07-30): the ticket IS the handoff, so the
+    # lanes owe NO Slack post and record NO delivery — the packet minting,
+    # stamping and launch URL are the whole contract.
+    assert result.delivery == "skipped:briefs_retired"
+    assert posts == []
+    assert session.deliveries == []
+    assert "Launch: http" in result.human_brief
+    assert "→ Axel" in result.human_brief
     stamp = idea.agent_details["packet"]
     assert stamp["handoff_id"] == str(result.handoff.id)
     assert stamp["owner_user_id"] == _OWNER
@@ -293,7 +291,7 @@ async def test_remint_of_unchanged_truth_is_silent(posts):
     assert first.created and second.ok and not second.created
     assert second.reason == "reused"
     assert second.delivery == "none"
-    assert len(session.deliveries) == 1  # the noise gate: one obligation, ever
+    assert session.deliveries == []  # briefs retired: no lane ever records one
     assert len(session.handoffs) == 1
     assert posts == []
 
@@ -308,20 +306,16 @@ async def test_changed_truth_supersedes_with_existing_vocabulary(posts):
     idea.title = "Maison L. melted hands — rerun requested"
     second = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=2), readers=_readers())
-    assert second.created and second.delivery == "recorded"
+    assert second.created and second.delivery == "skipped:briefs_retired"
     old = next(h for h in session.handoffs if str(h.id) == str(first.handoff.id))
     new = next(h for h in session.handoffs if str(h.id) == str(second.handoff.id))
     assert old.status == "archived"  # NEVER an invented status
     assert (old.metadata_ or {}).get("superseded_by") == str(new.id)
     assert (new.metadata_ or {}).get("supersedes") == str(old.id)
     assert idea.agent_details["packet"]["handoff_id"] == str(new.id)
-    # The undelivered first brief is retired by the transfer; the new mint's
-    # own obligation is the one that posts (a changed-truth re-mint owes a
-    # fresh reply — the old brief would have posted a dead launch link).
-    by_handoff = {str(d.handoff_id): d for d in session.deliveries}
-    assert by_handoff[str(old.id)].state == "superseded"
-    assert by_handoff[str(new.id)].state == "pending"
-    assert str(new.id) in by_handoff[str(new.id)].brief
+    # Briefs retired: neither mint records an obligation, and the supersede
+    # transfer finds nothing pending to carry.
+    assert session.deliveries == []
     assert posts == []
 
 
@@ -354,7 +348,9 @@ async def test_non_public_provenance_mints_but_never_records_delivery(posts):
         readers=_readers(),
     )
     assert result.ok and result.created
-    assert result.delivery == "skipped:non_public"
+    # With briefs retired the provenance never matters — every lane mint is
+    # silent, public channel or not.
+    assert result.delivery == "skipped:briefs_retired"
     assert session.deliveries == []  # nothing owed, ever — not even later
     assert posts == []
     assert len(session.handoffs) == 1  # the packet still exists for the digest
@@ -429,15 +425,14 @@ async def test_own_brief_in_thread_does_not_rotate_revision(posts):
     readers = Readers(slack=slack, github=NoGithub())
     first = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=readers)
-    assert first.created and len(session.deliveries) == 1
-    # Illo's brief (delivered post-commit) lands in the thread under the BOT
-    # user id from provenance.
+    assert first.created and session.deliveries == []
+    # A historical Illo brief (from the pre-retirement era) sitting in the
+    # thread under the BOT user id must still be echo-filtered.
     slack.extra.append({"ts": "1751964900.0", "user": "B0ILLO",
-                        "text": session.deliveries[0].brief})
+                        "text": first.human_brief})
     second = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=2), readers=readers)
     assert not second.created  # bot message filtered → same dossier → same key
-    assert len(session.deliveries) == 1  # no echo re-record
     assert len(session.handoffs) == 1
 
 
@@ -451,7 +446,7 @@ async def test_integrity_race_reselects_as_reused_and_stamps(posts):
                                  users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
     first = await mint_packet_after_triage(
         winner_session, event=_event(), run_row=SimpleNamespace(id=1), readers=_readers())
-    assert first.created and len(winner_session.deliveries) == 1
+    assert first.created and winner_session.deliveries == []
 
     # The loser: same content, but its insert flush raises IntegrityError.
     idea.agent_details = {**idea.agent_details}
@@ -501,6 +496,21 @@ def _clean_readers():
     return Readers(slack=FakeSlackReader(), github=CleanGithub())
 
 
+async def _seed_legacy_brief(session, handoff, brief: str):
+    """Record a pre-retirement pending brief the way the lanes used to.
+
+    The live lanes record no deliveries anymore; these rows exist only as
+    legacy outbox state whose drain/transfer semantics must keep holding."""
+    from brain.systems.briefing.deliver import DeliveryTarget, record_brief_delivery
+
+    await record_brief_delivery(
+        session, org_id=_ORG, handoff_id=str(handoff.id),
+        target=DeliveryTarget(channel="C0PROD", thread_ts="1751964840.0",
+                              bot_user_id="B0ILLO"),
+        brief=brief,
+    )
+
+
 async def test_refresh_unchanged_truth_is_silent_reuse(posts):
     from brain.systems.briefing.mint import refresh_packet_for_job
 
@@ -509,11 +519,12 @@ async def test_refresh_unchanged_truth_is_silent_reuse(posts):
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
     first = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=_clean_readers())
+    await _seed_legacy_brief(session, first.handoff, first.human_brief)
     result = await refresh_packet_for_job(
         session, org_id=_ORG, handoff_row=first.handoff, readers=_clean_readers())
     assert result.ok and not result.created
     assert result.delivery == "none"  # refresh never records a new post
-    assert len(session.deliveries) == 1  # the original obligation, untouched
+    assert len(session.deliveries) == 1  # the legacy obligation, untouched
     assert session.deliveries[0].state == "pending"
     assert len(session.handoffs) == 1
     assert posts == []
@@ -540,10 +551,9 @@ async def test_refresh_skips_on_degraded_gather(posts):
 
 
 async def test_refresh_changed_truth_supersedes_and_carries_pending_brief(posts):
-    """Refresh never creates a NEW post — but a triage-moment brief that
-    never went out must follow the superseding row (fresh brief, fresh
-    launch URL), or the thread would either stay silent forever or later
-    get a dead link."""
+    """Refresh never creates a NEW post — but a LEGACY pre-retirement brief
+    that never went out must still follow the superseding row (fresh brief,
+    fresh launch URL), or the drain would later post a dead link."""
     from brain.systems.briefing.mint import refresh_packet_for_job
 
     idea = _idea()
@@ -551,6 +561,7 @@ async def test_refresh_changed_truth_supersedes_and_carries_pending_brief(posts)
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
     first = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=_clean_readers())
+    await _seed_legacy_brief(session, first.handoff, first.human_brief)
     idea.title = "Maison L. melted hands — rerun verified"
     result = await refresh_packet_for_job(
         session, org_id=_ORG, handoff_row=first.handoff, readers=_clean_readers())
@@ -578,6 +589,7 @@ async def test_refresh_supersede_of_posted_brief_carries_nothing(posts):
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
     first = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=_clean_readers())
+    await _seed_legacy_brief(session, first.handoff, first.human_brief)
     session.deliveries[0].state = "posted"  # the deliverer already sent it
     idea.title = "Maison L. melted hands — rerun verified"
     result = await refresh_packet_for_job(
@@ -657,7 +669,7 @@ def _hermetic_assignment_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
-async def test_actionable_run_mints_job_home_and_records_delivery(posts):
+async def test_actionable_run_mints_job_home_silently(posts):
     from brain.systems.briefing.mint import mint_packet_after_actionable_run
 
     session = FakeSession(events=[_actionable_event()])
@@ -666,7 +678,8 @@ async def test_actionable_run_mints_job_home_and_records_delivery(posts):
         attribution=_attribution(), readers=_readers(),
     )
 
-    assert result.ok and result.created and result.delivery == "recorded"
+    assert result.ok and result.created
+    assert result.delivery == "skipped:briefs_retired"
     assert len(session.handoffs) == 1
     row = session.handoffs[0]
     assert row.source_surface == "inbound_triage"
@@ -684,12 +697,9 @@ async def test_actionable_run_mints_job_home_and_records_delivery(posts):
     assert "uwear-ai/uwear-backend#616" in (idea.description or "")
     assert details["packet"]["handoff_id"] == str(row.id)  # stamped
 
-    assert posts == []  # post-commit delivery, never in-transaction
-    assert len(session.deliveries) == 1
-    assert session.deliveries[0].channel == "C0PROD"
-    assert session.deliveries[0].thread_ts == "1751964840.0"
-    assert session.deliveries[0].state == "pending"
-    brief = session.deliveries[0].brief
+    assert posts == []  # briefs retired: the ticket IS the handoff
+    assert session.deliveries == []
+    brief = result.human_brief  # still composed for tracker/digest surfaces
     assert "half the batch melted" in brief
     assert "Illo run" not in brief
     assert "task_domain:" not in brief
@@ -697,7 +707,7 @@ async def test_actionable_run_mints_job_home_and_records_delivery(posts):
     assert _RUN_USER not in brief
 
 
-async def test_actionable_run_with_existing_reply_records_compact_human_follow_up(posts):
+async def test_actionable_run_with_existing_reply_composes_compact_follow_up(posts):
     from brain.systems.briefing.mint import mint_packet_after_actionable_run
 
     issue_title = "[Prod][Batch] POST /batch exceeds 25s while inner task keeps running"
@@ -738,12 +748,16 @@ async def test_actionable_run_with_existing_reply_records_compact_human_follow_u
         readers=Readers(slack=RollbarThread(), github=FiledIssue()),
     )
 
-    assert result.ok and result.created and result.delivery == "recorded"
+    assert result.ok and result.created
+    assert result.delivery == "skipped:briefs_retired"
     assert result.handoff.title == issue_title
     assert issue_title in result.handoff.instructions
     assert raw_alert not in result.handoff.instructions
 
-    brief = session.deliveries[0].brief
+    # No Slack delivery exists anymore; the compact form survives only as
+    # the composed human_brief for tracker/digest surfaces.
+    assert session.deliveries == []
+    brief = result.human_brief
     assert brief == f"→ Axel · Launch: {result.launch_url}"
     assert "Illo run" not in brief
     assert "task_domain:" not in brief
@@ -790,7 +804,7 @@ async def test_actionable_run_mint_is_one_shot_per_event(posts):
     assert second.reason == "packet already minted for event"
     assert len(session.handoffs) == 1
     assert len(session._ideas) == 1
-    assert len(session.deliveries) == 1
+    assert session.deliveries == []
 
 
 async def test_actionable_run_non_public_provenance_never_records_delivery(posts):
@@ -802,7 +816,7 @@ async def test_actionable_run_non_public_provenance_never_records_delivery(posts
         attribution=_attribution(), readers=_readers(),
     )
     assert result.ok and result.created
-    assert result.delivery == "skipped:non_public"
+    assert result.delivery == "skipped:briefs_retired"
     assert len(session.handoffs) == 1  # persistence is never suppressed
     assert session.deliveries == []
     assert posts == []

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -255,7 +255,7 @@ async def _ideas(session) -> list[Idea]:
     return list((await session.scalars(select(Idea))).all())
 
 
-async def test_slack_filed_issue_mints_packet_and_records_delivery(session, posts, caplog):
+async def test_slack_filed_issue_mints_packet_silently(session, posts, caplog):
     event_id, run_id = await _seed_slack_lane(
         session, tool_results=[("create_github_issue", _ISSUE_RESULT),
                                ("post_slack_reply", _REPLY_RESULT)],
@@ -281,22 +281,16 @@ async def test_slack_filed_issue_mints_packet_and_records_delivery(session, post
     assert "uwear-ai/uwear-backend#616" in (idea.description or "")
     assert (row.metadata_ or {}).get("job_ref") == f"idea:{idea.id}"
 
-    # In-transaction: NO Slack post — the outbox row carries the obligation.
+    # Briefs retired: no Slack post, no outbox obligation — the ticket IS
+    # the handoff.
     assert posts == []
-    deliveries = await _deliveries(session)
-    assert len(deliveries) == 1
-    delivery = deliveries[0]
-    assert delivery.state == "pending"
-    assert delivery.handoff_id == str(row.id)
-    assert delivery.idempotency_key == f"packet-brief:{row.id}"
-    assert delivery.channel == "C0ALERTS" and delivery.thread_ts == "1752600000.0"
-    assert str(row.id) in delivery.brief  # launch URL = the crash-dedup marker
+    assert await _deliveries(session) == []
 
     mint_lines = [r for r in caplog.records if "packet mint:" in r.getMessage()]
     assert len(mint_lines) == 1
     assert "lane=slack_teammate_run" in mint_lines[0].getMessage()
     assert "ok=True" in mint_lines[0].getMessage()
-    assert "delivery=recorded" in mint_lines[0].getMessage()
+    assert "delivery=skipped:briefs_retired" in mint_lines[0].getMessage()
 
     # The admission receipt and event stay exactly as the slack lane wrote them.
     stored = (await session.scalars(select(InboundDecisionReceiptRow))).one()
@@ -306,26 +300,12 @@ async def test_slack_filed_issue_mints_packet_and_records_delivery(session, post
     assert event.status == "processed"
     assert "triage" not in dict(event.action_result or {})
 
-    # Post-commit: the deliverer sends exactly the recorded brief to the
-    # recorded target and marks the row posted.
-    summary = await deliver_pending_briefs(
-        org_id=_ORG, session_factory=_lease_factory(session)
-    )
-    assert summary["posted"] == 1
-    assert len(posts) == 1
-    assert posts[0]["channel"] == "C0ALERTS"
-    assert posts[0]["thread_ts"] == "1752600000.0"
-    assert posts[0]["text"] == delivery.brief
-    deliveries = await _deliveries(session)
-    assert deliveries[0].state == "posted"
-    assert deliveries[0].posted_at is not None
-
-    # A second pass finds nothing to do — crash-retry safe at the sweep level.
+    # The drain sweep still runs for legacy rows and finds nothing new.
     summary = await deliver_pending_briefs(
         org_id=_ORG, session_factory=_lease_factory(session)
     )
     assert summary["selected"] == 0
-    assert len(posts) == 1
+    assert posts == []
 
 
 async def test_slack_reply_only_run_skips_with_log_line(session, posts, caplog):
@@ -353,7 +333,7 @@ async def test_slack_lane_mint_is_one_shot(session, posts, caplog):
         await reconcile_inbound_triage_run(session, run_id)  # duplicate reconcile
 
     assert len(await _handoffs(session)) == 1
-    assert len(await _deliveries(session)) == 1  # one obligation, ever
+    assert await _deliveries(session) == []  # briefs retired: none, ever
     second = [r for r in caplog.records if "packet mint:" in r.getMessage()]
     assert len(second) == 1
     assert "reason=packet already minted for event" in second[0].getMessage()
@@ -615,8 +595,7 @@ async def test_triage_lane_still_mints_unconditionally(session, posts):
     assert len(rows) == 1
     assert rows[0].source_surface == "inbound_triage"
     assert posts == []
-    deliveries = await _deliveries(session)
-    assert len(deliveries) == 1 and deliveries[0].state == "pending"
+    assert await _deliveries(session) == []  # briefs retired
 
 
 async def test_submit_mint_failure_is_retried_by_next_poll(session, posts, monkeypatch):
@@ -674,12 +653,10 @@ async def test_submit_mint_failure_is_retried_by_next_poll(session, posts, monke
     assert ideas[0].agent_details["packet"]["handoff_id"] == str(rows[0].id)
 
 
-async def test_mint_arms_fast_path_that_fires_only_after_commit(session, posts, monkeypatch):
-    """The post-commit fast path: the mint arms a one-shot after-commit
-    dispatch; nothing runs before the enclosing transaction commits (the
-    whole point — no Slack side effect can precede the terminal-status
-    write), and the commit triggers a delivery targeted at the minted
-    handoff."""
+async def test_mint_arms_no_fast_path_and_commit_dispatches_nothing(session, posts, monkeypatch):
+    """Briefs retired (Reda, 2026-07-30): the mint no longer arms the
+    after-commit dispatch, so committing the reconcile transaction must
+    trigger NO delivery attempt — the ticket is the handoff."""
     import asyncio
 
     import brain.systems.briefing.deliver as deliver_module
@@ -697,22 +674,10 @@ async def test_mint_arms_fast_path_that_fires_only_after_commit(session, posts, 
     )
     await reconcile_inbound_triage_run(session, run_id)
     rows = await _handoffs(session)
-    assert len(rows) == 1
-
-    await asyncio.sleep(0)
-    assert dispatched == []  # armed, not fired: the transaction is still open
+    assert len(rows) == 1  # the packet still mints
 
     await session.commit()
-    for _ in range(5):  # after_commit → call_soon → task; give the loop a few turns
+    for _ in range(5):  # give after_commit → call_soon → task turns to fire
         await asyncio.sleep(0)
-        if dispatched:
-            break
-    assert len(dispatched) == 1
-    assert dispatched[0]["org_id"] == _ORG
-    assert dispatched[0]["handoff_ids"] == [str(rows[0].id)]
-
-    # once=True: a later commit must not re-dispatch
-    await session.commit()
-    for _ in range(5):
-        await asyncio.sleep(0)
-    assert len(dispatched) == 1
+    assert dispatched == []
+    assert posts == []


### PR DESCRIPTION
## Why

Reda, 2026-07-30: *"we don't need handoffs anymore, the tickets are enough."* The "→ owner · Launch: …" thread posts kept appearing (twice again on today's Rollbar #2328 alerts) because the packet-mint pipeline records a Slack brief delivery on every created mint — behavior no run or guidance can switch off.

## What

- The triage and actionable lanes no longer resolve a delivery target, record a `PacketBriefDelivery`, or arm the after-commit fast-path dispatch. Lane mints report `delivery=skipped:briefs_retired`.
- **Packets still mint silently** — stamping, supersede vocabulary, and launch URLs (reachable from tickets, digests, tracker) are unchanged. Only the origin-thread Slack post is retired.
- The `deliver_to` mechanism on `mint_packet_for_job` and the outbox drain sweep survive for legacy rows; prod currently has **zero pending** deliveries (61 posted, history only), so nothing will post after deploy.
- Tests updated to the new contract; the legacy transfer/drain paths keep coverage via directly-seeded pre-retirement rows.

## Tests

`test_briefing_mint.py`, `test_briefing_deliver.py`, `test_briefing_compose.py`, `test_inbound_reconciliation.py`, `test_inbound_attribution.py`, `test_change_notifications.py` — 135 passed locally.

## Follow-up (not this PR)

Once the retirement has soaked, the outbox subsystem (`deliver.py`, transfer/refresh hooks, sweep wiring) can be deleted outright — kept now so a rollback is a pure revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)