### PR TITLE
fix(inbound): fence same-signature alert admissions against duplicate triage

### DIFF
--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from fnmatch import fnmatchcase
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -24,6 +24,7 @@ from brain.platform.db.models.inbound import (
     InboundEventRow,
     InboundSourcePolicyRow,
 )
+from brain.platform.provider_alerts import parse_rollbar_alert
 from brain.systems.external_agents import service as external_agents
 from brain.systems.cortex.thread_links import thread_link_payload
 from brain.systems.inbound.handlers import (
@@ -43,6 +44,7 @@ from brain.systems.inbound.preservation import (
     submission_preservation_prompt_lines,
 )
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.slack.monitored_intakes import SLACK_CHANNEL_MESSAGE_ORIGIN
 from brain.systems.task_domain import classify_task_domain
 from brain.systems.user_domains.service import AsyncDomainService, DomainError, DomainNotFound
 
@@ -52,6 +54,8 @@ ACTION_DOMAIN_PROJECTION_UPSERT = "domain_projection.upsert"
 ACTION_ILO_REQUIRED = "ilo_required"
 SUBMISSION_ENVELOPE_KIND = "submission"
 ACTION_ILLO_SUBMIT_QUEUED = "illo.submit_queued"
+ACTION_ALERT_SIGNATURE_DEDUPLICATED = "alert_signature.deduplicated"
+ALERT_SIGNATURE_DEDUP_WINDOW = timedelta(minutes=60)
 
 DOMAIN_PROJECTION_ACTIONS = frozenset(
     {ACTION_DOMAIN_PROJECTION_UPSERT, "domain_projection", "create_domain_record"}
@@ -64,6 +68,8 @@ MAX_INBOUND_KIND_LENGTH = 40
 MAX_INBOUND_ORIGIN_LENGTH = 240
 MAX_TRIAGE_MESSAGE_CHARS = 8000
 MAX_TRIAGE_PAYLOAD_CHARS = 5000
+
+logger = logging.getLogger(__name__)
 
 
 class InboundValidationError(ValueError):
@@ -168,6 +174,14 @@ async def submit_inbound_envelope(
     context = await _resolve_connection_context(session, connection)
     _require_signal_scope(context)
     normalized = _normalize_envelope(envelope)
+    alert_signature = _alert_signature_from_envelope(normalized)
+    if alert_signature is not None:
+        normalized["alert_signature"] = alert_signature
+        await _acquire_alert_signature_lock(
+            session,
+            org_id=context.org_id,
+            alert_signature=alert_signature,
+        )
     existing = await _find_idempotent_event(session, context, normalized.get("idempotency_key"))
     if existing is not None:
         return _result_from_event(existing, idempotent_replay=True)
@@ -190,6 +204,52 @@ async def submit_inbound_envelope(
     event, idempotent_replay = await _store_inbound_event(session, context, event)
     if idempotent_replay:
         return _result_from_event(event, idempotent_replay=True)
+    if alert_signature is not None:
+        original_event = await _find_recent_alert_signature_event(
+            session,
+            org_id=context.org_id,
+            alert_signature=alert_signature,
+            exclude_event_id=str(event.id),
+        )
+        if original_event is not None:
+            original_event_id = str(
+                dict(original_event.action_result or {}).get("original_event_id")
+                or original_event.id
+            )
+            logger.info(
+                "inbound_alert_signature_deduplicated",
+                extra={
+                    "org_id": context.org_id,
+                    "alert_signature": alert_signature,
+                    "event_id": str(event.id),
+                    "original_event_id": original_event_id,
+                    "dedup_window_minutes": int(
+                        ALERT_SIGNATURE_DEDUP_WINDOW.total_seconds() // 60
+                    ),
+                },
+            )
+            return await _complete_event(
+                session,
+                event,
+                policy=None,
+                status=STATUS_PROCESSED,
+                action_type=ACTION_ALERT_SIGNATURE_DEDUPLICATED,
+                action_result={
+                    "reason": "alert_signature_deduplicated",
+                    "deduplicated": True,
+                    "alert_signature": alert_signature,
+                    "original_event_id": original_event_id,
+                },
+                confidence=1.0,
+                target={
+                    "kind": "inbound_event",
+                    "event_id": original_event_id,
+                },
+                tool_use={"type": ACTION_ALERT_SIGNATURE_DEDUPLICATED},
+                reasoning_summary=(
+                    "A recent monitored-channel event already admitted this provider alert."
+                ),
+            )
 
     policy: InboundSourcePolicyRow | None = None
     projection: InboundDomainProjectionRow | None = None
@@ -458,6 +518,48 @@ def _normalize_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _rollbar_alert_signature(text: str) -> str | None:
+    parsed = parse_rollbar_alert(text)
+    if parsed is None:
+        return None
+    return f"rollbar:{parsed.project}:{parsed.item_number}"
+
+
+# PostHog is intentionally absent until its Slack alerts expose a stable issue
+# identity. Add provider extractors here only when they can fail closed.
+ALERT_SIGNATURE_EXTRACTORS: tuple[Callable[[str], str | None], ...] = (
+    _rollbar_alert_signature,
+)
+
+
+def extract_alert_signature(text: str | None) -> str | None:
+    """Extract a high-confidence provider issue identity from alert text."""
+
+    if not text:
+        return None
+    for extractor in ALERT_SIGNATURE_EXTRACTORS:
+        try:
+            signature = extractor(str(text))
+        except Exception:  # noqa: BLE001 — a broken extractor must never block admission
+            logger.warning(
+                "alert signature extractor %s failed; skipping",
+                getattr(extractor, "__name__", extractor),
+                exc_info=True,
+            )
+            continue
+        if signature is not None:
+            return signature
+    return None
+
+
+def _alert_signature_from_envelope(envelope: Mapping[str, Any]) -> str | None:
+    if envelope.get("origin") != SLACK_CHANNEL_MESSAGE_ORIGIN:
+        return None
+    payload = envelope.get("payload")
+    text = payload.get("text") if isinstance(payload, Mapping) else None
+    return extract_alert_signature(optional_text(text) or optional_text(envelope.get("summary")))
+
+
 def _normalize_submission_fields(data: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
     message = optional_text(data.get("message")) or optional_text(payload.get("message"))
     source = data.get("source", payload.get("source", {}))
@@ -530,6 +632,52 @@ async def _store_inbound_event(
             return existing, True
         raise
     return event, False
+
+
+async def _acquire_alert_signature_lock(
+    session: Any,
+    *,
+    org_id: str,
+    alert_signature: str,
+) -> None:
+    """Postgres advisory xact lock keyed on (org, signature) — released at the
+    caller's commit/rollback. Non-postgres sessions (unit tests on sqlite,
+    fakes) skip it: the races it closes are cross-connection, which those
+    environments don't exercise."""
+    try:
+        dialect = getattr(getattr(session, "bind", None), "dialect", None)
+        if getattr(dialect, "name", "") != "postgresql":
+            return
+    except Exception:  # noqa: BLE001 — no bind info → assume no lock support
+        return
+    from sqlalchemy import text as sql_text
+
+    await session.execute(
+        sql_text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+        {"key": f"inbound-alert-signature:{org_id}:{alert_signature}"},
+    )
+
+
+async def _find_recent_alert_signature_event(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    alert_signature: str,
+    exclude_event_id: str,
+) -> InboundEventRow | None:
+    stmt = (
+        select(InboundEventRow)
+        .where(
+            InboundEventRow.org_id == str(org_id),
+            InboundEventRow.id != str(exclude_event_id),
+            InboundEventRow.created_at >= utcnow() - ALERT_SIGNATURE_DEDUP_WINDOW,
+            InboundEventRow.envelope["alert_signature"].as_string()
+            == alert_signature,
+        )
+        .order_by(InboundEventRow.created_at.asc(), InboundEventRow.id.asc())
+        .limit(1)
+    )
+    return (await session.scalars(stmt)).first()
 
 
 async def _process_registered_envelope(

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
@@ -52,6 +53,17 @@ USER_ID = "22222222-2222-4222-8222-222222222222"
 CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
 TOKEN_ID = "44444444-4444-4444-8444-444444444444"
 RAW_TOKEN = "illo_conn_test_webhook_token"
+ROLLBAR_ITEM_2328_URL = "https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2328"
+ROLLBAR_ITEM_2328_TENTH_ERROR = (
+    f"<{ROLLBAR_ITEM_2328_URL}|#2328 10th error: "
+    "ValidationError: 1 validation error for GenerationPlan\n"
+    "Value error, Generation clothing snapshot identity is inconsistent>"
+)
+ROLLBAR_ITEM_2328_RATE_ALERT = (
+    f"<{ROLLBAR_ITEM_2328_URL}|#2328 10 occurrences in 5 minutes: "
+    "ValidationError: 1 validation error for GenerationPlan\n"
+    "Value error, Generation clothing snapshot identity is inconsistent>"
+)
 
 
 def _patch_sqlite_for_pg_types():
@@ -206,6 +218,15 @@ async def _post_mcp_raw(session, *, headers: dict[str, str] | None = None, conte
         app.dependency_overrides.update(overrides)
 
 
+def _slack_channel_alert_envelope(text: str, *, idempotency_key: str) -> dict:
+    return {
+        "origin": "slack.channel_message",
+        "payload": {"text": text},
+        "summary": text,
+        "idempotency_key": idempotency_key,
+    }
+
+
 async def _assert_queued_triage(session, outcome: dict, *, reason: str) -> dict:
     assert outcome["reason"] == reason
     triage = outcome["triage"]
@@ -232,6 +253,156 @@ async def _assert_queued_triage(session, outcome: dict, *, reason: str) -> dict:
     assert run.metadata_["producer"] == "inbound"
     assert run.metadata_["inbound_event"]["event_id"] == triage["event_id"]
     return triage
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            ROLLBAR_ITEM_2328_URL,
+            "rollbar:Uwear-API:2328",
+        ),
+        (
+            ROLLBAR_ITEM_2328_TENTH_ERROR,
+            "rollbar:Uwear-API:2328",
+        ),
+        (
+            "https://app.posthog.com/project/1/alerts/2328",
+            None,
+        ),
+    ],
+)
+async def test_alert_signature_extraction_is_provider_specific(text, expected):
+    assert inbound.extract_alert_signature(text) == expected
+
+
+async def test_same_rollbar_signature_deduplicates_channel_triage_run(session, caplog):
+    principal = await _seed_connection(session)
+    caplog.set_level(logging.INFO, logger="brain.systems.inbound.service")
+
+    first = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=_slack_channel_alert_envelope(
+            ROLLBAR_ITEM_2328_TENTH_ERROR,
+            idempotency_key="slack:rollbar:2328:tenth",
+        ),
+    )
+    second = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=_slack_channel_alert_envelope(
+            ROLLBAR_ITEM_2328_RATE_ALERT,
+            idempotency_key="slack:rollbar:2328:rate",
+        ),
+    )
+
+    assert first["status"] == "review_required"
+    assert second["status"] == "processed"
+    assert second["ilo_outcome"] == {
+        "reason": "alert_signature_deduplicated",
+        "deduplicated": True,
+        "alert_signature": "rollbar:Uwear-API:2328",
+        "original_event_id": first["event_id"],
+    }
+    assert await session.scalar(select(func.count()).select_from(AgentRunRow)) == 1
+    assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 2
+    first_event = await session.get(InboundEventRow, first["event_id"])
+    second_event = await session.get(InboundEventRow, second["event_id"])
+    assert first_event is not None
+    assert second_event is not None
+    assert first_event.envelope["alert_signature"] == "rollbar:Uwear-API:2328"
+    assert second_event.envelope["alert_signature"] == "rollbar:Uwear-API:2328"
+    assert second_event.action_type == "alert_signature.deduplicated"
+    assert second_event.action_result["original_event_id"] == first["event_id"]
+    assert (
+        await session.scalar(select(func.count()).select_from(InboundDecisionReceiptRow))
+        == 2
+    )
+    dedup_logs = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "inbound_alert_signature_deduplicated"
+    ]
+    assert len(dedup_logs) == 1
+    assert dedup_logs[0].alert_signature == "rollbar:Uwear-API:2328"
+    assert dedup_logs[0].original_event_id == first["event_id"]
+
+
+async def test_different_rollbar_items_queue_distinct_triage_runs(session):
+    principal = await _seed_connection(session)
+    other_item = ROLLBAR_ITEM_2328_RATE_ALERT.replace(
+        "/2328|#2328",
+        "/2329|#2329",
+    )
+
+    for index, text in enumerate((ROLLBAR_ITEM_2328_TENTH_ERROR, other_item)):
+        await inbound.submit_inbound_envelope(
+            session,
+            connection=principal,
+            envelope=_slack_channel_alert_envelope(
+                text,
+                idempotency_key=f"slack:rollbar:different:{index}",
+            ),
+        )
+
+    assert await session.scalar(select(func.count()).select_from(AgentRunRow)) == 2
+
+
+async def test_rollbar_signature_outside_window_queues_new_triage_run(session):
+    principal = await _seed_connection(session)
+    first = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=_slack_channel_alert_envelope(
+            ROLLBAR_ITEM_2328_TENTH_ERROR,
+            idempotency_key="slack:rollbar:outside:first",
+        ),
+    )
+    first_event = await session.get(InboundEventRow, first["event_id"])
+    assert first_event is not None
+    first_event.created_at = (
+        inbound.utcnow()
+        - inbound.ALERT_SIGNATURE_DEDUP_WINDOW
+        - timedelta(seconds=1)
+    )
+    await session.flush()
+
+    second = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=_slack_channel_alert_envelope(
+            ROLLBAR_ITEM_2328_RATE_ALERT,
+            idempotency_key="slack:rollbar:outside:second",
+        ),
+    )
+
+    assert second["status"] == "review_required"
+    assert await session.scalar(select(func.count()).select_from(AgentRunRow)) == 2
+
+
+async def test_unsigned_channel_alerts_preserve_existing_triage_behavior(session):
+    principal = await _seed_connection(session)
+
+    for index, text in enumerate(
+        (
+            "Production error threshold reached.",
+            "Production error rate threshold reached.",
+        )
+    ):
+        await inbound.submit_inbound_envelope(
+            session,
+            connection=principal,
+            envelope=_slack_channel_alert_envelope(
+                text,
+                idempotency_key=f"slack:plain-alert:{index}",
+            ),
+        )
+
+    events = (await session.scalars(select(InboundEventRow))).all()
+    assert len(events) == 2
+    assert all("alert_signature" not in event.envelope for event in events)
+    assert await session.scalar(select(func.count()).select_from(AgentRunRow)) == 2
 
 
 async def _assert_queued_submission(session, outcome: dict) -> dict:


### PR DESCRIPTION
## Why

Live incident 2026-07-30: Rollbar posted two messages 95 seconds apart for the same prod issue ([#2328](https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2328) — `GenerationPlan` snapshot identity) — a "10th error" notice, then a rate alert. Each spawned its own monitored-channel triage run; both obeyed "search before filing", but both searched **before either ticket existed**, so duplicate issues were filed (uwear-backend #1479 + #1480; #1479 closed by hand). A mandate can't fix an admission race — the fence has to be code.

## What

- **Signature extraction, high-confidence only**: the existing platform Rollbar parser yields `rollbar:<project>:<item>`; an extractor registry leaves a seam for more providers. PostHog is deliberately absent until its alerts expose a stable issue identity — no fuzzy text hashing, since a false-positive dedup silently drops a real distinct alert.
- Signature is stamped into the inbound envelope at admission (JSONB, no migration).
- **Race fence**: check-then-admit is serialized with `pg_advisory_xact_lock` on (org, signature) — same pattern as the packet-mint event lock; skipped on non-postgres test dialects.
- **60-minute window** (module constant): a same-signature event completes as `alert_signature.deduplicated` pointing at the original event — no rival triage run, no rival ticket. Dedup chains collapse to the true original, and the window slides across an ongoing burst (one triage job per burst). The 👀 ack is untouched.
- A failing extractor is contained (logged, skipped) — it can never block admission.
- Only `slack.channel_message` intake is affected; typed intakes, mentions and DMs are untouched.

## Tests

Fixtures are the actual two Rollbar messages from the incident. Covered: same signature within window → one run + dedup record; distinct items → two runs; outside window → new run; unsigned messages unchanged; extraction unit cases (wrapped/unwrapped Slack links, non-Rollbar URL → None). `test_inbound_webhooks.py`, `test_slack_channel_monitor.py`, `test_inbound_reconciliation.py`, `test_contact_form_monitor.py` — 95 passed locally.

Implementation by Codex (gpt-5.6-sol) from a Claude spec; Claude director review added the extractor containment guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)