### PR TITLE
fix(knowledge): circular repo sweep so one backfill cannot starve the others (#633)

### DIFF
--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -297,7 +297,7 @@ async def _enumerate_repository(
     state: dict[str, Any],
     *,
     remaining: int,
-) -> tuple[list[KnowledgeDraft], dict[str, Any], bool]:
+) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
     """Enumerate one repository without mutating another repository's state."""
 
     watermark_key = _timestamp_key(
@@ -384,13 +384,13 @@ async def _enumerate_repository(
             "high_watermark": high_key[0].isoformat(),
             "high_watermark_id": high_key[1],
         }
-        return repo_drafts, next_state, True
+        return repo_drafts, next_state
 
     next_state = {
         "watermark": high_key[0].isoformat(),
         "watermark_id": high_key[1],
     }
-    return repo_drafts, next_state, False
+    return repo_drafts, next_state
 
 
 class GitHubConnector:
@@ -410,6 +410,16 @@ class GitHubConnector:
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> KnowledgeEnumeration:
+        """Enumerate changes while preserving the version-2 cursor contract.
+
+        ``version`` is 2 and stays 2. Settled ``repositories`` entries contain
+        ``watermark`` and ``watermark_id``; mid-backfill entries contain
+        ``next_page``, ``high_watermark``, and ``high_watermark_id``.
+        ``active_repository`` is the wire name for the repository index where
+        the next sweep begins, and the sweep walks circularly from that index.
+        Rolling deploys are safe because old and new builds both read the
+        integer as a starting index.
+        """
         if int(cursor.get("version") or 0) != _CURSOR_VERSION:
             cursor = {}
         repositories = list(self.repositories or await _configured_repositories(session))
@@ -446,13 +456,11 @@ class GitHubConnector:
             repositories_left = repository_count - offset
             repository_limit = max(1, remaining // repositories_left)
             try:
-                repo_drafts, next_state, _has_next_page = (
-                    await _enumerate_repository(
-                        session,
-                        repo,
-                        state,
-                        remaining=repository_limit,
-                    )
+                repo_drafts, next_state = await _enumerate_repository(
+                    session,
+                    repo,
+                    state,
+                    remaining=repository_limit,
                 )
             except Exception as exc:
                 message = str(exc).strip() or type(exc).__name__

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -430,19 +430,28 @@ class GitHubConnector:
         drafts: list[KnowledgeDraft] = []
         failures: list[EnumerationFailure] = []
 
-        for repo_index in range(active_index, len(repositories)):
+        # ``active_repository`` is the first repository due in this sweep.
+        # Modulo traversal lets existing version-2 cursors wrap immediately.
+        repository_count = len(repositories)
+        for offset in range(repository_count):
+            repo_index = (active_index + offset) % repository_count
             repo = repositories[repo_index]
             state = dict(repo_states.get(repo) or {})
             remaining = self.max_items - len(drafts)
             if remaining <= 0:
                 break
+            # Reserve capacity for every repository that is still due in this
+            # circular sweep. A long page chain can use its share, but cannot
+            # prevent later repositories from checking their watermarks.
+            repositories_left = repository_count - offset
+            repository_limit = max(1, remaining // repositories_left)
             try:
-                repo_drafts, next_state, has_next_page = (
+                repo_drafts, next_state, _has_next_page = (
                     await _enumerate_repository(
                         session,
                         repo,
                         state,
-                        remaining=remaining,
+                        remaining=repository_limit,
                     )
                 )
             except Exception as exc:
@@ -457,30 +466,19 @@ class GitHubConnector:
 
             drafts.extend(repo_drafts)
             repo_states[repo] = next_state
-            if has_next_page:
-                return KnowledgeEnumeration(
-                    drafts=drafts,
-                    cursor={
-                        "version": _CURSOR_VERSION,
-                        "active_repository": repo_index,
-                        "repositories": repo_states,
-                    },
-                    failures=tuple(failures),
-                )
-
             if len(drafts) >= self.max_items:
                 return KnowledgeEnumeration(
                     drafts=drafts,
                     cursor={
                         "version": _CURSOR_VERSION,
-                        "active_repository": (repo_index + 1) % len(repositories),
+                        "active_repository": (repo_index + 1) % repository_count,
                         "repositories": repo_states,
                     },
                     failures=tuple(failures),
                 )
 
-        # Reaching the end completes this sweep even when one or more repositories
-        # were recorded as skipped, so the next invocation starts from index zero.
+        # Considering every repository completes this sweep even when one or more
+        # were skipped, so the next invocation starts from the canonical index zero.
         return KnowledgeEnumeration(
             drafts=drafts,
             cursor={

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1467,6 +1467,200 @@ async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
     assert enumeration.failures == ()
 
 
+async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
+    session,
+):
+    repositories = ["acme/stale", "acme/backfill"]
+    initial_cursor = {
+        "version": 2,
+        "active_repository": 1,
+        "repositories": {
+            "acme/stale": {
+                "watermark": "2026-07-29T12:00:00+00:00",
+                "watermark_id": 100,
+            },
+            "acme/backfill": {
+                "next_page": {"page": 1, "index": 90},
+                "high_watermark": "2026-07-30T12:00:00+00:00",
+                "high_watermark_id": 200,
+            },
+        },
+    }
+    issues = {
+        "acme/backfill": [
+            {
+                "id": issue_id,
+                "number": issue_id,
+                "title": f"Backfill issue {issue_id}",
+                "state": "open",
+                "body": "Historical backfill item.",
+                "labels": [],
+                "user": {"login": "octocat"},
+                "created_at": "2026-07-30T12:00:00Z",
+                "updated_at": f"2026-07-30T12:0{issue_id - 200}:00Z",
+            }
+            for issue_id in (201, 202)
+        ],
+        "acme/stale": [
+            {
+                "id": 100,
+                "number": 100,
+                "title": "Already settled",
+                "state": "open",
+                "body": "This item is already behind the watermark.",
+                "labels": [],
+                "user": {"login": "octocat"},
+                "created_at": "2026-07-29T12:00:00Z",
+                "updated_at": "2026-07-29T12:00:00Z",
+            },
+            {
+                "id": 101,
+                "number": 101,
+                "title": "Fresh lower-index issue",
+                "state": "open",
+                "body": "The stale repository gets a turn.",
+                "labels": [],
+                "user": {"login": "octocat"},
+                "created_at": "2026-07-31T09:00:00Z",
+                "updated_at": "2026-07-31T10:00:00Z",
+            },
+        ],
+    }
+    calls: dict[str, dict] = {}
+
+    async def list_issues(repo, **kwargs):
+        calls[repo] = kwargs
+        return {
+            "issues": issues[repo],
+            "next_page": (
+                {"page": 2, "index": 0} if repo == "acme/backfill" else None
+            ),
+        }
+
+    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    connector = GitHubConnector(repositories=repositories, max_items=4)
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=AsyncMock(side_effect=list_issues),
+    ):
+        enumeration = await connector.enumerate_changed(session, initial_cursor)
+
+    assert [draft.source_ref for draft in enumeration.drafts] == [
+        "github:acme/backfill#201",
+        "github:acme/backfill#202",
+        "github:acme/stale#101",
+    ]
+    assert calls["acme/backfill"]["cursor"] == {"page": 1, "index": 90}
+    assert calls["acme/backfill"]["since"] is None
+    assert calls["acme/stale"]["cursor"] is None
+    assert calls["acme/stale"]["since"] == "2026-07-29T12:00:00+00:00"
+    assert enumeration.cursor == {
+        "version": 2,
+        "active_repository": 0,
+        "repositories": {
+            "acme/stale": {
+                "watermark": "2026-07-31T10:00:00+00:00",
+                "watermark_id": 101,
+            },
+            "acme/backfill": {
+                "next_page": {"page": 2, "index": 0},
+                "high_watermark": "2026-07-30T12:02:00+00:00",
+                "high_watermark_id": 202,
+            },
+        },
+    }
+
+
+async def test_github_enumeration_advances_every_repo_during_long_backfill(session):
+    repositories = ["acme/steady-one", "acme/backfill", "acme/steady-two"]
+    initial_watermarks = {
+        "acme/steady-one": ("2026-07-27T08:00:00+00:00", 10),
+        "acme/steady-two": ("2026-07-27T08:00:00+00:00", 20),
+    }
+    cursor = {
+        "version": 2,
+        "active_repository": 1,
+        "repositories": {
+            repo: {"watermark": watermark, "watermark_id": row_id}
+            for repo, (watermark, row_id) in initial_watermarks.items()
+        }
+        | {
+            "acme/backfill": {
+                "next_page": {"page": 1},
+                "high_watermark": "2026-07-28T08:00:00+00:00",
+                "high_watermark_id": 30,
+            }
+        },
+    }
+    backfill_pages = {
+        1: (31, {"page": 2}),
+        2: (32, {"page": 3}),
+        3: (33, None),
+    }
+    steady_calls = {"acme/steady-one": 0, "acme/steady-two": 0}
+    seen_backfill_pages: list[int] = []
+
+    def issue(repo: str, issue_id: int, day: int) -> dict:
+        return {
+            "id": issue_id,
+            "number": issue_id,
+            "title": f"{repo} issue {issue_id}",
+            "state": "open",
+            "body": "Repository scheduling test item.",
+            "labels": [],
+            "user": {"login": "octocat"},
+            "created_at": f"2026-07-{day:02d}T08:00:00Z",
+            "updated_at": f"2026-07-{day:02d}T08:00:00Z",
+        }
+
+    async def list_issues(repo, **kwargs):
+        assert kwargs["limit"] == 1
+        if repo == "acme/backfill":
+            page = kwargs["cursor"]["page"]
+            seen_backfill_pages.append(page)
+            issue_id, next_page = backfill_pages[page]
+            return {
+                "issues": [issue(repo, issue_id, 28 + page)],
+                "next_page": next_page,
+            }
+
+        steady_calls[repo] += 1
+        call = steady_calls[repo]
+        issue_id = initial_watermarks[repo][1] + call
+        return {
+            "issues": [issue(repo, issue_id, 27 + call)],
+            "next_page": None,
+        }
+
+    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    connector = GitHubConnector(repositories=repositories, max_items=3)
+    enumerations = []
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=AsyncMock(side_effect=list_issues),
+    ):
+        for _ in range(3):
+            enumeration = await connector.enumerate_changed(session, cursor)
+            enumerations.append(enumeration)
+            cursor = enumeration.cursor
+
+    assert [len(enumeration.drafts) for enumeration in enumerations] == [3, 3, 3]
+    assert seen_backfill_pages == [1, 2, 3]
+    assert steady_calls == {"acme/steady-one": 3, "acme/steady-two": 3}
+    for repo, (initial_watermark, _) in initial_watermarks.items():
+        assert cursor["repositories"][repo]["watermark"] > initial_watermark
+    assert cursor["repositories"]["acme/backfill"] == {
+        "watermark": "2026-07-31T08:00:00+00:00",
+        "watermark_id": 33,
+    }
+
+
 async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
     session,
     caplog,

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1471,6 +1471,12 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
     session,
 ):
     repositories = ["acme/stale", "acme/backfill"]
+    initial_backfill_page = (
+        "eyJraW5kIjoiZ2l0aHViX2lzc3VlczphY21lL2JhY2tmaWxsIiwiaW5kZXgiOjkwfQ=="
+    )
+    next_backfill_page = (
+        "eyJraW5kIjoiZ2l0aHViX2lzc3VlczphY21lL2JhY2tmaWxsIiwiaW5kZXgiOjB9"
+    )
     initial_cursor = {
         "version": 2,
         "active_repository": 1,
@@ -1480,7 +1486,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
                 "watermark_id": 100,
             },
             "acme/backfill": {
-                "next_page": {"page": 1, "index": 90},
+                "next_page": initial_backfill_page,
                 "high_watermark": "2026-07-30T12:00:00+00:00",
                 "high_watermark_id": 200,
             },
@@ -1499,7 +1505,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
                 "created_at": "2026-07-30T12:00:00Z",
                 "updated_at": f"2026-07-30T12:0{issue_id - 200}:00Z",
             }
-            for issue_id in (201, 202)
+            for issue_id in (201, 202, 203, 204, 205)
         ],
         "acme/stale": [
             {
@@ -1531,10 +1537,8 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
     async def list_issues(repo, **kwargs):
         calls[repo] = kwargs
         return {
-            "issues": issues[repo],
-            "next_page": (
-                {"page": 2, "index": 0} if repo == "acme/backfill" else None
-            ),
+            "issues": issues[repo][: kwargs["limit"]],
+            "next_page": next_backfill_page if repo == "acme/backfill" else None,
         }
 
     authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
@@ -1553,7 +1557,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
         "github:acme/backfill#202",
         "github:acme/stale#101",
     ]
-    assert calls["acme/backfill"]["cursor"] == {"page": 1, "index": 90}
+    assert calls["acme/backfill"]["cursor"] == initial_backfill_page
     assert calls["acme/backfill"]["since"] is None
     assert calls["acme/stale"]["cursor"] is None
     assert calls["acme/stale"]["since"] == "2026-07-29T12:00:00+00:00"
@@ -1566,7 +1570,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
                 "watermark_id": 101,
             },
             "acme/backfill": {
-                "next_page": {"page": 2, "index": 0},
+                "next_page": next_backfill_page,
                 "high_watermark": "2026-07-30T12:02:00+00:00",
                 "high_watermark_id": 202,
             },
@@ -1576,6 +1580,11 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
 
 async def test_github_enumeration_advances_every_repo_during_long_backfill(session):
     repositories = ["acme/steady-one", "acme/backfill", "acme/steady-two"]
+    backfill_page_tokens = (
+        "eyJraW5kIjoiZ2l0aHViX2lzc3VlczphY21lL2JhY2tmaWxsIiwiaW5kZXgiOjF9",
+        "eyJraW5kIjoiZ2l0aHViX2lzc3VlczphY21lL2JhY2tmaWxsIiwiaW5kZXgiOjJ9",
+        "eyJraW5kIjoiZ2l0aHViX2lzc3VlczphY21lL2JhY2tmaWxsIiwiaW5kZXgiOjN9",
+    )
     initial_watermarks = {
         "acme/steady-one": ("2026-07-27T08:00:00+00:00", 10),
         "acme/steady-two": ("2026-07-27T08:00:00+00:00", 20),
@@ -1589,19 +1598,19 @@ async def test_github_enumeration_advances_every_repo_during_long_backfill(sessi
         }
         | {
             "acme/backfill": {
-                "next_page": {"page": 1},
+                "next_page": backfill_page_tokens[0],
                 "high_watermark": "2026-07-28T08:00:00+00:00",
                 "high_watermark_id": 30,
             }
         },
     }
     backfill_pages = {
-        1: (31, {"page": 2}),
-        2: (32, {"page": 3}),
-        3: (33, None),
+        backfill_page_tokens[0]: (31, backfill_page_tokens[1]),
+        backfill_page_tokens[1]: (32, backfill_page_tokens[2]),
+        backfill_page_tokens[2]: (33, None),
     }
     steady_calls = {"acme/steady-one": 0, "acme/steady-two": 0}
-    seen_backfill_pages: list[int] = []
+    seen_backfill_pages: list[str] = []
 
     def issue(repo: str, issue_id: int, day: int) -> dict:
         return {
@@ -1619,11 +1628,11 @@ async def test_github_enumeration_advances_every_repo_during_long_backfill(sessi
     async def list_issues(repo, **kwargs):
         assert kwargs["limit"] == 1
         if repo == "acme/backfill":
-            page = kwargs["cursor"]["page"]
+            page = kwargs["cursor"]
             seen_backfill_pages.append(page)
             issue_id, next_page = backfill_pages[page]
             return {
-                "issues": [issue(repo, issue_id, 28 + page)],
+                "issues": [issue(repo, issue_id, issue_id - 2)],
                 "next_page": next_page,
             }
 
@@ -1651,7 +1660,7 @@ async def test_github_enumeration_advances_every_repo_during_long_backfill(sessi
             cursor = enumeration.cursor
 
     assert [len(enumeration.drafts) for enumeration in enumerations] == [3, 3, 3]
-    assert seen_backfill_pages == [1, 2, 3]
+    assert seen_backfill_pages == list(backfill_page_tokens)
     assert steady_calls == {"acme/steady-one": 3, "acme/steady-two": 3}
     for repo, (initial_watermark, _) in initial_watermarks.items():
         assert cursor["repositories"][repo]["watermark"] > initial_watermark


### PR DESCRIPTION
Closes #633

## What was wrong

The GitHub knowledge connector swept repositories **forward only**, from `active_repository` to the end of the list, and handed the first repository in that loop the **entire** per-run item budget. A repository that returned `next_page` wrote the cursor back unchanged (`active_repository: repo_index`), so it parked the pointer on its own index for the whole length of its backfill.

Live on illo-dev at 20:30Z today:

```
active_repository: 5   -> uwear-ai/uwear-website, first full backfill,
                          next_page {"page":1,"index":90}, no watermark yet

0 Illospace/illospace   watermark 2026-07-29T14:51:32Z   <-- unreachable
1 uwear-ai/uwearaiapp    2 uwear-ai/uwear-backend    3 uwear-ai/agent-mission-control
4 uwear-ai/uwear-mobile-app    5 uwear-ai/uwear-website    6 helloianneo/ian-xiaohei-illustrations
```

`Illospace/illospace` sits at index 0, behind the cursor, so it had been frozen for **over two days** while every hourly tick spent all 100 items on the website backfill. `last_status` read `ok` the entire time — the starvation was completely silent.

This is a different failure from the two already fixed in this file: #627 (an unreachable repo *raised* and froze every watermark) and #628 (`parse_github_repo_slug`). Both of those were error paths. This one is the normal, successful path.

## What changed

`brain/systems/knowledge/connectors/github.py` — 32 lines:

- The sweep is **circular** from `active_repository` (`(active_index + offset) % repository_count`) instead of forward-only, so a repository at a lower index is reachable in the same run.
- Each repository still due in the sweep **reserves a share** of the remaining budget (`max(1, remaining // repositories_left)`), so one repository cannot consume the whole tick.
- A paginating repository no longer returns early. It keeps its `next_page` state, uses its share, and resumes on the next pass.

Cursor stays at `version: 2`. Both stored shapes round-trip unchanged (`watermark`/`watermark_id` and `next_page`/`high_watermark`/`high_watermark_id`), so **no watermark reset and no re-ingest on deploy**. The stored value `active_repository: 5` now simply means "start the circle at index 5", which reaches index 0 on the third step of the very first run after deploy.

## How to check it

Full CI suite, run by the orchestrator in the worktree, not a subset:

```
python3 -m pytest tests/ -m "not requires_db and not requires_browser and not live_provider" -q
# 4622 passed, 11 skipped, 82 deselected in 71.58s
```

After this deploys to illo-dev, the connector should serve `Illospace/illospace` on its first tick:

```
ssh illo-dev docker exec illospace-api-1 python -c "
import asyncio, json
from sqlalchemy import text
from brain.platform.db import SessionFactory
async def m():
    async with SessionFactory() as s:
        r = await s.execute(text(\"select cursor from knowledge_sync_state where source='github'\"))
        print(json.dumps(r.scalar(), indent=1))
asyncio.run(m())"
```

Expect `Illospace/illospace`'s `watermark` to move past `2026-07-29T14:51:32+00:00`, and `github:Illospace/illospace#593` / `#606` to become searchable.

## Acceptance checks

1. A repository mid-pagination cannot take the whole budget — a stale **lower-index** repository still gets drafts in the same call. → `test_github_enumeration_reserves_capacity_for_stale_lower_index_repo`
2. Over consecutive cursor-driven calls, **every** repository's watermark advances during a long backfill. → `test_github_enumeration_advances_every_repo_during_long_backfill`
3. A repository whose enumeration raises is still skipped without freezing the others (#627 behaviour preserved). → `test_github_enumeration_isolates_repo_failures_and_wraps_cursor`, unchanged and green.
4. Stored `version: 2` cursors in both shapes round-trip without losing position or re-ingesting settled items. → asserted on the exact live cursor shape in check 1.
5. The backfill still makes forward progress rather than being starved in turn — `seen_backfill_pages == [1, 2, 3]` across three calls in check 2.

## Code-quality review, and one thing I chose not to do

A Codex maintainability review ran before this PR opened. No blocking findings, four should-fix. Three are folded into commit `720dc916`:

- The capacity test **claimed** a paginating repository cannot take the whole budget but did not prove it — its fake ignored the `limit` it was handed, and the backfill held fewer items than the budget, so there was no contention. The backfill now holds 5 items against a 4-item budget and the fake honors `limit`. Confirmed to discriminate by restoring the old full-budget allocation and watching it fail for the right reason.
- Page tokens in both fakes are now opaque base64 strings, matching what the API returns and what the live cursor stores. They were dicts.
- `_enumerate_repository`'s third return value went dead when the sweep stopped returning early on pagination. Removed rather than kept for a hypothetical caller. `enumerate_changed` now documents the persisted cursor contract.

**Rejected, deliberately:** the review also proposed extracting a pure repository-turn scheduling seam (`_repository_turns` / `_RepositoryTurn.limit_for(...)`) and a typed cursor model. Both are reasonable in the abstract. I declined them here because this file has had three defects in one week (#627, #628, #633), and wrapping the scheduling loop in a new abstraction right now adds more risk than the density it removes. If you disagree, it is a clean follow-up on a quiet file rather than a change to make under this one.

Full review: `state/evidence/633-thermo-review-20260731T2110.md` in `uwear-routines`.

## Assumptions and things worth your eye

- **Fair share, not priority.** Every repository gets an equal slice. I did not make `Illospace/illospace` special, even though it is the repo people actually ask Illo about. If you want freshness on the primary repo prioritised over other repos' history, that is a policy call and a separate change.
- **More GitHub calls per tick.** The sweep now issues up to one list call per repository per tick (7) instead of one. Item volume is unchanged because `max_items` is unchanged. At 7 calls/hour against a 5000/hour authenticated limit this is not a concern, but it is a real behaviour change.
- **This does not by itself make #578 measurable.** After merge and deploy, `Illospace/illospace` still has two days of backlog to ingest before the recall re-run means anything.

<sub>Implemented by a Codex worker at `xhigh` under Routine R3, reviewed and pushed by the orchestrator. Base `origin/main@111e517d`, re-verified unmoved before push.</sub>
