### PR TITLE
fix(project-context): reject non-GitHub URLs in parse_github_repo_slug (#628)

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -116,22 +116,22 @@ class GithubIssueClosure:
     fixing_pull_requests: tuple[GithubFixingPullRequest, ...]
 
 
+# The prefixes that mark a value as an explicit GitHub reference. Stated once: the
+# same list decides whether the origin is trusted AND what gets stripped, so the two
+# can never drift apart.
+_GITHUB_PREFIX_RE = re.compile(
+    r"^(?:git@github\.com:|https?://github\.com/|github://|github\.com/)",
+    flags=re.IGNORECASE,
+)
+
+
 def parse_github_repo_slug(value: str) -> str | None:
     slug = (value or "").strip()
     if not slug:
         return None
-    has_github_prefix = bool(
-        re.match(
-            r"^(?:git@github\.com:|https?://github\.com/|github://|github\.com/)",
-            slug,
-            flags=re.IGNORECASE,
-        )
-    )
-    slug = re.sub(r"^git@github\.com:", "", slug, flags=re.IGNORECASE)
-    slug = re.sub(r"^https?://github\.com/", "", slug, flags=re.IGNORECASE)
-    slug = re.sub(r"^github://", "", slug, flags=re.IGNORECASE)
-    slug = re.sub(r"^github\.com/", "", slug, flags=re.IGNORECASE)
-    slug = re.sub(r"[?#].*$", "", slug)
+    stripped = _GITHUB_PREFIX_RE.sub("", slug, count=1)
+    has_github_prefix = stripped != slug
+    slug = re.sub(r"[?#].*$", "", stripped)
     if not has_github_prefix:
         if slug.startswith("/") or len(slug.strip("/").split("/")) != 2:
             return None

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -120,11 +120,22 @@ def parse_github_repo_slug(value: str) -> str | None:
     slug = (value or "").strip()
     if not slug:
         return None
+    has_github_prefix = bool(
+        re.match(
+            r"^(?:git@github\.com:|https?://github\.com/|github://|github\.com/)",
+            slug,
+            flags=re.IGNORECASE,
+        )
+    )
     slug = re.sub(r"^git@github\.com:", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"^https?://github\.com/", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"^github://", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"^github\.com/", "", slug, flags=re.IGNORECASE)
-    slug = re.sub(r"[?#].*$", "", slug).strip("/")
+    slug = re.sub(r"[?#].*$", "", slug)
+    if not has_github_prefix:
+        if slug.startswith("/") or len(slug.strip("/").split("/")) != 2:
+            return None
+    slug = slug.strip("/")
     parts = [part for part in slug.split("/") if part]
     if len(parts) < 2:
         return None

--- a/tests/test_project_context_github.py
+++ b/tests/test_project_context_github.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from brain.systems.cortex.project_context.github import parse_github_repo_slug
+from brain.systems.knowledge.connectors.github import _resource_repositories
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://github.com/owner/repo", "owner/repo"),
+        ("https://github.com/owner/repo/tree/main", "owner/repo"),
+        ("http://github.com/owner/repo/issues/1", "owner/repo"),
+        ("git@github.com:owner/repo.git", "owner/repo"),
+        ("github://owner/repo/tree/main", "owner/repo"),
+        ("github.com/owner/repo", "owner/repo"),
+        ("owner/repo", "owner/repo"),
+    ],
+)
+def test_parse_github_repo_slug_accepts_github_references(value: str, expected: str):
+    assert parse_github_repo_slug(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/static/uploads/whatever.pdf",
+        "static/uploads/whatever.pdf",
+        "https://gitlab.com/owner/repo",
+        "https://example.com/a/b",
+        "file:///a/b",
+    ],
+)
+def test_parse_github_repo_slug_rejects_non_github_references(value: str):
+    assert parse_github_repo_slug(value) is None
+
+
+def test_resource_repositories_ignores_uploaded_file_uri():
+    context = {"resources": [{"uri": "/static/uploads/x.pdf"}]}
+
+    assert _resource_repositories(context) == []
+
+
+def test_resource_repositories_keeps_github_urls_in_generic_resource_fields():
+    context = {
+        "resources": [
+            {"uri": "https://github.com/owner/first"},
+            {"url": "https://github.com/owner/second/tree/main"},
+        ]
+    }
+
+    assert _resource_repositories(context) == ["owner/first", "owner/second"]


### PR DESCRIPTION
Closes #628.

## What was wrong

`parse_github_repo_slug()` stripped a list of known GitHub prefixes and then, if none
matched, simply split whatever it was handed on `/` and took the first two segments. It
never checked the value was a GitHub reference at all.

`_resource_repositories()` feeds it every `uri`/`url` off a `ProjectProfile.project_context`
— generic resource URLs. So the uploaded-file path `/static/uploads/<file>.pdf` parsed into
the phantom repo slug **`static/uploads`**, and the knowledge GitHub connector then tried to
index it and got a 404.

Verified on illo-dev (read-only): `static/uploads` was a live entry in the connector's
8-repo list, contributed by profiles `test-project-stripe` and `Aritzia / Uwear Client Project`.

This is the data-side half of #627. #627 (PR #629) fixes the *robustness* problem — one
unreachable repo aborted the whole connector and froze every repo's watermark for two days.
This PR is the reason an unreachable repo was in the list at all.

## The rule

A value carrying a recognized GitHub prefix (`git@github.com:`, `https?://github.com/`,
`github://`, `github.com/`) keeps today's behaviour, trailing path segments included.

A **bare** value with no such prefix is the one ambiguous case worth keeping — `owner/repo`
is used as a config value in several places, including `KNOWLEDGE_GITHUB_REPOSITORIES`. It
is accepted only when unambiguously a bare slug: no leading `/`, and exactly two segments.
That is what separates `owner/repo` (keep) from `/static/uploads/x.pdf` (reject) and
`static/uploads/x.pdf` (reject).

Everything else — any scheme or host that is not github.com — is now rejected.

## Review surface

No UI. The behaviour is a pure function; the table below is the whole change.

| input | before | after |
|---|---|---|
| `/static/uploads/whatever.pdf` | `static/uploads` | `None` |
| `static/uploads/whatever.pdf` | `static/uploads` | `None` |
| `https://gitlab.com/owner/repo` | `https:/gitlab.com` | `None` |
| `https://example.com/a/b` | `https:/example.com` | `None` |
| `https://github.com/owner/repo` | `owner/repo` | `owner/repo` |
| `https://github.com/owner/repo/tree/main` | `owner/repo` | `owner/repo` |
| `git@github.com:owner/repo.git` | `owner/repo` | `owner/repo` |
| `owner/repo` (bare config slug) | `owner/repo` | `owner/repo` |

Reproduce without checking anything out:

```
python -c "from brain.systems.cortex.project_context.github import parse_github_repo_slug as p; print([p(x) for x in ['/static/uploads/a.pdf','https://gitlab.com/o/r','https://github.com/o/r','o/r']])"
```

## Acceptance checks

1. `_resource_repositories({"resources": [{"uri": "/static/uploads/x.pdf"}]})` returns `[]`,
   while a resource whose `uri` genuinely is a GitHub URL still contributes its slug.
2. Bare configured slugs still resolve — `KNOWLEDGE_GITHUB_REPOSITORIES` keeps working.
3. After deploy, the GitHub connector's resolved repo list on illo-dev no longer contains
   `static/uploads` (down from 8 entries to 7).
4. Full CI selection green.

## Verification

- Full CI selection, run by me outside the Codex sandbox: **4607 passed, 11 skipped, 82
  deselected** in 75s. Re-run after the second commit: same.
- The worker reported 1 failure + 5 errors; those are the known sandbox artifact where
  binding `127.0.0.1` raises `PermissionError`. Confirmed by re-running outside the sandbox
  — 4th time this signature has appeared.
- Call-site audit covered all six non-knowledge callers (`deploy_state_github`,
  `project_context/materializer`, `project_context/merge`, `runs/project_execution_env`,
  `runs/tool_catalog/handlers/github`, `api/routers/cortex/_project_context`). All pass
  explicit GitHub inputs, recognized remotes, or configured bare slugs — all still supported.

## Deliberately out of scope

The issue's third suggestion — *a repo with no Vault binding should be reported as
unconfigured rather than silently attempted unauthenticated* — is **not** in this PR. That
code lives in `_github_authority` / the connector enumeration path, which PR #629 rewrites
(`connectors/github.py` lines 287–490). Doing it here would have guaranteed a conflict. It
wants a follow-up ticket once #629 merges; `uwear-ai/agent-mission-control` is the live
instance (a real private repo with no active Vault `github_app` binding, so the request goes
out unauthenticated and 404s).

Also left alone: `_resource_repositories` still reads the generic `uri`/`url` keys. Resource
normalization does store legitimate GitHub URLs there, and the tightened parser is now
sufficient to reject the rest — so narrowing the key list would have removed real signal to
fix a problem already fixed upstream of it.

## Note on the second commit

`52b06b82` (the worker's fix) stated the four GitHub prefixes twice — once to decide whether
the origin was trusted, once to strip them — so a fifth prefix would have had to be
remembered in both places. `38581229` folds them into one compiled pattern where the match
result *is* the origin decision. No behaviour change; test counts identical before and after.
