### PR TITLE
fix(knowledge): refuse anonymous GitHub reads in the knowledge sync sweep

### DIFF
--- a/brain/systems/github_read_failures.py
+++ b/brain/systems/github_read_failures.py
@@ -1,0 +1,35 @@
+"""Stable failure vocabulary for authenticated GitHub reads."""
+
+from __future__ import annotations
+
+from brain.systems.cortex.project_context.github import GitHubConnectorError
+
+
+GITHUB_READ_AUTHENTICATION_REQUIRED = "github_authentication_required"
+GITHUB_READ_ACCESS_FORBIDDEN = "github_access_forbidden"
+GITHUB_READ_CONNECTOR_ERROR = "github_connector_error"
+GITHUB_READ_AUTH_FAILURE_REASONS = frozenset(
+    {
+        GITHUB_READ_AUTHENTICATION_REQUIRED,
+        GITHUB_READ_ACCESS_FORBIDDEN,
+    }
+)
+
+
+def github_read_reason_code(exc: GitHubConnectorError) -> str:
+    """Translate connector statuses into the shared stable read vocabulary."""
+
+    if exc.status_code == 401:
+        return GITHUB_READ_AUTHENTICATION_REQUIRED
+    if exc.status_code == 403:
+        return GITHUB_READ_ACCESS_FORBIDDEN
+    return GITHUB_READ_CONNECTOR_ERROR
+
+
+__all__ = [
+    "GITHUB_READ_ACCESS_FORBIDDEN",
+    "GITHUB_READ_AUTHENTICATION_REQUIRED",
+    "GITHUB_READ_AUTH_FAILURE_REASONS",
+    "GITHUB_READ_CONNECTOR_ERROR",
+    "github_read_reason_code",
+]

--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,14 +33,22 @@ class KnowledgeDraft:
     distill: bool = False
 
 
+class EnumerationFailureKind(StrEnum):
+    """How the sync service must account for an enumeration failure."""
+
+    TRANSIENT = "transient"
+    CONFIGURATION = "configuration"
+
+
 @dataclass(frozen=True)
 class EnumerationFailure:
     """One source scope that could not be enumerated."""
 
     scope: str
     message: str
+    kind: EnumerationFailureKind = EnumerationFailureKind.TRANSIENT
     reason_code: str | None = None
-    configuration_fault: bool = False
+    remediation: str | None = None
 
 
 @dataclass(frozen=True)
@@ -65,6 +74,7 @@ class KnowledgeConnector(Protocol):
 
 __all__ = [
     "EnumerationFailure",
+    "EnumerationFailureKind",
     "KnowledgeConnector",
     "KnowledgeDraft",
     "KnowledgeEnumeration",

--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -38,6 +38,8 @@ class EnumerationFailure:
 
     scope: str
     message: str
+    reason_code: str | None = None
+    configuration_fault: bool = False
 
 
 @dataclass(frozen=True)

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -17,13 +17,18 @@ from brain.kernel.config import (
     KNOWLEDGE_GITHUB_REPOSITORIES,
 )
 from brain.platform.db.models.idea import ProjectProfile
-from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
     GithubIssueClosure,
     async_get_issue_closure_info,
     async_list_repo_issues,
     parse_github_repo_slug,
+)
+from brain.systems.production_gate_github import (
+    GITHUB_READ_ACCESS_FORBIDDEN,
+    GITHUB_READ_AUTH_FAILURE_REASONS,
+    github_read_reason_code,
 )
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
@@ -31,7 +36,8 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeEnumeration,
 )
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS
-from brain.systems.vault import async_resolve_project_bound_env_tokens
+from brain.systems.vault import async_resolve_org_project_bound_env_tokens
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
 
 _ISSUE_REF_RE = re.compile(
@@ -142,48 +148,78 @@ async def _github_authority(session: AsyncSession, repo: str) -> _GitHubAuthorit
         .limit(1)
     )
     if binding is None:
-        return _GitHubAuthority(token=None, org_id=None, actor_user_id=None)
-    actor = None
-    if binding.created_by_user_id:
-        actor = await session.get(User, str(binding.created_by_user_id))
-    if actor is None:
-        actor = (
-            await session.scalars(
-                select(User)
-                .where(User.org_id == str(binding.org_id))
-                .order_by(User.created_at.asc(), User.id.asc())
-                .limit(1)
-            )
-        ).first()
-    if actor is None:
-        return _GitHubAuthority(
-            token=None,
-            org_id=str(binding.org_id),
-            actor_user_id=None,
+        raise GitHubConnectorError(
+            status_code=401,
+            message=(
+                "No active GitHub App Vault project binding exists for the "
+                "knowledge sync."
+            ),
         )
-    env = await async_resolve_project_bound_env_tokens(
-        actor_user_id=str(actor.id),
-        org_id=str(actor.org_id),
-        project_slug=repo,
-        github_app_only=True,
-        github_app_permissions=_READ_PERMISSIONS,
-    )
+    org_id = str(binding.org_id)
+    try:
+        env = await async_resolve_org_project_bound_env_tokens(
+            org_id=org_id,
+            accessed_by="knowledge_index_sync",
+            project_slug=repo,
+            github_app_only=True,
+            github_app_permissions=_READ_PERMISSIONS,
+        )
+    except GitHubConnectorError as exc:
+        if exc.status_code in {403, 404, 422}:
+            raise GitHubConnectorError(
+                status_code=403,
+                message=(
+                    f"The bound GitHub App could not mint a token for {repo}: {exc}"
+                ),
+            ) from exc
+        raise
+    except RuntimeSecretUnavailable as exc:
+        raise GitHubConnectorError(
+            status_code=401,
+            message=f"The bound GitHub App credential could not mint a token: {exc}",
+        ) from exc
     for key in ("GITHUB_TOKEN", "GH_TOKEN"):
         token = str(env.get(key) or "").strip()
         if token:
             return _GitHubAuthority(
                 token=token,
-                org_id=str(actor.org_id),
-                actor_user_id=str(actor.id),
+                org_id=org_id,
+                actor_user_id=None,
             )
     token = next(
         (str(value).strip() for value in env.values() if str(value).strip()),
         None,
     )
-    return _GitHubAuthority(
-        token=token,
-        org_id=str(actor.org_id),
-        actor_user_id=str(actor.id),
+    if not token:
+        raise GitHubConnectorError(
+            status_code=401,
+            message="The active GitHub App Vault binding did not resolve a token.",
+        )
+    return _GitHubAuthority(token=token, org_id=org_id, actor_user_id=None)
+
+
+def _configuration_failure(
+    repo: str,
+    exc: GitHubConnectorError,
+) -> EnumerationFailure | None:
+    reason_code = github_read_reason_code(exc)
+    if reason_code not in GITHUB_READ_AUTH_FAILURE_REASONS:
+        return None
+    if reason_code == GITHUB_READ_ACCESS_FORBIDDEN:
+        remediation = (
+            f"Grant the installed GitHub App access to {repo}, then reconnect or "
+            "update its active Vault project binding for this exact repository slug."
+        )
+    else:
+        remediation = (
+            f"Install or reconnect the GitHub App for {repo}, then create an active "
+            "VaultProjectBinding to a github_app secret for this exact repository slug."
+        )
+    return EnumerationFailure(
+        scope=repo,
+        reason_code=reason_code,
+        configuration_fault=True,
+        message=f"{exc.message.rstrip('.')}. Remediation: {remediation}",
     )
 
 
@@ -310,6 +346,11 @@ async def _enumerate_repository(
     )
     authority = await _github_authority(session, repo)
     token = authority.token
+    if not token:
+        raise GitHubConnectorError(
+            status_code=401,
+            message="The knowledge GitHub connector refused an anonymous request.",
+        )
     payload = await async_list_repo_issues(
         repo,
         token=token,
@@ -340,37 +381,26 @@ async def _enumerate_repository(
             continue
         kind = "pr" if issue.get("type") == "pull_request" else "issue"
         closure = None
-        closure_unavailable_reason = None
         if str(issue.get("state") or "").lower() == "closed" and kind == "issue":
-            if not token:
-                closure_unavailable_reason = "authentication_required"
-                logger.warning(
-                    "GitHub closure enrichment skipped for %s#%s: "
-                    "authenticated GraphQL access is unavailable",
+            try:
+                closure = await async_get_issue_closure_info(
+                    repo,
+                    int(issue.get("number") or 0),
+                    token=token,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "GitHub closure enrichment unavailable for %s#%s: %s",
                     repo,
                     issue.get("number"),
+                    exc,
                 )
-            else:
-                try:
-                    closure = await async_get_issue_closure_info(
-                        repo,
-                        int(issue.get("number") or 0),
-                        token=token,
-                    )
-                except Exception as exc:
-                    logger.exception(
-                        "GitHub closure enrichment unavailable for %s#%s: %s",
-                        repo,
-                        issue.get("number"),
-                        exc,
-                    )
-                    raise
+                raise
         repo_drafts.append(
             _draft_for_issue(
                 repo,
                 issue,
                 closure=closure,
-                closure_unavailable_reason=closure_unavailable_reason,
                 org_id=authority.org_id,
                 actor_user_id=authority.actor_user_id,
             )
@@ -462,6 +492,25 @@ class GitHubConnector:
                     state,
                     remaining=repository_limit,
                 )
+            except GitHubConnectorError as exc:
+                failure = _configuration_failure(repo, exc)
+                if failure is None:
+                    failure = EnumerationFailure(scope=repo, message=exc.message)
+                    logger.exception(
+                        "GitHub knowledge enumeration skipped repository %s: %s",
+                        repo,
+                        failure.message,
+                    )
+                else:
+                    logger.error(
+                        "GitHub knowledge configuration fault for repository %s "
+                        "(%s): %s",
+                        repo,
+                        failure.reason_code,
+                        failure.message,
+                    )
+                failures.append(failure)
+                continue
             except Exception as exc:
                 message = str(exc).strip() or type(exc).__name__
                 failures.append(EnumerationFailure(scope=repo, message=message))

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -25,13 +25,15 @@ from brain.systems.cortex.project_context.github import (
     async_list_repo_issues,
     parse_github_repo_slug,
 )
-from brain.systems.production_gate_github import (
+from brain.systems.github_read_failures import (
     GITHUB_READ_ACCESS_FORBIDDEN,
+    GITHUB_READ_AUTHENTICATION_REQUIRED,
     GITHUB_READ_AUTH_FAILURE_REASONS,
     github_read_reason_code,
 )
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
+    EnumerationFailureKind,
     KnowledgeDraft,
     KnowledgeEnumeration,
 )
@@ -53,11 +55,47 @@ _CURSOR_VERSION = 2
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _GitHubAuthority:
-    token: str | None
-    org_id: str | None
-    actor_user_id: str | None
+    token: str
+    org_id: str
+
+
+@dataclass(slots=True)
+class _GitHubConfigurationError(Exception):
+    """A local knowledge-connector configuration failure."""
+
+    reason_code: str
+    message: str
+    remediation: str
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
+
+
+def _configuration_remediation(repo: str, reason_code: str) -> str:
+    if reason_code == GITHUB_READ_ACCESS_FORBIDDEN:
+        return (
+            f"Grant the installed GitHub App access to {repo}, then reconnect or "
+            "update its active Vault project binding for this exact repository slug."
+        )
+    return (
+        f"Install or reconnect the GitHub App for {repo}, then create an active "
+        "VaultProjectBinding to a github_app secret for this exact repository slug."
+    )
+
+
+def _configuration_error(
+    repo: str,
+    *,
+    reason_code: str,
+    message: str,
+) -> _GitHubConfigurationError:
+    return _GitHubConfigurationError(
+        reason_code=reason_code,
+        message=message,
+        remediation=_configuration_remediation(repo, reason_code),
+    )
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -148,8 +186,9 @@ async def _github_authority(session: AsyncSession, repo: str) -> _GitHubAuthorit
         .limit(1)
     )
     if binding is None:
-        raise GitHubConnectorError(
-            status_code=401,
+        raise _configuration_error(
+            repo,
+            reason_code=GITHUB_READ_AUTHENTICATION_REQUIRED,
             message=(
                 "No active GitHub App Vault project binding exists for the "
                 "knowledge sync."
@@ -165,17 +204,25 @@ async def _github_authority(session: AsyncSession, repo: str) -> _GitHubAuthorit
             github_app_permissions=_READ_PERMISSIONS,
         )
     except GitHubConnectorError as exc:
-        if exc.status_code in {403, 404, 422}:
-            raise GitHubConnectorError(
-                status_code=403,
+        if exc.status_code == 401:
+            raise _configuration_error(
+                repo,
+                reason_code=GITHUB_READ_AUTHENTICATION_REQUIRED,
                 message=(
-                    f"The bound GitHub App could not mint a token for {repo}: {exc}"
+                    f"The bound GitHub App credential could not mint a token: {exc}"
                 ),
+            ) from exc
+        if exc.status_code in {403, 404, 422}:
+            raise _configuration_error(
+                repo,
+                reason_code=GITHUB_READ_ACCESS_FORBIDDEN,
+                message=f"The bound GitHub App could not mint a token for {repo}: {exc}",
             ) from exc
         raise
     except RuntimeSecretUnavailable as exc:
-        raise GitHubConnectorError(
-            status_code=401,
+        raise _configuration_error(
+            repo,
+            reason_code=GITHUB_READ_AUTHENTICATION_REQUIRED,
             message=f"The bound GitHub App credential could not mint a token: {exc}",
         ) from exc
     for key in ("GITHUB_TOKEN", "GH_TOKEN"):
@@ -184,42 +231,47 @@ async def _github_authority(session: AsyncSession, repo: str) -> _GitHubAuthorit
             return _GitHubAuthority(
                 token=token,
                 org_id=org_id,
-                actor_user_id=None,
             )
     token = next(
         (str(value).strip() for value in env.values() if str(value).strip()),
         None,
     )
     if not token:
-        raise GitHubConnectorError(
-            status_code=401,
+        raise _configuration_error(
+            repo,
+            reason_code=GITHUB_READ_AUTHENTICATION_REQUIRED,
             message="The active GitHub App Vault binding did not resolve a token.",
         )
-    return _GitHubAuthority(token=token, org_id=org_id, actor_user_id=None)
+    return _GitHubAuthority(token=token, org_id=org_id)
 
 
 def _configuration_failure(
+    repo: str,
+    exc: _GitHubConfigurationError,
+) -> EnumerationFailure:
+    return EnumerationFailure(
+        scope=repo,
+        message=exc.message,
+        kind=EnumerationFailureKind.CONFIGURATION,
+        reason_code=exc.reason_code,
+        remediation=exc.remediation,
+    )
+
+
+def _repository_visibility_failure(
     repo: str,
     exc: GitHubConnectorError,
 ) -> EnumerationFailure | None:
     reason_code = github_read_reason_code(exc)
     if reason_code not in GITHUB_READ_AUTH_FAILURE_REASONS:
         return None
-    if reason_code == GITHUB_READ_ACCESS_FORBIDDEN:
-        remediation = (
-            f"Grant the installed GitHub App access to {repo}, then reconnect or "
-            "update its active Vault project binding for this exact repository slug."
-        )
-    else:
-        remediation = (
-            f"Install or reconnect the GitHub App for {repo}, then create an active "
-            "VaultProjectBinding to a github_app secret for this exact repository slug."
-        )
-    return EnumerationFailure(
-        scope=repo,
-        reason_code=reason_code,
-        configuration_fault=True,
-        message=f"{exc.message.rstrip('.')}. Remediation: {remediation}",
+    return _configuration_failure(
+        repo,
+        _configuration_error(
+            repo,
+            reason_code=reason_code,
+            message=exc.message,
+        ),
     )
 
 
@@ -228,9 +280,7 @@ def _draft_for_issue(
     issue: Mapping[str, Any],
     *,
     closure: GithubIssueClosure | None = None,
-    closure_unavailable_reason: str | None = None,
     org_id: str | None = None,
-    actor_user_id: str | None = None,
 ) -> KnowledgeDraft:
     labels = [
         str(label.get("name") or "").strip()
@@ -290,11 +340,6 @@ def _draft_for_issue(
         if closure is not None
         else []
     )
-    if closure_unavailable_reason:
-        closure_extra["closure_enrichment"] = {
-            "status": "unavailable",
-            "reason": closure_unavailable_reason,
-        }
     return KnowledgeDraft(
         source="github",
         kind=kind,
@@ -319,7 +364,6 @@ def _draft_for_issue(
             "body_total_chars": int(issue.get("body_total_chars") or len(body)),
             **closure_extra,
             **({"org_id": org_id} if org_id else {}),
-            **({"actor_user_id": actor_user_id} if actor_user_id else {}),
         },
         source_created_at=_parse_timestamp(issue.get("created_at")),
         source_updated_at=_parse_timestamp(issue.get("updated_at")),
@@ -346,11 +390,6 @@ async def _enumerate_repository(
     )
     authority = await _github_authority(session, repo)
     token = authority.token
-    if not token:
-        raise GitHubConnectorError(
-            status_code=401,
-            message="The knowledge GitHub connector refused an anonymous request.",
-        )
     payload = await async_list_repo_issues(
         repo,
         token=token,
@@ -402,7 +441,6 @@ async def _enumerate_repository(
                 issue,
                 closure=closure,
                 org_id=authority.org_id,
-                actor_user_id=authority.actor_user_id,
             )
         )
 
@@ -492,10 +530,25 @@ class GitHubConnector:
                     state,
                     remaining=repository_limit,
                 )
-            except GitHubConnectorError as exc:
+            except _GitHubConfigurationError as exc:
                 failure = _configuration_failure(repo, exc)
+                logger.error(
+                    "GitHub knowledge configuration fault for repository %s "
+                    "(%s): %s",
+                    repo,
+                    failure.reason_code,
+                    failure.message,
+                )
+                failures.append(failure)
+                continue
+            except GitHubConnectorError as exc:
+                failure = _repository_visibility_failure(repo, exc)
                 if failure is None:
-                    failure = EnumerationFailure(scope=repo, message=exc.message)
+                    failure = EnumerationFailure(
+                        scope=repo,
+                        message=exc.message,
+                        reason_code=github_read_reason_code(exc),
+                    )
                     logger.exception(
                         "GitHub knowledge enumeration skipped repository %s: %s",
                         repo,

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -53,6 +53,7 @@ class KnowledgeSyncStats:
     truncated: int = 0
     pending: int = 0
     distilled: int = 0
+    config_faults: int = 0
 
     def to_dict(self) -> dict[str, int]:
         payload = {
@@ -65,6 +66,8 @@ class KnowledgeSyncStats:
             payload["pending"] = self.pending
         if self.distilled:
             payload["distilled"] = self.distilled
+        if self.config_faults:
+            payload["config_faults"] = self.config_faults
         return payload
 
 
@@ -76,6 +79,7 @@ class KnowledgeSyncResult:
     cursor: dict[str, Any]
     corpus_empty: bool
     error: str | None = None
+    config_faults: tuple[EnumerationFailure, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -87,6 +91,11 @@ class KnowledgeSyncResult:
         }
         if self.error:
             payload["error"] = self.error
+        if self.config_faults:
+            payload["config_faults"] = [
+                _enumeration_failure_payload(failure)
+                for failure in self.config_faults
+            ]
         return payload
 
 
@@ -194,14 +203,54 @@ def _manifest_enumeration_failures(value: Any) -> tuple[EnumerationFailure, ...]
         scope = str(item.get("scope") or "").strip()
         message = str(item.get("message") or "").strip()
         if scope and message:
-            failures.append(EnumerationFailure(scope=scope, message=message))
+            failures.append(
+                EnumerationFailure(
+                    scope=scope,
+                    message=message,
+                    reason_code=(
+                        str(item.get("reason_code") or "").strip() or None
+                    ),
+                    configuration_fault=item.get("configuration_fault") is True,
+                )
+            )
     return tuple(failures)
+
+
+def _enumeration_failure_payload(failure: EnumerationFailure) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "scope": failure.scope,
+        "message": failure.message,
+    }
+    if failure.reason_code:
+        payload["reason_code"] = failure.reason_code
+    if failure.configuration_fault:
+        payload["configuration_fault"] = True
+    return payload
 
 
 def _enumeration_error(failures: tuple[EnumerationFailure, ...]) -> str | None:
     return "; ".join(
-        f"{failure.scope}: {failure.message}" for failure in failures
+        f"{failure.scope}: "
+        f"{f'[{failure.reason_code}] ' if failure.reason_code else ''}"
+        f"{failure.message}"
+        for failure in failures
     ) or None
+
+
+def _account_enumeration_failures(
+    stats: KnowledgeSyncStats,
+    failures: tuple[EnumerationFailure, ...],
+) -> tuple[EnumerationFailure, ...]:
+    config_faults = tuple(
+        failure for failure in failures if failure.configuration_fault
+    )
+    stats.config_faults += len(config_faults)
+    stats.failed += len(failures) - len(config_faults)
+    return config_faults
+
+
+def _sync_status(stats: KnowledgeSyncStats) -> str:
+    return "ok" if stats.failed == 0 and stats.config_faults == 0 else "degraded"
 
 
 def _pending_cursor(
@@ -219,7 +268,7 @@ def _pending_cursor(
     }
     if enumeration_failures:
         manifest[_ENUMERATION_ERRORS_KEY] = [
-            {"scope": failure.scope, "message": failure.message}
+            _enumeration_failure_payload(failure)
             for failure in enumeration_failures
         ]
     return {
@@ -540,6 +589,7 @@ async def _finalize_sync(
     stats: KnowledgeSyncStats,
     run_at: datetime,
     error: str | None = None,
+    config_faults: tuple[EnumerationFailure, ...] = (),
 ) -> KnowledgeSyncResult:
     """Persist one sync outcome and expose its current searchable corpus state."""
 
@@ -568,6 +618,7 @@ async def _finalize_sync(
         cursor=result_cursor,
         corpus_empty=corpus_empty,
         error=error,
+        config_faults=config_faults,
     )
 
 
@@ -663,7 +714,11 @@ async def sync_connector(
             session,
             list(manifest.get("entries") or []),
         )
-        stats.failed += failures + len(enumeration_failures)
+        stats.failed += failures
+        config_faults = _account_enumeration_failures(
+            stats,
+            enumeration_failures,
+        )
         stats.distilled = sum(
             1 for _draft, should_embed in resolved if should_embed
         )
@@ -690,9 +745,10 @@ async def sync_connector(
                 stats=stats,
                 run_at=run_at,
                 error=enumeration_error,
+                config_faults=config_faults,
             )
 
-        status = "ok" if stats.failed == 0 else "degraded"
+        status = _sync_status(stats)
         return await _finalize_sync(
             session,
             source=source,
@@ -702,6 +758,7 @@ async def sync_connector(
             stats=stats,
             run_at=run_at,
             error=enumeration_error,
+            config_faults=config_faults,
         )
 
     cursor = dict(stored_cursor)
@@ -725,7 +782,7 @@ async def sync_connector(
         )
 
     enumeration_error = _enumeration_error(enumeration_failures)
-    stats.failed += len(enumeration_failures)
+    config_faults = _account_enumeration_failures(stats, enumeration_failures)
 
     structural: list[tuple[KnowledgeDraft, bool]] = []
     distillable: list[KnowledgeDraft] = []
@@ -781,6 +838,7 @@ async def sync_connector(
             stats=stats,
             run_at=run_at,
             error=enumeration_error,
+            config_faults=config_faults,
         )
 
     if admission_fallbacks:
@@ -793,7 +851,7 @@ async def sync_connector(
             run_at=run_at,
         )
 
-    status = "ok" if stats.failed == 0 else "degraded"
+    status = _sync_status(stats)
     return await _finalize_sync(
         session,
         source=source,
@@ -803,6 +861,7 @@ async def sync_connector(
         stats=stats,
         run_at=run_at,
         error=enumeration_error,
+        config_faults=config_faults,
     )
 
 

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -22,6 +22,7 @@ from brain.platform.db.models.knowledge import (
 )
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
+    EnumerationFailureKind,
     KnowledgeConnector,
     KnowledgeDraft,
 )
@@ -203,14 +204,23 @@ def _manifest_enumeration_failures(value: Any) -> tuple[EnumerationFailure, ...]
         scope = str(item.get("scope") or "").strip()
         message = str(item.get("message") or "").strip()
         if scope and message:
+            try:
+                kind = EnumerationFailureKind(
+                    str(item.get("kind") or EnumerationFailureKind.TRANSIENT)
+                )
+            except ValueError:
+                kind = EnumerationFailureKind.TRANSIENT
             failures.append(
                 EnumerationFailure(
                     scope=scope,
                     message=message,
+                    kind=kind,
                     reason_code=(
                         str(item.get("reason_code") or "").strip() or None
                     ),
-                    configuration_fault=item.get("configuration_fault") is True,
+                    remediation=(
+                        str(item.get("remediation") or "").strip() or None
+                    ),
                 )
             )
     return tuple(failures)
@@ -220,11 +230,12 @@ def _enumeration_failure_payload(failure: EnumerationFailure) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "scope": failure.scope,
         "message": failure.message,
+        "kind": failure.kind.value,
     }
     if failure.reason_code:
         payload["reason_code"] = failure.reason_code
-    if failure.configuration_fault:
-        payload["configuration_fault"] = True
+    if failure.remediation:
+        payload["remediation"] = failure.remediation
     return payload
 
 
@@ -242,7 +253,9 @@ def _account_enumeration_failures(
     failures: tuple[EnumerationFailure, ...],
 ) -> tuple[EnumerationFailure, ...]:
     config_faults = tuple(
-        failure for failure in failures if failure.configuration_fault
+        failure
+        for failure in failures
+        if failure.kind is EnumerationFailureKind.CONFIGURATION
     )
     stats.config_faults += len(config_faults)
     stats.failed += len(failures) - len(config_faults)

--- a/brain/systems/production_gate_github.py
+++ b/brain/systems/production_gate_github.py
@@ -14,15 +14,19 @@ from brain.systems.cortex.project_context.github import (
 from brain.systems.deploy_state import DeployStateBatch
 
 
-CLOSURE_READ_AUTHENTICATION_REQUIRED = "github_authentication_required"
-CLOSURE_READ_ACCESS_FORBIDDEN = "github_access_forbidden"
-CLOSURE_READ_CONNECTOR_ERROR = "github_connector_error"
-CLOSURE_READ_AUTH_FAILURE_REASONS = frozenset(
+GITHUB_READ_AUTHENTICATION_REQUIRED = "github_authentication_required"
+GITHUB_READ_ACCESS_FORBIDDEN = "github_access_forbidden"
+GITHUB_READ_CONNECTOR_ERROR = "github_connector_error"
+GITHUB_READ_AUTH_FAILURE_REASONS = frozenset(
     {
-        CLOSURE_READ_AUTHENTICATION_REQUIRED,
-        CLOSURE_READ_ACCESS_FORBIDDEN,
+        GITHUB_READ_AUTHENTICATION_REQUIRED,
+        GITHUB_READ_ACCESS_FORBIDDEN,
     }
 )
+CLOSURE_READ_AUTHENTICATION_REQUIRED = GITHUB_READ_AUTHENTICATION_REQUIRED
+CLOSURE_READ_ACCESS_FORBIDDEN = GITHUB_READ_ACCESS_FORBIDDEN
+CLOSURE_READ_CONNECTOR_ERROR = GITHUB_READ_CONNECTOR_ERROR
+CLOSURE_READ_AUTH_FAILURE_REASONS = GITHUB_READ_AUTH_FAILURE_REASONS
 
 
 @dataclass(slots=True)
@@ -103,14 +107,18 @@ class BackendClosureGithubClient:
 
 
 def _closure_read_failure(exc: GitHubConnectorError) -> ClosureReadFailure:
-    if exc.status_code == 401:
-        reason_code = CLOSURE_READ_AUTHENTICATION_REQUIRED
-    elif exc.status_code == 403:
-        reason_code = CLOSURE_READ_ACCESS_FORBIDDEN
-    else:
-        reason_code = CLOSURE_READ_CONNECTOR_ERROR
     return ClosureReadFailure(
-        reason_code=reason_code,
+        reason_code=github_read_reason_code(exc),
         status_code=exc.status_code,
         message=exc.message,
     )
+
+
+def github_read_reason_code(exc: GitHubConnectorError) -> str:
+    """Translate connector statuses into the shared stable read vocabulary."""
+
+    if exc.status_code == 401:
+        return GITHUB_READ_AUTHENTICATION_REQUIRED
+    if exc.status_code in {403, 404}:
+        return GITHUB_READ_ACCESS_FORBIDDEN
+    return GITHUB_READ_CONNECTOR_ERROR

--- a/brain/systems/production_gate_github.py
+++ b/brain/systems/production_gate_github.py
@@ -12,21 +12,7 @@ from brain.systems.cortex.project_context.github import (
     GithubIssueClosure as IssueClosure,
 )
 from brain.systems.deploy_state import DeployStateBatch
-
-
-GITHUB_READ_AUTHENTICATION_REQUIRED = "github_authentication_required"
-GITHUB_READ_ACCESS_FORBIDDEN = "github_access_forbidden"
-GITHUB_READ_CONNECTOR_ERROR = "github_connector_error"
-GITHUB_READ_AUTH_FAILURE_REASONS = frozenset(
-    {
-        GITHUB_READ_AUTHENTICATION_REQUIRED,
-        GITHUB_READ_ACCESS_FORBIDDEN,
-    }
-)
-CLOSURE_READ_AUTHENTICATION_REQUIRED = GITHUB_READ_AUTHENTICATION_REQUIRED
-CLOSURE_READ_ACCESS_FORBIDDEN = GITHUB_READ_ACCESS_FORBIDDEN
-CLOSURE_READ_CONNECTOR_ERROR = GITHUB_READ_CONNECTOR_ERROR
-CLOSURE_READ_AUTH_FAILURE_REASONS = GITHUB_READ_AUTH_FAILURE_REASONS
+from brain.systems.github_read_failures import github_read_reason_code
 
 
 @dataclass(slots=True)
@@ -112,13 +98,3 @@ def _closure_read_failure(exc: GitHubConnectorError) -> ClosureReadFailure:
         status_code=exc.status_code,
         message=exc.message,
     )
-
-
-def github_read_reason_code(exc: GitHubConnectorError) -> str:
-    """Translate connector statuses into the shared stable read vocabulary."""
-
-    if exc.status_code == 401:
-        return GITHUB_READ_AUTHENTICATION_REQUIRED
-    if exc.status_code in {403, 404}:
-        return GITHUB_READ_ACCESS_FORBIDDEN
-    return GITHUB_READ_CONNECTOR_ERROR

--- a/brain/systems/staging_only_closure.py
+++ b/brain/systems/staging_only_closure.py
@@ -11,13 +11,13 @@ from typing import Any
 from brain.platform.db.models.domain import DomainRecord
 from brain.systems import deploy_tracker
 from brain.systems.deploy_state import DeployStateBatch
+from brain.systems.github_read_failures import GITHUB_READ_AUTH_FAILURE_REASONS
 from brain.systems.production_gate_evidence import (
     ProductionEvidenceReader,
     StoredAlertEvidenceReader,
 )
 from brain.systems.production_gate_github import (
     BackendClosureGithubClient,
-    CLOSURE_READ_AUTH_FAILURE_REASONS,
     ClosureReadFailure,
     ClosureGithubClient,
     FixingPullRequest,
@@ -238,7 +238,7 @@ async def _read_closed_issues(
         if (
             len(typed_failures) == len(failures)
             and len(reason_codes) == 1
-            and reason_codes <= CLOSURE_READ_AUTH_FAILURE_REASONS
+            and reason_codes <= GITHUB_READ_AUTH_FAILURE_REASONS
         ):
             failure = typed_failures[0]
             logger.error(

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -69,6 +69,7 @@ async def test_read_github_source_handler_lists_issues_with_canonical_repo_and_b
     assert list_issues.await_args.kwargs["labels"] == ["bug"]
     assert list_issues.await_args.kwargs["assignee"] == "redawear"
     assert list_issues.await_args.kwargs["limit"] == 100
+    assert list_issues.await_args.kwargs["token"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -33,12 +33,15 @@ from brain.platform.db.models.org import Org, User
 from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
+    EnumerationFailureKind,
     KnowledgeDraft,
     KnowledgeEnumeration,
 )
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import (
     GitHubConnector,
+    _GitHubAuthority,
+    _GitHubConfigurationError,
     _draft_for_issue,
     _github_authority,
 )
@@ -52,6 +55,12 @@ from brain.systems.cortex.project_context.github import (
     GithubFixingPullRequest,
     GithubIssueClosure,
 )
+from brain.systems.github_read_failures import (
+    GITHUB_READ_ACCESS_FORBIDDEN,
+    GITHUB_READ_AUTHENTICATION_REQUIRED,
+    GITHUB_READ_CONNECTOR_ERROR,
+)
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
 
 _ORG_ID = "11111111-1111-4111-8111-111111111111"
@@ -235,7 +244,6 @@ def test_github_closed_issue_draft_carries_closure_facts_into_distillation():
             ),
         ),
         org_id=_ORG_ID,
-        actor_user_id="22222222-2222-4222-8222-222222222222",
     )
 
     assert draft.distill is True
@@ -255,6 +263,7 @@ def test_github_closed_issue_draft_carries_closure_facts_into_distillation():
         }
     ]
     assert draft.extra["org_id"] == _ORG_ID
+    assert "actor_user_id" not in draft.extra
 
 
 @pytest.fixture
@@ -1404,11 +1413,7 @@ async def test_github_closure_enrichment_failure_retries_without_advancing_curso
     )
     list_issues = AsyncMock(return_value={"issues": [issue], "next_page": None})
     get_closure = AsyncMock(side_effect=[RuntimeError("temporary"), closure])
-    authority = SimpleNamespace(
-        token="token",
-        org_id=_ORG_ID,
-        actor_user_id=user_id,
-    )
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
     connector = GitHubConnector(repositories=[repo])
 
     with patch(
@@ -1443,11 +1448,7 @@ async def test_github_closure_enrichment_failure_retries_without_advancing_curso
 async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
     repo = "Illospace/illospace"
     list_issues = AsyncMock(return_value={"issues": [], "next_page": None})
-    authority = SimpleNamespace(
-        token="token",
-        org_id=_ORG_ID,
-        actor_user_id="77777777-7777-4777-8777-777777777777",
-    )
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
     connector = GitHubConnector(repositories=[repo])
     legacy_cursor = {
         "active_repository": 0,
@@ -1548,7 +1549,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
             "next_page": next_backfill_page if repo == "acme/backfill" else None,
         }
 
-    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
     connector = GitHubConnector(repositories=repositories, max_items=4)
     with patch(
         "brain.systems.knowledge.connectors.github._github_authority",
@@ -1651,7 +1652,7 @@ async def test_github_enumeration_advances_every_repo_during_long_backfill(sessi
             "next_page": None,
         }
 
-    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
     connector = GitHubConnector(repositories=repositories, max_items=3)
     enumerations = []
     with patch(
@@ -1731,7 +1732,7 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
             "next_page": None,
         }
 
-    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
     connector = GitHubConnector(repositories=repositories, max_items=10)
     with patch(
         "brain.systems.knowledge.connectors.github._github_authority",
@@ -1763,14 +1764,8 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
         assert enumeration.failures == (
             EnumerationFailure(
                 scope="acme/missing",
-                message=(
-                    "Repository not found or not visible to this token. "
-                    "Remediation: Grant the installed GitHub App access to "
-                    "acme/missing, then reconnect or update its active Vault "
-                    "project binding for this exact repository slug."
-                ),
-                reason_code="github_access_forbidden",
-                configuration_fault=True,
+                message="Repository not found or not visible to this token.",
+                reason_code=GITHUB_READ_CONNECTOR_ERROR,
             ),
         )
 
@@ -1782,31 +1777,53 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
 
     payload = result.to_dict()
     assert result.status == "degraded"
-    assert result.stats["failed"] == 0
-    assert result.stats["config_faults"] == 1
+    assert result.stats["failed"] == 1
+    assert "config_faults" not in result.stats
     assert payload["error"] == (
-        "acme/missing: [github_access_forbidden] Repository not found or not "
-        "visible to this token. Remediation: Grant the installed GitHub App "
-        "access to acme/missing, then reconnect or update its active Vault "
-        "project binding for this exact repository slug."
+        "acme/missing: [github_connector_error] Repository not found or not "
+        "visible to this token."
     )
-    assert payload["config_faults"] == [
-        {
-            "scope": "acme/missing",
-            "message": (
-                "Repository not found or not visible to this token. Remediation: "
-                "Grant the installed GitHub App access to acme/missing, then "
-                "reconnect or update its active Vault project binding for this "
-                "exact repository slug."
-            ),
-            "reason_code": "github_access_forbidden",
-            "configuration_fault": True,
-        }
-    ]
+    assert "config_faults" not in payload
     assert any(
         "acme/missing" in record.message
         and "Repository not found or not visible to this token." in record.message
         for record in caplog.records
+    )
+
+
+async def test_github_repository_access_denial_is_a_configuration_failure(session):
+    repo = "acme/restricted"
+    authority = _GitHubAuthority(token="token", org_id=_ORG_ID)
+    list_issues = AsyncMock(
+        side_effect=GitHubConnectorError(
+            status_code=403,
+            message="Resource not accessible by integration.",
+        )
+    )
+
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=list_issues,
+    ):
+        enumeration = await GitHubConnector(
+            repositories=[repo]
+        ).enumerate_changed(session, {})
+
+    assert enumeration.failures == (
+        EnumerationFailure(
+            scope=repo,
+            message="Resource not accessible by integration.",
+            kind=EnumerationFailureKind.CONFIGURATION,
+            reason_code=GITHUB_READ_ACCESS_FORBIDDEN,
+            remediation=(
+                "Grant the installed GitHub App access to acme/restricted, then "
+                "reconnect or update its active Vault project binding for this "
+                "exact repository slug."
+            ),
+        ),
     )
 
 
@@ -1894,6 +1911,7 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
         {
             "scope": "acme/missing",
             "message": "Repository not found or not visible to this token.",
+            "kind": "transient",
         }
     ]
     run = (await session.scalars(select(AgentRunRow))).one()
@@ -1927,18 +1945,21 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
     assert degraded.to_dict()["error"] == expected_error
 
 
-async def test_github_knowledge_sweep_refuses_anonymous_read_without_binding(
+async def test_github_knowledge_sweep_reports_missing_binding_without_read(
     session,
 ):
     repo = "Illospace/illospace"
     list_issues = AsyncMock()
     get_closure = AsyncMock()
-    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    authority_session = SimpleNamespace(scalar=AsyncMock(return_value=None))
     connector = GitHubConnector(repositories=[repo])
+
+    async def missing_binding(_session, repository):
+        return await _github_authority(authority_session, repository)
 
     with patch(
         "brain.systems.knowledge.connectors.github._github_authority",
-        new=AsyncMock(return_value=authority),
+        new=missing_binding,
     ), patch(
         "brain.systems.knowledge.connectors.github.async_list_repo_issues",
         new=list_issues,
@@ -1961,13 +1982,16 @@ async def test_github_knowledge_sweep_refuses_anonymous_read_without_binding(
         {
             "scope": repo,
             "message": (
-                "The knowledge GitHub connector refused an anonymous request. "
-                "Remediation: Install or reconnect the GitHub App for "
-                "Illospace/illospace, then create an active VaultProjectBinding to "
-                "a github_app secret for this exact repository slug."
+                "No active GitHub App Vault project binding exists for the "
+                "knowledge sync."
             ),
-            "reason_code": "github_authentication_required",
-            "configuration_fault": True,
+            "kind": "configuration",
+            "reason_code": GITHUB_READ_AUTHENTICATION_REQUIRED,
+            "remediation": (
+                "Install or reconnect the GitHub App for Illospace/illospace, then "
+                "create an active VaultProjectBinding to a github_app secret for "
+                "this exact repository slug."
+            ),
         }
     ]
     list_issues.assert_not_awaited()
@@ -1979,12 +2003,57 @@ async def test_github_knowledge_authority_reports_missing_binding():
     session = SimpleNamespace(scalar=AsyncMock(return_value=None))
 
     with pytest.raises(
-        GitHubConnectorError,
+        _GitHubConfigurationError,
         match="No active GitHub App Vault project binding exists",
     ) as exc_info:
         await _github_authority(session, "Illospace/illospace")
 
-    assert exc_info.value.status_code == 401
+    assert exc_info.value.reason_code == GITHUB_READ_AUTHENTICATION_REQUIRED
+    assert not hasattr(exc_info.value, "status_code")
+
+
+async def test_github_knowledge_authority_reports_unmintable_credential():
+    repo = "uwear-ai/uwear-backend"
+    session = SimpleNamespace(
+        scalar=AsyncMock(return_value=SimpleNamespace(org_id=_ORG_ID))
+    )
+    resolve = AsyncMock(
+        side_effect=RuntimeSecretUnavailable("GitHub App private key is invalid")
+    )
+
+    with patch(
+        "brain.systems.knowledge.connectors.github."
+        "async_resolve_org_project_bound_env_tokens",
+        new=resolve,
+    ), pytest.raises(
+        _GitHubConfigurationError,
+        match="credential could not mint a token",
+    ) as exc_info:
+        await _github_authority(session, repo)
+
+    assert exc_info.value.reason_code == GITHUB_READ_AUTHENTICATION_REQUIRED
+    assert exc_info.value.message.endswith("GitHub App private key is invalid")
+    assert not hasattr(exc_info.value, "status_code")
+
+
+async def test_github_knowledge_authority_reports_empty_token_resolution():
+    repo = "uwear-ai/uwear-backend"
+    session = SimpleNamespace(
+        scalar=AsyncMock(return_value=SimpleNamespace(org_id=_ORG_ID))
+    )
+
+    with patch(
+        "brain.systems.knowledge.connectors.github."
+        "async_resolve_org_project_bound_env_tokens",
+        new=AsyncMock(return_value={}),
+    ), pytest.raises(
+        _GitHubConfigurationError,
+        match="did not resolve a token",
+    ) as exc_info:
+        await _github_authority(session, repo)
+
+    assert exc_info.value.reason_code == GITHUB_READ_AUTHENTICATION_REQUIRED
+    assert not hasattr(exc_info.value, "status_code")
 
 
 async def test_github_knowledge_authority_mints_without_user_actor():
@@ -2003,7 +2072,7 @@ async def test_github_knowledge_authority_mints_without_user_actor():
 
     assert authority.token == "installation-token"
     assert authority.org_id == _ORG_ID
-    assert authority.actor_user_id is None
+    assert not hasattr(authority, "actor_user_id")
     resolve.assert_awaited_once_with(
         org_id=_ORG_ID,
         accessed_by="knowledge_index_sync",

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -37,7 +37,11 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeEnumeration,
 )
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
-from brain.systems.knowledge.connectors.github import GitHubConnector, _draft_for_issue
+from brain.systems.knowledge.connectors.github import (
+    GitHubConnector,
+    _draft_for_issue,
+    _github_authority,
+)
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
@@ -1544,7 +1548,7 @@ async def test_github_enumeration_reserves_capacity_for_stale_lower_index_repo(
             "next_page": next_backfill_page if repo == "acme/backfill" else None,
         }
 
-    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
     connector = GitHubConnector(repositories=repositories, max_items=4)
     with patch(
         "brain.systems.knowledge.connectors.github._github_authority",
@@ -1647,7 +1651,7 @@ async def test_github_enumeration_advances_every_repo_during_long_backfill(sessi
             "next_page": None,
         }
 
-    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
     connector = GitHubConnector(repositories=repositories, max_items=3)
     enumerations = []
     with patch(
@@ -1727,7 +1731,7 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
             "next_page": None,
         }
 
-    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    authority = SimpleNamespace(token="token", org_id=None, actor_user_id=None)
     connector = GitHubConnector(repositories=repositories, max_items=10)
     with patch(
         "brain.systems.knowledge.connectors.github._github_authority",
@@ -1759,7 +1763,14 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
         assert enumeration.failures == (
             EnumerationFailure(
                 scope="acme/missing",
-                message="Repository not found or not visible to this token.",
+                message=(
+                    "Repository not found or not visible to this token. "
+                    "Remediation: Grant the installed GitHub App access to "
+                    "acme/missing, then reconnect or update its active Vault "
+                    "project binding for this exact repository slug."
+                ),
+                reason_code="github_access_forbidden",
+                configuration_fault=True,
             ),
         )
 
@@ -1771,10 +1782,27 @@ async def test_github_enumeration_isolates_repo_failures_and_wraps_cursor(
 
     payload = result.to_dict()
     assert result.status == "degraded"
-    assert result.stats["failed"] == 1
+    assert result.stats["failed"] == 0
+    assert result.stats["config_faults"] == 1
     assert payload["error"] == (
-        "acme/missing: Repository not found or not visible to this token."
+        "acme/missing: [github_access_forbidden] Repository not found or not "
+        "visible to this token. Remediation: Grant the installed GitHub App "
+        "access to acme/missing, then reconnect or update its active Vault "
+        "project binding for this exact repository slug."
     )
+    assert payload["config_faults"] == [
+        {
+            "scope": "acme/missing",
+            "message": (
+                "Repository not found or not visible to this token. Remediation: "
+                "Grant the installed GitHub App access to acme/missing, then "
+                "reconnect or update its active Vault project binding for this "
+                "exact repository slug."
+            ),
+            "reason_code": "github_access_forbidden",
+            "configuration_fault": True,
+        }
+    ]
     assert any(
         "acme/missing" in record.message
         and "Repository not found or not visible to this token." in record.message
@@ -1899,25 +1927,11 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
     assert degraded.to_dict()["error"] == expected_error
 
 
-async def test_public_github_closure_uses_accounted_structural_fallback(
+async def test_github_knowledge_sweep_refuses_anonymous_read_without_binding(
     session,
-    embedding_runtime,
 ):
-    del embedding_runtime
     repo = "Illospace/illospace"
-    issue = {
-        "id": 577,
-        "number": 577,
-        "title": "Knowledge slice 2",
-        "state": "closed",
-        "body": "Implement the conversational knowledge layer.",
-        "labels": [],
-        "user": {"login": "redawear"},
-        "created_at": "2026-07-28T18:00:00Z",
-        "updated_at": "2026-07-28T20:10:00Z",
-        "closed_at": "2026-07-28T20:10:00Z",
-    }
-    list_issues = AsyncMock(return_value={"issues": [issue], "next_page": None})
+    list_issues = AsyncMock()
     get_closure = AsyncMock()
     authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
     connector = GitHubConnector(repositories=[repo])
@@ -1941,12 +1955,63 @@ async def test_public_github_closure_uses_accounted_structural_fallback(
     )
     assert result.status == "degraded"
     assert result.cursor["version"] == 2
-    assert result.stats["failed"] == 1
-    assert get_closure.await_count == 0
-    assert item is not None
-    assert item.resolution == "Closed at 2026-07-28T20:10:00Z"
-    assert item.extra["closure_enrichment"] == {
-        "status": "unavailable",
-        "reason": "authentication_required",
-    }
-    assert item.extra["distillation"]["status"] == "failed"
+    assert result.stats["failed"] == 0
+    assert result.stats["config_faults"] == 1
+    assert result.to_dict()["config_faults"] == [
+        {
+            "scope": repo,
+            "message": (
+                "The knowledge GitHub connector refused an anonymous request. "
+                "Remediation: Install or reconnect the GitHub App for "
+                "Illospace/illospace, then create an active VaultProjectBinding to "
+                "a github_app secret for this exact repository slug."
+            ),
+            "reason_code": "github_authentication_required",
+            "configuration_fault": True,
+        }
+    ]
+    list_issues.assert_not_awaited()
+    get_closure.assert_not_awaited()
+    assert item is None
+
+
+async def test_github_knowledge_authority_reports_missing_binding():
+    session = SimpleNamespace(scalar=AsyncMock(return_value=None))
+
+    with pytest.raises(
+        GitHubConnectorError,
+        match="No active GitHub App Vault project binding exists",
+    ) as exc_info:
+        await _github_authority(session, "Illospace/illospace")
+
+    assert exc_info.value.status_code == 401
+
+
+async def test_github_knowledge_authority_mints_without_user_actor():
+    repo = "uwear-ai/uwear-backend"
+    session = SimpleNamespace(
+        scalar=AsyncMock(return_value=SimpleNamespace(org_id=_ORG_ID))
+    )
+    resolve = AsyncMock(return_value={"GITHUB_TOKEN": "installation-token"})
+
+    with patch(
+        "brain.systems.knowledge.connectors.github."
+        "async_resolve_org_project_bound_env_tokens",
+        new=resolve,
+    ):
+        authority = await _github_authority(session, repo)
+
+    assert authority.token == "installation-token"
+    assert authority.org_id == _ORG_ID
+    assert authority.actor_user_id is None
+    resolve.assert_awaited_once_with(
+        org_id=_ORG_ID,
+        accessed_by="knowledge_index_sync",
+        project_slug=repo,
+        github_app_only=True,
+        github_app_permissions={
+            "contents": "read",
+            "issues": "read",
+            "pull_requests": "read",
+        },
+    )

--- a/tests/test_staging_only_closure.py
+++ b/tests/test_staging_only_closure.py
@@ -32,10 +32,12 @@ from brain.systems.deploy_tracker import (
     PRODUCTION_GATE_FIELD,
     PRODUCTION_GATE_PENDING,
 )
+from brain.systems.github_read_failures import (
+    GITHUB_READ_ACCESS_FORBIDDEN,
+    GITHUB_READ_AUTHENTICATION_REQUIRED,
+    GITHUB_READ_CONNECTOR_ERROR,
+)
 from brain.systems.production_gate_github import (
-    CLOSURE_READ_ACCESS_FORBIDDEN,
-    CLOSURE_READ_AUTHENTICATION_REQUIRED,
-    CLOSURE_READ_CONNECTOR_ERROR,
     ClosureReadFailure,
 )
 from brain.systems.staging_only_closure import (
@@ -258,7 +260,7 @@ class _AuthFailingGithub:
     async def get_issue_closure(self, *, repo: str, issue_number: int):
         self.reads.append((repo, issue_number))
         raise ClosureReadFailure(
-            reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
+            reason_code=GITHUB_READ_ACCESS_FORBIDDEN,
             status_code=403,
             message="API rate limit exceeded for 207.134.142.114.",
         )
@@ -350,7 +352,7 @@ async def test_mixed_success_and_auth_failure_does_not_report_all_reads_failed(
         {
             (REPO, 1281): None,
             (REPO, 1282): ClosureReadFailure(
-                reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
+                reason_code=GITHUB_READ_ACCESS_FORBIDDEN,
                 status_code=403,
                 message="Access forbidden",
             ),
@@ -380,12 +382,12 @@ async def test_different_auth_reasons_do_not_report_one_all_reads_failure(sessio
     github = _PerIssueGithub(
         {
             (REPO, 1281): ClosureReadFailure(
-                reason_code=CLOSURE_READ_AUTHENTICATION_REQUIRED,
+                reason_code=GITHUB_READ_AUTHENTICATION_REQUIRED,
                 status_code=401,
                 message="Authentication required",
             ),
             (REPO, 1282): ClosureReadFailure(
-                reason_code=CLOSURE_READ_ACCESS_FORBIDDEN,
+                reason_code=GITHUB_READ_ACCESS_FORBIDDEN,
                 status_code=403,
                 message="Access forbidden",
             ),
@@ -414,7 +416,7 @@ async def test_non_auth_closure_failure_does_not_report_authentication_error(ses
     github = _PerIssueGithub(
         {
             (REPO, 1281): ClosureReadFailure(
-                reason_code=CLOSURE_READ_CONNECTOR_ERROR,
+                reason_code=GITHUB_READ_CONNECTOR_ERROR,
                 status_code=503,
                 message="GitHub unavailable",
             )

--- a/tests/test_staging_only_closure_github.py
+++ b/tests/test_staging_only_closure_github.py
@@ -15,10 +15,12 @@ from brain.systems.cortex.project_context.github import (
 )
 from brain.systems.deploy_state import DeployStateBatch
 from brain.systems.deploy_state_github import ancestry_failure
+from brain.systems.github_read_failures import (
+    GITHUB_READ_ACCESS_FORBIDDEN,
+    GITHUB_READ_AUTHENTICATION_REQUIRED,
+    GITHUB_READ_CONNECTOR_ERROR,
+)
 from brain.systems.production_gate_github import (
-    CLOSURE_READ_ACCESS_FORBIDDEN,
-    CLOSURE_READ_AUTHENTICATION_REQUIRED,
-    CLOSURE_READ_CONNECTOR_ERROR,
     BackendClosureGithubClient,
     ClosureReadFailure,
 )
@@ -244,10 +246,9 @@ async def test_backend_adapter_uses_shared_closure_and_deploy_state_reads(monkey
 @pytest.mark.parametrize(
     ("status_code", "reason_code"),
     [
-        (401, CLOSURE_READ_AUTHENTICATION_REQUIRED),
-        (403, CLOSURE_READ_ACCESS_FORBIDDEN),
-        (404, CLOSURE_READ_ACCESS_FORBIDDEN),
-        (503, CLOSURE_READ_CONNECTOR_ERROR),
+        (401, GITHUB_READ_AUTHENTICATION_REQUIRED),
+        (403, GITHUB_READ_ACCESS_FORBIDDEN),
+        (503, GITHUB_READ_CONNECTOR_ERROR),
     ],
 )
 async def test_backend_adapter_translates_connector_errors(

--- a/tests/test_staging_only_closure_github.py
+++ b/tests/test_staging_only_closure_github.py
@@ -246,6 +246,7 @@ async def test_backend_adapter_uses_shared_closure_and_deploy_state_reads(monkey
     [
         (401, CLOSURE_READ_AUTHENTICATION_REQUIRED),
         (403, CLOSURE_READ_ACCESS_FORBIDDEN),
+        (404, CLOSURE_READ_ACCESS_FORBIDDEN),
         (503, CLOSURE_READ_CONNECTOR_ERROR),
     ],
 )


### PR DESCRIPTION
Closes #641

## What was wrong

Every `knowledge_index_sync` run reported the GitHub connector as `degraded` with
`failed: 3`, and three configured repos never advanced their watermarks. The
errors named GitHub's **anonymous per-IP rate limit** — which means those requests
carried no token at all.

`_github_authority` returned `token=None` on three separate paths (no active
`VaultProjectBinding`, no actor `User`, empty mint result), and
`_enumerate_repository` passed that `None` straight into `async_list_repo_issues`.
There was no guard. This is the same bug class as #637/PR #638, in a second code
path.

## What changed

- **The sweep refuses anonymous reads.** A missing binding, an unmintable
  credential, or an empty token resolution now raises a named configuration error
  carrying its own remediation sentence, instead of silently degrading to an
  anonymous request.
- **Token minting no longer needs a user actor.** It resolves through the
  org-scoped `async_resolve_org_project_bound_env_tokens`, which already existed.
- **A permanent config fault is accounted separately from a transient failure.**
  `EnumerationFailure` gained a `kind` discriminator (`transient` /
  `configuration`) plus `reason_code` and `remediation` fields. The run summary now
  reports `config_faults: N` with a per-repo remediation payload instead of
  inflating `stats.failed`. The connector stays `degraded` while a repo is
  misconfigured — that is honest, it genuinely is.

## The firewall this does NOT cross

Reading a **public** repo with no credential stays legitimate for **runtime tool
calls** — an agent asked to look at a public repo it has no binding for.
`tests/test_github_source_tool.py` asserts the runtime handler still passes
`token=None`. Only the background maintenance sweep refuses. Same boundary PR #638
drew.

## Review findings folded in

A Codex code-quality review and my own review each found one blocking issue, and
they shared a root cause — the first pass manufactured HTTP status codes (401 for
"no Vault binding", 403 for "cannot mint") to describe local configuration
conditions.

1. **The laundering itself.** One status code carried two unrelated meanings, and
   no downstream reader could tell a real GitHub 403 from a local decision without
   parsing message text. Replaced with a dedicated configuration exception.
2. **It leaked into another subsystem.** To serve those invented codes, the shared
   reason-code helper had grown a `404 → access_forbidden` branch.
   `staging_only_closure.py:241` aborts the entire closure sweep and reports
   `github_issue_authentication_all_reads_failed` when every read shares one auth
   reason code — so a sweep where every tracked issue returned 404 (deleted or
   moved issues) would have reported a **false authentication outage** in #638's
   subsystem. The mapping is restored to `401 → auth`, `403 → forbidden`,
   everything else → connector error.
3. **Dead surfaces removed:** `closure_unavailable_reason` (unreachable once
   anonymous reads are refused), the `actor_user_id` threading (always `None` after
   org-scoped minting), and the impossible empty-token guard. `_GitHubAuthority`
   now requires `token` and `org_id`.
4. **The half-finished rename is finished.** The shared read-failure vocabulary
   moved to `brain/systems/github_read_failures.py` — a knowledge connector
   importing `production_gate_github` was the wrong dependency direction — and the
   `CLOSURE_READ_*` aliases are gone.

Dropping `actor_user_id` is safe and I checked it: `_resolve_actor` in
`brain/systems/knowledge/distillation.py:217` already falls back to the oldest user
in `org_id`, and `org_id` stays populated. This deletes a duplicated owner rather
than losing one.

## What you should know before merging

**This may stop `Illospace/illospace` syncing too.** It appeared in the
rate-limit errors, so it has no working binding either. It has no special
credential path — after this change it needs an active exact-slug
`VaultProjectBinding` to a `github_app` secret. If that does not exist, the repo
stops syncing until the App is installed or reconnected. The change trades a
silent freeze for a loud, named one. That is the intent, but it is a real
consequence.

**Two repos still need a decision, and it is not a code change.** The sweep's repo
list comes from active Project Context resources in the DB, not from env or code.
`uwear-ai/agent-mission-control` (retired 2026-07-09) and
`helloianneo/ian-xiaohei-illustrations` (a personal account outside the org) either
get the App installed or get removed from the Project Context. This PR
deliberately does not remove, disable, or hardcode-skip any repo.

## How to check it

Tests, run outside the sandbox on the exact CI selection:

```
python3 -m pytest tests/ -m "not requires_db and not requires_browser and not live_provider" -q
```

Acceptance checks:

1. A repo with no Vault binding produces **zero** GitHub requests — not one
   anonymous request — and one `config_faults` entry naming the remediation.
2. The run summary separates `config_faults` from `failed`; a transient connector
   error still increments `failed`.
3. A runtime tool call can still read a public repo with no credential.
4. After deploy, `knowledge_index_sync` result summaries stop showing GitHub's
   anonymous per-IP rate-limit message. Repos that advance keep advancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
