### PR TITLE
fix(cycles): settle a canceled run's CycleRun at cancel time (#622)

### DIFF
--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -27,12 +27,12 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.services.notifications import (
     async_build_notification_summary,
 )
-from brain.systems.runs.cortex import async_finalize_canceled_cycle_run_if_needed
 from brain.systems.runs.cortex.read_models import (
     public_failed_run_artifact,
     public_failure_for_run,
     run_stream_payload,
 )
+from brain.systems.runs.cycle_settlement import async_finalize_cycle_run_if_needed
 from brain.app.api.routers.cortex._helpers import (
     _infer_feedback_tags,
     _parse_message_type,
@@ -503,7 +503,7 @@ async def idea_cancel_all(idea_id: str, user: dict[str, Any] = Depends(get_curre
                 reason="canceled_for_thread",
             )
             if canceled.status == RunStatus.CANCELED:
-                await async_finalize_canceled_cycle_run_if_needed(int(row.id))
+                await async_finalize_cycle_run_if_needed(int(row.id), status="canceled")
             count += 1
     return {"ok": True, "canceled": count, "cancelled": count}
 

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -27,6 +27,7 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.services.notifications import (
     async_build_notification_summary,
 )
+from brain.systems.runs.cortex import async_finalize_canceled_cycle_run_if_needed
 from brain.systems.runs.cortex.read_models import (
     public_failed_run_artifact,
     public_failure_for_run,
@@ -496,7 +497,13 @@ async def idea_cancel_all(idea_id: str, user: dict[str, Any] = Depends(get_curre
                     root_run_id=row.root_run_id,
                 )
             )
-            await store.set_status(row.id, RunStatus.CANCELED, reason="canceled_for_thread")
+            canceled = await store.set_status(
+                row.id,
+                RunStatus.CANCELED,
+                reason="canceled_for_thread",
+            )
+            if canceled.status == RunStatus.CANCELED:
+                await async_finalize_canceled_cycle_run_if_needed(int(row.id))
             count += 1
     return {"ok": True, "canceled": count, "cancelled": count}
 

--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -16,7 +16,10 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.authorization import require_org_context
 from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
 from brain.app.api.routers.cortex._router import router
-from brain.systems.runs.cortex import queue_status_async
+from brain.systems.runs.cortex import (
+    async_finalize_canceled_cycle_run_if_needed,
+    queue_status_async,
+)
 from brain.systems.runs.cortex.permissions import RunReadScope, run_belongs_to_scope
 from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
 from brain.systems.runs.cortex.recording import (
@@ -89,6 +92,7 @@ async def _cancel_run_with_event(store: AsyncAgentRunStore, run_id: int, *, reas
     await store.append_event(
         run_event(int(run_id), "run.canceled", {"reason": reason}, root_run_id=row.root_run_id)
     )
+    await async_finalize_canceled_cycle_run_if_needed(int(run_id))
 
 
 async def _require_idea_for_run_history(session, idea_id: str, user: dict[str, Any]) -> None:

--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -16,10 +16,8 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.authorization import require_org_context
 from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
 from brain.app.api.routers.cortex._router import router
-from brain.systems.runs.cortex import (
-    async_finalize_canceled_cycle_run_if_needed,
-    queue_status_async,
-)
+from brain.systems.runs.cortex import queue_status_async
+from brain.systems.runs.cycle_settlement import async_finalize_cycle_run_if_needed
 from brain.systems.runs.cortex.permissions import RunReadScope, run_belongs_to_scope
 from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
 from brain.systems.runs.cortex.recording import (
@@ -92,7 +90,7 @@ async def _cancel_run_with_event(store: AsyncAgentRunStore, run_id: int, *, reas
     await store.append_event(
         run_event(int(run_id), "run.canceled", {"reason": reason}, root_run_id=row.root_run_id)
     )
-    await async_finalize_canceled_cycle_run_if_needed(int(run_id))
+    await async_finalize_cycle_run_if_needed(int(run_id), status="canceled")
 
 
 async def _require_idea_for_run_history(session, idea_id: str, user: dict[str, Any]) -> None:

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 
+from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
 )
@@ -87,17 +88,21 @@ TERMINAL_RUN_STATUSES = CYCLE_RUN_TERMINAL_STATUSES
 DEFAULT_STALE_CYCLE_RUN_SECONDS = 60
 DEFAULT_CYCLE_RUN_CATCHUP_WINDOW_SECONDS = 24 * 60 * 60
 _UWEAR_COORDINATOR_CYCLE_NAME = "Uwear Ticket Coordinator Check-ins"
+# User cancellations currently count toward the repeated-failure guard. The open
+# alternative is "skipped" with skip_reason="canceled", which the guard ignores.
+CANCELED_RUN_CYCLE_DISPOSITION = "failed"
 RUN_STATUS_TO_CYCLE_RUN_STATUS = {
     "completed": "completed",
     "failed": "failed",
     "error": "failed",
-    "canceled": "failed",
-    "cancelled": "failed",
+    "canceled": CANCELED_RUN_CYCLE_DISPOSITION,
+    "cancelled": CANCELED_RUN_CYCLE_DISPOSITION,
     "expired": "failed",
     "blocked": "failed",
 }
 
 __all__ = [
+    "CANCELED_RUN_CYCLE_DISPOSITION",
     "REUSABLE_THREAD_EXECUTION_MODE",
     "async_add_cycle_guidance",
     "async_add_cycle_output_target",
@@ -947,9 +952,21 @@ async def async_finalize_cycle_run_from_run(
     status: str,
     error: str | None = None,
 ) -> None:
-    if status not in {"completed", "failed", "expired"}:
+    if status not in TERMINAL_RUN_STATUS_VALUES:
         return
-    effective_status = "failed" if status == "expired" else status
+    effective_status = RUN_STATUS_TO_CYCLE_RUN_STATUS[status]
+    is_canceled = status == "canceled"
+    canceled_skip_reason = (
+        "canceled"
+        if is_canceled and effective_status == "skipped"
+        else None
+    )
+    if (
+        is_canceled
+        and effective_status == "failed"
+        and not str(error or "").strip()
+    ):
+        error = "Agent run was canceled"
     async with UnitOfWork() as uow:
         agent_run = await uow.session.get(AgentRun, run_id)
         metadata = agent_run.metadata_ if agent_run else None
@@ -963,15 +980,27 @@ async def async_finalize_cycle_run_from_run(
         if not run or not cycle or run.status in TERMINAL_RUN_STATUSES:
             return
         verdict = persisted_cycle_contract_verdict(run)
-        if effective_status == "completed" and verdict is None:
+        if (
+            not is_canceled
+            and effective_status == "completed"
+            and verdict is None
+        ):
             verdict = await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
-        elif effective_status == "failed" and verdict is None:
+        elif (
+            not is_canceled
+            and effective_status == "failed"
+            and verdict is None
+        ):
             verdict = await async_prepare_cycle_run_visible_finalization(
                 uow.session,
                 int(run_id),
                 provider_errors_only=True,
             )
-        if effective_status == "failed" and not str(error or "").strip():
+        if (
+            not is_canceled
+            and effective_status == "failed"
+            and not str(error or "").strip()
+        ):
             failure_event = (
                 await uow.session.scalars(
                     select(AgentRunEventRow)
@@ -993,16 +1022,21 @@ async def async_finalize_cycle_run_from_run(
                 or failure_payload.get("reason")
                 or ""
             ).strip() or None
-        final_status, final_error = cycle_finalization_status_from_verdict(
-            effective_status,
-            verdict=verdict,
-            error=error if effective_status == "failed" else None,
-        )
+        if is_canceled:
+            final_status = effective_status
+            final_error = error if effective_status == "failed" else None
+        else:
+            final_status, final_error = cycle_finalization_status_from_verdict(
+                effective_status,
+                verdict=verdict,
+                error=error if effective_status == "failed" else None,
+            )
         await _finalize_cycle_run(
             run,
             cycle,
             status=final_status,
             error=final_error,
+            skip_reason=canceled_skip_reason,
             session=uow.session,
         )
 

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -955,18 +955,6 @@ async def async_finalize_cycle_run_from_run(
     if status not in TERMINAL_RUN_STATUS_VALUES:
         return
     effective_status = RUN_STATUS_TO_CYCLE_RUN_STATUS[status]
-    is_canceled = status == "canceled"
-    canceled_skip_reason = (
-        "canceled"
-        if is_canceled and effective_status == "skipped"
-        else None
-    )
-    if (
-        is_canceled
-        and effective_status == "failed"
-        and not str(error or "").strip()
-    ):
-        error = "Agent run was canceled"
     async with UnitOfWork() as uow:
         agent_run = await uow.session.get(AgentRun, run_id)
         metadata = agent_run.metadata_ if agent_run else None
@@ -979,28 +967,28 @@ async def async_finalize_cycle_run_from_run(
         cycle = await uow.session.get(Cycle, run.cycle_id) if run else None
         if not run or not cycle or run.status in TERMINAL_RUN_STATUSES:
             return
+        if status == "canceled":
+            if effective_status == "failed" and not str(error or "").strip():
+                error = "Agent run was canceled"
+            await _finalize_cycle_run(
+                run,
+                cycle,
+                status=effective_status,
+                error=error if effective_status == "failed" else None,
+                skip_reason="canceled" if effective_status == "skipped" else None,
+                session=uow.session,
+            )
+            return
         verdict = persisted_cycle_contract_verdict(run)
-        if (
-            not is_canceled
-            and effective_status == "completed"
-            and verdict is None
-        ):
+        if effective_status == "completed" and verdict is None:
             verdict = await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
-        elif (
-            not is_canceled
-            and effective_status == "failed"
-            and verdict is None
-        ):
+        elif effective_status == "failed" and verdict is None:
             verdict = await async_prepare_cycle_run_visible_finalization(
                 uow.session,
                 int(run_id),
                 provider_errors_only=True,
             )
-        if (
-            not is_canceled
-            and effective_status == "failed"
-            and not str(error or "").strip()
-        ):
+        if effective_status == "failed" and not str(error or "").strip():
             failure_event = (
                 await uow.session.scalars(
                     select(AgentRunEventRow)
@@ -1022,21 +1010,16 @@ async def async_finalize_cycle_run_from_run(
                 or failure_payload.get("reason")
                 or ""
             ).strip() or None
-        if is_canceled:
-            final_status = effective_status
-            final_error = error if effective_status == "failed" else None
-        else:
-            final_status, final_error = cycle_finalization_status_from_verdict(
-                effective_status,
-                verdict=verdict,
-                error=error if effective_status == "failed" else None,
-            )
+        final_status, final_error = cycle_finalization_status_from_verdict(
+            effective_status,
+            verdict=verdict,
+            error=error if effective_status == "failed" else None,
+        )
         await _finalize_cycle_run(
             run,
             cycle,
             status=final_status,
             error=final_error,
-            skip_reason=canceled_skip_reason,
             session=uow.session,
         )
 

--- a/brain/systems/runs/cortex/__init__.py
+++ b/brain/systems/runs/cortex/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from brain.systems.runs.events import run_event
@@ -15,6 +16,7 @@ from brain.systems.runs.cortex.runner import (
 )
 
 UnitOfWork = None
+logger = logging.getLogger(__name__)
 
 
 def _unit_of_work_factory():
@@ -89,6 +91,20 @@ async def _get_adaptation_history(run_id: int, *, session=None) -> list[dict[str
         return await _read(session)
     async with _unit_of_work_factory()() as uow:
         return await _read(uow.session)
+
+
+async def async_finalize_canceled_cycle_run_if_needed(run_id: int) -> None:
+    try:
+        from brain.systems.cycles.service import async_finalize_cycle_run_from_run
+
+        await async_finalize_cycle_run_from_run(int(run_id), status="canceled")
+    except Exception:
+        logger.exception(
+            "cycle_run_settlement_failed",
+            extra={"run_id": run_id, "status": "canceled"},
+        )
+
+
 async def async_cancel_runs_for_idea(idea_id: str) -> int:
     from sqlalchemy import select
     from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
@@ -115,7 +131,13 @@ async def async_cancel_runs_for_idea(idea_id: str) -> int:
                     root_run_id=row.root_run_id,
                 )
             )
-            await store.set_status(row.id, RunStatus.CANCELED, reason="canceled_for_thread")
+            canceled = await store.set_status(
+                row.id,
+                RunStatus.CANCELED,
+                reason="canceled_for_thread",
+            )
+            if canceled.status == RunStatus.CANCELED:
+                await async_finalize_canceled_cycle_run_if_needed(int(row.id))
             count += 1
     return count
 
@@ -136,6 +158,7 @@ __all__ = [
     "_parse_skill_mentions",
     "_parse_skill_override",
     "_record_adaptation",
+    "async_finalize_canceled_cycle_run_if_needed",
     "cancel_idea_runs",
     "async_cancel_runs_for_idea",
     "async_idea_run_history",

--- a/brain/systems/runs/cortex/__init__.py
+++ b/brain/systems/runs/cortex/__init__.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+from brain.systems.runs.cycle_settlement import (
+    async_finalize_cycle_run_if_needed as _async_finalize_cycle_run_if_needed,
+)
 from brain.systems.runs.events import run_event
 from brain.systems.runs.skill_commands import iter_slash_skill_commands, parse_slash_skill_names
 from brain.systems.runs.cortex.runner import (
@@ -16,7 +18,6 @@ from brain.systems.runs.cortex.runner import (
 )
 
 UnitOfWork = None
-logger = logging.getLogger(__name__)
 
 
 def _unit_of_work_factory():
@@ -93,18 +94,6 @@ async def _get_adaptation_history(run_id: int, *, session=None) -> list[dict[str
         return await _read(uow.session)
 
 
-async def async_finalize_canceled_cycle_run_if_needed(run_id: int) -> None:
-    try:
-        from brain.systems.cycles.service import async_finalize_cycle_run_from_run
-
-        await async_finalize_cycle_run_from_run(int(run_id), status="canceled")
-    except Exception:
-        logger.exception(
-            "cycle_run_settlement_failed",
-            extra={"run_id": run_id, "status": "canceled"},
-        )
-
-
 async def async_cancel_runs_for_idea(idea_id: str) -> int:
     from sqlalchemy import select
     from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
@@ -137,7 +126,7 @@ async def async_cancel_runs_for_idea(idea_id: str) -> int:
                 reason="canceled_for_thread",
             )
             if canceled.status == RunStatus.CANCELED:
-                await async_finalize_canceled_cycle_run_if_needed(int(row.id))
+                await _async_finalize_cycle_run_if_needed(int(row.id), status="canceled")
             count += 1
     return count
 
@@ -158,7 +147,6 @@ __all__ = [
     "_parse_skill_mentions",
     "_parse_skill_override",
     "_record_adaptation",
-    "async_finalize_canceled_cycle_run_if_needed",
     "cancel_idea_runs",
     "async_cancel_runs_for_idea",
     "async_idea_run_history",

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -23,6 +23,7 @@ from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
 from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.cycle_settlement import async_finalize_cycle_run_if_needed
 from brain.systems.runs.evidence_health import (
     materialization_failures_for_worker,
     record_parent_evidence_failures,
@@ -785,12 +786,7 @@ async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict
 async def _finalize_cycle_run_if_needed_async(run_id: int, *, status: str, error: str | None = None) -> None:
     if status not in {"completed", "failed"}:
         return
-    try:
-        from brain.systems.cycles.service import async_finalize_cycle_run_from_run
-
-        await async_finalize_cycle_run_from_run(int(run_id), status=status, error=error)
-    except Exception:
-        logger.exception("cycle_run_settlement_failed", extra={"run_id": run_id, "status": status})
+    await async_finalize_cycle_run_if_needed(int(run_id), status=status, error=error)
 
 
 def _run_has_project_context(run: AgentRunRow | None) -> bool:

--- a/brain/systems/runs/cycle_settlement.py
+++ b/brain/systems/runs/cycle_settlement.py
@@ -1,0 +1,24 @@
+"""Best-effort settlement bridge from agent runs to cycle runs."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def async_finalize_cycle_run_if_needed(
+    run_id: int,
+    *,
+    status: str,
+    error: str | None = None,
+) -> None:
+    try:
+        from brain.systems.cycles.service import async_finalize_cycle_run_from_run
+
+        await async_finalize_cycle_run_from_run(int(run_id), status=status, error=error)
+    except Exception:
+        logger.exception(
+            "cycle_run_settlement_failed",
+            extra={"run_id": run_id, "status": status},
+        )

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -2330,14 +2330,14 @@ async def test_cancel_endpoint_helper_records_run_canceled_event(session_factory
     session = session_factory()
     store = AsyncAgentRunStore(session)
     run = await store.create_run(_run_request(thread_id="thread-1", message="cancel me"))
-    settled_run_ids = []
+    settled = []
 
-    async def capture_cycle_settlement(run_id: int):
-        settled_run_ids.append(run_id)
+    async def capture_cycle_settlement(run_id: int, *, status: str, error=None):
+        settled.append((run_id, status, error))
 
     monkeypatch.setattr(
         run_routes,
-        "async_finalize_canceled_cycle_run_if_needed",
+        "async_finalize_cycle_run_if_needed",
         capture_cycle_settlement,
     )
 
@@ -2356,7 +2356,7 @@ async def test_cancel_endpoint_helper_records_run_canceled_event(session_factory
     row = await session.get(AgentRunRow, run.id)
     assert row is not None
     assert row.status == RunStatus.CANCELED.value
-    assert settled_run_ids == [run.id]
+    assert settled == [(run.id, "canceled", None)]
     events = await _event_types(session, run.id)
     assert "run.canceled" in events
     assert events.count("run.canceled") == 1
@@ -2435,7 +2435,7 @@ async def test_cancel_all_route_settles_each_canceled_cycle_run(monkeypatch):
         SimpleNamespace(id=41, root_run_id=41),
         SimpleNamespace(id=42, root_run_id=42),
     ]
-    settled_run_ids = []
+    settled = []
 
     async def select_runs(_statement):
         return SimpleNamespace(all=lambda: rows)
@@ -2455,8 +2455,8 @@ async def test_cancel_all_route_settles_each_canceled_cycle_run(monkeypatch):
     async def allow_idea(*_args, **_kwargs):
         return None
 
-    async def capture_cycle_settlement(run_id):
-        settled_run_ids.append(run_id)
+    async def capture_cycle_settlement(run_id, *, status, error=None):
+        settled.append((run_id, status, error))
 
     monkeypatch.setattr(
         idea_routes,
@@ -2467,14 +2467,14 @@ async def test_cancel_all_route_settles_each_canceled_cycle_run(monkeypatch):
     monkeypatch.setattr(idea_routes, "AsyncAgentRunStore", lambda _session: _Store())
     monkeypatch.setattr(
         idea_routes,
-        "async_finalize_canceled_cycle_run_if_needed",
+        "async_finalize_cycle_run_if_needed",
         capture_cycle_settlement,
     )
 
     result = await idea_routes.idea_cancel_all("idea-1", {"id": "user-1"})
 
     assert result == {"ok": True, "canceled": 2, "cancelled": 2}
-    assert settled_run_ids == [41, 42]
+    assert settled == [(41, "canceled", None), (42, "canceled", None)]
 
 
 async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned_runs(session_factory):

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -2324,12 +2324,22 @@ async def test_auto_commit_store_finishes_event_transactions(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_cancel_endpoint_helper_records_run_canceled_event(session_factory):
-    from brain.app.api.routers.cortex._run import _cancel_run_with_event
+async def test_cancel_endpoint_helper_records_run_canceled_event(session_factory, monkeypatch):
+    from brain.app.api.routers.cortex import _run as run_routes
 
     session = session_factory()
     store = AsyncAgentRunStore(session)
     run = await store.create_run(_run_request(thread_id="thread-1", message="cancel me"))
+    settled_run_ids = []
+
+    async def capture_cycle_settlement(run_id: int):
+        settled_run_ids.append(run_id)
+
+    monkeypatch.setattr(
+        run_routes,
+        "async_finalize_canceled_cycle_run_if_needed",
+        capture_cycle_settlement,
+    )
 
     class _AsyncStore:
         async def require_run(self, run_id: int):
@@ -2341,24 +2351,69 @@ async def test_cancel_endpoint_helper_records_run_canceled_event(session_factory
         async def set_status(self, run_id: int, status, *, reason: str | None = None):
             return await store.set_status(run_id, status, reason=reason)
 
-    await _cancel_run_with_event(_AsyncStore(), run.id, reason="user_canceled")
+    await run_routes._cancel_run_with_event(_AsyncStore(), run.id, reason="user_canceled")
 
     row = await session.get(AgentRunRow, run.id)
     assert row is not None
     assert row.status == RunStatus.CANCELED.value
+    assert settled_run_ids == [run.id]
     events = await _event_types(session, run.id)
     assert "run.canceled" in events
     assert events.count("run.canceled") == 1
 
 
-async def test_cancel_runs_for_idea_records_run_canceled_event(session_factory):
+async def test_cancel_endpoint_helper_ignores_cycle_settlement_failure(
+    session_factory,
+    monkeypatch,
+    caplog,
+):
+    from brain.app.api.routers.cortex import _run as run_routes
+    from brain.systems.cycles import service as cycle_service
+
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(_run_request(thread_id="thread-1", message="cancel me"))
+
+    async def fail_cycle_settlement(*_args, **_kwargs):
+        raise RuntimeError("cycles unavailable")
+
+    monkeypatch.setattr(
+        cycle_service,
+        "async_finalize_cycle_run_from_run",
+        fail_cycle_settlement,
+    )
+
+    await run_routes._cancel_run_with_event(store, run.id, reason="user_canceled")
+
+    row = await session.get(AgentRunRow, run.id)
+    assert row is not None
+    assert row.status == RunStatus.CANCELED.value
+    assert "run.canceled" in await _event_types(session, run.id)
+    assert "cycle_run_settlement_failed" in caplog.text
+
+
+async def test_cancel_runs_for_idea_records_run_canceled_event(
+    session_factory,
+    monkeypatch,
+):
     from brain.systems.runs.cortex import async_cancel_runs_for_idea
+    from brain.systems.cycles import service as cycle_service
 
     session = session_factory()
     store = AsyncAgentRunStore(session)
     run = await store.create_run(_run_request(thread_id="idea-1", message="cancel me"))
     await store.set_status(run.id, RunStatus.STARTING)
     await store.set_status(run.id, RunStatus.RUNNING)
+    settled = []
+
+    async def capture_cycle_settlement(run_id, *, status, error=None):
+        settled.append((run_id, status, error))
+
+    monkeypatch.setattr(
+        cycle_service,
+        "async_finalize_cycle_run_from_run",
+        capture_cycle_settlement,
+    )
 
     with patch("brain.systems.runs.cortex.UnitOfWork", return_value=_SessionUoW(session)):
         count = await async_cancel_runs_for_idea("idea-1")
@@ -2367,9 +2422,59 @@ async def test_cancel_runs_for_idea_records_run_canceled_event(session_factory):
     assert count == 1
     assert row is not None
     assert row.status == RunStatus.CANCELED.value
+    assert settled == [(run.id, "canceled", None)]
     events = await _event_types(session, run.id)
     assert "run.canceled" in events
     assert events.count("run.canceled") == 1
+
+
+async def test_cancel_all_route_settles_each_canceled_cycle_run(monkeypatch):
+    from brain.app.api.routers.cortex import _idea_ops as idea_routes
+
+    rows = [
+        SimpleNamespace(id=41, root_run_id=41),
+        SimpleNamespace(id=42, root_run_id=42),
+    ]
+    settled_run_ids = []
+
+    async def select_runs(_statement):
+        return SimpleNamespace(all=lambda: rows)
+
+    async def flush():
+        return None
+
+    session = SimpleNamespace(scalars=select_runs, flush=flush)
+
+    class _Store:
+        async def append_event(self, _event):
+            return None
+
+        async def set_status(self, _run_id, _status, *, reason=None):
+            return SimpleNamespace(status=RunStatus.CANCELED)
+
+    async def allow_idea(*_args, **_kwargs):
+        return None
+
+    async def capture_cycle_settlement(run_id):
+        settled_run_ids.append(run_id)
+
+    monkeypatch.setattr(
+        idea_routes,
+        "UnitOfWork",
+        lambda: _SessionUoW(session),
+    )
+    monkeypatch.setattr(idea_routes, "_require_idea_for_user", allow_idea)
+    monkeypatch.setattr(idea_routes, "AsyncAgentRunStore", lambda _session: _Store())
+    monkeypatch.setattr(
+        idea_routes,
+        "async_finalize_canceled_cycle_run_if_needed",
+        capture_cycle_settlement,
+    )
+
+    result = await idea_routes.idea_cancel_all("idea-1", {"id": "user-1"})
+
+    assert result == {"ok": True, "canceled": 2, "cancelled": 2}
+    assert settled_run_ids == [41, 42]
 
 
 async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned_runs(session_factory):

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -43,8 +43,6 @@ RAW_PROVIDER_ERROR = (
     "ID `a7dd7556-test` in your message. | server_error | server_error"
 )
 
-EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION = "failed"
-
 RESULT_CONTRACT_REQUIRED_OUTPUTS = [
     "answer_the_cycle_mission",
     "summarize_workspace_evidence_or_explicit_gaps",
@@ -3593,6 +3591,10 @@ def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch, status):
     assert cycle.last_status is None
 
 
+def test_canceled_run_cycle_disposition_counts_as_failed():
+    assert service.CANCELED_RUN_CYCLE_DISPOSITION == "failed"
+
+
 @pytest.mark.parametrize("run_status", TERMINAL_RUN_STATUS_VALUES)
 def test_finalize_cycle_run_from_run_maps_every_terminal_run_status(
     monkeypatch,
@@ -3601,7 +3603,7 @@ def test_finalize_cycle_run_from_run_maps_every_terminal_run_status(
     expected_statuses = {
         "completed": "completed",
         "failed": "failed",
-        "canceled": EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION,
+        "canceled": service.CANCELED_RUN_CYCLE_DISPOSITION,
         "expired": "failed",
     }
     supplied_errors = {
@@ -3611,7 +3613,6 @@ def test_finalize_cycle_run_from_run_maps_every_terminal_run_status(
         "expired": "Agent run interruption limit exhausted",
     }
     assert tuple(expected_statuses) == TERMINAL_RUN_STATUS_VALUES
-    assert service.CANCELED_RUN_CYCLE_DISPOSITION == EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION
 
     session, cycle_run, cycle, _ = _contract_finalization_scenario(
         cycle_id=8,
@@ -3635,14 +3636,14 @@ def test_finalize_cycle_run_from_run_maps_every_terminal_run_status(
     assert cycle_run.completed_at is not None
     assert cycle.last_status == expected_statuses[run_status]
     if run_status == "canceled":
-        if EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION == "failed":
+        if service.CANCELED_RUN_CYCLE_DISPOSITION == "failed":
             assert cycle_run.error == "Agent run was canceled"
             assert "ended without cycle-run finalization" not in cycle_run.error
         else:
             assert cycle_run.error is None
         assert cycle_run.skip_reason == (
             "canceled"
-            if EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION == "skipped"
+            if service.CANCELED_RUN_CYCLE_DISPOSITION == "skipped"
             else None
         )
     else:
@@ -3677,7 +3678,7 @@ def test_finalize_cycle_failure_uses_original_run_failed_event(monkeypatch):
     )
     finalized = []
 
-    async def capture_finalize(run, active_cycle, *, status, error, skip_reason, session):
+    async def capture_finalize(run, active_cycle, *, status, error, session):
         finalized.append((run, active_cycle, status, error, session))
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 
 from brain.app.api.schemas.cycles import CycleCreate, CycleRead, CycleRunRead
+from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.systems.cycles import access as cycle_access
 from brain.systems.cycles import execution as cycle_execution
 from brain.systems.cycles import prompts as cycle_prompts
@@ -41,6 +42,8 @@ RAW_PROVIDER_ERROR = (
     "through our help center at help.openai.com if the error persists. Please include the request "
     "ID `a7dd7556-test` in your message. | server_error | server_error"
 )
+
+EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION = "failed"
 
 RESULT_CONTRACT_REQUIRED_OUTPUTS = [
     "answer_the_cycle_mission",
@@ -3567,7 +3570,8 @@ async def test_cycle_contract_provider_error_degrades_without_leaking_and_preser
     assert all("help.openai.com" not in str(artifact.text or "") for artifact in session._artifacts)
 
 
-def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch):
+@pytest.mark.parametrize("status", ("failed", "canceled"))
+def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch, status):
     agent_run = AgentRun()
     agent_run.metadata_ = {"source": "user"}
 
@@ -3583,10 +3587,67 @@ def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch):
         ]),
     )
 
-    service.finalize_cycle_run_from_run(44, status="failed", error="boom")
+    service.finalize_cycle_run_from_run(44, status=status, error="boom")
 
     assert cycle_run.status == "running"
     assert cycle.last_status is None
+
+
+@pytest.mark.parametrize("run_status", TERMINAL_RUN_STATUS_VALUES)
+def test_finalize_cycle_run_from_run_maps_every_terminal_run_status(
+    monkeypatch,
+    run_status,
+):
+    expected_statuses = {
+        "completed": "completed",
+        "failed": "failed",
+        "canceled": EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION,
+        "expired": "failed",
+    }
+    supplied_errors = {
+        "completed": None,
+        "failed": "Agent run failed",
+        "canceled": None,
+        "expired": "Agent run interruption limit exhausted",
+    }
+    assert tuple(expected_statuses) == TERMINAL_RUN_STATUS_VALUES
+    assert service.CANCELED_RUN_CYCLE_DISPOSITION == EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION
+
+    session, cycle_run, cycle, _ = _contract_finalization_scenario(
+        cycle_id=8,
+        mission=REFLEX_MISSION,
+        answer=REFLEX_ANSWER,
+    )
+    if run_status == "canceled":
+        cycle_run.context_snapshot["mission_result_contract_verdict"] = {
+            "settlement_status": "mission_contract_failed",
+            "provider_error": "server_error",
+        }
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(
+        44,
+        status=run_status,
+        error=supplied_errors[run_status],
+    )
+
+    assert cycle_run.status == expected_statuses[run_status]
+    assert cycle_run.completed_at is not None
+    assert cycle.last_status == expected_statuses[run_status]
+    if run_status == "canceled":
+        if EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION == "failed":
+            assert cycle_run.error == "Agent run was canceled"
+            assert "ended without cycle-run finalization" not in cycle_run.error
+        else:
+            assert cycle_run.error is None
+        assert cycle_run.skip_reason == (
+            "canceled"
+            if EXPECTED_CANCELED_RUN_CYCLE_DISPOSITION == "skipped"
+            else None
+        )
+    else:
+        assert cycle_run.error == supplied_errors[run_status]
+        assert cycle_run.skip_reason is None
 
 
 def test_finalize_cycle_failure_uses_original_run_failed_event(monkeypatch):
@@ -3616,7 +3677,7 @@ def test_finalize_cycle_failure_uses_original_run_failed_event(monkeypatch):
     )
     finalized = []
 
-    async def capture_finalize(run, active_cycle, *, status, error, session):
+    async def capture_finalize(run, active_cycle, *, status, error, skip_reason, session):
         finalized.append((run, active_cycle, status, error, session))
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))


### PR DESCRIPTION
Closes #622.

## What changes for a user

Cancel a cycle-backed run today and the cycle side of it stays open for up to a minute, then gets cleaned up by the **stale-run reconciler** — the path meant for runs that died. The `CycleRun` ends up stamped `error = "Agent run ended without cycle-run finalization"`, which reads as a system anomaly rather than "someone pressed cancel". In between, the cycle still counts that run as active, so a `max_concurrency = 1` cycle finalizes its next tick as `skipped / previous_run_active`.

After this, both cancel routes settle the `CycleRun` immediately, with the error string saying the run was canceled.

## The decision this does NOT make

**The disposition stays `failed` — exactly what happens today** — held in one constant, `CANCELED_RUN_CYCLE_DISPOSITION` (`brain/systems/cycles/service.py`).

The open question from #622 is whether a user cancel should instead settle as `skipped`. It matters: `failed` counts toward `CYCLE_REPEATED_FAILURE_ALERT_CLASS`, so three user cancels can trip the repeated-failure guard on a cycle that never failed; `skipped` is ignored by that guard. My read is still `skipped` — a human cancelling is not the cycle failing — but that is a call about what you want to be alerted to, so this PR deliberately preserves today's behavior and makes the flip **one line**: change that constant to `"skipped"` and the one test that pins it. `skip_reason="canceled"` is already wired for that branch.

## How to judge it without reading the diff

There is no UI surface here, so the reviewable artifact is behavior:

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-622-fix1
../../illospace-project/venv/bin/python -m pytest \
  tests/test_cycles_service.py tests/test_agent_run_state_machine.py \
  tests/test_agent_run_runtime.py tests/test_architecture_boundaries.py -q
```

**286 passed, 8 skipped** (the 8 are the real-Postgres cases; they run in the DB CI lane).

Acceptance checks:

1. **A cancel settles at cancel time.** Cancelling a cycle-backed run finalizes its `CycleRun` in the same request — no dependency on the 60s sweeper — with `error = "Agent run was canceled"`, never `"ended without cycle-run finalization"`.
2. **Nothing else moved.** `completed` / `failed` / `expired` keep their exact prior behavior; that path's diff is now only the derived allowlist and the mapping lookup. `test_finalize_cycle_run_from_run_maps_every_terminal_run_status` is parametrized over `TERMINAL_RUN_STATUS_VALUES` and asserts the tuple itself, so adding a terminal status fails loudly instead of silently falling through — the original defect class.
3. **Cancelling a non-cycle run is untouched**, and a cycles-side exception during cancel cannot break the cancel itself (covered by `test_cancel_endpoint_helper_ignores_cycle_settlement_failure`).
4. **The policy flip is one line** — `CANCELED_RUN_CYCLE_DISPOSITION` plus its single pinning test.

## Assumptions I made

- The runner's narrower `{completed, failed}` gate is **correct, not a bug**, and was left alone: `expired` reaches cycles directly via `interruption.py`, bypassing the runner. (The original ticket claimed otherwise; that claim was corrected on the issue.)
- `canceled` is never passed down to `finalize_cycle_run` raw — it is mapped through `RUN_STATUS_TO_CYCLE_RUN_STATUS` at the boundary, because `"canceled"` is in neither the active nor terminal `CycleRun` status sets and would produce a row invisible to both the reconciler and the terminal check.

## Review findings I did not fold in

A Codex maintainability review raised a third blocking item: `_idea_ops.idea_cancel_all` and `cortex.async_cancel_runs_for_idea` are two verbatim copies of the same cancel-all loop, so this change had to write its settlement call into both. I refused it here as scope creep — the duplication is pre-existing and touches API-router transaction boundaries — and filed it as #624 instead.

<sub>Draft PR opened by Routine R3. Implemented by Codex (gpt-5.6-sol, xhigh), reviewed and fix-passed by the R3 director; the maintainability review that produced the second commit was also run through Codex.</sub>
