### PR TITLE
fix(knowledge): tombstone deleted Slack threads so one deletion cannot wedge the sync

### DIFF
--- a/brain/systems/knowledge/connectors/slack.py
+++ b/brain/systems/knowledge/connectors/slack.py
@@ -19,6 +19,7 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
 )
+from brain.systems.slack.client import SlackApiError
 from brain.systems.slack.monitored_intakes import visible_slack_content
 from brain.systems.slack.monitors import monitored_channels
 
@@ -26,6 +27,12 @@ from brain.systems.slack.monitors import monitored_channels
 _CURSOR_VERSION = 1
 _SLACK_MESSAGE_KIND = "slack_message"
 _THREAD_PAGE_SIZE = 200
+
+# The one Slack error that proves the thread root no longer exists. Broader
+# errors (channel_not_found, auth faults) stay fatal: they can mean a stale
+# channel id or a wrong-workspace token, and archiving reachable content on a
+# configuration fault would be silent data loss.
+_GONE_THREAD_ERRORS = frozenset({"thread_not_found"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -197,6 +204,10 @@ class SlackKnowledgeConnector:
     event queue is caught up, the same bounded history cursor continuously
     refreshes monitored channels so message edits and Illo-authored replies that
     intake intentionally ignores cannot leave the index stale forever.
+
+    A thread whose root was deleted at the source is archived through a
+    tombstone draft instead of raising, so one deleted message can never pin
+    the cursor and wedge the whole sync.
     """
 
     source_key = "slack"
@@ -430,12 +441,24 @@ class SlackKnowledgeConnector:
         cursor: str | None = None
         seen_cursors: set[str] = set()
         while True:
-            response = await client.conversation_replies(
-                channel=channel.id,
-                thread_ts=thread_ts,
-                limit=_THREAD_PAGE_SIZE,
-                cursor=cursor,
-            )
+            try:
+                response = await client.conversation_replies(
+                    channel=channel.id,
+                    thread_ts=thread_ts,
+                    limit=_THREAD_PAGE_SIZE,
+                    cursor=cursor,
+                )
+            except SlackApiError as exc:
+                if _clean(getattr(exc, "error", "")) not in _GONE_THREAD_ERRORS:
+                    raise
+                # The thread root was deleted. One gone thread must not wedge
+                # the cursor forever — and partially fetched pages or a
+                # just-deleted history root must not be indexed as live.
+                return self._deleted_thread_draft(
+                    connection=connection,
+                    channel=channel,
+                    thread_ts=thread_ts,
+                )
             for message in response.get("messages") or []:
                 if isinstance(message, Mapping) and _clean(message.get("ts")):
                     messages_by_ts[_clean(message.get("ts"))] = dict(message)
@@ -455,8 +478,10 @@ class SlackKnowledgeConnector:
                 messages_by_ts.setdefault(root_ts, dict(root_fallback))
         messages = sorted(messages_by_ts.values(), key=_slack_timestamp_key)
         if not messages:
-            raise RuntimeError(
-                f"Slack returned no messages for {channel.id}:{thread_ts}"
+            return self._deleted_thread_draft(
+                connection=connection,
+                channel=channel,
+                thread_ts=thread_ts,
             )
 
         root = messages[0]
@@ -496,6 +521,44 @@ class SlackKnowledgeConnector:
             source_created_at=source_created_at,
             source_updated_at=source_updated_at,
             distill=True,
+        )
+
+    def _deleted_thread_draft(
+        self,
+        *,
+        connection: ExternalAgentConnectionRow,
+        channel: _Channel,
+        thread_ts: str,
+    ) -> KnowledgeDraft:
+        """Archive a thread Slack no longer serves so recall cannot cite it."""
+
+        team_id = _team_id(connection)
+        channel_label = f"#{channel.name}" if channel.name else channel.id
+        thread_at = _slack_datetime(thread_ts)
+        return KnowledgeDraft(
+            source=self.source_key,
+            kind="slack_thread",
+            source_ref=f"slack:{team_id}:{channel.id}:{thread_ts}",
+            title=f"Slack {channel_label}: deleted thread {thread_ts}",
+            summary=(
+                f"Slack thread {thread_ts} in {channel_label} was deleted at "
+                "the source. Its indexed content is archived."
+            ),
+            entities=[channel.id, *([channel.name] if channel.name else [])],
+            raw_text="",
+            extra={
+                "org_id": str(connection.org_id),
+                "actor_user_id": str(connection.owner_user_id),
+                "connection_id": str(connection.id),
+                "team_id": team_id,
+                "channel_id": channel.id,
+                "channel_name": channel.name,
+                "thread_ts": thread_ts,
+                "deleted": True,
+            },
+            source_created_at=thread_at,
+            source_updated_at=thread_at,
+            archived_at=datetime.now(timezone.utc),
         )
 
 

--- a/tests/test_knowledge_slack_connector.py
+++ b/tests/test_knowledge_slack_connector.py
@@ -27,6 +27,7 @@ from brain.platform.db.models.org import Org, User
 from brain.jobs.pipelines.knowledge_index_sync import CONNECTOR_FACTORIES
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
 from brain.systems.knowledge.connectors.slack import SlackKnowledgeConnector
+from brain.systems.slack.client import SlackApiError
 from brain.systems.knowledge.search import search_knowledge
 from brain.systems.knowledge.service import sync_connector
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
@@ -537,3 +538,228 @@ async def test_slack_connector_repulls_one_complete_thread_when_a_reply_arrives(
     assert refreshed[0].extra["participants"] == ["BILLO", "U1", "U2"]
     assert "Confirmed healthy after the timeout change" in refreshed[0].raw_text
     assert refresh_cursor["phase"] == "incremental"
+
+
+class _DeletedThreadSlack:
+    """Replies raise per-thread Slack errors; history serves configured roots."""
+
+    def __init__(
+        self,
+        *,
+        threads: dict[str, list[dict] | str],
+        roots: list[dict] | None = None,
+    ) -> None:
+        # threads maps thread_ts to reply messages, or to an error string.
+        self.threads = threads
+        self.roots = list(roots or [])
+
+    async def conversation_history(self, *, channel, limit, cursor=None):
+        del channel, limit, cursor
+        return {
+            "messages": list(self.roots),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    async def conversation_replies(self, *, channel, thread_ts, limit, cursor=None):
+        del channel, limit, cursor
+        outcome = self.threads[thread_ts]
+        if isinstance(outcome, str):
+            raise SlackApiError(outcome)
+        return {
+            "messages": list(outcome),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+
+def _incremental_cursor() -> dict:
+    return {
+        "version": 1,
+        "connection_id": _CONNECTION_ID,
+        "channel_set_digest": hashlib.sha256(b"CINCIDENTS").hexdigest(),
+        "phase": "incremental",
+        "channel_id": None,
+        "history_cursor": None,
+        "event_created_at": None,
+        "event_id": None,
+    }
+
+
+def _slack_message_event(*, event_id: str, thread_ts: str, created_at: datetime):
+    return InboundEventRow(
+        id=event_id,
+        org_id=_ORG_ID,
+        connection_id=_CONNECTION_ID,
+        kind="slack_message",
+        origin="slack.channel_message",
+        idempotency_key=f"slack:T789:CINCIDENTS:{thread_ts}:{event_id}",
+        raw_payload={},
+        normalized_payload={
+            "kind": "slack_message",
+            "origin": "slack.channel_message",
+            "payload": {
+                "team_id": "T789",
+                "channel_id": "CINCIDENTS",
+                "thread_ts": thread_ts,
+                "message_ts": thread_ts,
+            },
+        },
+        envelope={},
+        ingress_context={},
+        source_actor={},
+        status="processed",
+        created_at=created_at,
+    )
+
+
+async def test_deleted_thread_becomes_a_tombstone_and_the_cursor_still_advances(
+    session,
+):
+    await _seed_monitored_slack(session)
+    slack = _DeletedThreadSlack(
+        threads={
+            "1785283200.000100": "thread_not_found",
+            "1785283260.000200": [
+                {"ts": "1785283260.000200", "user": "U2", "text": "Still here"}
+            ],
+        }
+    )
+    session.add(
+        _slack_message_event(
+            event_id="55555555-5555-4555-8555-555555555555",
+            thread_ts="1785283200.000100",
+            created_at=datetime(2026, 7, 29, 0, 1, tzinfo=timezone.utc),
+        )
+    )
+    session.add(
+        _slack_message_event(
+            event_id="66666666-6666-4666-8666-666666666666",
+            thread_ts="1785283260.000200",
+            created_at=datetime(2026, 7, 29, 0, 2, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+
+    enumeration = await SlackKnowledgeConnector(
+        client=slack,
+        max_items=10,
+    ).enumerate_changed(session, _incremental_cursor())
+
+    assert [draft.source_ref for draft in enumeration.drafts] == [
+        "slack:T789:CINCIDENTS:1785283200.000100",
+        "slack:T789:CINCIDENTS:1785283260.000200",
+    ]
+    tombstone, alive = enumeration.drafts
+    assert tombstone.archived_at is not None
+    assert tombstone.distill is False
+    assert tombstone.raw_text == ""
+    assert tombstone.extra["deleted"] is True
+    assert alive.archived_at is None
+    assert alive.distill is True
+    assert "Still here" in alive.raw_text
+    assert enumeration.cursor["event_id"] == "66666666-6666-4666-8666-666666666666"
+    assert enumeration.cursor["event_created_at"] == "2026-07-29T00:02:00+00:00"
+
+
+async def test_deleted_thread_tombstone_archives_the_indexed_item(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    await _seed_monitored_slack(session)
+    session.add(
+        KnowledgeItem(
+            source="slack",
+            kind="slack_thread",
+            source_ref="slack:T789:CINCIDENTS:1785283200.000100",
+            title="Slack #incidents: Checkout is failing",
+            summary="Indexed before the thread was deleted.",
+            entities=[],
+            raw_text="Checkout is failing",
+            search_text="Checkout is failing",
+            extra={},
+            content_digest="stale",
+            ingested_at=datetime(2026, 7, 29, tzinfo=timezone.utc),
+        )
+    )
+    session.add(
+        _slack_message_event(
+            event_id="55555555-5555-4555-8555-555555555555",
+            thread_ts="1785283200.000100",
+            created_at=datetime(2026, 7, 29, 0, 1, tzinfo=timezone.utc),
+        )
+    )
+    session.add(
+        KnowledgeSyncState(
+            source="slack",
+            cursor=_incremental_cursor(),
+            last_stats={},
+        )
+    )
+    await session.flush()
+
+    result = await sync_connector(
+        session,
+        SlackKnowledgeConnector(
+            client=_DeletedThreadSlack(
+                threads={"1785283200.000100": "thread_not_found"}
+            ),
+            max_items=10,
+        ),
+    )
+
+    assert result.status == "ok"
+    item = (
+        await session.scalars(
+            select(KnowledgeItem).where(
+                KnowledgeItem.source_ref
+                == "slack:T789:CINCIDENTS:1785283200.000100"
+            )
+        )
+    ).one()
+    assert item.archived_at is not None
+    state = await session.get(KnowledgeSyncState, "slack")
+    assert state.cursor["event_id"] == "55555555-5555-4555-8555-555555555555"
+
+
+async def test_backfill_tombstones_a_root_deleted_between_history_and_replies(
+    session,
+):
+    await _seed_monitored_slack(session)
+    root = {"ts": "1785283200.000100", "user": "U1", "text": "Just deleted"}
+    slack = _DeletedThreadSlack(
+        threads={"1785283200.000100": "thread_not_found"},
+        roots=[root],
+    )
+
+    enumeration = await SlackKnowledgeConnector(
+        client=slack,
+        max_items=10,
+    ).enumerate_changed(session, {})
+
+    assert len(enumeration.drafts) == 1
+    draft = enumeration.drafts[0]
+    assert draft.archived_at is not None
+    assert draft.distill is False
+    assert draft.raw_text == ""
+    assert enumeration.cursor["phase"] == "incremental"
+
+
+@pytest.mark.parametrize("error", ["ratelimited", "channel_not_found"])
+async def test_non_deletion_slack_errors_still_fail_the_enumeration(session, error):
+    await _seed_monitored_slack(session)
+    session.add(
+        _slack_message_event(
+            event_id="55555555-5555-4555-8555-555555555555",
+            thread_ts="1785283200.000100",
+            created_at=datetime(2026, 7, 29, 0, 1, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+
+    with pytest.raises(SlackApiError):
+        await SlackKnowledgeConnector(
+            client=_DeletedThreadSlack(
+                threads={"1785283200.000100": error}
+            ),
+            max_items=10,
+        ).enumerate_changed(session, _incremental_cursor())


### PR DESCRIPTION
## What broke

`knowledge_index_sync` failed every run from 2026-08-01 21:30Z with `thread_not_found` (Slack alerts at 22:00Z and 22:32Z). Root cause:

- The Slack connector walks the inbound-event backlog ~100 events per run. At 21:00Z it reached the 2026-07-16 position. The next batch contains #alerts thread `1784482221.247479` (2026-07-19), whose root message was deleted.
- `conversations.replies` raises `thread_not_found` for a deleted root. `_draft_for_thread` let it escape, and `sync_connector` does not advance the cursor on a failed enumeration.
- Result: a poison-pill. The same batch replays and fails every 30-minute slot, forever.

## The fix

- A gone thread now returns an **archived tombstone draft** instead of raising. The cursor advances, and any previously indexed copy of the thread is archived, so recall cannot cite deleted content.
- Partial reply pages and a just-deleted history root are discarded, not indexed as live.
- Only `thread_not_found` counts as gone. `channel_not_found` and every other error stay fatal, because they can mean a stale channel id or a wrong-workspace token.

## Verification

- 10/10 connector tests pass, including 4 new ones: incremental tombstone + cursor advance, end-to-end archive of an indexed item, backfill race tombstone, and fatal non-deletion errors (`ratelimited`, `channel_not_found`).
- Full related suites green: 88 passed (`test_knowledge_slack_connector`, `test_knowledge_index`, `test_scheduler_programs`, `test_scheduler`).
- Codex review ran on the diff; both findings (keep `channel_not_found` fatal; reject partial pages) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)