### PR TITLE
fix(github): authenticate the staging-only closure sweep's GitHub reads

### DIFF
--- a/brain/systems/production_gate_github.py
+++ b/brain/systems/production_gate_github.py
@@ -3,13 +3,38 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Protocol
 
 from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
     GithubFixingPullRequest as FixingPullRequest,
     GithubIssueClosure as IssueClosure,
 )
 from brain.systems.deploy_state import DeployStateBatch
+
+
+CLOSURE_READ_AUTHENTICATION_REQUIRED = "github_authentication_required"
+CLOSURE_READ_ACCESS_FORBIDDEN = "github_access_forbidden"
+CLOSURE_READ_CONNECTOR_ERROR = "github_connector_error"
+CLOSURE_READ_AUTH_FAILURE_REASONS = frozenset(
+    {
+        CLOSURE_READ_AUTHENTICATION_REQUIRED,
+        CLOSURE_READ_ACCESS_FORBIDDEN,
+    }
+)
+
+
+@dataclass(slots=True)
+class ClosureReadFailure(Exception):
+    """Stable closure-read failure translated from a connector error."""
+
+    reason_code: str
+    status_code: int
+    message: str
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
 
 
 class ClosureGithubClient(Protocol):
@@ -29,8 +54,15 @@ class ClosureGithubClient(Protocol):
 class BackendClosureGithubClient:
     """Supply backend credentials to shared typed GitHub read primitives."""
 
-    def __init__(self, *, org_id: str, user_id: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        org_id: str,
+        caller_label: str,
+        user_id: str | None = None,
+    ) -> None:
         self.org_id = str(org_id)
+        self.caller_label = str(caller_label)
         self.user_id = user_id
 
     async def get_issue_closure(
@@ -43,12 +75,16 @@ class BackendClosureGithubClient:
             github_issue_closure_for_backend,
         )
 
-        return await github_issue_closure_for_backend(
-            repo_slug=repo,
-            issue_number=issue_number,
-            org_id=self.org_id,
-            user_id=self.user_id,
-        )
+        try:
+            return await github_issue_closure_for_backend(
+                repo_slug=repo,
+                issue_number=issue_number,
+                org_id=self.org_id,
+                user_id=self.user_id,
+                caller_label=self.caller_label,
+            )
+        except GitHubConnectorError as exc:
+            raise _closure_read_failure(exc) from exc
 
     async def derive_deploy_states(
         self,
@@ -62,4 +98,19 @@ class BackendClosureGithubClient:
             refs,
             org_id=self.org_id,
             user_id=self.user_id,
+            caller_label=self.caller_label,
         )
+
+
+def _closure_read_failure(exc: GitHubConnectorError) -> ClosureReadFailure:
+    if exc.status_code == 401:
+        reason_code = CLOSURE_READ_AUTHENTICATION_REQUIRED
+    elif exc.status_code == 403:
+        reason_code = CLOSURE_READ_ACCESS_FORBIDDEN
+    else:
+        reason_code = CLOSURE_READ_CONNECTOR_ERROR
+    return ClosureReadFailure(
+        reason_code=reason_code,
+        status_code=exc.status_code,
+        message=exc.message,
+    )

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -197,6 +197,7 @@ async def _github_token_candidates(
     repo_slugs: list[str] | None = None,
     for_write: bool = False,
     require_authenticated: bool = False,
+    caller_label: str | None = None,
     org_id: str | None = None,
     user_id: str | None = None,
 ) -> list[dict[str, str | None]]:
@@ -211,6 +212,8 @@ async def _github_token_candidates(
 
     ``require_authenticated`` prevents backend maintenance reads from spending
     GitHub's shared unauthenticated per-IP budget.
+
+    ``caller_label`` names an org-scoped backend reader for vault auditing.
 
     ``repo_slugs`` lets a cross-repository operation mint one installation
     token down-scoped to every participating repository binding.
@@ -262,6 +265,7 @@ async def _github_token_candidates(
             elif require_authenticated:
                 bound_env = await async_resolve_org_project_bound_env_tokens(
                     org_id=org_id,
+                    accessed_by=caller_label or "github_connector",
                     project_slug=repo_slug,
                     project_slugs=repo_slugs,
                     github_app_only=for_write,
@@ -1622,6 +1626,7 @@ async def github_issue_closure_for_backend(
     issue_number: int,
     org_id: str,
     user_id: str | None = None,
+    caller_label: str = "github_connector",
 ) -> GithubIssueClosure | None:
     """Read one issue's closure/closing-PR facts with backend identities."""
 
@@ -1629,6 +1634,7 @@ async def github_issue_closure_for_backend(
         repo_slug=repo_slug,
         token_secret_key=None,
         require_authenticated=True,
+        caller_label=caller_label,
         org_id=org_id,
         user_id=user_id,
     )
@@ -1676,6 +1682,7 @@ async def github_deploy_states_for_backend(
     *,
     org_id: str,
     user_id: str | None = None,
+    caller_label: str = "github_connector",
 ) -> DeployStateBatch[Hashable]:
     """Batch ancestry reads using the backend caller's ordered identities."""
     normalized_refs = {
@@ -1695,6 +1702,7 @@ async def github_deploy_states_for_backend(
                 repo_slug=repo_slug,
                 token_secret_key=None,
                 require_authenticated=True,
+                caller_label=caller_label,
                 org_id=org_id,
                 user_id=user_id,
             )

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -54,6 +54,7 @@ from brain.systems.vault import (
     VAULT_AGENT_ACCESS_AVAILABLE,
     async_get_secret,
     async_list_secrets,
+    async_resolve_org_project_bound_env_tokens,
     async_resolve_project_bound_env_tokens,
     normalize_agent_access_level,
 )
@@ -195,6 +196,7 @@ async def _github_token_candidates(
     token_secret_key: str | None,
     repo_slugs: list[str] | None = None,
     for_write: bool = False,
+    require_authenticated: bool = False,
     org_id: str | None = None,
     user_id: str | None = None,
 ) -> list[dict[str, str | None]]:
@@ -206,6 +208,9 @@ async def _github_token_candidates(
     ``for_write`` restricts automatic identity selection to GitHub App project
     bindings. Writes may also use an explicit ``token_secret_key``. Reads keep
     the broader project-binding and vault-inventory fallback behavior.
+
+    ``require_authenticated`` prevents backend maintenance reads from spending
+    GitHub's shared unauthenticated per-IP budget.
 
     ``repo_slugs`` lets a cross-repository operation mint one installation
     token down-scoped to every participating repository binding.
@@ -244,22 +249,32 @@ async def _github_token_candidates(
 
     await add_secret_key(token_secret_key, "explicit")
 
-    if user_id and org_id:
+    if org_id:
         try:
-            bound_env = await async_resolve_project_bound_env_tokens(
-                actor_user_id=user_id,
-                org_id=org_id,
-                project_slug=repo_slug,
-                project_slugs=repo_slugs,
-                github_app_only=for_write,
-            )
+            if user_id:
+                bound_env = await async_resolve_project_bound_env_tokens(
+                    actor_user_id=user_id,
+                    org_id=org_id,
+                    project_slug=repo_slug,
+                    project_slugs=repo_slugs,
+                    github_app_only=for_write,
+                )
+            elif require_authenticated:
+                bound_env = await async_resolve_org_project_bound_env_tokens(
+                    org_id=org_id,
+                    project_slug=repo_slug,
+                    project_slugs=repo_slugs,
+                    github_app_only=for_write,
+                )
+            else:
+                bound_env = {}
         except Exception:
             bound_env = {}
         for env_name in ("GITHUB_TOKEN", "GH_TOKEN"):
             await add_token(bound_env.get(env_name), f"project_binding:{env_name}")
 
         sorted_secrets: list[dict[str, Any]] = []
-        if not for_write:
+        if user_id and not for_write:
             try:
                 secrets = await async_list_secrets(actor_user_id=user_id, org_id=org_id)
             except Exception:
@@ -295,13 +310,13 @@ async def _github_token_candidates(
                 continue
             await add_token(token, f"project_binding:{env_name}")
 
-        if not for_write:
+        if user_id and not for_write:
             for secret in sorted_secrets:
                 if str(secret.get("key_name") or "") == "GITHUB_TOKEN":
                     continue
                 await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
 
-    if not candidates:
+    if not candidates and not require_authenticated:
         candidates.append({"key_name": None, "token": None, "source": "public"})
     return candidates
 
@@ -1542,7 +1557,10 @@ async def github_read_ref_for_backend(
     )
 
     candidates = await _github_token_candidates(
-        repo_slug=repo_slug, token_secret_key=None, org_id=org_id, user_id=user_id
+        repo_slug=repo_slug,
+        token_secret_key=None,
+        org_id=org_id,
+        user_id=user_id,
     )
     read_candidates = _ordered_read_candidates(
         candidates, repo_slug=repo_slug, state=_github_read_state()
@@ -1610,6 +1628,7 @@ async def github_issue_closure_for_backend(
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,
         token_secret_key=None,
+        require_authenticated=True,
         org_id=org_id,
         user_id=user_id,
     )
@@ -1675,6 +1694,7 @@ async def github_deploy_states_for_backend(
             candidates = await _github_token_candidates(
                 repo_slug=repo_slug,
                 token_secret_key=None,
+                require_authenticated=True,
                 org_id=org_id,
                 user_id=user_id,
             )
@@ -1683,9 +1703,14 @@ async def github_deploy_states_for_backend(
                 repo_slug=repo_slug,
                 state=_github_read_state(),
             )
+            if not ordered:
+                raise GitHubConnectorError(
+                    status_code=401,
+                    message="No GitHub token candidates were available",
+                )
             tokens_by_repo[repo_slug] = tuple(
                 candidate.get("token") for candidate in ordered
-            ) or (None,)
+            )
         except Exception as exc:  # noqa: BLE001
             failure = ancestry_failure("credentials", exc)
             resolution_failures[repo_slug] = DeployStateObservation(

--- a/brain/systems/staging_only_closure.py
+++ b/brain/systems/staging_only_closure.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any
 
 from brain.platform.db.models.domain import DomainRecord
 from brain.systems import deploy_tracker
+from brain.systems.cortex.project_context.github import GitHubConnectorError
 from brain.systems.deploy_state import DeployStateBatch
 from brain.systems.production_gate_evidence import (
     ProductionEvidenceReader,
@@ -36,6 +38,14 @@ from brain.systems.production_gate_policy import (
 TRACKER_DOMAIN_ID = 1
 TRACKER_DOMAIN_SLUG = "github-ticket-tracker"
 logger = logging.getLogger("illo.staging_only_closure")
+
+
+@dataclass(frozen=True, slots=True)
+class _ClosureReadOutcome:
+    repo: str
+    issue_number: int
+    candidate: tuple[DomainRecord, IssueClosure] | None = None
+    error: Exception | None = None
 
 
 async def run_staging_only_closure_sweep(
@@ -179,7 +189,7 @@ async def _read_closed_issues(
 
     async def read(
         record: DomainRecord,
-    ) -> tuple[DomainRecord, IssueClosure] | None:
+    ) -> _ClosureReadOutcome | None:
         identity = tracked_issue_identity(
             dict(record.data or {}),
             title=record.title,
@@ -194,24 +204,66 @@ async def _read_closed_issues(
                     issue_number=issue_number,
                 )
         except Exception as exc:  # noqa: BLE001 - isolate one repository read
-            logger.warning(
-                "closure read failed for %s#%s: %s",
-                repo,
-                issue_number,
-                exc,
+            return _ClosureReadOutcome(
+                repo=repo,
+                issue_number=issue_number,
+                error=exc,
             )
-            errors.append(f"github_issue:{repo}#{issue_number}:{exc}")
-            return None
         if (
             closure is None
             or closure.state.casefold() != "closed"
             or not closure.fixing_pull_requests
         ):
-            return None
-        return record, closure
+            return _ClosureReadOutcome(repo=repo, issue_number=issue_number)
+        return _ClosureReadOutcome(
+            repo=repo,
+            issue_number=issue_number,
+            candidate=(record, closure),
+        )
 
     results = await asyncio.gather(*(read(record) for record in records))
-    return [result for result in results if result is not None]
+    attempts = [result for result in results if result is not None]
+    failures = [result for result in attempts if result.error is not None]
+    if failures and len(failures) == len(attempts):
+        auth_failures = {
+            _authentication_failure(result.error)
+            for result in failures
+            if result.error is not None
+        }
+        auth_failure = next(iter(auth_failures)) if len(auth_failures) == 1 else None
+        if auth_failure is not None:
+            status_code, message = auth_failure
+            logger.error(
+                "closure authentication failed for all %s GitHub issue reads: %s",
+                len(failures),
+                message,
+            )
+            errors.append(
+                "github_issue_authentication_all_reads_failed:"
+                f"count={len(failures)}:status={status_code}:{message}"
+            )
+            return []
+    for failure in failures:
+        logger.warning(
+            "closure read failed for %s#%s: %s",
+            failure.repo,
+            failure.issue_number,
+            failure.error,
+        )
+        errors.append(
+            f"github_issue:{failure.repo}#{failure.issue_number}:{failure.error}"
+        )
+    return [
+        result.candidate
+        for result in attempts
+        if result.candidate is not None
+    ]
+
+
+def _authentication_failure(exc: Exception) -> tuple[int, str] | None:
+    if isinstance(exc, GitHubConnectorError) and exc.status_code in {401, 403}:
+        return exc.status_code, str(exc)
+    return None
 
 
 async def _read_deploy_states(
@@ -220,6 +272,12 @@ async def _read_deploy_states(
     github: ClosureGithubClient,
     errors: list[str],
 ) -> DeployStateBatch:
+    if not candidates:
+        return DeployStateBatch(
+            {},
+            observations_by_key={},
+            observations_by_ref={},
+        )
     refs = {
         (closure.repo, closure.number, pull_request.number): (
             pull_request.repo,

--- a/brain/systems/staging_only_closure.py
+++ b/brain/systems/staging_only_closure.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from brain.platform.db.models.domain import DomainRecord
 from brain.systems import deploy_tracker
-from brain.systems.cortex.project_context.github import GitHubConnectorError
 from brain.systems.deploy_state import DeployStateBatch
 from brain.systems.production_gate_evidence import (
     ProductionEvidenceReader,
@@ -18,6 +17,8 @@ from brain.systems.production_gate_evidence import (
 )
 from brain.systems.production_gate_github import (
     BackendClosureGithubClient,
+    CLOSURE_READ_AUTH_FAILURE_REASONS,
+    ClosureReadFailure,
     ClosureGithubClient,
     FixingPullRequest,
     IssueClosure,
@@ -62,7 +63,10 @@ async def run_staging_only_closure_sweep(
 
     current_time = _utc(now) or datetime.now(timezone.utc)
     evidence_since = current_time - timedelta(hours=24)
-    github = github or BackendClosureGithubClient(org_id=str(org_id))
+    github = github or BackendClosureGithubClient(
+        org_id=str(org_id),
+        caller_label="staging_only_closure_sweep",
+    )
     errors: list[str] = []
     field_summary = await deploy_tracker.ensure_production_gate_fields(
         session,
@@ -225,22 +229,27 @@ async def _read_closed_issues(
     attempts = [result for result in results if result is not None]
     failures = [result for result in attempts if result.error is not None]
     if failures and len(failures) == len(attempts):
-        auth_failures = {
-            _authentication_failure(result.error)
+        typed_failures = [
+            result.error
             for result in failures
-            if result.error is not None
-        }
-        auth_failure = next(iter(auth_failures)) if len(auth_failures) == 1 else None
-        if auth_failure is not None:
-            status_code, message = auth_failure
+            if isinstance(result.error, ClosureReadFailure)
+        ]
+        reason_codes = {failure.reason_code for failure in typed_failures}
+        if (
+            len(typed_failures) == len(failures)
+            and len(reason_codes) == 1
+            and reason_codes <= CLOSURE_READ_AUTH_FAILURE_REASONS
+        ):
+            failure = typed_failures[0]
             logger.error(
                 "closure authentication failed for all %s GitHub issue reads: %s",
                 len(failures),
-                message,
+                failure.message,
             )
             errors.append(
                 "github_issue_authentication_all_reads_failed:"
-                f"count={len(failures)}:status={status_code}:{message}"
+                f"count={len(failures)}:reason={failure.reason_code}:"
+                f"status={failure.status_code}:{failure.message}"
             )
             return []
     for failure in failures:
@@ -258,12 +267,6 @@ async def _read_closed_issues(
         for result in attempts
         if result.candidate is not None
     ]
-
-
-def _authentication_failure(exc: Exception) -> tuple[int, str] | None:
-    if isinstance(exc, GitHubConnectorError) and exc.status_code in {401, 403}:
-        return exc.status_code, str(exc)
-    return None
 
 
 async def _read_deploy_states(

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -674,8 +674,52 @@ async def async_resolve_project_bound_env_tokens(
     """
     if not project_slug and not project_slugs and target_registry_id is None:
         return {}
+    return await _async_resolve_project_bound_env_tokens(
+        actor_user_id=_require_actor_user_id(actor_user_id),
+        org_id=org_id,
+        project_slug=project_slug,
+        project_slugs=project_slugs,
+        target_registry_id=target_registry_id,
+        github_app_only=github_app_only,
+        github_app_permissions=github_app_permissions,
+    )
+
+
+async def async_resolve_org_project_bound_env_tokens(
+    *,
+    org_id: str,
+    project_slug: str | None = None,
+    project_slugs: list[str] | tuple[str, ...] | set[str] | None = None,
+    target_registry_id: int | None = None,
+    github_app_only: bool = False,
+    github_app_permissions: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve bound tokens for an org-scoped backend maintenance caller."""
+
+    return await _async_resolve_project_bound_env_tokens(
+        actor_user_id=None,
+        org_id=org_id,
+        project_slug=project_slug,
+        project_slugs=project_slugs,
+        target_registry_id=target_registry_id,
+        github_app_only=github_app_only,
+        github_app_permissions=github_app_permissions,
+    )
+
+
+async def _async_resolve_project_bound_env_tokens(
+    *,
+    actor_user_id: str | None,
+    org_id: str | None,
+    project_slug: str | None,
+    project_slugs: list[str] | tuple[str, ...] | set[str] | None,
+    target_registry_id: int | None,
+    github_app_only: bool,
+    github_app_permissions: dict[str, str] | None,
+) -> dict[str, str]:
+    if not project_slug and not project_slugs and target_registry_id is None:
+        return {}
     clean_org_id = _require_org_id(org_id)
-    clean_actor_user_id = _require_actor_user_id(actor_user_id)
     env_assignments: list[tuple[str, str | None, list[str] | None, str | None]] = []
     github_app_assignments: dict[tuple[str, int], dict[str, Any]] = {}
     async with UnitOfWork() as uow:
@@ -700,7 +744,7 @@ async def async_resolve_project_bound_env_tokens(
                     secret.access_count = (secret.access_count or 0) + 1
                     await _async_log_access(
                         org_id=clean_org_id,
-                        actor_user_id=clean_actor_user_id,
+                        actor_user_id=actor_user_id,
                         secret_id=secret.id,
                         key_name=secret.key_name,
                         action="read",
@@ -723,7 +767,7 @@ async def async_resolve_project_bound_env_tokens(
             secret.access_count = (secret.access_count or 0) + 1
             await _async_log_access(
                 org_id=clean_org_id,
-                actor_user_id=clean_actor_user_id,
+                actor_user_id=actor_user_id,
                 secret_id=secret.id,
                 key_name=secret.key_name,
                 action="read",

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -41,6 +41,7 @@ VAULT_AGENT_GRANT_TTL = timedelta(minutes=15)
 VAULT_ACCESS_ACTORS = {"user", "agent", "api"}
 VAULT_ACCESS_ACTOR_ALIASES = {
     "github_connector": "api",
+    "staging_only_closure_sweep": "api",
 }
 VAULT_AGENT_ACCESS_AVAILABLE = "available"
 VAULT_AGENT_ACCESS_ASK = "ask"
@@ -676,6 +677,7 @@ async def async_resolve_project_bound_env_tokens(
         return {}
     return await _async_resolve_project_bound_env_tokens(
         actor_user_id=_require_actor_user_id(actor_user_id),
+        accessed_by="agent",
         org_id=org_id,
         project_slug=project_slug,
         project_slugs=project_slugs,
@@ -688,16 +690,18 @@ async def async_resolve_project_bound_env_tokens(
 async def async_resolve_org_project_bound_env_tokens(
     *,
     org_id: str,
+    accessed_by: str,
     project_slug: str | None = None,
     project_slugs: list[str] | tuple[str, ...] | set[str] | None = None,
     target_registry_id: int | None = None,
     github_app_only: bool = False,
     github_app_permissions: dict[str, str] | None = None,
 ) -> dict[str, str]:
-    """Resolve bound tokens for an org-scoped backend maintenance caller."""
+    """Resolve bound tokens and audit the org-scoped maintenance caller."""
 
     return await _async_resolve_project_bound_env_tokens(
         actor_user_id=None,
+        accessed_by=accessed_by,
         org_id=org_id,
         project_slug=project_slug,
         project_slugs=project_slugs,
@@ -710,6 +714,7 @@ async def async_resolve_org_project_bound_env_tokens(
 async def _async_resolve_project_bound_env_tokens(
     *,
     actor_user_id: str | None,
+    accessed_by: str,
     org_id: str | None,
     project_slug: str | None,
     project_slugs: list[str] | tuple[str, ...] | set[str] | None,
@@ -748,8 +753,7 @@ async def _async_resolve_project_bound_env_tokens(
                         secret_id=secret.id,
                         key_name=secret.key_name,
                         action="read",
-                        # github_app mint reads audit as agent on the binding lane.
-                        accessed_by="agent",
+                        accessed_by=accessed_by,
                         uow=uow,
                     )
                     assignment = {
@@ -771,7 +775,7 @@ async def _async_resolve_project_bound_env_tokens(
                 secret_id=secret.id,
                 key_name=secret.key_name,
                 action="read",
-                accessed_by="agent",
+                accessed_by=accessed_by,
                 uow=uow,
             )
             env_assignments.append((binding.env_name, _decrypt(bytes(secret.encrypted_value)), None, None))

--- a/tests/test_staging_only_closure.py
+++ b/tests/test_staging_only_closure.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,6 +22,7 @@ from brain.platform.db.models.domain import (
     DomainRelationType,
 )
 from brain.platform.db.models.provider_alert import ProviderAlertOccurrence
+from brain.systems.cortex.project_context.github import GitHubConnectorError
 from brain.systems.deploy_state import (
     DeployState,
     DeployStateBatch,
@@ -244,6 +246,21 @@ class _BatchGithub:
         return self.batch
 
 
+class _AuthFailingGithub:
+    def __init__(self):
+        self.reads = []
+
+    async def get_issue_closure(self, *, repo: str, issue_number: int):
+        self.reads.append((repo, issue_number))
+        raise GitHubConnectorError(
+            status_code=403,
+            message="API rate limit exceeded for 207.134.142.114.",
+        )
+
+    async def derive_deploy_states(self, refs):
+        raise AssertionError("No deploy-state reads are expected")
+
+
 class _Slack:
     def __init__(self):
         self.posts = []
@@ -251,6 +268,54 @@ class _Slack:
     async def post_message(self, **kwargs):
         self.posts.append(kwargs)
         return {"ok": True, "ts": "1785144000.000001"}
+
+
+@pytest.mark.asyncio
+async def test_all_issue_reads_failing_same_auth_reason_surface_one_sweep_error(
+    session,
+    caplog,
+):
+    domain = await _tracker(session)
+    await _tracked_issue(
+        session,
+        domain,
+        number=1281,
+        title="PostgreSQL deadlock",
+    )
+    await _tracked_issue(
+        session,
+        domain,
+        number=1282,
+        title="PostgreSQL lock timeout",
+    )
+    github = _AuthFailingGithub()
+
+    with caplog.at_level(logging.WARNING, logger="illo.staging_only_closure"):
+        summary = await run_staging_only_closure_sweep(
+            session,
+            org_id=ORG_ID,
+            github=github,
+            production_evidence=_Evidence(()),
+            notify=False,
+            now=CLOSED_AT,
+        )
+
+    assert sorted(github.reads) == [(REPO, 1281), (REPO, 1282)]
+    assert summary["examined"] == 2
+    assert summary["closed"] == 0
+    assert summary["errors"] == [
+        "github_issue_authentication_all_reads_failed:"
+        "count=2:status=403:API rate limit exceeded for 207.134.142.114."
+    ]
+    closure_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "illo.staging_only_closure"
+    ]
+    assert closure_logs == [
+        "closure authentication failed for all 2 GitHub issue reads: "
+        "API rate limit exceeded for 207.134.142.114."
+    ]
 
 
 class _ResolvableSlack(_Slack):

--- a/tests/test_staging_only_closure.py
+++ b/tests/test_staging_only_closure.py
@@ -22,7 +22,6 @@ from brain.platform.db.models.domain import (
     DomainRelationType,
 )
 from brain.platform.db.models.provider_alert import ProviderAlertOccurrence
-from brain.systems.cortex.project_context.github import GitHubConnectorError
 from brain.systems.deploy_state import (
     DeployState,
     DeployStateBatch,
@@ -32,6 +31,12 @@ from brain.systems.deploy_state_github import AncestryObservation
 from brain.systems.deploy_tracker import (
     PRODUCTION_GATE_FIELD,
     PRODUCTION_GATE_PENDING,
+)
+from brain.systems.production_gate_github import (
+    CLOSURE_READ_ACCESS_FORBIDDEN,
+    CLOSURE_READ_AUTHENTICATION_REQUIRED,
+    CLOSURE_READ_CONNECTOR_ERROR,
+    ClosureReadFailure,
 )
 from brain.systems.staging_only_closure import (
     FixingPullRequest,
@@ -252,10 +257,25 @@ class _AuthFailingGithub:
 
     async def get_issue_closure(self, *, repo: str, issue_number: int):
         self.reads.append((repo, issue_number))
-        raise GitHubConnectorError(
+        raise ClosureReadFailure(
+            reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
             status_code=403,
             message="API rate limit exceeded for 207.134.142.114.",
         )
+
+    async def derive_deploy_states(self, refs):
+        raise AssertionError("No deploy-state reads are expected")
+
+
+class _PerIssueGithub:
+    def __init__(self, outcomes):
+        self.outcomes = dict(outcomes)
+
+    async def get_issue_closure(self, *, repo: str, issue_number: int):
+        outcome = self.outcomes[(repo, issue_number)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
 
     async def derive_deploy_states(self, refs):
         raise AssertionError("No deploy-state reads are expected")
@@ -305,7 +325,8 @@ async def test_all_issue_reads_failing_same_auth_reason_surface_one_sweep_error(
     assert summary["closed"] == 0
     assert summary["errors"] == [
         "github_issue_authentication_all_reads_failed:"
-        "count=2:status=403:API rate limit exceeded for 207.134.142.114."
+        "count=2:reason=github_access_forbidden:"
+        "status=403:API rate limit exceeded for 207.134.142.114."
     ]
     closure_logs = [
         record.getMessage()
@@ -315,6 +336,102 @@ async def test_all_issue_reads_failing_same_auth_reason_surface_one_sweep_error(
     assert closure_logs == [
         "closure authentication failed for all 2 GitHub issue reads: "
         "API rate limit exceeded for 207.134.142.114."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mixed_success_and_auth_failure_does_not_report_all_reads_failed(
+    session,
+):
+    domain = await _tracker(session)
+    await _tracked_issue(session, domain, number=1281, title="Readable issue")
+    await _tracked_issue(session, domain, number=1282, title="Unreadable issue")
+    github = _PerIssueGithub(
+        {
+            (REPO, 1281): None,
+            (REPO, 1282): ClosureReadFailure(
+                reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
+                status_code=403,
+                message="Access forbidden",
+            ),
+        }
+    )
+
+    summary = await run_staging_only_closure_sweep(
+        session,
+        org_id=ORG_ID,
+        github=github,
+        production_evidence=_Evidence(()),
+        notify=False,
+        now=CLOSED_AT,
+    )
+
+    assert summary["closed"] == 0
+    assert summary["errors"] == [
+        f"github_issue:{REPO}#1282:Access forbidden"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_different_auth_reasons_do_not_report_one_all_reads_failure(session):
+    domain = await _tracker(session)
+    await _tracked_issue(session, domain, number=1281, title="Missing credentials")
+    await _tracked_issue(session, domain, number=1282, title="Forbidden credentials")
+    github = _PerIssueGithub(
+        {
+            (REPO, 1281): ClosureReadFailure(
+                reason_code=CLOSURE_READ_AUTHENTICATION_REQUIRED,
+                status_code=401,
+                message="Authentication required",
+            ),
+            (REPO, 1282): ClosureReadFailure(
+                reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
+                status_code=403,
+                message="Access forbidden",
+            ),
+        }
+    )
+
+    summary = await run_staging_only_closure_sweep(
+        session,
+        org_id=ORG_ID,
+        github=github,
+        production_evidence=_Evidence(()),
+        notify=False,
+        now=CLOSED_AT,
+    )
+
+    assert summary["errors"] == [
+        f"github_issue:{REPO}#1281:Authentication required",
+        f"github_issue:{REPO}#1282:Access forbidden",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_auth_closure_failure_does_not_report_authentication_error(session):
+    domain = await _tracker(session)
+    await _tracked_issue(session, domain, number=1281, title="GitHub unavailable")
+    github = _PerIssueGithub(
+        {
+            (REPO, 1281): ClosureReadFailure(
+                reason_code=CLOSURE_READ_CONNECTOR_ERROR,
+                status_code=503,
+                message="GitHub unavailable",
+            )
+        }
+    )
+
+    summary = await run_staging_only_closure_sweep(
+        session,
+        org_id=ORG_ID,
+        github=github,
+        production_evidence=_Evidence(()),
+        notify=False,
+        now=CLOSED_AT,
+    )
+
+    assert summary["errors"] == [
+        f"github_issue:{REPO}#1281:GitHub unavailable"
     ]
 
 

--- a/tests/test_staging_only_closure_github.py
+++ b/tests/test_staging_only_closure_github.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
     GithubFixingPullRequest,
     GithubIssueClosure,
     async_get_issue_closure_info,
@@ -78,7 +79,83 @@ async def test_issue_closure_read_resolves_closer_and_fixing_pr_deploy_facts():
         ("GET", "/repos/uwear-ai/uwear-backend/issues/1281"),
         ("POST", "/graphql"),
     ]
-    assert request.await_args_list[1].kwargs["token"] == "read-token"
+    assert [call.kwargs["token"] for call in request.await_args_list] == [
+        "read-token",
+        "read-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_org_only_backend_closure_read_resolves_authenticated_project_token(
+    monkeypatch,
+):
+    import brain.systems.runs.tool_catalog.handlers.github as handler
+
+    closure = GithubIssueClosure(
+        repo="uwear-ai/uwear-backend",
+        number=1281,
+        title="PostgreSQL deadlock",
+        state="closed",
+        closed_at=datetime(2026, 7, 27, 9, 8, 19, tzinfo=timezone.utc),
+        closed_by="uwear-claw",
+        fixing_pull_requests=(),
+    )
+    resolve_bound = AsyncMock(
+        return_value={"GITHUB_TOKEN": "installation-token"}
+    )
+    closure_read = AsyncMock(return_value=closure)
+    monkeypatch.setattr(
+        handler,
+        "async_resolve_org_project_bound_env_tokens",
+        resolve_bound,
+    )
+    monkeypatch.setattr(handler, "async_get_issue_closure_info", closure_read)
+
+    result = await handler.github_issue_closure_for_backend(
+        repo_slug="uwear-ai/uwear-backend",
+        issue_number=1281,
+        org_id="org-1",
+    )
+
+    assert result is closure
+    resolve_bound.assert_awaited_once_with(
+        org_id="org-1",
+        project_slug="uwear-ai/uwear-backend",
+        project_slugs=None,
+        github_app_only=False,
+    )
+    closure_read.assert_awaited_once_with(
+        "uwear-ai/uwear-backend",
+        1281,
+        token="installation-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_org_only_backend_closure_read_never_falls_back_to_public(
+    monkeypatch,
+):
+    import brain.systems.runs.tool_catalog.handlers.github as handler
+
+    monkeypatch.setattr(
+        handler,
+        "async_resolve_org_project_bound_env_tokens",
+        AsyncMock(return_value={}),
+    )
+    closure_read = AsyncMock()
+    monkeypatch.setattr(handler, "async_get_issue_closure_info", closure_read)
+
+    with pytest.raises(
+        GitHubConnectorError,
+        match="No GitHub token candidates were available",
+    ):
+        await handler.github_issue_closure_for_backend(
+            repo_slug="uwear-ai/uwear-backend",
+            issue_number=1281,
+            org_id="org-1",
+        )
+
+    closure_read.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_staging_only_closure_github.py
+++ b/tests/test_staging_only_closure_github.py
@@ -14,7 +14,14 @@ from brain.systems.cortex.project_context.github import (
     async_get_issue_closure_info,
 )
 from brain.systems.deploy_state import DeployStateBatch
-from brain.systems.staging_only_closure import BackendClosureGithubClient
+from brain.systems.deploy_state_github import ancestry_failure
+from brain.systems.production_gate_github import (
+    CLOSURE_READ_ACCESS_FORBIDDEN,
+    CLOSURE_READ_AUTHENTICATION_REQUIRED,
+    CLOSURE_READ_CONNECTOR_ERROR,
+    BackendClosureGithubClient,
+    ClosureReadFailure,
+)
 
 
 @pytest.mark.asyncio
@@ -115,11 +122,13 @@ async def test_org_only_backend_closure_read_resolves_authenticated_project_toke
         repo_slug="uwear-ai/uwear-backend",
         issue_number=1281,
         org_id="org-1",
+        caller_label="staging_only_closure_sweep",
     )
 
     assert result is closure
     resolve_bound.assert_awaited_once_with(
         org_id="org-1",
+        accessed_by="staging_only_closure_sweep",
         project_slug="uwear-ai/uwear-backend",
         project_slugs=None,
         github_app_only=False,
@@ -153,6 +162,7 @@ async def test_org_only_backend_closure_read_never_falls_back_to_public(
             repo_slug="uwear-ai/uwear-backend",
             issue_number=1281,
             org_id="org-1",
+            caller_label="staging_only_closure_sweep",
         )
 
     closure_read.assert_not_awaited()
@@ -197,7 +207,11 @@ async def test_backend_adapter_uses_shared_closure_and_deploy_state_reads(monkey
         "github_deploy_states_for_backend",
         deploy_read,
     )
-    client = BackendClosureGithubClient(org_id="org-1", user_id="user-1")
+    client = BackendClosureGithubClient(
+        org_id="org-1",
+        user_id="user-1",
+        caller_label="staging_only_closure_sweep",
+    )
 
     closure = await client.get_issue_closure(
         repo="uwear-ai/uwear-backend",
@@ -216,9 +230,90 @@ async def test_backend_adapter_uses_shared_closure_and_deploy_state_reads(monkey
         issue_number=1281,
         org_id="org-1",
         user_id="user-1",
+        caller_label="staging_only_closure_sweep",
     )
     deploy_read.assert_awaited_once_with(
         {"key": ("uwear-ai/uwear-backend", "a" * 40)},
         org_id="org-1",
         user_id="user-1",
+        caller_label="staging_only_closure_sweep",
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "reason_code"),
+    [
+        (401, CLOSURE_READ_AUTHENTICATION_REQUIRED),
+        (403, CLOSURE_READ_ACCESS_FORBIDDEN),
+        (503, CLOSURE_READ_CONNECTOR_ERROR),
+    ],
+)
+async def test_backend_adapter_translates_connector_errors(
+    monkeypatch,
+    status_code,
+    reason_code,
+):
+    import brain.systems.runs.tool_catalog.handlers.github as handler
+
+    monkeypatch.setattr(
+        handler,
+        "github_issue_closure_for_backend",
+        AsyncMock(
+            side_effect=GitHubConnectorError(
+                status_code=status_code,
+                message="stable test message",
+            )
+        ),
+    )
+    client = BackendClosureGithubClient(
+        org_id="org-1",
+        caller_label="staging_only_closure_sweep",
+    )
+
+    with pytest.raises(ClosureReadFailure) as exc_info:
+        await client.get_issue_closure(
+            repo="uwear-ai/uwear-backend",
+            issue_number=1281,
+        )
+
+    assert exc_info.value.reason_code == reason_code
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.message == "stable test message"
+
+
+@pytest.mark.asyncio
+async def test_backend_deploy_state_empty_candidates_raise_credential_failure(
+    monkeypatch,
+):
+    import brain.systems.runs.tool_catalog.handlers.github as handler
+
+    candidates = AsyncMock(return_value=[])
+    healthy_batch = DeployStateBatch(
+        {},
+        observations_by_key={},
+        observations_by_ref={},
+    )
+    derive = AsyncMock(return_value=healthy_batch)
+    captured_errors = []
+
+    def capture_failure(branch, exc):
+        captured_errors.append(exc)
+        return ancestry_failure(branch, exc)
+
+    monkeypatch.setattr(handler, "_github_token_candidates", candidates)
+    monkeypatch.setattr(handler, "derive_deploy_states", derive)
+    monkeypatch.setattr(handler, "ancestry_failure", capture_failure)
+
+    batch = await handler.github_deploy_states_for_backend(
+        {"fix": ("uwear-ai/uwear-backend", "a" * 40)},
+        org_id="org-1",
+        caller_label="staging_only_closure_sweep",
+    )
+
+    assert batch["fix"] is None
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], GitHubConnectorError)
+    assert captured_errors[0].status_code == 401
+    assert captured_errors[0].message == "No GitHub token candidates were available"
+    derive.assert_awaited_once_with({}, tokens={})

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -346,6 +346,7 @@ async def test_resolve_org_project_bound_env_tokens_for_backend(patch_uow, sessi
 
     env = await async_resolve_org_project_bound_env_tokens(
         org_id=ORG_ID,
+        accessed_by="staging_only_closure_sweep",
         project_slug="uwear-ai/uwear-backend",
     )
 
@@ -361,7 +362,7 @@ async def test_resolve_org_project_bound_env_tokens_for_backend(patch_uow, sessi
         )
     ).one()
     assert access_log.actor_user_id is None
-    assert access_log.accessed_by == "agent"
+    assert access_log.accessed_by == "api"
 
 
 async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, session, monkeypatch):

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -327,6 +327,43 @@ async def test_resolve_project_bound_env_tokens_returns_org_bound_tokens_for_mem
     assert github.access_count == 1
 
 
+async def test_resolve_org_project_bound_env_tokens_for_backend(patch_uow, session):
+    from brain.systems.vault import async_resolve_org_project_bound_env_tokens
+
+    github = await _secret(
+        session,
+        "GITHUB_TOKEN",
+        "backend-github-token",
+        org_id=ORG_ID,
+        access_level="ask",
+    )
+    await _binding(
+        session,
+        github,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GITHUB_TOKEN",
+    )
+
+    env = await async_resolve_org_project_bound_env_tokens(
+        org_id=ORG_ID,
+        project_slug="uwear-ai/uwear-backend",
+    )
+
+    assert env == {"GITHUB_TOKEN": "backend-github-token"}
+    await session.refresh(github)
+    assert github.access_count == 1
+    access_log = (
+        await session.scalars(
+            select(VaultAccessLog).where(
+                VaultAccessLog.secret_id == github.id,
+                VaultAccessLog.action == "read",
+            )
+        )
+    ).one()
+    assert access_log.actor_user_id is None
+    assert access_log.accessed_by == "agent"
+
+
 async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, session, monkeypatch):
     from brain.systems.vault import async_resolve_project_bound_env_tokens
 


### PR DESCRIPTION
Closes #637

## What was broken

The staging-only closure sweep read **every** tracked issue from GitHub **unauthenticated**. One sweep on illo-dev at `2026-08-01T15:24:10Z` produced 80 consecutive failures in about 6 seconds:

```
closure read failed for Illospace/illospace#281: API rate limit exceeded for 207.134.142.114.
```

`API rate limit exceeded for <IP>` is GitHub's message for unauthenticated requests (60/hour per IP). Two causes, both proven by a Codex worker following the token from the call site:

1. `_github_token_candidates` appended a `{"key_name": None, "token": None, "source": "public"}` candidate whenever nothing else resolved. That candidate produced a real request with no credential — which is why no "No GitHub token candidates were available" error ever appeared.
2. The backend caller passes `org_id` with **no `user_id`**, and project-bound token resolution was gated on `if user_id and org_id`, so it never even looked for the org's token.

Each failure was swallowed per record, so the sweep reported `examined: N, closed: 0` and looked healthy. This is the sweep that detects "the fixing PR merged to staging, so this tracked issue is really done" — its tracked records went stale instead.

## What this changes

- Backend maintenance reads resolve **org-scoped** project bindings (new `async_resolve_org_project_bound_env_tokens`) and refuse the unauthenticated fallback (`require_authenticated`).
- `BackendClosureGithubClient` translates connector errors into typed closure failures with a stable `reason_code`; the sweep aggregates them instead of matching `str(exc)`.
- A sweep whose reads all fail for the same auth reason now surfaces one named error rather than looking like a clean zero-result run.
- The org-scoped vault read logs `accessed_by="api"` with a caller label (`staging_only_closure_sweep`) instead of claiming to be an agent. `actor_user_id` stays NULL — it is a `users` FK — and there is no migration.

## Verification

- Full CI selection, run locally unsandboxed: **4643 passed, 11 skipped, 82 deselected** (`pytest tests/ -m "not requires_db and not requires_browser and not live_provider"`). Baseline before this branch: 4636.
- The `requires_db` vault suite runs in CI's own job; the SQLite vault tests pass locally.
- A Codex code-quality review ran against the first commit; its two blocking findings (the dishonest audit row, the transport classification leaking across the client boundary) are folded in the second commit.

## How to judge it (no diff reading needed)

After merge and deploy, on illo-dev:

1. `docker logs illospace-scheduler-1 | grep "closure read failed"` → should be empty, where it produced 80 lines per sweep before.
2. The sweep's result should start reporting real `closed`/`updated` counts instead of `closed: 0`.
3. `vault_access_log` rows for the sweep should read `accessed_by = api`.

## What I deliberately did not do

The review also asked to replace `require_authenticated` / `for_write` / `user_id` / `org_id` in `_github_token_candidates` with one named policy object. I declined it. That function sits on the hot path of many runtime callers, and a policy refactor does not belong inside a bug fix for a broken sweep. It is a real observation and worth its own ticket if the flag set grows again.

Note also that the unauthenticated `public` candidate still exists for **runtime** (user-context) reads, where reading a public repo without credentials is legitimate. Only backend maintenance reads refuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
