### PR TITLE
refactor(runs): one owner for thread cancellation (#624)

### DIFF
--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -15,12 +15,11 @@ from sqlalchemy import and_, func, or_, select, union
 from sqlalchemy.orm import aliased
 
 from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-from brain.systems.runs.events import run_event
 from brain.systems.runs.status import (
-    RunStatus,
     TERMINAL_RUN_STATUSES,
     coerce_run_status,
 )
+from brain.systems.runs.cancel import async_cancel_open_runs_for_thread
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.ui_events import public_run_event_payload
 from brain.app.api.auth import get_current_user
@@ -32,7 +31,6 @@ from brain.systems.runs.cortex.read_models import (
     public_failure_for_run,
     run_stream_payload,
 )
-from brain.systems.runs.cycle_settlement import async_finalize_cycle_run_if_needed
 from brain.app.api.routers.cortex._helpers import (
     _infer_feedback_tags,
     _parse_message_type,
@@ -480,31 +478,7 @@ async def _publish_notification_summary_updates(
 async def idea_cancel_all(idea_id: str, user: dict[str, Any] = Depends(get_current_user)):
     async with UnitOfWork() as uow:
         await _require_idea_for_user(uow.session, idea_id, user)
-        result = await uow.session.scalars(
-            select(AgentRun).where(
-                AgentRun.thread_id == idea_id,
-                AgentRun.status.in_(OPEN_RUN_STATUS_VALUES),
-            )
-        )
-        store = AsyncAgentRunStore(uow.session)
-        count = 0
-        for row in result.all():
-            await store.append_event(
-                run_event(
-                    int(row.id),
-                    "run.canceled",
-                    {"reason": "canceled_for_thread"},
-                    root_run_id=row.root_run_id,
-                )
-            )
-            canceled = await store.set_status(
-                row.id,
-                RunStatus.CANCELED,
-                reason="canceled_for_thread",
-            )
-            if canceled.status == RunStatus.CANCELED:
-                await async_finalize_cycle_run_if_needed(int(row.id), status="canceled")
-            count += 1
+        count = await async_cancel_open_runs_for_thread(uow.session, idea_id)
     return {"ok": True, "canceled": count, "cancelled": count}
 
 

--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -30,10 +30,8 @@ from brain.app.api.routers.cortex._helpers import (
     _row_to_dict,
 )
 from brain.app.api.routers.cortex._router import router
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES, TERMINAL_RUN_STATUS_VALUES
-from brain.systems.runs.events import run_event
-from brain.systems.runs.status import RunStatus
-from brain.systems.runs.store import AsyncAgentRunStore as _AgentRunStore
+from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
+from brain.systems.runs.cancel import async_cancel_open_runs_for_thread
 from brain.systems.runs.cortex.analytics import RunAuditNotFound, async_build_idea_audit_summary
 from brain.systems.runs.cortex.read_models import (
     project_run_status,
@@ -113,29 +111,6 @@ async def _public_thread_message_projections(
         )
         projected.append((message, str(content or ""), metadata, failure))
     return projected
-
-
-async def _cancel_active_runs_for_idea(session, idea_id: str, *, reason: str) -> int:
-    result = await session.scalars(
-        select(AgentRun).where(
-            AgentRun.thread_id == idea_id,
-            AgentRun.status.in_(OPEN_RUN_STATUS_VALUES),
-        )
-    )
-    store = _AgentRunStore(session)
-    count = 0
-    for row in result.all():
-        await store.append_event(
-            run_event(
-                int(row.id),
-                "run.canceled",
-                {"reason": reason},
-                root_run_id=row.root_run_id,
-            )
-        )
-        await store.set_status(row.id, RunStatus.CANCELED, reason=reason)
-        count += 1
-    return count
 
 
 async def _store_generated_display_title(
@@ -499,7 +474,11 @@ async def split_idea(idea_id: str, request: Request, user: dict[str, Any] = Depe
                 actor=user,
             ),
         )
-        await _cancel_active_runs_for_idea(uow.session, idea_id, reason="Parent split into branches")
+        await async_cancel_open_runs_for_thread(
+            uow.session,
+            idea_id,
+            reason="Parent split into branches",
+        )
 
     thought_split_payload = {"parent_id": idea_id, "children": created_ids}
     status_payload = {"idea_id": idea_id, "new_status": "resolved"}

--- a/brain/systems/runs/cancel.py
+++ b/brain/systems/runs/cancel.py
@@ -1,4 +1,4 @@
-"""Cancellation token for active AgentRun execution."""
+"""Cancellation operations for active AgentRun execution."""
 
 from __future__ import annotations
 
@@ -7,10 +7,51 @@ import time
 from typing import Callable
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.systems.runs.cycle_settlement import async_finalize_cycle_run_if_needed
+from brain.systems.runs.events import run_event
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES
+from brain.systems.runs.store import AsyncAgentRunStore
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+
+async def async_cancel_open_runs_for_thread(
+    session: AsyncSession,
+    thread_id: str,
+    *,
+    reason: str = "canceled_for_thread",
+) -> int:
+    """Cancel every open run on a thread within the caller's transaction."""
+
+    result = await session.scalars(
+        select(AgentRunRow).where(
+            AgentRunRow.thread_id == thread_id,
+            AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES),
+        )
+    )
+    store = AsyncAgentRunStore(session)
+    count = 0
+    for row in result.all():
+        await store.append_event(
+            run_event(
+                int(row.id),
+                "run.canceled",
+                {"reason": reason},
+                root_run_id=row.root_run_id,
+            )
+        )
+        canceled = await store.set_status(
+            row.id,
+            RunStatus.CANCELED,
+            reason=reason,
+        )
+        if canceled.status == RunStatus.CANCELED:
+            await async_finalize_cycle_run_if_needed(int(row.id), status="canceled")
+        count += 1
+    return count
 
 
 @dataclass
@@ -48,4 +89,4 @@ class RunCancelToken:
         return self._canceled
 
 
-__all__ = ["RunCancelToken"]
+__all__ = ["RunCancelToken", "async_cancel_open_runs_for_thread"]

--- a/brain/systems/runs/cortex/__init__.py
+++ b/brain/systems/runs/cortex/__init__.py
@@ -104,17 +104,12 @@ async def async_idea_run_history(idea_id: str) -> list[dict[str, Any]]:
     return await serialize_run_history_async(idea_id)
 
 
-cancel_idea_runs = async_cancel_runs_for_idea
-supersede_runs_for_idea = async_cancel_runs_for_idea
-
-
 __all__ = [
     "DrainResult",
     "_get_adaptation_history",
     "_parse_skill_mentions",
     "_parse_skill_override",
     "_record_adaptation",
-    "cancel_idea_runs",
     "async_cancel_runs_for_idea",
     "async_idea_run_history",
     "queue_status",
@@ -122,5 +117,4 @@ __all__ = [
     "ensure_schema",
     "start_runner",
     "stop_runner",
-    "supersede_runs_for_idea",
 ]

--- a/brain/systems/runs/cortex/__init__.py
+++ b/brain/systems/runs/cortex/__init__.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from brain.systems.runs.cycle_settlement import (
-    async_finalize_cycle_run_if_needed as _async_finalize_cycle_run_if_needed,
-)
 from brain.systems.runs.events import run_event
 from brain.systems.runs.skill_commands import iter_slash_skill_commands, parse_slash_skill_names
 from brain.systems.runs.cortex.runner import (
@@ -95,40 +92,10 @@ async def _get_adaptation_history(run_id: int, *, session=None) -> list[dict[str
 
 
 async def async_cancel_runs_for_idea(idea_id: str) -> int:
-    from sqlalchemy import select
-    from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-    from brain.systems.runs.status import RunStatus
-    from brain.platform.db.models.agent_run import AgentRunRow
+    from brain.systems.runs.cancel import async_cancel_open_runs_for_thread
 
-    count = 0
     async with _unit_of_work_factory()() as uow:
-        from brain.systems.runs.store import AsyncAgentRunStore as _AgentRunStore
-
-        store = _AgentRunStore(uow.session)
-        result = await uow.session.scalars(
-            select(AgentRunRow).where(
-                AgentRunRow.thread_id == idea_id,
-                AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES),
-            )
-        )
-        for row in result.all():
-            await store.append_event(
-                run_event(
-                    int(row.id),
-                    "run.canceled",
-                    {"reason": "canceled_for_thread"},
-                    root_run_id=row.root_run_id,
-                )
-            )
-            canceled = await store.set_status(
-                row.id,
-                RunStatus.CANCELED,
-                reason="canceled_for_thread",
-            )
-            if canceled.status == RunStatus.CANCELED:
-                await _async_finalize_cycle_run_if_needed(int(row.id), status="canceled")
-            count += 1
-    return count
+        return await async_cancel_open_runs_for_thread(uow.session, idea_id)
 
 
 async def async_idea_run_history(idea_id: str) -> list[dict[str, Any]]:

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -2391,18 +2391,23 @@ async def test_cancel_endpoint_helper_ignores_cycle_settlement_failure(
     assert "cycle_run_settlement_failed" in caplog.text
 
 
-async def test_cancel_runs_for_idea_records_run_canceled_event(
+@pytest.mark.parametrize("entry_point", ("route", "helper"))
+async def test_cancel_all_entry_points_persist_shared_cancellation_side_effects(
     session_factory,
     monkeypatch,
+    entry_point,
 ):
-    from brain.systems.runs.cortex import async_cancel_runs_for_idea
     from brain.systems.cycles import service as cycle_service
+    from brain.systems.runs import cortex as cortex_runs
 
     session = session_factory()
     store = AsyncAgentRunStore(session)
-    run = await store.create_run(_run_request(thread_id="idea-1", message="cancel me"))
-    await store.set_status(run.id, RunStatus.STARTING)
-    await store.set_status(run.id, RunStatus.RUNNING)
+    runs = [
+        await store.create_run(_run_request(thread_id="idea-1", message="cancel me")),
+        await store.create_run(_run_request(thread_id="idea-1", message="cancel me too")),
+    ]
+    await store.set_status(runs[0].id, RunStatus.STARTING)
+    await store.set_status(runs[0].id, RunStatus.RUNNING)
     settled = []
 
     async def capture_cycle_settlement(run_id, *, status, error=None):
@@ -2414,66 +2419,60 @@ async def test_cancel_runs_for_idea_records_run_canceled_event(
         capture_cycle_settlement,
     )
 
-    with patch("brain.systems.runs.cortex.UnitOfWork", return_value=_SessionUoW(session)):
-        count = await async_cancel_runs_for_idea("idea-1")
+    if entry_point == "helper":
+        monkeypatch.setattr(
+            cortex_runs,
+            "UnitOfWork",
+            lambda: _SessionUoW(session),
+        )
+        count = await cortex_runs.async_cancel_runs_for_idea("idea-1")
+        assert count == 2
+    else:
+        from httpx import ASGITransport, AsyncClient
 
-    row = await session.get(AgentRunRow, run.id)
-    assert count == 1
-    assert row is not None
-    assert row.status == RunStatus.CANCELED.value
-    assert settled == [(run.id, "canceled", None)]
-    events = await _event_types(session, run.id)
-    assert "run.canceled" in events
-    assert events.count("run.canceled") == 1
+        from brain.app.api.auth import get_current_user
+        from brain.app.api.main import app
+        from brain.app.api.routers.cortex import _idea_ops as idea_routes
 
-
-async def test_cancel_all_route_settles_each_canceled_cycle_run(monkeypatch):
-    from brain.app.api.routers.cortex import _idea_ops as idea_routes
-
-    rows = [
-        SimpleNamespace(id=41, root_run_id=41),
-        SimpleNamespace(id=42, root_run_id=42),
-    ]
-    settled = []
-
-    async def select_runs(_statement):
-        return SimpleNamespace(all=lambda: rows)
-
-    async def flush():
-        return None
-
-    session = SimpleNamespace(scalars=select_runs, flush=flush)
-
-    class _Store:
-        async def append_event(self, _event):
+        async def allow_idea(*_args, **_kwargs):
             return None
 
-        async def set_status(self, _run_id, _status, *, reason=None):
-            return SimpleNamespace(status=RunStatus.CANCELED)
+        monkeypatch.setattr(
+            idea_routes,
+            "UnitOfWork",
+            lambda: _SessionUoW(session),
+        )
+        monkeypatch.setattr(idea_routes, "_require_idea_for_user", allow_idea)
+        overrides = dict(app.dependency_overrides)
+        app.dependency_overrides[get_current_user] = lambda: {
+            "id": "user-1",
+            "org_id": "org-1",
+            "role": "owner",
+            "principal_type": "human",
+            "permissions": ["run:manage"],
+        }
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/api/cortex/ideas/idea-1/cancel-all")
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(overrides)
 
-    async def allow_idea(*_args, **_kwargs):
-        return None
+        assert response.status_code == 200
+        assert response.json() == {"ok": True, "canceled": 2, "cancelled": 2}
 
-    async def capture_cycle_settlement(run_id, *, status, error=None):
-        settled.append((run_id, status, error))
-
-    monkeypatch.setattr(
-        idea_routes,
-        "UnitOfWork",
-        lambda: _SessionUoW(session),
-    )
-    monkeypatch.setattr(idea_routes, "_require_idea_for_user", allow_idea)
-    monkeypatch.setattr(idea_routes, "AsyncAgentRunStore", lambda _session: _Store())
-    monkeypatch.setattr(
-        idea_routes,
-        "async_finalize_cycle_run_if_needed",
-        capture_cycle_settlement,
-    )
-
-    result = await idea_routes.idea_cancel_all("idea-1", {"id": "user-1"})
-
-    assert result == {"ok": True, "canceled": 2, "cancelled": 2}
-    assert settled == [(41, "canceled", None), (42, "canceled", None)]
+    assert sorted(settled) == [
+        (run.id, "canceled", None)
+        for run in runs
+    ]
+    for run in runs:
+        row = await session.get(AgentRunRow, run.id)
+        assert row is not None
+        assert row.status == RunStatus.CANCELED.value
+        events = await _event_types(session, run.id)
+        assert "run.canceled" in events
+        assert events.count("run.canceled") == 1
 
 
 async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned_runs(session_factory):

--- a/tests/test_cortex_misc_failure_projection.py
+++ b/tests/test_cortex_misc_failure_projection.py
@@ -119,6 +119,7 @@ async def test_split_projects_legacy_failed_message_before_copying_it():
         )
     )
     copied_commands = []
+    cancel_open_runs = AsyncMock(return_value=0)
 
     async def capture_message(_session, *, idea, command, apply_lifecycle):
         copied_commands.append(command)
@@ -133,7 +134,11 @@ async def test_split_projects_legacy_failed_message_before_copying_it():
         ),
         patch.object(_misc, "post_thread_message", side_effect=capture_message),
         patch.object(_misc, "transition_thought_status", AsyncMock()),
-        patch.object(_misc, "_cancel_active_runs_for_idea", AsyncMock(return_value=0)),
+        patch.object(
+            _misc,
+            "async_cancel_open_runs_for_thread",
+            cancel_open_runs,
+        ),
         patch("brain.systems.cortex.events.publish"),
     ):
         result = await _misc.split_idea(
@@ -143,6 +148,11 @@ async def test_split_projects_legacy_failed_message_before_copying_it():
         )
 
     assert result["ok"] is True
+    cancel_open_runs.assert_awaited_once_with(
+        session,
+        "idea-1",
+        reason="Parent split into branches",
+    )
     assert len(copied_commands) == 1
     copied = copied_commands[0]
     assert "raw-secret" not in copied.content


### PR DESCRIPTION
Closes #624.

## What was wrong

Three near-verbatim implementations of "cancel every open run on a thread" existed side by side:

| entry point | reason passed | settles the `CycleRun`? |
|---|---|---|
| `POST /ideas/{id}/cancel-all` → `idea_cancel_all` (`_idea_ops.py`) | `canceled_for_thread` | yes |
| `async_cancel_runs_for_idea` (`runs/cortex/__init__.py`) | `canceled_for_thread` | yes |
| `_cancel_active_runs_for_idea` (`_misc.py`), used by the thought split | `Parent split into branches` | **no** |

Each ran the identical loop per open run: emit `run.canceled` → `set_status(CANCELED)` → settle the backing `CycleRun` → count.

That third step is why this ticket exists. #622 added the cycle settlement to the loop and had to write it into **each** copy, with nothing that would fail if one were forgotten — and one *was*. The issue itself only found two of the three, because it grepped the reason string `canceled_for_thread`; the split path passes a different reason, so it never showed up. The third copy was surfaced by the code-quality review of the first commit here.

## What this does

Extracts one session-scoped owner and has all three call sites delegate to it:

```python
async def async_cancel_open_runs_for_thread(
    session, thread_id, *, reason="canceled_for_thread"
) -> int
```

- Lives in `brain/systems/runs/cancel.py`, next to `RunCancelToken` — the command and the runtime token that observes cancellation are one domain.
- Owns the select, the event, the status transition, the settlement, and the count. It does **not** open or commit a transaction; each caller keeps that. The route still owns its `UnitOfWork` (and still runs `_require_idea_for_user` first), the helper still opens its own, the split still runs inside the split's transaction.
- Also removes two dead aliases, `cancel_idea_runs` and `supersede_runs_for_idea` (zero consumers repo-wide). The second one was actively misleading: it promised replacement semantics the operation neither models nor records.

## One intentional behavior change

**The thought-split path now settles the backing `CycleRun`, as the other two paths already did.**

Before this, splitting a thought cancelled its open runs and left any backing `CycleRun` untouched. It was then picked up ~60s later by `async_recover_stale_cycle_runs_once` and recorded as the anomaly *"Agent run ended without cycle-run finalization"* — for what was a deliberate cancellation. That is the #622 defect, surviving in a third place.

It is safe to add: `async_finalize_cycle_run_if_needed` swallows and logs every exception, so it cannot fail a split.

Everything else is behavior-preserving — same events, same statuses, same counts, same response body (`{"ok", "canceled", "cancelled"}`, both spellings retained).

## The regression this ships with

The old tests could not have caught the drift they existed to prevent:

- the route test faked the session **and** the store with `SimpleNamespace`, so it asserted that the route called a stub;
- the split test patched `_cancel_active_runs_for_idea` — the bypass itself.

Replaced by:

1. one parametrized test driving **both** the route (through the real ASGI app) and the helper against a real session, asserting the persisted side effects each time: `run.canceled` present exactly once, row status `CANCELED`, settlement recorded for every run;
2. the split test retargeted to the canonical owner, asserting it is awaited once with the split's session, idea id, and `reason="Parent split into branches"`.

That is the issue's acceptance criterion: a side effect added to the shared owner is observed through every entry point.

## Verification

```
python3 -m pytest tests/ -m "not requires_db and not requires_browser and not live_provider" -q
```

The exact fast-suite selection from `.github/workflows/brain-ci.yml`, run in full (not a subset) on this branch outside the agent sandbox: **4620 passed, 11 skipped, 82 deselected in 73s** — identical to the count on `main`.

No UI surface, no migration, no config.

<sub>Opened by Routine R3. Draft on purpose — Reda reviews and merges.</sub>
