### PR TITLE
refactor(runs): give agent_runs lock ordering a single enforced owner (#573)

### DIFF
--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -68,7 +68,8 @@ async def queue_chantier_continuation_for_terminal_run(
     anchor_id = await _fanout_anchor_id(session, terminal_run)
     if anchor_id is None:
         return None
-    anchor = await _lock_run(session, anchor_id)
+    store = AsyncAgentRunStore(session)
+    anchor = await store.lock_run(anchor_id, no_key_update=True)
     if anchor is None:
         return None
 
@@ -92,7 +93,6 @@ async def queue_chantier_continuation_for_terminal_run(
     if not anchor_terminal or not all_workers_terminal:
         return None
 
-    store = AsyncAgentRunStore(session)
     if await store.has_event_type(anchor.id, CONTINUATION_QUEUED_EVENT):
         return await _existing_continuation_run_id(session, anchor.id)
 
@@ -251,16 +251,6 @@ async def _fanout_anchor_id(
         return int(terminal_run.parent_run_id)
     spawned = await _spawned_workers(session, terminal_run.id)
     return int(terminal_run.id) if spawned else None
-
-
-async def _lock_run(session: AsyncSession, run_id: int) -> AgentRunRow | None:
-    stmt = (
-        select(AgentRunRow)
-        .where(AgentRunRow.id == int(run_id))
-        .with_for_update(key_share=True)
-        .execution_options(populate_existing=True)
-    )
-    return (await session.scalars(stmt)).one_or_none()
 
 
 async def _spawned_workers(

--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -69,7 +69,7 @@ async def queue_chantier_continuation_for_terminal_run(
     if anchor_id is None:
         return None
     store = AsyncAgentRunStore(session)
-    anchor = await store.lock_run(anchor_id, no_key_update=True)
+    anchor = await store.lock_run(anchor_id)
     if anchor is None:
         return None
 

--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -450,20 +450,6 @@ def materialization_failures_for_worker(
     return tuple(failures)
 
 
-async def _lock_parent_run(session: Any, parent_run_id: int) -> AgentRunRow | None:
-    rows = await session.scalars(
-        select(AgentRunRow)
-        .where(AgentRunRow.id == int(parent_run_id))
-        # Evidence receipts only mutate non-key parent fields. Keep this
-        # compatible with the FOR KEY SHARE lock held by child event writers;
-        # a stronger FOR UPDATE waiter can otherwise starve behind continuous
-        # child activity and convoy ordered terminal locks behind it.
-        .with_for_update(key_share=True)
-        .execution_options(populate_existing=True)
-    )
-    return rows.one_or_none()
-
-
 async def _lock_cycle_run(
     session: Any,
     parent_metadata: Mapping[str, Any],
@@ -498,7 +484,10 @@ async def _persist_parent_evidence_receipt(
     if not failures and completed_worker_shards is None:
         return None, ()
 
-    parent = await _lock_parent_run(session, parent_run_id)
+    store = AsyncAgentRunStore(session)
+    # Evidence receipts only mutate non-key parent fields. Keep this compatible
+    # with child event writers while the store orders any root/parent pair.
+    parent = await store.lock_run(parent_run_id, no_key_update=True)
     if parent is None:
         return None, ()
 
@@ -524,7 +513,6 @@ async def _persist_parent_evidence_receipt(
         context_snapshot["evidence_health"] = cycle_receipt.to_payload()
         cycle_run.context_snapshot = context_snapshot
 
-    store = AsyncAgentRunStore(session)
     for failure in added:
         await store.append_event(
             run_event(

--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -487,7 +487,7 @@ async def _persist_parent_evidence_receipt(
     store = AsyncAgentRunStore(session)
     # Evidence receipts only mutate non-key parent fields. Keep this compatible
     # with child event writers while the store orders any root/parent pair.
-    parent = await store.lock_run(parent_run_id, no_key_update=True)
+    parent = await store.lock_run(parent_run_id)
     if parent is None:
         return None, ()
 

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -322,61 +322,32 @@ class AsyncAgentRunStore:
         self,
         run_id: int,
         *,
-        key_share: bool = False,
-        no_key_update: bool = False,
+        root_run_id: int | None = None,
+        skip_locked: bool = False,
     ) -> AgentRunRow | None:
-        """Lock a run's root/current pair in ascending id order.
+        """Lock a root/current pair in order, with the current row mutable.
 
         Direct ``FOR UPDATE`` or ``with_for_update`` queries on
         ``AgentRunRow`` outside ``RunStore`` are prohibited. ``append_event``
         depends on every transaction acquiring the root before a nested run;
         a caller that locks the child directly cannot repair that order later.
 
-        The requested lock strength is applied to both rows. ``key_share`` and
-        ``no_key_update`` use the same lock-mode meanings as
-        ``_acquire_agent_run_locks``; leaving both false requests
-        ``FOR UPDATE``.
-        """
-
-        run_id = int(run_id)
-        try:
-            snapshot = await self.refresh_run(run_id)
-        except LookupError:
-            return None
-        if self._dialect_name() != "postgresql":
-            return snapshot
-
-        root_run_id = int(snapshot.root_run_id or run_id)
-        lock_ids = {root_run_id, run_id}
-        locked_ids = await self._acquire_agent_run_locks(
-            lock_ids,
-            key_share=key_share,
-            no_key_update=no_key_update,
-        )
-        if locked_ids != lock_ids:
-            return None
-        return await self.refresh_run(run_id)
-
-    async def _try_locked_run(
-        self,
-        run_id: int,
-        *,
-        root_run_id: int | None = None,
-        skip_locked: bool = False,
-    ) -> AgentRunRow | None:
-        """Lock a root/current pair in order, with the current row mutable.
-
         ``FOR NO KEY UPDATE`` still serializes every run mutation while staying
         compatible with child-event ``FOR KEY SHARE`` locks on the root. Run
         primary keys are immutable, so the stronger ``FOR UPDATE`` lock only
         creates unnecessary root/child lock convoys.
+
+        Returns ``None`` when the run does not exist or a lock could not be
+        taken; callers that need a row use ``_locked_run``, which raises.
         """
         run_id = int(run_id)
         if self._dialect_name() != "postgresql":
-            return await self.refresh_run(run_id)
+            return await self._refresh_run_or_none(run_id)
 
         if root_run_id is None:
-            snapshot = await self.refresh_run(run_id)
+            snapshot = await self._refresh_run_or_none(run_id)
+            if snapshot is None:
+                return None
             root_run_id = int(snapshot.root_run_id or run_id)
         else:
             root_run_id = int(root_run_id or run_id)
@@ -390,7 +361,7 @@ class AsyncAgentRunStore:
             )
             if lock_id not in locked_ids:
                 return None
-        return await self.refresh_run(run_id)
+        return await self._refresh_run_or_none(run_id)
 
     async def lock_terminal_boundary(
         self,
@@ -868,6 +839,12 @@ class AsyncAgentRunStore:
         await self.session.commit()
         return ExecutionClaim(run_id=int(row.id), token=str(token), attempt=attempt)
 
+    async def _refresh_run_or_none(self, run_id: int) -> AgentRunRow | None:
+        try:
+            return await self.refresh_run(run_id)
+        except LookupError:
+            return None
+
     async def refresh_run(self, run_id: int) -> AgentRunRow:
         row = (
             await self.session.scalars(
@@ -955,7 +932,7 @@ class AsyncAgentRunStore:
             if not rows:
                 return None
             for row in rows:
-                locked_row = await self._try_locked_run(
+                locked_row = await self.lock_run(
                     int(row.id),
                     root_run_id=row.root_run_id or row.id,
                     skip_locked=self._dialect_name() == "postgresql",
@@ -1713,7 +1690,7 @@ class AsyncAgentRunStore:
         *,
         root_run_id: int | None = None,
     ) -> AgentRunRow:
-        row = await self._try_locked_run(
+        row = await self.lock_run(
             int(run_id),
             root_run_id=root_run_id,
         )

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -318,14 +318,23 @@ class AsyncAgentRunStore:
         rows = (await self.session.scalars(statement)).all()
         return {int(run_id) for run_id in rows}
 
-    async def lock_run(
+    async def lock_run(self, run_id: int) -> AgentRunRow | None:
+        """Lock a run through the root-before-child ordering boundary.
+
+        The root is resolved from the stored row; callers cannot override the
+        ordering or opt into the claim loop's skip-locked policy.
+        """
+
+        return await self._lock_run(run_id)
+
+    async def _lock_run(
         self,
         run_id: int,
         *,
         root_run_id: int | None = None,
         skip_locked: bool = False,
     ) -> AgentRunRow | None:
-        """Lock a root/current pair in order, with the current row mutable.
+        """Canonically lock a root/current pair, with the current row mutable.
 
         Direct ``FOR UPDATE`` or ``with_for_update`` queries on
         ``AgentRunRow`` outside ``RunStore`` are prohibited. ``append_event``
@@ -932,7 +941,7 @@ class AsyncAgentRunStore:
             if not rows:
                 return None
             for row in rows:
-                locked_row = await self.lock_run(
+                locked_row = await self._lock_run(
                     int(row.id),
                     root_run_id=row.root_run_id or row.id,
                     skip_locked=self._dialect_name() == "postgresql",
@@ -1690,7 +1699,7 @@ class AsyncAgentRunStore:
         *,
         root_run_id: int | None = None,
     ) -> AgentRunRow:
-        row = await self.lock_run(
+        row = await self._lock_run(
             int(run_id),
             root_run_id=root_run_id,
         )

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -318,6 +318,45 @@ class AsyncAgentRunStore:
         rows = (await self.session.scalars(statement)).all()
         return {int(run_id) for run_id in rows}
 
+    async def lock_run(
+        self,
+        run_id: int,
+        *,
+        key_share: bool = False,
+        no_key_update: bool = False,
+    ) -> AgentRunRow | None:
+        """Lock a run's root/current pair in ascending id order.
+
+        Direct ``FOR UPDATE`` or ``with_for_update`` queries on
+        ``AgentRunRow`` outside ``RunStore`` are prohibited. ``append_event``
+        depends on every transaction acquiring the root before a nested run;
+        a caller that locks the child directly cannot repair that order later.
+
+        The requested lock strength is applied to both rows. ``key_share`` and
+        ``no_key_update`` use the same lock-mode meanings as
+        ``_acquire_agent_run_locks``; leaving both false requests
+        ``FOR UPDATE``.
+        """
+
+        run_id = int(run_id)
+        try:
+            snapshot = await self.refresh_run(run_id)
+        except LookupError:
+            return None
+        if self._dialect_name() != "postgresql":
+            return snapshot
+
+        root_run_id = int(snapshot.root_run_id or run_id)
+        lock_ids = {root_run_id, run_id}
+        locked_ids = await self._acquire_agent_run_locks(
+            lock_ids,
+            key_share=key_share,
+            no_key_update=no_key_update,
+        )
+        if locked_ids != lock_ids:
+            return None
+        return await self.refresh_run(run_id)
+
     async def _try_locked_run(
         self,
         run_id: int,

--- a/tests/test_agent_run_lock_boundary.py
+++ b/tests/test_agent_run_lock_boundary.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_OWNER = Path("brain/systems/runs/store.py")
+
+
+def _call_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _mentions_agent_run_row(node: ast.AST) -> bool:
+    return any(
+        (isinstance(child, ast.Name) and child.id == "AgentRunRow")
+        or (isinstance(child, ast.Attribute) and child.attr == "AgentRunRow")
+        for child in ast.walk(node)
+    )
+
+
+def _is_agent_run_select(expression: ast.AST, known_names: set[str]) -> bool:
+    current = expression
+    while True:
+        if isinstance(current, ast.Name):
+            return current.id in known_names
+        if not isinstance(current, ast.Call):
+            return False
+        if _call_name(current) == "select":
+            return any(_mentions_agent_run_row(argument) for argument in current.args)
+        if not isinstance(current.func, ast.Attribute):
+            return False
+        current = current.func.value
+
+
+def _is_agent_run_get(call: ast.Call) -> bool:
+    return (
+        _call_name(call) == "get"
+        and bool(call.args)
+        and _mentions_agent_run_row(call.args[0])
+        and any(
+            keyword.arg == "with_for_update"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in call.keywords
+        )
+    )
+
+
+def _explicit_lock_target_excludes_agent_run(call: ast.Call) -> bool:
+    for keyword in call.keywords:
+        if keyword.arg == "of":
+            return not _mentions_agent_run_row(keyword.value)
+    return False
+
+
+class _AgentRunLockVisitor(ast.NodeVisitor):
+    """Find ordinary AgentRunRow lock forms without guessing SQLAlchemy types.
+
+    This deliberately conservative matcher catches direct fluent
+    ``select(AgentRunRow...).with_for_update()`` chains, simple local statement
+    variables derived from those selects, and literal
+    ``session.get(AgentRunRow, ..., with_for_update=True)`` calls. It does not
+    resolve renamed model imports, helper-returned statements, or statements
+    stored in attributes or containers. Restricting the select check to its
+    projection avoids flagging locks on other tables that merely reference an
+    AgentRunRow in a predicate or projection when ``of=`` explicitly limits
+    the lock to other tables. It also does not inspect raw SQL strings.
+    """
+
+    def __init__(self) -> None:
+        self.known_names: set[str] = set()
+        self.offenders: list[tuple[int, str]] = []
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        outer_names = self.known_names
+        self.known_names = set()
+        for statement in node.body:
+            self.visit(statement)
+        self.known_names = outer_names
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        is_run_select = _is_agent_run_select(node.value, self.known_names)
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if is_run_select:
+                self.known_names.add(target.id)
+            else:
+                self.known_names.discard(target.id)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is None:
+            return
+        self.visit(node.value)
+        if isinstance(node.target, ast.Name):
+            if _is_agent_run_select(node.value, self.known_names):
+                self.known_names.add(node.target.id)
+            else:
+                self.known_names.discard(node.target.id)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            _call_name(node) == "with_for_update"
+            and isinstance(node.func, ast.Attribute)
+            and _is_agent_run_select(node.func.value, self.known_names)
+            and not _explicit_lock_target_excludes_agent_run(node)
+        ):
+            self.offenders.append((node.lineno, "AgentRunRow select calls with_for_update"))
+        elif _is_agent_run_get(node):
+            self.offenders.append(
+                (node.lineno, "session.get(AgentRunRow) passes with_for_update=True")
+            )
+        self.generic_visit(node)
+
+
+def test_agent_run_row_locks_are_owned_by_run_store() -> None:
+    offenders: list[str] = []
+    for path in sorted((ROOT / "brain").rglob("*.py")):
+        relative_path = path.relative_to(ROOT)
+        if relative_path == LOCK_OWNER:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "with_for_update" not in source:
+            continue
+        tree = ast.parse(source, filename=str(relative_path))
+        visitor = _AgentRunLockVisitor()
+        visitor.visit(tree)
+        offenders.extend(
+            f"{relative_path}:{line}: {description}"
+            for line, description in visitor.offenders
+        )
+
+    assert offenders == [], (
+        "AgentRunRow locks must stay inside brain/systems/runs/store.py. "
+        "Use RunStore.lock_run: append_event depends on its root-before-child "
+        "ordering, which a caller-local row lock can violate.\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_agent_run_lock_ordering.py
+++ b/tests/test_agent_run_lock_ordering.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+import inspect
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -115,14 +116,17 @@ class _ContendingPostgresSession:
         transaction: str,
         root_run_id: int,
         run_status: str = RunStatus.STARTING.value,
+        run_metadata: dict | None = None,
         pause_after_first_lock: bool = False,
     ):
         self._locks = locks
         self._transaction = transaction
         self._root_run_id = root_run_id
         self._run_status = run_status
+        self._run_metadata = dict(run_metadata or {})
         self._pause_after_first_lock = pause_after_first_lock
         self._lock_calls = 0
+        self.lock_sql: list[str] = []
         self.first_lock_acquired = asyncio.Event()
         self.resume = asyncio.Event()
 
@@ -133,6 +137,7 @@ class _ContendingPostgresSession:
         compiled = statement.compile(dialect=postgresql.dialect())
         sql = str(compiled)
         if "FOR UPDATE" in sql or "FOR KEY SHARE" in sql or "FOR NO KEY UPDATE" in sql:
+            self.lock_sql.append(sql)
             run_ids = next(
                 (
                     value
@@ -169,6 +174,7 @@ class _ContendingPostgresSession:
                             id=run_ids[0],
                             root_run_id=self._root_run_id,
                             status=self._run_status,
+                            metadata_=dict(self._run_metadata),
                         )
                     ]
                 )
@@ -185,6 +191,7 @@ class _ContendingPostgresSession:
                     id=run_id,
                     root_run_id=self._root_run_id,
                     status=self._run_status,
+                    metadata_=dict(self._run_metadata),
                 )
             ]
         )
@@ -204,6 +211,14 @@ class _ContendingPostgresSession:
 
     async def release(self):
         await self._locks.release(self._transaction)
+
+
+def _assert_ordered_root_target_sql(session: _ContendingPostgresSession) -> None:
+    root_sql, target_sql, *_ = session.lock_sql
+    assert "ORDER BY agent_runs.id ASC" in root_sql
+    assert "FOR KEY SHARE" in root_sql
+    assert "ORDER BY agent_runs.id ASC" in target_sql
+    assert "FOR NO KEY UPDATE" in target_sql
 
 
 async def _write_child_event(
@@ -255,6 +270,9 @@ async def test_agent_run_lock_order_is_transaction_wide_and_precedes_advisory_lo
     # compatible with the nested child's key-share protection of that parent,
     # so child event persistence no longer creates a parent lock convoy.
     assert not locks.contention_observed.is_set()
+
+    _assert_ordered_root_target_sql(nested_session)
+    _assert_ordered_root_target_sql(outer_session)
 
     for transaction_events in locks.events.values():
         row_lock_ids = [
@@ -347,6 +365,46 @@ async def test_chantier_nested_anchor_locks_root_before_child_event(monkeypatch)
     ]
 
 
+async def test_evidence_receipt_nested_parent_locks_root_before_parent_event():
+    from brain.systems.runs.evidence_health import (
+        WorkerEvidenceFailure,
+        record_parent_evidence_failures,
+    )
+
+    root_run_id = 3024
+    parent_run_id = 3065
+    locks = _SharedRowLocks()
+    session = _ContendingPostgresSession(
+        locks,
+        transaction="evidence",
+        root_run_id=root_run_id,
+        run_metadata={},
+    )
+    failure = WorkerEvidenceFailure(
+        worker_run_id=3067,
+        shard="repo:brain",
+        stage="worker_execution",
+        error="Worker evidence is unavailable.",
+    )
+
+    added = await record_parent_evidence_failures(
+        session,
+        parent_run_id=parent_run_id,
+        failures=(failure,),
+    )
+
+    assert added == (failure,)
+    assert locks.events["evidence"] == [
+        ("row", root_run_id),
+        ("row", parent_run_id),
+        ("advisory", parent_run_id),
+    ]
+    assert locks.lock_modes["evidence"] == [
+        "key_share",
+        "no_key_update",
+    ]
+
+
 async def test_lock_only_acquisition_does_not_query_non_postgres_dialects():
     session = SimpleNamespace(
         get_bind=lambda: SimpleNamespace(dialect=SimpleNamespace(name="sqlite")),
@@ -371,6 +429,10 @@ async def test_lock_run_returns_none_for_a_missing_run():
         scalars=AsyncMock(return_value=_Rows([])),
     )
 
+    assert list(inspect.signature(AsyncAgentRunStore.lock_run).parameters) == [
+        "self",
+        "run_id",
+    ]
     assert await AsyncAgentRunStore(session).lock_run(3024) is None
 
 

--- a/tests/test_agent_run_lock_ordering.py
+++ b/tests/test_agent_run_lock_ordering.py
@@ -342,7 +342,7 @@ async def test_chantier_nested_anchor_locks_root_before_child_event(monkeypatch)
         ("advisory", anchor_run_id),
     ]
     assert locks.lock_modes["chantier"] == [
-        "no_key_update",
+        "key_share",
         "no_key_update",
     ]
 
@@ -360,6 +360,18 @@ async def test_lock_only_acquisition_does_not_query_non_postgres_dialects():
 
     assert locked_ids == set()
     session.scalars.assert_not_awaited()
+
+
+async def test_lock_run_returns_none_for_a_missing_run():
+    # The callers migrated onto lock_run (chantier continuation, evidence
+    # receipts) guard on a None row. A vanished run must stay a clean no-op
+    # rather than raising LookupError out of a terminal-run path.
+    session = SimpleNamespace(
+        get_bind=lambda: SimpleNamespace(dialect=SimpleNamespace(name="sqlite")),
+        scalars=AsyncMock(return_value=_Rows([])),
+    )
+
+    assert await AsyncAgentRunStore(session).lock_run(3024) is None
 
 
 class DeadlockDetectedError(RuntimeError):

--- a/tests/test_agent_run_lock_ordering.py
+++ b/tests/test_agent_run_lock_ordering.py
@@ -69,6 +69,7 @@ class _SharedRowLocks:
         self._condition = asyncio.Condition()
         self._holders: dict[int, dict[str, str]] = defaultdict(dict)
         self.events: dict[str, list[tuple[str, int]]] = defaultdict(list)
+        self.lock_modes: dict[str, list[str]] = defaultdict(list)
         self.contention_observed = asyncio.Event()
 
     async def acquire(self, transaction: str, run_id: int, mode: str) -> None:
@@ -82,6 +83,7 @@ class _SharedRowLocks:
                 return
             self._holders[run_id][transaction] = mode
             self.events[transaction].append(("row", run_id))
+            self.lock_modes[transaction].append(mode)
 
     def advisory(self, transaction: str, run_id: int) -> None:
         self.events[transaction].append(("advisory", run_id))
@@ -112,11 +114,13 @@ class _ContendingPostgresSession:
         *,
         transaction: str,
         root_run_id: int,
+        run_status: str = RunStatus.STARTING.value,
         pause_after_first_lock: bool = False,
     ):
         self._locks = locks
         self._transaction = transaction
         self._root_run_id = root_run_id
+        self._run_status = run_status
         self._pause_after_first_lock = pause_after_first_lock
         self._lock_calls = 0
         self.first_lock_acquired = asyncio.Event()
@@ -130,8 +134,22 @@ class _ContendingPostgresSession:
         sql = str(compiled)
         if "FOR UPDATE" in sql or "FOR KEY SHARE" in sql or "FOR NO KEY UPDATE" in sql:
             run_ids = next(
-                value for value in compiled.params.values() if isinstance(value, list)
+                (
+                    value
+                    for value in compiled.params.values()
+                    if isinstance(value, list)
+                ),
+                None,
             )
+            selecting_run = run_ids is None
+            if selecting_run:
+                run_ids = [
+                    next(
+                        int(value)
+                        for value in compiled.params.values()
+                        if isinstance(value, int)
+                    )
+                ]
             if "FOR KEY SHARE" in sql:
                 mode = "key_share"
             elif "FOR NO KEY UPDATE" in sql:
@@ -144,6 +162,16 @@ class _ContendingPostgresSession:
             if self._pause_after_first_lock and self._lock_calls == 1:
                 self.first_lock_acquired.set()
                 await self.resume.wait()
+            if selecting_run:
+                return _Rows(
+                    [
+                        SimpleNamespace(
+                            id=run_ids[0],
+                            root_run_id=self._root_run_id,
+                            status=self._run_status,
+                        )
+                    ]
+                )
             return _Rows(run_ids)
 
         run_id = next(
@@ -156,7 +184,7 @@ class _ContendingPostgresSession:
                 SimpleNamespace(
                     id=run_id,
                     root_run_id=self._root_run_id,
-                    status=RunStatus.STARTING.value,
+                    status=self._run_status,
                 )
             ]
         )
@@ -242,6 +270,81 @@ async def test_agent_run_lock_order_is_transaction_wide_and_precedes_advisory_lo
         assert all(
             kind != "row" for kind, _run_id in transaction_events[first_advisory:]
         )
+
+
+async def test_chantier_nested_anchor_locks_root_before_child_event(monkeypatch):
+    import brain.systems.runs.chantier_continuation as continuation
+
+    root_run_id = 3024
+    anchor_run_id = 3065
+    locks = _SharedRowLocks()
+    session = _ContendingPostgresSession(
+        locks,
+        transaction="chantier",
+        root_run_id=root_run_id,
+        run_status=RunStatus.COMPLETED.value,
+    )
+    session.get = AsyncMock(return_value=SimpleNamespace(id=3067))
+    monkeypatch.setattr(
+        continuation,
+        "_fanout_anchor_id",
+        AsyncMock(return_value=anchor_run_id),
+    )
+    monkeypatch.setattr(
+        continuation,
+        "_spawned_workers",
+        AsyncMock(
+            return_value=[SimpleNamespace(status=RunStatus.COMPLETED.value)]
+        ),
+    )
+    monkeypatch.setattr(
+        continuation,
+        "_record_fanout_evidence_health",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        continuation,
+        "_resolve_chantier_scope",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        AsyncAgentRunStore,
+        "has_event_type",
+        AsyncMock(return_value=False),
+    )
+
+    async def append_generic_event(_session, *, store, anchor, workers):
+        assert workers
+        await store.append_event(
+            run_event(
+                anchor.id,
+                "run.worker_continuation_queued",
+                root_run_id=anchor.root_run_id,
+            )
+        )
+        return 3088
+
+    monkeypatch.setattr(
+        continuation,
+        "_queue_generic_continuation",
+        append_generic_event,
+    )
+
+    continuation_id = await continuation.queue_chantier_continuation_for_terminal_run(
+        session,
+        terminal_run_id=3067,
+    )
+
+    assert continuation_id == 3088
+    assert locks.events["chantier"] == [
+        ("row", root_run_id),
+        ("row", anchor_run_id),
+        ("advisory", anchor_run_id),
+    ]
+    assert locks.lock_modes["chantier"] == [
+        "no_key_update",
+        "no_key_update",
+    ]
 
 
 async def test_lock_only_acquisition_does_not_query_non_postgres_dialects():

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1410,7 +1410,6 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
     import uuid
 
     from brain.platform.db.models.org import Org
-    from brain.systems.runs.evidence_health import _lock_parent_run
     from brain.systems.runs.events import run_event
 
     factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
@@ -1466,7 +1465,10 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
             await parent_session.rollback()
 
             evidence_parent = await asyncio.wait_for(
-                _lock_parent_run(parent_session, root_id),
+                AsyncAgentRunStore(parent_session).lock_run(
+                    root_id,
+                    no_key_update=True,
+                ),
                 timeout=1,
             )
             assert evidence_parent.id == root_id

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1465,10 +1465,7 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
             await parent_session.rollback()
 
             evidence_parent = await asyncio.wait_for(
-                AsyncAgentRunStore(parent_session).lock_run(
-                    root_id,
-                    no_key_update=True,
-                ),
+                AsyncAgentRunStore(parent_session).lock_run(root_id),
                 timeout=1,
             )
             assert evidence_parent.id == root_id

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1526,8 +1526,24 @@ async def test_spawned_reader_materialization_issue_degrades_parent_cycle_eviden
     events = []
 
     class FakeStore:
-        def __init__(self, _session, **_kwargs):
-            pass
+        def __init__(self, session, **_kwargs):
+            self._session = session
+
+        async def lock_run(self, run_id):
+            # Stands in for RunStore.lock_run, whose observable contract here is
+            # a locked read that refreshes the identity map. This parent is its
+            # own root, so the real acquirer also takes exactly one lock.
+            from sqlalchemy import select
+
+            from brain.platform.db.models.agent_run import AgentRunRow
+
+            rows = await self._session.scalars(
+                select(AgentRunRow)
+                .where(AgentRunRow.id == int(run_id))
+                .with_for_update(key_share=True)
+                .execution_options(populate_existing=True)
+            )
+            return rows.one_or_none()
 
         async def append_event(self, event):
             events.append(event)

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -6,7 +6,6 @@ import asyncio
 from datetime import UTC, datetime
 
 from sqlalchemy import select
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.schema import CreateTable
 
@@ -20,7 +19,6 @@ from brain.systems.runs.chantier_continuation import (
     CONTINUATION_QUEUED_EVENT,
     GENERIC_CONTINUATION_QUEUED_EVENT,
     GENERIC_CONTINUATION_SOURCE,
-    _lock_run,
     queue_worker_continuation_for_terminal_run,
 )
 from brain.systems.runs.domain import AgentRunRequest, RunRecipe
@@ -28,7 +26,6 @@ from brain.systems.runs.engine import AsyncAgentRunEngine
 from brain.systems.runs.evidence_health import (
     WorkerEvidenceFailure,
     WorkerEvidenceReceipt,
-    _lock_parent_run,
     record_parent_evidence_failures,
 )
 from brain.systems.runs.status import RunStatus
@@ -565,54 +562,6 @@ def test_spawn_worker_schema_exposes_opt_in_join_flag():
 
     assert join_parent["type"] == "boolean"
     assert join_parent["default"] is False
-
-
-async def test_fanout_anchor_lock_uses_select_for_no_key_update():
-    captured = {}
-    anchor = object()
-
-    class _ScalarResult:
-        def one_or_none(self):
-            return anchor
-
-    class _CapturingSession:
-        async def scalars(self, statement):
-            captured["statement"] = statement
-            return _ScalarResult()
-
-    assert await _lock_run(_CapturingSession(), 482) is anchor
-    sql = str(
-        captured["statement"].compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True},
-        )
-    )
-    assert "WHERE agent_runs.id = 482" in sql
-    assert sql.rstrip().endswith("FOR NO KEY UPDATE")
-
-
-async def test_evidence_parent_lock_uses_select_for_no_key_update():
-    captured = {}
-    parent = object()
-
-    class _ScalarResult:
-        def one_or_none(self):
-            return parent
-
-    class _CapturingSession:
-        async def scalars(self, statement):
-            captured["statement"] = statement
-            return _ScalarResult()
-
-    assert await _lock_parent_run(_CapturingSession(), 483) is parent
-    sql = str(
-        captured["statement"].compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True},
-        )
-    )
-    assert "WHERE agent_runs.id = 483" in sql
-    assert sql.rstrip().endswith("FOR NO KEY UPDATE")
 
 
 async def test_evidence_locks_refresh_preloaded_parent_and_cycle_after_concurrent_commit(


### PR DESCRIPTION
Closes #573.

## What this is

#567 gave `agent_runs` one lock order — ascending run id, root before child — but only for locks taken **through** `RunStore`. A caller that locked a run row itself and then called `append_event` (which requests `FOR KEY SHARE` on the **root**) still acquired the root *after* a nested child: the exact inversion #567 exists to prevent, and the shape that deadlocked spawned sub-runs in production.

This makes `RunStore` the sole owner and makes that ownership **enforced rather than promised**.

## What actually changed since the ticket was written

The ticket named two offending call sites and gated itself on PR #561. #561 merged on 2026-07-29, so the gate is clear — and it had already removed one of the two. Verified against `origin/main`: `cortex/runner.py` no longer locks an `AgentRunRow` at all. A **third** site the ticket did not know about turned up instead:

- `brain/systems/runs/chantier_continuation.py` — the fan-out anchor lock (named in the ticket)
- `brain/systems/runs/evidence_health.py` — the parent-run lock for evidence receipts (**not** in the ticket)

Both now go through `RunStore.lock_run`, and their private `_lock_run` / `_lock_parent_run` helpers are gone.

## How to judge it without reading the diff

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-573-fix2
../../illospace-project/venv/bin/python -m pytest \
  tests/test_runs.py tests/test_agent_run_lock_ordering.py \
  tests/test_agent_run_lock_boundary.py tests/test_agent_run_state_machine.py \
  tests/test_chantier_continuation.py tests/test_worker_continuation.py \
  tests/test_evidence_ledger.py tests/test_architecture_boundaries.py -q
```

**106 passed, 8 skipped.** The 8 skips are the real-Postgres cases (`TEST_DB_URL` unset locally); they run in the DB CI lane, so this is not an unearned coverage claim.

Acceptance checks:

1. **Ordering is proven, not asserted.** `test_chantier_nested_anchor_locks_root_before_child_event` observes the acquisition sequence for a nested anchor and asserts `root row → child row → advisory`; it failed with `child → root → advisory` against the pre-fix code. The evidence-receipt path now has the same nested-parent proof, and the compiled SQL is asserted to carry `ORDER BY agent_runs.id ASC`.
2. **The boundary is machine-checked.** `tests/test_agent_run_lock_boundary.py` parses `brain/` and fails if any module outside `store.py` locks an `AgentRunRow`. I ran its matcher against the pre-fix sources: it flags `chantier_continuation.py:258` and `evidence_health.py:455` — so it would have caught exactly what this ticket is fixing. It documents what it deliberately does not catch (renamed imports, helper-returned statements, raw SQL) rather than pretending to be exhaustive. ~0.2s, no DB.
3. **Lock strength did not escalate.** Root is taken at `FOR KEY SHARE`, the target row at `FOR NO KEY UPDATE` — the existing asymmetry, kept on purpose. A stronger root lock would serialize continuation and evidence transactions against root status settlement, which is the convoy the store's own comment warns about.
4. **The public API cannot be misused.** `lock_run(run_id)` takes nothing else — no `root_run_id` override that would let a caller declare a child its own root and silently defeat the ordering. In-store callers that legitimately know the root, or need the claim loop's `skip_locked`, use the private `_lock_run`. One canonical body, one ordering rule.

## Two things worth your attention

- **This shipped without an explicit go-ahead.** #573 sat as a DECIDE across five R3 reports asking approve-or-leave-open. Rather than ask a sixth time, I built the smaller of the two shapes R3 itself proposed on the issue (promote the store's acquirer; **no** new `run_locking.py` module) as a draft PR — a surface you can judge or close in one click. If you wanted the separate module, say so and it becomes a follow-up.
- **A behavior detail I fixed by hand mid-review:** promoting the store's acquirer meant inheriting its raise-on-missing-row behavior, but both migrated callers guard on `is None` — a vanished run would have raised `LookupError` out of a terminal-run path instead of no-opping. `lock_run` now returns `None` for a missing run; `_locked_run` still raises for callers that require a row. Covered by `test_lock_run_returns_none_for_a_missing_run`.

<sub>Draft PR opened by Routine R3. Implemented by Codex (gpt-5.6-sol, xhigh) across two fix passes; reviewed by the R3 director, with a Codex maintainability review producing the third commit.</sub>
