### PR TITLE
refactor(knowledge): derive the harvester's terminal run statuses from RunStatus (#621)

### DIFF
--- a/brain/systems/knowledge/recall_eval_harvester.py
+++ b/brain/systems/knowledge/recall_eval_harvester.py
@@ -23,7 +23,10 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.contracts.statuses import LEGACY_AGENT_RUN_STATUS_VALUES
+from brain.contracts.statuses import (
+    LEGACY_AGENT_RUN_STATUS_VALUES,
+    TERMINAL_RUN_STATUS_VALUES,
+)
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.knowledge import KnowledgeItem
 from brain.systems.knowledge.recall_eval import EvidencePointer
@@ -45,10 +48,7 @@ _QUESTION_PREFIXES = (
     "why ",
 )
 _TERMINAL_RUN_STATUSES = (
-    "completed",
-    "failed",
-    "canceled",
-    "expired",
+    *TERMINAL_RUN_STATUS_VALUES,
     *LEGACY_AGENT_RUN_STATUS_VALUES,
 )
 


### PR DESCRIPTION
Closes #621.

Last open acceptance item of #613. Two of the three hand-listed terminal run-status sets were fixed in #615; the third lived only on the then-unmerged #614 branch, so a worker cut from `main` could not reach it. Both merged an hour ago, so it is now debt on `main` — this removes it.

## The change (5 lines, one file)

`brain/systems/knowledge/recall_eval_harvester.py` — the four string literals become the canonical constant:

```python
_TERMINAL_RUN_STATUSES = (*TERMINAL_RUN_STATUS_VALUES, *LEGACY_AGENT_RUN_STATUS_VALUES)
```

**The legacy splat deliberately stays.** This harvester queries `AgentRunRow.status` directly, so it genuinely needs the historical DB spellings (`cancelled`, `error`, `blocked`) that the runtime state machine never produces. It is *not* meant to equal `TERMINAL_RUN_STATUS_VALUES`, and swapping the constant in alone would have been a behavior change.

## Verification

**Zero behavior change, proven rather than asserted.** Imported both the constant and the module and compared the resulting tuple:

```
('completed', 'failed', 'canceled', 'expired', 'cancelled', 'error', 'blocked')
```

— identical, member for member and in order, to the pre-fix literal tuple.

**Full suite, outside the Codex sandbox:** `4594 passed · 0 failed · 92 skipped · 79.2s`.

**Base is current:** cut from `main@2a2822fc` (includes #619 and #620, which merged mid-run). Neither touches `knowledge/` or `contracts/`.

## Acceptance checks you can run

1. `git grep -n "TERMINAL_RUN_STATUS_VALUES" brain/` — three consumers now (`_misc.py:926`, `runs/status.py`, this harvester); no hand-listed copy remains.
2. ```
   venv/bin/python -c "from brain.systems.knowledge.recall_eval_harvester import _TERMINAL_RUN_STATUSES as T; print(T)"
   ```
   must print the seven values above.
3. `venv/bin/python -m pytest tests/ -q` — green.

## Not in this PR

The code-quality review gate was **skipped deliberately**: the guardrail says not to burn the Codex window on trivial or no-op diffs, and this is five lines with a proven-identical result.

While verifying acceptance check 1 I found a related but **behavioral** problem and filed it rather than folding it in: **#622** — cycle-run finalization is gated by two more hand-listed status allowlists (`cycles/service.py:950`, `cortex/runner.py:785`) and `canceled` is in neither, so a canceled cycle-backed run appears to leave its `CycleRun` non-terminal forever. That one needs a product call on what `canceled` should mean, which is why it is not here.
