### PR TITLE
fix(knowledge): one unreachable repo no longer freezes every GitHub watermark (#627)

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -87,6 +87,9 @@ class GitHubConnectorError(Exception):
     status_code: int
     message: str
 
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
 
 @dataclass(frozen=True, slots=True)
 class GithubFixingPullRequest:

--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -32,6 +32,23 @@ class KnowledgeDraft:
     distill: bool = False
 
 
+@dataclass(frozen=True)
+class EnumerationFailure:
+    """One source scope that could not be enumerated."""
+
+    scope: str
+    message: str
+
+
+@dataclass(frozen=True)
+class KnowledgeEnumeration:
+    """The complete result of one bounded connector enumeration."""
+
+    drafts: list[KnowledgeDraft]
+    cursor: dict[str, Any]
+    failures: tuple[EnumerationFailure, ...] = ()
+
+
 class KnowledgeConnector(Protocol):
     """One bounded source enumerator with a durable resume cursor."""
 
@@ -41,7 +58,12 @@ class KnowledgeConnector(Protocol):
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
-    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]: ...
+    ) -> KnowledgeEnumeration: ...
 
 
-__all__ = ["KnowledgeConnector", "KnowledgeDraft"]
+__all__ = [
+    "EnumerationFailure",
+    "KnowledgeConnector",
+    "KnowledgeDraft",
+    "KnowledgeEnumeration",
+]

--- a/brain/systems/knowledge/connectors/domain_records.py
+++ b/brain/systems/knowledge/connectors/domain_records.py
@@ -11,7 +11,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
 from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
 from brain.systems.user_domains.service import AsyncDomainService
 
 
@@ -43,7 +46,7 @@ class DomainRecordsConnector:
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
-    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+    ) -> KnowledgeEnumeration:
         marker = _cursor_datetime(cursor.get("updated_at"))
         marker_id = max(0, int(cursor.get("id") or 0))
         stmt = (
@@ -107,12 +110,15 @@ class DomainRecordsConnector:
             )
 
         if not rows:
-            return drafts, dict(cursor)
+            return KnowledgeEnumeration(drafts=drafts, cursor=dict(cursor))
         last_record = rows[-1][0]
-        return drafts, {
-            "updated_at": _utc_iso(last_record.updated_at),
-            "id": last_record.id,
-        }
+        return KnowledgeEnumeration(
+            drafts=drafts,
+            cursor={
+                "updated_at": _utc_iso(last_record.updated_at),
+                "id": last_record.id,
+            },
+        )
 
 
 __all__ = ["DomainRecordsConnector"]

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -25,7 +25,11 @@ from brain.systems.cortex.project_context.github import (
     async_list_repo_issues,
     parse_github_repo_slug,
 )
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    EnumerationFailure,
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
@@ -400,23 +404,20 @@ class GitHubConnector:
     ):
         self.repositories = tuple(repositories) if repositories is not None else None
         self.max_items = max(1, int(max_items))
-        self._enumeration_errors: list[str] = []
-
-    @property
-    def enumeration_errors(self) -> tuple[str, ...]:
-        return tuple(self._enumeration_errors)
 
     async def enumerate_changed(
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
-    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
-        self._enumeration_errors = []
+    ) -> KnowledgeEnumeration:
         if int(cursor.get("version") or 0) != _CURSOR_VERSION:
             cursor = {}
         repositories = list(self.repositories or await _configured_repositories(session))
         if not repositories:
-            return [], {**dict(cursor), "version": _CURSOR_VERSION}
+            return KnowledgeEnumeration(
+                drafts=[],
+                cursor={**dict(cursor), "version": _CURSOR_VERSION},
+            )
         repo_states = {
             str(key): dict(value)
             for key, value in (cursor.get("repositories") or {}).items()
@@ -427,6 +428,7 @@ class GitHubConnector:
             len(repositories) - 1,
         )
         drafts: list[KnowledgeDraft] = []
+        failures: list[EnumerationFailure] = []
 
         for repo_index in range(active_index, len(repositories)):
             repo = repositories[repo_index]
@@ -445,8 +447,7 @@ class GitHubConnector:
                 )
             except Exception as exc:
                 message = str(exc).strip() or type(exc).__name__
-                error = f"{repo}: {message}"
-                self._enumeration_errors.append(error)
+                failures.append(EnumerationFailure(scope=repo, message=message))
                 logger.exception(
                     "GitHub knowledge enumeration skipped repository %s: %s",
                     repo,
@@ -457,26 +458,38 @@ class GitHubConnector:
             drafts.extend(repo_drafts)
             repo_states[repo] = next_state
             if has_next_page:
-                return drafts, {
-                    "version": _CURSOR_VERSION,
-                    "active_repository": repo_index,
-                    "repositories": repo_states,
-                }
+                return KnowledgeEnumeration(
+                    drafts=drafts,
+                    cursor={
+                        "version": _CURSOR_VERSION,
+                        "active_repository": repo_index,
+                        "repositories": repo_states,
+                    },
+                    failures=tuple(failures),
+                )
 
             if len(drafts) >= self.max_items:
-                return drafts, {
-                    "version": _CURSOR_VERSION,
-                    "active_repository": (repo_index + 1) % len(repositories),
-                    "repositories": repo_states,
-                }
+                return KnowledgeEnumeration(
+                    drafts=drafts,
+                    cursor={
+                        "version": _CURSOR_VERSION,
+                        "active_repository": (repo_index + 1) % len(repositories),
+                        "repositories": repo_states,
+                    },
+                    failures=tuple(failures),
+                )
 
         # Reaching the end completes this sweep even when one or more repositories
         # were recorded as skipped, so the next invocation starts from index zero.
-        return drafts, {
-            "version": _CURSOR_VERSION,
-            "active_repository": 0,
-            "repositories": repo_states,
-        }
+        return KnowledgeEnumeration(
+            drafts=drafts,
+            cursor={
+                "version": _CURSOR_VERSION,
+                "active_repository": 0,
+                "repositories": repo_states,
+            },
+            failures=tuple(failures),
+        )
 
 
 __all__ = ["GitHubConnector"]

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -287,6 +287,108 @@ def _draft_for_issue(
     )
 
 
+async def _enumerate_repository(
+    session: AsyncSession,
+    repo: str,
+    state: dict[str, Any],
+    *,
+    remaining: int,
+) -> tuple[list[KnowledgeDraft], dict[str, Any], bool]:
+    """Enumerate one repository without mutating another repository's state."""
+
+    watermark_key = _timestamp_key(
+        state.get("watermark"),
+        state.get("watermark_id"),
+    )
+    high_key = _timestamp_key(
+        state.get("high_watermark") or state.get("watermark"),
+        state.get("high_watermark_id") or state.get("watermark_id"),
+    )
+    authority = await _github_authority(session, repo)
+    token = authority.token
+    payload = await async_list_repo_issues(
+        repo,
+        token=token,
+        state="all",
+        since=state.get("watermark"),
+        include_pull_requests=True,
+        limit=remaining,
+        cursor=state.get("next_page"),
+        # Project-context reads compact bodies to 1000 chars for LLM
+        # budgets; an index wants the whole body and bounds it once,
+        # in the pipeline, at RAW_TEXT_MAX_CHARS.
+        body_limit=RAW_TEXT_MAX_CHARS,
+    )
+    issues = [
+        item
+        for item in payload.get("issues") or []
+        if isinstance(item, Mapping)
+    ]
+    repo_drafts: list[KnowledgeDraft] = []
+    for issue in issues:
+        issue_key = _timestamp_key(issue.get("updated_at"), issue.get("id"))
+        high_key = max(high_key, issue_key)
+        if (
+            not state.get("next_page")
+            and state.get("watermark")
+            and issue_key <= watermark_key
+        ):
+            continue
+        kind = "pr" if issue.get("type") == "pull_request" else "issue"
+        closure = None
+        closure_unavailable_reason = None
+        if str(issue.get("state") or "").lower() == "closed" and kind == "issue":
+            if not token:
+                closure_unavailable_reason = "authentication_required"
+                logger.warning(
+                    "GitHub closure enrichment skipped for %s#%s: "
+                    "authenticated GraphQL access is unavailable",
+                    repo,
+                    issue.get("number"),
+                )
+            else:
+                try:
+                    closure = await async_get_issue_closure_info(
+                        repo,
+                        int(issue.get("number") or 0),
+                        token=token,
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        "GitHub closure enrichment unavailable for %s#%s: %s",
+                        repo,
+                        issue.get("number"),
+                        exc,
+                    )
+                    raise
+        repo_drafts.append(
+            _draft_for_issue(
+                repo,
+                issue,
+                closure=closure,
+                closure_unavailable_reason=closure_unavailable_reason,
+                org_id=authority.org_id,
+                actor_user_id=authority.actor_user_id,
+            )
+        )
+
+    next_page = payload.get("next_page")
+    if next_page:
+        next_state = {
+            **state,
+            "next_page": next_page,
+            "high_watermark": high_key[0].isoformat(),
+            "high_watermark_id": high_key[1],
+        }
+        return repo_drafts, next_state, True
+
+    next_state = {
+        "watermark": high_key[0].isoformat(),
+        "watermark_id": high_key[1],
+    }
+    return repo_drafts, next_state, False
+
+
 class GitHubConnector:
     source_key = "github"
 
@@ -298,12 +400,18 @@ class GitHubConnector:
     ):
         self.repositories = tuple(repositories) if repositories is not None else None
         self.max_items = max(1, int(max_items))
+        self._enumeration_errors: list[str] = []
+
+    @property
+    def enumeration_errors(self) -> tuple[str, ...]:
+        return tuple(self._enumeration_errors)
 
     async def enumerate_changed(
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        self._enumeration_errors = []
         if int(cursor.get("version") or 0) != _CURSOR_VERSION:
             cursor = {}
         repositories = list(self.repositories or await _configured_repositories(session))
@@ -323,104 +431,47 @@ class GitHubConnector:
         for repo_index in range(active_index, len(repositories)):
             repo = repositories[repo_index]
             state = dict(repo_states.get(repo) or {})
-            watermark_key = _timestamp_key(
-                state.get("watermark"),
-                state.get("watermark_id"),
-            )
-            high_key = _timestamp_key(
-                state.get("high_watermark") or state.get("watermark"),
-                state.get("high_watermark_id") or state.get("watermark_id"),
-            )
             remaining = self.max_items - len(drafts)
             if remaining <= 0:
                 break
-            authority = await _github_authority(session, repo)
-            token = authority.token
-            payload = await async_list_repo_issues(
-                repo,
-                token=token,
-                state="all",
-                since=state.get("watermark"),
-                include_pull_requests=True,
-                limit=remaining,
-                cursor=state.get("next_page"),
-                # Project-context reads compact bodies to 1000 chars for LLM
-                # budgets; an index wants the whole body and bounds it once,
-                # in the pipeline, at RAW_TEXT_MAX_CHARS.
-                body_limit=RAW_TEXT_MAX_CHARS,
-            )
-            issues = [item for item in payload.get("issues") or [] if isinstance(item, Mapping)]
-            for issue in issues:
-                issue_key = _timestamp_key(issue.get("updated_at"), issue.get("id"))
-                high_key = max(high_key, issue_key)
-                if not state.get("next_page") and state.get("watermark") and issue_key <= watermark_key:
-                    continue
-                kind = "pr" if issue.get("type") == "pull_request" else "issue"
-                closure = None
-                closure_unavailable_reason = None
-                if (
-                    str(issue.get("state") or "").lower() == "closed"
-                    and kind == "issue"
-                ):
-                    if not token:
-                        closure_unavailable_reason = "authentication_required"
-                        logger.warning(
-                            "GitHub closure enrichment skipped for %s#%s: "
-                            "authenticated GraphQL access is unavailable",
-                            repo,
-                            issue.get("number"),
-                        )
-                    else:
-                        try:
-                            closure = await async_get_issue_closure_info(
-                                repo,
-                                int(issue.get("number") or 0),
-                                token=token,
-                            )
-                        except Exception as exc:
-                            logger.exception(
-                                "GitHub closure enrichment unavailable for %s#%s: %s",
-                                repo,
-                                issue.get("number"),
-                                exc,
-                            )
-                            raise
-                drafts.append(
-                    _draft_for_issue(
+            try:
+                repo_drafts, next_state, has_next_page = (
+                    await _enumerate_repository(
+                        session,
                         repo,
-                        issue,
-                        closure=closure,
-                        closure_unavailable_reason=closure_unavailable_reason,
-                        org_id=authority.org_id,
-                        actor_user_id=authority.actor_user_id,
+                        state,
+                        remaining=remaining,
                     )
                 )
+            except Exception as exc:
+                message = str(exc).strip() or type(exc).__name__
+                error = f"{repo}: {message}"
+                self._enumeration_errors.append(error)
+                logger.exception(
+                    "GitHub knowledge enumeration skipped repository %s: %s",
+                    repo,
+                    message,
+                )
+                continue
 
-            next_page = payload.get("next_page")
-            if next_page:
-                repo_states[repo] = {
-                    **state,
-                    "next_page": next_page,
-                    "high_watermark": high_key[0].isoformat(),
-                    "high_watermark_id": high_key[1],
-                }
+            drafts.extend(repo_drafts)
+            repo_states[repo] = next_state
+            if has_next_page:
                 return drafts, {
                     "version": _CURSOR_VERSION,
                     "active_repository": repo_index,
                     "repositories": repo_states,
                 }
 
-            repo_states[repo] = {
-                "watermark": high_key[0].isoformat(),
-                "watermark_id": high_key[1],
-            }
             if len(drafts) >= self.max_items:
                 return drafts, {
                     "version": _CURSOR_VERSION,
-                    "active_repository": min(repo_index + 1, len(repositories) - 1),
+                    "active_repository": (repo_index + 1) % len(repositories),
                     "repositories": repo_states,
                 }
 
+        # Reaching the end completes this sweep even when one or more repositories
+        # were recorded as skipped, so the next invocation starts from index zero.
         return drafts, {
             "version": _CURSOR_VERSION,
             "active_repository": 0,

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -18,7 +18,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
 from brain.platform.db.models.knowledge import KnowledgeItem
 from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
 
 _SHARED_VISIBILITIES = ("org", "team")
 _KNOWLEDGE_NODE_KINDS = ("content",)
@@ -118,7 +121,7 @@ class MemoryConnector:
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
-    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+    ) -> KnowledgeEnumeration:
         marker = _cursor_datetime(cursor.get("updated_at"))
         marker_id = max(0, int(cursor.get("id") or 0))
         statement = (
@@ -140,7 +143,7 @@ class MemoryConnector:
 
         rows = list((await session.scalars(statement)).all())
         if not rows:
-            return [], dict(cursor)
+            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
         source_refs = [f"memory_node:{node.id}" for node in rows]
         existing_refs = set(
             (
@@ -178,10 +181,13 @@ class MemoryConnector:
             or f"memory_node:{node.id}" in existing_refs
         ]
         last = rows[-1]
-        return drafts, {
-            "updated_at": _utc_iso(last.updated_at),
-            "id": last.id,
-        }
+        return KnowledgeEnumeration(
+            drafts=drafts,
+            cursor={
+                "updated_at": _utc_iso(last.updated_at),
+                "id": last.id,
+            },
+        )
 
 
 __all__ = ["MemoryConnector"]

--- a/brain/systems/knowledge/connectors/slack.py
+++ b/brain/systems/knowledge/connectors/slack.py
@@ -15,7 +15,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
 from brain.systems.slack.monitored_intakes import visible_slack_content
 from brain.systems.slack.monitors import monitored_channels
 
@@ -223,10 +226,10 @@ class SlackKnowledgeConnector:
         self,
         session: AsyncSession,
         cursor: dict[str, Any],
-    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+    ) -> KnowledgeEnumeration:
         connection, channels = await _monitored_connection(session)
         if connection is None:
-            return [], dict(cursor)
+            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
 
         connection_id = str(connection.id)
         if not _team_id(connection):
@@ -249,19 +252,21 @@ class SlackKnowledgeConnector:
         )
         client = await self._resolve_client(connection)
         if state.get("phase") != "incremental":
-            return await self._backfill(
+            drafts, new_cursor = await self._backfill(
                 client=client,
                 connection=connection,
                 channels=channels,
                 state=state,
             )
-        return await self._incremental(
-            session=session,
-            client=client,
-            connection=connection,
-            channels=channels,
-            state=state,
-        )
+        else:
+            drafts, new_cursor = await self._incremental(
+                session=session,
+                client=client,
+                connection=connection,
+                channels=channels,
+                state=state,
+            )
+        return KnowledgeEnumeration(drafts=drafts, cursor=new_cursor)
 
     async def _backfill(
         self,

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -37,6 +37,7 @@ from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 logger = logging.getLogger(__name__)
 
 RAW_TEXT_MAX_CHARS = 20_000
+_ENUMERATION_ERRORS_KEY = "enumeration_errors"
 
 
 @dataclass
@@ -178,20 +179,34 @@ def _manifest_cursor(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
 
 
+def _error_messages(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [message for item in value if (message := str(item).strip())]
+
+
+def _connector_enumeration_errors(connector: KnowledgeConnector) -> list[str]:
+    return _error_messages(getattr(connector, "enumeration_errors", ()))
+
+
 def _pending_cursor(
     *,
     committed_cursor: dict[str, Any],
     proposed_cursor: dict[str, Any],
     entries: list[dict[str, Any]],
+    enumeration_errors: list[str] | None = None,
 ) -> dict[str, Any]:
+    manifest = {
+        "version": DISTILLATION_MANIFEST_VERSION,
+        "committed_cursor": dict(committed_cursor),
+        "proposed_cursor": dict(proposed_cursor),
+        "entries": entries,
+    }
+    if enumeration_errors:
+        manifest[_ENUMERATION_ERRORS_KEY] = list(enumeration_errors)
     return {
         **committed_cursor,
-        DISTILLATION_CURSOR_KEY: {
-            "version": DISTILLATION_MANIFEST_VERSION,
-            "committed_cursor": dict(committed_cursor),
-            "proposed_cursor": dict(proposed_cursor),
-            "entries": entries,
-        },
+        DISTILLATION_CURSOR_KEY: manifest,
     }
 
 
@@ -622,11 +637,15 @@ async def sync_connector(
     if manifest is not None:
         committed_cursor = _manifest_cursor(manifest.get("committed_cursor"))
         proposed_cursor = _manifest_cursor(manifest.get("proposed_cursor"))
+        enumeration_errors = _error_messages(
+            manifest.get(_ENUMERATION_ERRORS_KEY)
+        )
+        enumeration_error = "; ".join(enumeration_errors) or None
         pending, resolved, failures = await _harvest_distillations(
             session,
             list(manifest.get("entries") or []),
         )
-        stats.failed += failures
+        stats.failed += failures + len(enumeration_errors)
         stats.distilled = sum(
             1 for _draft, should_embed in resolved if should_embed
         )
@@ -646,11 +665,13 @@ async def sync_connector(
                     committed_cursor=committed_cursor,
                     proposed_cursor=proposed_cursor,
                     entries=pending,
+                    enumeration_errors=enumeration_errors,
                 ),
                 result_cursor=committed_cursor,
                 status="pending",
                 stats=stats,
                 run_at=run_at,
+                error=enumeration_error,
             )
 
         status = "ok" if stats.failed == 0 else "degraded"
@@ -662,6 +683,7 @@ async def sync_connector(
             status=status,
             stats=stats,
             run_at=run_at,
+            error=enumeration_error,
         )
 
     cursor = dict(stored_cursor)
@@ -680,6 +702,10 @@ async def sync_connector(
             run_at=run_at,
             error=str(exc),
         )
+
+    enumeration_errors = _connector_enumeration_errors(connector)
+    enumeration_error = "; ".join(enumeration_errors) or None
+    stats.failed += len(enumeration_errors)
 
     structural: list[tuple[KnowledgeDraft, bool]] = []
     distillable: list[KnowledgeDraft] = []
@@ -728,11 +754,13 @@ async def sync_connector(
                 committed_cursor=cursor,
                 proposed_cursor=dict(new_cursor),
                 entries=entries,
+                enumeration_errors=enumeration_errors,
             ),
             result_cursor=cursor,
             status="pending",
             stats=stats,
             run_at=run_at,
+            error=enumeration_error,
         )
 
     if admission_fallbacks:
@@ -754,6 +782,7 @@ async def sync_connector(
         status=status,
         stats=stats,
         run_at=run_at,
+        error=enumeration_error,
     )
 
 

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 import hashlib
@@ -19,7 +20,11 @@ from brain.platform.db.models.knowledge import (
     KnowledgeItemEmbedding,
     KnowledgeSyncState,
 )
-from brain.systems.knowledge.connectors.base import KnowledgeConnector, KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    EnumerationFailure,
+    KnowledgeConnector,
+    KnowledgeDraft,
+)
 from brain.systems.knowledge.distillation import (
     DISTILLATION_CURSOR_KEY,
     DISTILLATION_MANIFEST_VERSION,
@@ -179,14 +184,24 @@ def _manifest_cursor(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
 
 
-def _error_messages(value: Any) -> list[str]:
-    if not isinstance(value, (list, tuple)):
-        return []
-    return [message for item in value if (message := str(item).strip())]
+def _manifest_enumeration_failures(value: Any) -> tuple[EnumerationFailure, ...]:
+    if not isinstance(value, list):
+        return ()
+    failures: list[EnumerationFailure] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        scope = str(item.get("scope") or "").strip()
+        message = str(item.get("message") or "").strip()
+        if scope and message:
+            failures.append(EnumerationFailure(scope=scope, message=message))
+    return tuple(failures)
 
 
-def _connector_enumeration_errors(connector: KnowledgeConnector) -> list[str]:
-    return _error_messages(getattr(connector, "enumeration_errors", ()))
+def _enumeration_error(failures: tuple[EnumerationFailure, ...]) -> str | None:
+    return "; ".join(
+        f"{failure.scope}: {failure.message}" for failure in failures
+    ) or None
 
 
 def _pending_cursor(
@@ -194,7 +209,7 @@ def _pending_cursor(
     committed_cursor: dict[str, Any],
     proposed_cursor: dict[str, Any],
     entries: list[dict[str, Any]],
-    enumeration_errors: list[str] | None = None,
+    enumeration_failures: tuple[EnumerationFailure, ...] = (),
 ) -> dict[str, Any]:
     manifest = {
         "version": DISTILLATION_MANIFEST_VERSION,
@@ -202,8 +217,11 @@ def _pending_cursor(
         "proposed_cursor": dict(proposed_cursor),
         "entries": entries,
     }
-    if enumeration_errors:
-        manifest[_ENUMERATION_ERRORS_KEY] = list(enumeration_errors)
+    if enumeration_failures:
+        manifest[_ENUMERATION_ERRORS_KEY] = [
+            {"scope": failure.scope, "message": failure.message}
+            for failure in enumeration_failures
+        ]
     return {
         **committed_cursor,
         DISTILLATION_CURSOR_KEY: manifest,
@@ -637,15 +655,15 @@ async def sync_connector(
     if manifest is not None:
         committed_cursor = _manifest_cursor(manifest.get("committed_cursor"))
         proposed_cursor = _manifest_cursor(manifest.get("proposed_cursor"))
-        enumeration_errors = _error_messages(
+        enumeration_failures = _manifest_enumeration_failures(
             manifest.get(_ENUMERATION_ERRORS_KEY)
         )
-        enumeration_error = "; ".join(enumeration_errors) or None
+        enumeration_error = _enumeration_error(enumeration_failures)
         pending, resolved, failures = await _harvest_distillations(
             session,
             list(manifest.get("entries") or []),
         )
-        stats.failed += failures + len(enumeration_errors)
+        stats.failed += failures + len(enumeration_failures)
         stats.distilled = sum(
             1 for _draft, should_embed in resolved if should_embed
         )
@@ -665,7 +683,7 @@ async def sync_connector(
                     committed_cursor=committed_cursor,
                     proposed_cursor=proposed_cursor,
                     entries=pending,
-                    enumeration_errors=enumeration_errors,
+                    enumeration_failures=enumeration_failures,
                 ),
                 result_cursor=committed_cursor,
                 status="pending",
@@ -688,7 +706,10 @@ async def sync_connector(
 
     cursor = dict(stored_cursor)
     try:
-        drafts, new_cursor = await connector.enumerate_changed(session, cursor)
+        enumeration = await connector.enumerate_changed(session, cursor)
+        drafts = enumeration.drafts
+        new_cursor = enumeration.cursor
+        enumeration_failures = enumeration.failures
     except Exception as exc:
         stats.failed = 1
         logger.exception("Knowledge connector %s enumeration failed", source)
@@ -703,9 +724,8 @@ async def sync_connector(
             error=str(exc),
         )
 
-    enumeration_errors = _connector_enumeration_errors(connector)
-    enumeration_error = "; ".join(enumeration_errors) or None
-    stats.failed += len(enumeration_errors)
+    enumeration_error = _enumeration_error(enumeration_failures)
+    stats.failed += len(enumeration_failures)
 
     structural: list[tuple[KnowledgeDraft, bool]] = []
     distillable: list[KnowledgeDraft] = []
@@ -754,7 +774,7 @@ async def sync_connector(
                 committed_cursor=cursor,
                 proposed_cursor=dict(new_cursor),
                 entries=entries,
-                enumeration_errors=enumeration_errors,
+                enumeration_failures=enumeration_failures,
             ),
             result_cursor=cursor,
             status="pending",

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -40,6 +40,7 @@ from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
     GithubFixingPullRequest,
     GithubIssueClosure,
 )
@@ -1406,11 +1407,16 @@ async def test_github_closure_enrichment_failure_retries_without_advancing_curso
         failed = await sync_connector(session, connector)
         retried = await sync_connector(session, connector)
 
-    assert failed.status == "failed"
-    assert failed.cursor == {}
+    assert failed.status == "degraded"
+    assert failed.cursor == {
+        "version": 2,
+        "active_repository": 0,
+        "repositories": {},
+    }
     assert failed.stats["failed"] == 1
+    assert failed.error == "Illospace/illospace: temporary"
     assert retried.status == "pending"
-    assert retried.cursor == {}
+    assert retried.cursor == failed.cursor
     assert get_closure.await_count == 2
     state = await session.get(KnowledgeSyncState, "github")
     assert state is not None
@@ -1448,6 +1454,214 @@ async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
     assert drafts == []
     assert list_issues.await_args.kwargs["since"] is None
     assert cursor["version"] == 2
+
+
+async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
+    session,
+    caplog,
+):
+    repositories = ["acme/healthy-one", "acme/missing", "acme/healthy-two"]
+    initial_cursor = {
+        "version": 2,
+        "active_repository": 0,
+        "repositories": {
+            repo: {
+                "watermark": "2026-07-29T12:00:00+00:00",
+                "watermark_id": index,
+            }
+            for index, repo in enumerate(repositories, start=1)
+        },
+    }
+    issues = {
+        "acme/healthy-one": {
+            "id": 101,
+            "number": 11,
+            "title": "First healthy issue",
+            "state": "open",
+            "body": "Healthy repository one advanced.",
+            "labels": [],
+            "user": {"login": "octocat"},
+            "created_at": "2026-07-30T09:00:00Z",
+            "updated_at": "2026-07-30T10:00:00Z",
+        },
+        "acme/healthy-two": {
+            "id": 303,
+            "number": 33,
+            "title": "Second healthy issue",
+            "state": "open",
+            "body": "Healthy repository two advanced.",
+            "labels": [],
+            "user": {"login": "octocat"},
+            "created_at": "2026-07-30T11:00:00Z",
+            "updated_at": "2026-07-30T12:00:00Z",
+        },
+    }
+    emit_issues = True
+
+    async def list_issues(repo, **kwargs):
+        del kwargs
+        if repo == "acme/missing":
+            raise GitHubConnectorError(
+                status_code=404,
+                message="Repository not found or not visible to this token.",
+            )
+        return {
+            "issues": [issues[repo]] if emit_issues else [],
+            "next_page": None,
+        }
+
+    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    connector = GitHubConnector(repositories=repositories, max_items=10)
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=AsyncMock(side_effect=list_issues),
+    ):
+        drafts, cursor = await connector.enumerate_changed(session, initial_cursor)
+
+        assert [draft.source_ref for draft in drafts] == [
+            "github:acme/healthy-one#11",
+            "github:acme/healthy-two#33",
+        ]
+        assert cursor["repositories"]["acme/healthy-one"] == {
+            "watermark": "2026-07-30T10:00:00+00:00",
+            "watermark_id": 101,
+        }
+        assert cursor["repositories"]["acme/healthy-two"] == {
+            "watermark": "2026-07-30T12:00:00+00:00",
+            "watermark_id": 303,
+        }
+        assert (
+            cursor["repositories"]["acme/missing"]
+            == initial_cursor["repositories"]["acme/missing"]
+        )
+        assert cursor["active_repository"] == 0
+        assert connector.enumeration_errors == (
+            "acme/missing: Repository not found or not visible to this token.",
+        )
+
+        emit_issues = False
+        result = await sync_connector(
+            session,
+            GitHubConnector(repositories=repositories, max_items=10),
+        )
+
+    payload = result.to_dict()
+    assert result.status == "degraded"
+    assert result.stats["failed"] == 1
+    assert payload["error"] == (
+        "acme/missing: Repository not found or not visible to this token."
+    )
+    assert any(
+        "acme/missing" in record.message
+        and "Repository not found or not visible to this token." in record.message
+        for record in caplog.records
+    )
+
+
+async def test_github_connector_error_message_surfaces_in_failed_sync_payload(session):
+    message = "Repository not found or not visible to this token."
+    error = GitHubConnectorError(status_code=404, message=message)
+
+    assert str(error) == message
+    assert error.args == (message,)
+    assert error.status_code == 404
+    assert error.message == message
+    assert error == GitHubConnectorError(status_code=404, message=message)
+    assert repr(error) == (
+        "GitHubConnectorError(status_code=404, "
+        "message='Repository not found or not visible to this token.')"
+    )
+
+    connector = SimpleNamespace(
+        source_key="github",
+        enumerate_changed=AsyncMock(side_effect=error),
+    )
+    result = await sync_connector(session, connector)
+
+    assert result.status == "failed"
+    assert result.stats["failed"] == 1
+    assert result.to_dict()["error"] == message
+
+
+async def test_enumeration_error_survives_pending_distillation_as_degraded(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "88888888-8888-4888-8888-888888888888"
+    session.add(Org(id=_ORG_ID, name="Degraded Org", slug="degraded-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Degraded Worker",
+            email="degraded@example.com",
+        )
+    )
+    await session.flush()
+    proposed_cursor = {
+        "version": 2,
+        "active_repository": 0,
+        "repositories": {
+            "acme/healthy": {
+                "watermark": "2026-07-30T12:00:00+00:00",
+                "watermark_id": 303,
+            }
+        },
+    }
+    connector = _StubConnector(
+        source_key="github",
+        drafts=[
+            KnowledgeDraft(
+                source="github",
+                kind="issue",
+                source_ref="github:acme/healthy#33",
+                title="Healthy issue",
+                summary="A healthy repository continued indexing.",
+                raw_text="Healthy repository body.",
+                extra={"org_id": _ORG_ID, "actor_user_id": user_id},
+                distill=True,
+            )
+        ],
+        new_cursor=proposed_cursor,
+    )
+    connector.enumeration_errors = (
+        "acme/missing: Repository not found or not visible to this token.",
+    )
+
+    pending = await sync_connector(session, connector)
+    run = (await session.scalars(select(AgentRunRow))).one()
+    run.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=run.id,
+            root_run_id=run.root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "What changed in the healthy repository?",
+                    "summary": "The healthy repository continued indexing.",
+                    "resolution": None,
+                    "systems": ["knowledge"],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    degraded = await sync_connector(session, connector)
+
+    assert pending.status == "pending"
+    assert pending.stats["failed"] == 1
+    assert pending.to_dict()["error"]
+    assert degraded.status == "degraded"
+    assert degraded.stats["failed"] == 1
+    assert degraded.cursor == proposed_cursor
+    assert degraded.to_dict()["error"] == connector.enumeration_errors[0]
 
 
 async def test_public_github_closure_uses_accounted_structural_fallback(

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -31,7 +31,11 @@ from brain.platform.db.models.knowledge import (
 )
 from brain.platform.db.models.org import Org, User
 from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import (
+    EnumerationFailure,
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector, _draft_for_issue
 from brain.systems.knowledge.connectors.memory import MemoryConnector
@@ -56,16 +60,22 @@ class _StubConnector:
         source_key: str,
         drafts: list[KnowledgeDraft],
         new_cursor: dict | None = None,
+        failures: tuple[EnumerationFailure, ...] = (),
     ):
         self.source_key = source_key
         self.drafts = drafts
         self.new_cursor = dict(new_cursor or {})
+        self.failures = failures
         self.seen_cursors: list[dict] = []
 
     async def enumerate_changed(self, session, cursor):
         del session
         self.seen_cursors.append(dict(cursor))
-        return list(self.drafts), dict(self.new_cursor)
+        return KnowledgeEnumeration(
+            drafts=list(self.drafts),
+            cursor=dict(self.new_cursor),
+            failures=self.failures,
+        )
 
 
 class _McpAsyncSession:
@@ -1449,11 +1459,12 @@ async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
         "brain.systems.knowledge.connectors.github.async_list_repo_issues",
         new=list_issues,
     ):
-        drafts, cursor = await connector.enumerate_changed(session, legacy_cursor)
+        enumeration = await connector.enumerate_changed(session, legacy_cursor)
 
-    assert drafts == []
+    assert enumeration.drafts == []
     assert list_issues.await_args.kwargs["since"] is None
-    assert cursor["version"] == 2
+    assert enumeration.cursor["version"] == 2
+    assert enumeration.failures == ()
 
 
 async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
@@ -1519,12 +1530,13 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
         "brain.systems.knowledge.connectors.github.async_list_repo_issues",
         new=AsyncMock(side_effect=list_issues),
     ):
-        drafts, cursor = await connector.enumerate_changed(session, initial_cursor)
+        enumeration = await connector.enumerate_changed(session, initial_cursor)
 
-        assert [draft.source_ref for draft in drafts] == [
+        assert [draft.source_ref for draft in enumeration.drafts] == [
             "github:acme/healthy-one#11",
             "github:acme/healthy-two#33",
         ]
+        cursor = enumeration.cursor
         assert cursor["repositories"]["acme/healthy-one"] == {
             "watermark": "2026-07-30T10:00:00+00:00",
             "watermark_id": 101,
@@ -1538,8 +1550,11 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
             == initial_cursor["repositories"]["acme/missing"]
         )
         assert cursor["active_repository"] == 0
-        assert connector.enumeration_errors == (
-            "acme/missing: Repository not found or not visible to this token.",
+        assert enumeration.failures == (
+            EnumerationFailure(
+                scope="acme/missing",
+                message="Repository not found or not visible to this token.",
+            ),
         )
 
         emit_issues = False
@@ -1627,12 +1642,26 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
             )
         ],
         new_cursor=proposed_cursor,
+        failures=(
+            EnumerationFailure(
+                scope="acme/missing",
+                message="Repository not found or not visible to this token.",
+            ),
+        ),
     )
-    connector.enumeration_errors = (
-        "acme/missing: Repository not found or not visible to this token.",
+    expected_error = (
+        "acme/missing: Repository not found or not visible to this token."
     )
 
     pending = await sync_connector(session, connector)
+    state = await session.get(KnowledgeSyncState, "github")
+    assert state is not None
+    assert state.cursor["_distillation_pending"]["enumeration_errors"] == [
+        {
+            "scope": "acme/missing",
+            "message": "Repository not found or not visible to this token.",
+        }
+    ]
     run = (await session.scalars(select(AgentRunRow))).one()
     run.status = "completed"
     session.add(
@@ -1657,11 +1686,11 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
 
     assert pending.status == "pending"
     assert pending.stats["failed"] == 1
-    assert pending.to_dict()["error"]
+    assert pending.to_dict()["error"] == expected_error
     assert degraded.status == "degraded"
     assert degraded.stats["failed"] == 1
     assert degraded.cursor == proposed_cursor
-    assert degraded.to_dict()["error"] == connector.enumeration_errors[0]
+    assert degraded.to_dict()["error"] == expected_error
 
 
 async def test_public_github_closure_uses_accounted_structural_fallback(

--- a/tests/test_knowledge_slack_connector.py
+++ b/tests/test_knowledge_slack_connector.py
@@ -391,14 +391,15 @@ async def test_slack_connector_does_not_inherit_the_monitor_prompt_text_cap(sess
         }
     ]
 
-    drafts, _cursor = await SlackKnowledgeConnector(
+    enumeration = await SlackKnowledgeConnector(
         client=slack,
         max_items=1,
     ).enumerate_changed(session, {})
 
-    assert len(drafts) == 1
-    assert drafts[0].raw_text.endswith("TAIL_MARKER")
-    assert len(drafts[0].raw_text) > 5000
+    assert len(enumeration.drafts) == 1
+    assert enumeration.drafts[0].raw_text.endswith("TAIL_MARKER")
+    assert len(enumeration.drafts[0].raw_text) > 5000
+    assert enumeration.failures == ()
 
 
 async def test_slack_connector_reuses_runtime_transport_under_connection_authority(
@@ -420,12 +421,12 @@ async def test_slack_connector_reuses_runtime_transport_under_connection_authori
         fake_runtime_client,
     )
 
-    drafts, _cursor = await SlackKnowledgeConnector(max_items=1).enumerate_changed(
+    enumeration = await SlackKnowledgeConnector(max_items=1).enumerate_changed(
         session,
         {},
     )
 
-    assert len(drafts) == 1
+    assert len(enumeration.drafts) == 1
     assert calls == [
         {
             "requested_by": "knowledge_index_sync",
@@ -441,7 +442,9 @@ async def test_slack_connector_repulls_one_complete_thread_when_a_reply_arrives(
     slack = _SlackHistory()
     connector = SlackKnowledgeConnector(client=slack, max_items=1)
 
-    first, cursor = await connector.enumerate_changed(session, {})
+    first_enumeration = await connector.enumerate_changed(session, {})
+    first = first_enumeration.drafts
+    cursor = first_enumeration.cursor
 
     assert len(first) == 1
     assert first[0].source_ref == "slack:T789:CINCIDENTS:1785283200.000100"
@@ -502,7 +505,9 @@ async def test_slack_connector_repulls_one_complete_thread_when_a_reply_arrives(
     )
     await session.flush()
 
-    second, new_cursor = await connector.enumerate_changed(session, cursor)
+    second_enumeration = await connector.enumerate_changed(session, cursor)
+    second = second_enumeration.drafts
+    new_cursor = second_enumeration.cursor
 
     assert len(second) == 1
     assert second[0].source_ref == first[0].source_ref
@@ -523,7 +528,9 @@ async def test_slack_connector_repulls_one_complete_thread_when_a_reply_arrives(
         }
     )
 
-    refreshed, refresh_cursor = await connector.enumerate_changed(session, new_cursor)
+    refresh_enumeration = await connector.enumerate_changed(session, new_cursor)
+    refreshed = refresh_enumeration.drafts
+    refresh_cursor = refresh_enumeration.cursor
 
     assert len(refreshed) == 1
     assert refreshed[0].extra["message_count"] == 4


### PR DESCRIPTION
Closes #627

## What was wrong

`knowledge_index_sync` has failed on every run since 2026-07-29, and the Illospace knowledge index has been answering every query from a two-day-stale corpus with no signal to the caller.

`GitHubConnector.enumerate_changed` called `async_list_repo_issues` per repository with **no `try`/`except`**. The connector's live repo list (resolved from active `ProjectProfile`s) contains two unreachable entries — `uwear-ai/agent-mission-control` (real private repo, no active Vault `github_app` binding, so the request goes out unauthenticated) and `static/uploads` (not a repo at all; see #628). Either one returns HTTP 404, which raised out of the whole connector. `sync_connector` then finalized with the **original** cursor, so **no** repository's watermark advanced — not just the failing one. `Illospace/illospace` sat frozen at `2026-07-29T14:51:32Z`; `uwear-ai/uwear-backend` sat pinned mid-pagination at page 15.

**Why two days of alerts said nothing but `Command exited with status 1`:** `GitHubConnectorError` is declared `@dataclass class GitHubConnectorError(Exception)`. A dataclass-generated `__init__` never calls `Exception.__init__`, so `args == ()` and `str(exc) == ''`. `sync_connector` passed `error=str(exc)` → `""`, and `KnowledgeSyncResult.to_dict()`'s `if self.error:` dropped the empty string. The `logger.exception` traceback *was* written — to stderr, where the Slack connector (which runs after GitHub) floods hundreds of httpx INFO lines and evicts it from the captured `stderr_tail`. That is why #594 closed calling the cause "unrecoverable."

Reproduced live and read-only on illo-dev before writing any code:

```
type       : GitHubConnectorError
status_code: 404
message    : 'Repository not found or not visible to this token.'
str(exc)   : ''        <-- empty
```

## What this changes

- **Per-repository isolation.** `_enumerate_repository` is extracted so one repo's failure cannot mutate another's state. A failing repo is recorded and skipped; the sweep continues; healthy repositories still advance. The sync reports **`degraded` with the failure named**, not `failed` with everything stalled — so the job exits 0 and the index keeps moving while the bad repo stays visible.
- **Cursor wraparound.** `active_repository` now advances with `% len(repositories)`. The previous `min(repo_index + 1, len(repositories) - 1)` pinned the cursor on the last repository once it got there, so earlier repositories were never revisited — a second, independent starvation bug.
- **`GitHubConnectorError` carries its message.** `__post_init__` calls `Exception.__init__(self.message)`, so every message `_github_error()` builds actually survives to the durable payload.
- **Enumeration failures are a declared contract**, not a side channel: `enumerate_changed` returns `KnowledgeEnumeration(drafts, cursor, failures)` with a typed `EnumerationFailure(scope, message)` across all four connectors.

## How to verify

No UI. Run the repo's own CI selection:

```
python3 -m pytest tests/ -m "not requires_db and not requires_browser and not live_provider" -q
```

**4596 passed, 11 skipped** on this branch — identical to `main`'s count, run twice (once per commit).

Three regression tests, in `tests/test_knowledge_index.py`:
1. `test_github_enumeration_isolates_repo_failures_and_wraps_cursor` — a 404 on a *middle* repo; asserts the healthy repos on both sides still emit drafts and advance their watermarks, and the cursor wraps.
2. `test_github_connector_error_message_surfaces_in_failed_sync_payload` — the message reaches the payload instead of `''`.
3. `test_enumeration_error_survives_pending_distillation_as_degraded` — failures survive the pending-distillation round-trip and land as `degraded`.

### Acceptance checks after deploy
1. `knowledge_index_sync` stops tripping consecutive/rolling-window failure alerts (it should now finish `degraded`, exit 0).
2. `Illospace/illospace`'s watermark advances past `2026-07-29T14:51:32Z`.
3. `knowledge.search` returns #620, #593, #606 — the issues currently missing from the index.
4. The sync result names the two skipped repos rather than reporting a bare `Command exited with status 1`.

## Assumptions and deliberate omissions

- The two unreachable repos are **not** cleaned up here — that is the data-side half, filed as **#628** (`parse_github_repo_slug` never checks the value is a GitHub URL, so `/static/uploads/…` parses into a phantom repo). This PR makes the connector robust to them regardless; both tickets are worth landing.
- The issue's fourth acceptance criterion — a readable per-source staleness/lag signal — is **not** in this PR. It is a design decision about where staleness surfaces (doctor? search response?), not a bug fix, and it deserves its own change.
- A code-quality review pass raised two further items I deliberately deferred rather than folding in: the distillation manifest is drifting toward an untyped property bag and wants a typed `PendingSyncManifest` (it predates this change), and `tests/test_knowledge_index.py` is now 1,717 lines and should be split. Neither blocks this fix.

<sub>Routine R3 — root cause diagnosed read-only on illo-dev (`enumerate_changed` only, session rolled back, nothing written). Evidence: `state/evidence/illo-627-root-cause-20260731T1400.md`, [diagnosis comment](https://github.com/Illospace/illospace/issues/627#issuecomment-5143612578).</sub>