### PR TITLE
fix(knowledge): make the recall score say why it moved

### DIFF
--- a/brain/app/cli/knowledge_recall.py
+++ b/brain/app/cli/knowledge_recall.py
@@ -19,6 +19,10 @@ from brain.systems.knowledge.recall_eval import (
 from brain.systems.knowledge.recall_eval_comparison import (
     compare_knowledge_recall_artifacts,
 )
+from brain.systems.knowledge.recall_eval_contract import (
+    KnowledgeRecallArtifact,
+    parse_knowledge_recall_artifact_json,
+)
 from brain.systems.knowledge.recall_eval_harvester import (
     harvest_knowledge_recall_candidates,
 )
@@ -161,14 +165,13 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         return candidates.to_dict()
 
 
-def _load_artifact(path: Path, *, label: str) -> dict[str, Any]:
+def _load_artifact(path: Path, *, label: str) -> KnowledgeRecallArtifact:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid {label} artifact JSON at {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError(f"{label} artifact must be a JSON object")
-    return payload
+        return parse_knowledge_recall_artifact_json(
+            path.read_text(encoding="utf-8")
+        )
+    except ValueError as exc:
+        raise ValueError(f"Invalid {label} artifact at {path}: {exc}") from exc
 
 
 def _compare(args: argparse.Namespace) -> dict[str, Any]:
@@ -195,8 +198,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
     if args.command == "eval" and payload["result_type"] == "invalid":
         return 1
-    if args.command == "compare" and not payload["comparability"]["comparable"]:
-        return 1
+    if args.command == "compare":
+        verdict = payload["comparability"]["verdict"]
+        if verdict != "ranking-attributable":
+            return 1
     return 0
 
 

--- a/brain/app/cli/knowledge_recall.py
+++ b/brain/app/cli/knowledge_recall.py
@@ -1,12 +1,12 @@
-"""Evaluate or harvest knowledge-recall cases against the live database."""
+"""Evaluate, harvest, or compare knowledge-recall artifacts."""
 
 from __future__ import annotations
 
 import argparse
 import asyncio
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Any, Sequence
 
 from brain.platform.db import SessionFactory
@@ -15,6 +15,9 @@ from brain.systems.knowledge.recall_eval import (
     DEFAULT_QUESTION_SET_PATH,
     load_knowledge_recall_question_set,
     run_knowledge_recall_eval,
+)
+from brain.systems.knowledge.recall_eval_comparison import (
+    compare_knowledge_recall_artifacts,
 )
 from brain.systems.knowledge.recall_eval_harvester import (
     harvest_knowledge_recall_candidates,
@@ -62,7 +65,7 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Evaluate or harvest Illo Knowledge recall cases.",
+        description="Evaluate, harvest, or compare Illo Knowledge recall artifacts.",
     )
     commands = parser.add_subparsers(dest="command", required=True)
 
@@ -100,6 +103,29 @@ def _parser() -> argparse.ArgumentParser:
     )
     _add_common_arguments(harvest_parser)
     harvest_parser.add_argument("--limit-per-source", type=int, default=25)
+
+    compare_parser = commands.add_parser(
+        "compare",
+        help="Compare two serialized recall evaluation artifacts.",
+    )
+    compare_parser.add_argument(
+        "--baseline",
+        type=Path,
+        required=True,
+        help="Baseline evaluation artifact JSON.",
+    )
+    compare_parser.add_argument(
+        "--candidate",
+        type=Path,
+        required=True,
+        help="Candidate evaluation artifact JSON.",
+    )
+    compare_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON to this path instead of stdout.",
+    )
     return parser
 
 
@@ -135,10 +161,31 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         return candidates.to_dict()
 
 
+def _load_artifact(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid {label} artifact JSON at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} artifact must be a JSON object")
+    return payload
+
+
+def _compare(args: argparse.Namespace) -> dict[str, Any]:
+    return compare_knowledge_recall_artifacts(
+        _load_artifact(args.baseline, label="baseline"),
+        _load_artifact(args.candidate, label="candidate"),
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        payload = asyncio.run(_run(args))
+        payload = (
+            _compare(args)
+            if args.command == "compare"
+            else asyncio.run(_run(args))
+        )
         _emit(payload, args.output)
     except Exception as exc:
         print(
@@ -147,6 +194,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
     if args.command == "eval" and payload["result_type"] == "invalid":
+        return 1
+    if args.command == "compare" and not payload["comparability"]["comparable"]:
         return 1
     return 0
 

--- a/brain/systems/knowledge/recall_eval.py
+++ b/brain/systems/knowledge/recall_eval.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-import hashlib
-import json
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.systems.knowledge.search import search_knowledge
+from brain.platform.db.models.knowledge import KnowledgeItem
+from brain.systems.knowledge.search import (
+    knowledge_item_filters,
+    search_knowledge,
+)
 from brain.systems.knowledge.search_contract import (
     KNOWLEDGE_SEARCH_MAX_RESULTS,
     KnowledgeSearchResponse,
@@ -26,6 +31,138 @@ DEFAULT_QUESTION_SET_PATH = (
 )
 
 KnowledgeSearch = Callable[..., Awaitable[Any]]
+
+
+def _iso_utc(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class KnowledgeRecallCorpusFingerprint:
+    """Stable summary of the knowledge rows visible to one organization."""
+
+    total_item_count: int
+    source_counts: tuple[tuple[str, int], ...]
+    newest_source_updated_at: str | None
+    newest_ingested_at: str | None
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Mapping[str, Any],
+    ) -> KnowledgeRecallCorpusFingerprint:
+        """Load and verify the serialized form used by evaluation artifacts."""
+
+        raw_source_counts = value.get("source_counts")
+        if not isinstance(raw_source_counts, Mapping):
+            raise ValueError("corpus_fingerprint.source_counts must be an object")
+        try:
+            fingerprint = cls(
+                total_item_count=int(value["total_item_count"]),
+                source_counts=tuple(
+                    sorted(
+                        (str(source), int(count))
+                        for source, count in raw_source_counts.items()
+                    )
+                ),
+                newest_source_updated_at=value.get("newest_source_updated_at"),
+                newest_ingested_at=value.get("newest_ingested_at"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"invalid corpus fingerprint: {exc}") from exc
+        stored_digest = str(value.get("fingerprint") or "").strip()
+        if stored_digest != fingerprint.fingerprint:
+            raise ValueError("corpus fingerprint digest does not match its values")
+        return fingerprint
+
+    def _values_dict(self) -> dict[str, Any]:
+        return {
+            "total_item_count": self.total_item_count,
+            "source_counts": {
+                source: count for source, count in self.source_counts
+            },
+            "newest_source_updated_at": self.newest_source_updated_at,
+            "newest_ingested_at": self.newest_ingested_at,
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        encoded = json.dumps(
+            self._values_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self._values_dict(),
+            "fingerprint": self.fingerprint,
+        }
+
+    def changed_fields_from(
+        self,
+        baseline: KnowledgeRecallCorpusFingerprint,
+    ) -> dict[str, dict[str, Any]]:
+        """Return serialized field changes without duplicating the schema."""
+
+        baseline_values = baseline.to_dict()
+        candidate_values = self.to_dict()
+        return {
+            field_name: {
+                "baseline": baseline_value,
+                "candidate": candidate_values[field_name],
+            }
+            for field_name, baseline_value in baseline_values.items()
+            if baseline_value != candidate_values[field_name]
+        }
+
+
+async def build_knowledge_recall_corpus_fingerprint(
+    session: AsyncSession,
+    *,
+    org_id: str,
+) -> KnowledgeRecallCorpusFingerprint:
+    """Summarize the same organization-visible rows used by knowledge search."""
+
+    rows = (
+        await session.execute(
+            select(
+                KnowledgeItem.source,
+                func.count(KnowledgeItem.id),
+                func.max(KnowledgeItem.source_updated_at),
+                func.max(KnowledgeItem.ingested_at),
+            )
+            .where(
+                *knowledge_item_filters(
+                    org_id=org_id,
+                    sources=None,
+                    kinds=None,
+                )
+            )
+            .group_by(KnowledgeItem.source)
+        )
+    ).all()
+    sorted_rows = sorted(rows, key=lambda row: row[0])
+    source_updated_values = [row[2] for row in sorted_rows if row[2] is not None]
+    ingested_values = [row[3] for row in sorted_rows if row[3] is not None]
+    return KnowledgeRecallCorpusFingerprint(
+        total_item_count=sum(int(row[1]) for row in sorted_rows),
+        source_counts=tuple(
+            (str(row[0]), int(row[1])) for row in sorted_rows
+        ),
+        newest_source_updated_at=_iso_utc(
+            max(source_updated_values) if source_updated_values else None
+        ),
+        newest_ingested_at=_iso_utc(
+            max(ingested_values) if ingested_values else None
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -178,6 +315,7 @@ class KnowledgeRecallInvalidResult:
     question_set: KnowledgeRecallQuestionSet
     k_values: tuple[int, ...]
     requested_search_limit: int
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
     errors: tuple[KnowledgeRecallCaseError, ...]
 
     def to_dict(self) -> dict[str, Any]:
@@ -192,6 +330,7 @@ class KnowledgeRecallInvalidResult:
                 "k_values": list(self.k_values),
                 "requested_search_limit": self.requested_search_limit,
             },
+            "corpus_fingerprint": self.corpus_fingerprint.to_dict(),
             "errors": [error.to_dict() for error in self.errors],
         }
 
@@ -210,6 +349,7 @@ class KnowledgeRecallSuiteResult:
     k_values: tuple[int, ...]
     requested_search_limit: int
     effective_search_limit: int
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
     results: tuple[KnowledgeRecallCaseResult, ...]
 
     @property
@@ -251,6 +391,7 @@ class KnowledgeRecallSuiteResult:
                 "requested_search_limit": self.requested_search_limit,
                 "effective_search_limit": self.effective_search_limit,
             },
+            "corpus_fingerprint": self.corpus_fingerprint.to_dict(),
             "semantic_available": self.semantic_available,
             "semantic_degraded_reason": " | ".join(reasons) if reasons else None,
             "summary": {
@@ -443,6 +584,10 @@ async def run_knowledge_recall_eval(
     normalized_k = normalize_k_values(k_values)
     requested_search_limit = int(search_limit)
     report_generated_at = generated_at or datetime.now(timezone.utc).isoformat()
+    corpus_fingerprint = await build_knowledge_recall_corpus_fingerprint(
+        session,
+        org_id=clean_org_id,
+    )
     if not loaded_question_set.cases:
         return KnowledgeRecallInvalidResult(
             suite="knowledge-recall",
@@ -452,6 +597,7 @@ async def run_knowledge_recall_eval(
             question_set=loaded_question_set,
             k_values=normalized_k,
             requested_search_limit=requested_search_limit,
+            corpus_fingerprint=corpus_fingerprint,
             errors=(
                 KnowledgeRecallCaseError(
                     case_id=loaded_question_set.question_set_id,
@@ -480,6 +626,7 @@ async def run_knowledge_recall_eval(
             question_set=loaded_question_set,
             k_values=normalized_k,
             requested_search_limit=requested_search_limit,
+            corpus_fingerprint=corpus_fingerprint,
             errors=tuple(
                 KnowledgeRecallCaseError(case_id=case.case_id, cause=cause)
                 for case in loaded_question_set.cases
@@ -574,6 +721,7 @@ async def run_knowledge_recall_eval(
             question_set=loaded_question_set,
             k_values=normalized_k,
             requested_search_limit=requested_search_limit,
+            corpus_fingerprint=corpus_fingerprint,
             errors=tuple(case_errors),
         )
 
@@ -586,6 +734,7 @@ async def run_knowledge_recall_eval(
         k_values=normalized_k,
         requested_search_limit=requested_search_limit,
         effective_search_limit=observed_depths[0][1],
+        corpus_fingerprint=corpus_fingerprint,
         results=tuple(case_results),
     )
 
@@ -596,12 +745,14 @@ __all__ = [
     "EvidencePointer",
     "KnowledgeRecallCaseError",
     "KnowledgeRecallCaseResult",
+    "KnowledgeRecallCorpusFingerprint",
     "KnowledgeRecallEvaluationResult",
     "KnowledgeRecallInvalidResult",
     "KnowledgeRecallQuestion",
     "KnowledgeRecallQuestionSet",
     "KnowledgeRecallSuiteResult",
     "RankedKnowledgeResult",
+    "build_knowledge_recall_corpus_fingerprint",
     "load_knowledge_recall_question_set",
     "normalize_k_values",
     "run_knowledge_recall_eval",

--- a/brain/systems/knowledge/recall_eval.py
+++ b/brain/systems/knowledge/recall_eval.py
@@ -4,16 +4,31 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.knowledge import KnowledgeItem
+from brain.systems.knowledge.recall_eval_contract import (
+    KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION,
+    KnowledgeRecallArtifactCaseError,
+    KnowledgeRecallArtifactCaseResult,
+    KnowledgeRecallArtifactConfiguration,
+    KnowledgeRecallArtifactEvidence,
+    KnowledgeRecallArtifactQuestionSet,
+    KnowledgeRecallArtifactRankedResult,
+    KnowledgeRecallArtifactSummary,
+    KnowledgeRecallCorpusFingerprint,
+    KnowledgeRecallInvalidArtifact,
+    KnowledgeRecallInvalidArtifactConfiguration,
+    KnowledgeRecallValidArtifact,
+)
 from brain.systems.knowledge.search import (
     knowledge_item_filters,
     search_knowledge,
@@ -41,88 +56,6 @@ def _iso_utc(value: datetime | None) -> str | None:
     return value.astimezone(timezone.utc).isoformat()
 
 
-@dataclass(frozen=True)
-class KnowledgeRecallCorpusFingerprint:
-    """Stable summary of the knowledge rows visible to one organization."""
-
-    total_item_count: int
-    source_counts: tuple[tuple[str, int], ...]
-    newest_source_updated_at: str | None
-    newest_ingested_at: str | None
-
-    @classmethod
-    def from_dict(
-        cls,
-        value: Mapping[str, Any],
-    ) -> KnowledgeRecallCorpusFingerprint:
-        """Load and verify the serialized form used by evaluation artifacts."""
-
-        raw_source_counts = value.get("source_counts")
-        if not isinstance(raw_source_counts, Mapping):
-            raise ValueError("corpus_fingerprint.source_counts must be an object")
-        try:
-            fingerprint = cls(
-                total_item_count=int(value["total_item_count"]),
-                source_counts=tuple(
-                    sorted(
-                        (str(source), int(count))
-                        for source, count in raw_source_counts.items()
-                    )
-                ),
-                newest_source_updated_at=value.get("newest_source_updated_at"),
-                newest_ingested_at=value.get("newest_ingested_at"),
-            )
-        except (KeyError, TypeError, ValueError) as exc:
-            raise ValueError(f"invalid corpus fingerprint: {exc}") from exc
-        stored_digest = str(value.get("fingerprint") or "").strip()
-        if stored_digest != fingerprint.fingerprint:
-            raise ValueError("corpus fingerprint digest does not match its values")
-        return fingerprint
-
-    def _values_dict(self) -> dict[str, Any]:
-        return {
-            "total_item_count": self.total_item_count,
-            "source_counts": {
-                source: count for source, count in self.source_counts
-            },
-            "newest_source_updated_at": self.newest_source_updated_at,
-            "newest_ingested_at": self.newest_ingested_at,
-        }
-
-    @property
-    def fingerprint(self) -> str:
-        encoded = json.dumps(
-            self._values_dict(),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
-        return hashlib.sha256(encoded).hexdigest()[:16]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            **self._values_dict(),
-            "fingerprint": self.fingerprint,
-        }
-
-    def changed_fields_from(
-        self,
-        baseline: KnowledgeRecallCorpusFingerprint,
-    ) -> dict[str, dict[str, Any]]:
-        """Return serialized field changes without duplicating the schema."""
-
-        baseline_values = baseline.to_dict()
-        candidate_values = self.to_dict()
-        return {
-            field_name: {
-                "baseline": baseline_value,
-                "candidate": candidate_values[field_name],
-            }
-            for field_name, baseline_value in baseline_values.items()
-            if baseline_value != candidate_values[field_name]
-        }
-
-
 async def build_knowledge_recall_corpus_fingerprint(
     session: AsyncSession,
     *,
@@ -133,10 +66,14 @@ async def build_knowledge_recall_corpus_fingerprint(
     rows = (
         await session.execute(
             select(
+                KnowledgeItem.id,
                 KnowledgeItem.source,
-                func.count(KnowledgeItem.id),
-                func.max(KnowledgeItem.source_updated_at),
-                func.max(KnowledgeItem.ingested_at),
+                KnowledgeItem.source_ref,
+                KnowledgeItem.content_digest,
+                KnowledgeItem.search_text,
+                KnowledgeItem.source_created_at,
+                KnowledgeItem.source_updated_at,
+                KnowledgeItem.ingested_at,
             )
             .where(
                 *knowledge_item_filters(
@@ -145,23 +82,42 @@ async def build_knowledge_recall_corpus_fingerprint(
                     kinds=None,
                 )
             )
-            .group_by(KnowledgeItem.source)
+            .order_by(KnowledgeItem.source.asc(), KnowledgeItem.source_ref.asc())
         )
     ).all()
-    sorted_rows = sorted(rows, key=lambda row: row[0])
-    source_updated_values = [row[2] for row in sorted_rows if row[2] is not None]
-    ingested_values = [row[3] for row in sorted_rows if row[3] is not None]
+    canonical_rows = [
+        {
+            "id": int(row.id),
+            "source": str(row.source),
+            "source_ref": str(row.source_ref),
+            "content_digest": str(row.content_digest),
+            "search_text": str(row.search_text),
+            "source_created_at": _iso_utc(row.source_created_at),
+            "source_updated_at": _iso_utc(row.source_updated_at),
+        }
+        for row in rows
+    ]
+    encoded_rows = json.dumps(
+        canonical_rows,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    source_counts = Counter(str(row.source) for row in rows)
+    source_updated_values = [
+        row.source_updated_at for row in rows if row.source_updated_at is not None
+    ]
+    ingested_values = [row.ingested_at for row in rows if row.ingested_at is not None]
     return KnowledgeRecallCorpusFingerprint(
-        total_item_count=sum(int(row[1]) for row in sorted_rows),
-        source_counts=tuple(
-            (str(row[0]), int(row[1])) for row in sorted_rows
-        ),
+        total_item_count=len(rows),
+        source_counts=dict(sorted(source_counts.items())),
         newest_source_updated_at=_iso_utc(
             max(source_updated_values) if source_updated_values else None
         ),
         newest_ingested_at=_iso_utc(
             max(ingested_values) if ingested_values else None
         ),
+        fingerprint=hashlib.sha256(encoded_rows).hexdigest(),
     )
 
 
@@ -177,6 +133,12 @@ class EvidencePointer:
             "source": self.source,
             "source_ref": self.source_ref,
         }
+
+    def to_artifact(self) -> KnowledgeRecallArtifactEvidence:
+        return KnowledgeRecallArtifactEvidence(
+            source=self.source,
+            source_ref=self.source_ref,
+        )
 
 
 @dataclass(frozen=True)
@@ -222,13 +184,13 @@ class KnowledgeRecallQuestionSet:
             "cases": [case.to_dict() for case in self.cases],
         }
 
-    def identity_dict(self) -> dict[str, Any]:
-        return {
-            "id": self.question_set_id,
-            "version": self.version,
-            "digest": self.digest,
-            "case_count": len(self.cases),
-        }
+    def to_artifact(self) -> KnowledgeRecallArtifactQuestionSet:
+        return KnowledgeRecallArtifactQuestionSet(
+            id=self.question_set_id,
+            version=self.version,
+            digest=self.digest,
+            case_count=len(self.cases),
+        )
 
 
 @dataclass(frozen=True)
@@ -240,15 +202,15 @@ class RankedKnowledgeResult:
     matched: bool
     scores: KnowledgeSearchScores
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "rank": self.rank,
-            "evidence": self.evidence.to_dict(),
-            "kind": self.kind,
-            "title": self.title,
-            "matched": self.matched,
-            "scores": self.scores.model_dump(mode="json"),
-        }
+    def to_artifact(self) -> KnowledgeRecallArtifactRankedResult:
+        return KnowledgeRecallArtifactRankedResult(
+            rank=self.rank,
+            evidence=self.evidence.to_artifact(),
+            kind=self.kind,
+            title=self.title,
+            matched=self.matched,
+            scores=self.scores,
+        )
 
 
 @dataclass(frozen=True)
@@ -268,24 +230,24 @@ class KnowledgeRecallCaseResult:
     def missed(self) -> bool:
         return self.best_evidence_rank is None
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "case_id": self.case_id,
-            "question": self.question,
-            "acceptable_evidence": [
-                pointer.to_dict() for pointer in self.acceptable_evidence
-            ],
-            "origin": dict(self.origin),
-            "best_evidence_rank": self.best_evidence_rank,
-            "missed": self.missed,
-            "reciprocal_rank": self.reciprocal_rank,
-            "hits_at_k": {
-                str(k): hit for k, hit in sorted(self.hits_at_k.items())
-            },
-            "semantic_available": self.semantic_available,
-            "semantic_degraded_reason": self.semantic_degraded_reason,
-            "ranked_results": [result.to_dict() for result in self.ranked_results],
-        }
+    def to_artifact(self) -> KnowledgeRecallArtifactCaseResult:
+        return KnowledgeRecallArtifactCaseResult(
+            case_id=self.case_id,
+            question=self.question,
+            acceptable_evidence=tuple(
+                pointer.to_artifact() for pointer in self.acceptable_evidence
+            ),
+            origin=dict(self.origin),
+            best_evidence_rank=self.best_evidence_rank,
+            missed=self.missed,
+            reciprocal_rank=self.reciprocal_rank,
+            hits_at_k=dict(sorted(self.hits_at_k.items())),
+            semantic_available=self.semantic_available,
+            semantic_degraded_reason=self.semantic_degraded_reason,
+            ranked_results=tuple(
+                result.to_artifact() for result in self.ranked_results
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -295,11 +257,11 @@ class KnowledgeRecallCaseError:
     case_id: str
     cause: str
 
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "case_id": self.case_id,
-            "cause": self.cause,
-        }
+    def to_artifact(self) -> KnowledgeRecallArtifactCaseError:
+        return KnowledgeRecallArtifactCaseError(
+            case_id=self.case_id,
+            cause=self.cause,
+        )
 
 
 @dataclass(frozen=True)
@@ -318,21 +280,25 @@ class KnowledgeRecallInvalidResult:
     corpus_fingerprint: KnowledgeRecallCorpusFingerprint
     errors: tuple[KnowledgeRecallCaseError, ...]
 
+    def to_artifact(self) -> KnowledgeRecallInvalidArtifact:
+        return KnowledgeRecallInvalidArtifact(
+            schema_version=KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION,
+            result_type=self.result_type,
+            suite=self.suite,
+            generated_at=self.generated_at,
+            live_database=self.live_database,
+            question_set=self.question_set.to_artifact(),
+            configuration=KnowledgeRecallInvalidArtifactConfiguration(
+                org_id=self.org_id,
+                k_values=self.k_values,
+                requested_search_limit=self.requested_search_limit,
+            ),
+            corpus_fingerprint=self.corpus_fingerprint,
+            errors=tuple(error.to_artifact() for error in self.errors),
+        )
+
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "result_type": self.result_type,
-            "suite": self.suite,
-            "generated_at": self.generated_at,
-            "live_database": self.live_database,
-            "question_set": self.question_set.identity_dict(),
-            "configuration": {
-                "org_id": self.org_id,
-                "k_values": list(self.k_values),
-                "requested_search_limit": self.requested_search_limit,
-            },
-            "corpus_fingerprint": self.corpus_fingerprint.to_dict(),
-            "errors": [error.to_dict() for error in self.errors],
-        }
+        return self.to_artifact().model_dump(mode="json")
 
 
 @dataclass(frozen=True)
@@ -368,49 +334,53 @@ class KnowledgeRecallSuiteResult:
             )
         )
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_artifact(self) -> KnowledgeRecallValidArtifact:
         total = len(self.results)
         hits = {
-            str(k): sum(1 for result in self.results if result.hits_at_k[k])
+            k: sum(1 for result in self.results if result.hits_at_k[k])
             for k in self.k_values
         }
         recall_at_k = {
-            str(k): _metric(hits[str(k)] / total if total else 0.0)
+            k: _metric(hits[k] / total if total else 0.0)
             for k in self.k_values
         }
         reasons = self.semantic_degraded_reasons
-        return {
-            "result_type": self.result_type,
-            "suite": self.suite,
-            "generated_at": self.generated_at,
-            "live_database": self.live_database,
-            "question_set": self.question_set.identity_dict(),
-            "configuration": {
-                "org_id": self.org_id,
-                "k_values": list(self.k_values),
-                "requested_search_limit": self.requested_search_limit,
-                "effective_search_limit": self.effective_search_limit,
-            },
-            "corpus_fingerprint": self.corpus_fingerprint.to_dict(),
-            "semantic_available": self.semantic_available,
-            "semantic_degraded_reason": " | ".join(reasons) if reasons else None,
-            "summary": {
-                "total": total,
-                "missed": sum(result.missed for result in self.results),
-                "semantic_degraded_cases": sum(
+        return KnowledgeRecallValidArtifact(
+            schema_version=KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION,
+            result_type=self.result_type,
+            suite=self.suite,
+            generated_at=self.generated_at,
+            live_database=self.live_database,
+            question_set=self.question_set.to_artifact(),
+            configuration=KnowledgeRecallArtifactConfiguration(
+                org_id=self.org_id,
+                k_values=self.k_values,
+                requested_search_limit=self.requested_search_limit,
+                effective_search_limit=self.effective_search_limit,
+            ),
+            corpus_fingerprint=self.corpus_fingerprint,
+            semantic_available=self.semantic_available,
+            semantic_degraded_reason=" | ".join(reasons) if reasons else None,
+            summary=KnowledgeRecallArtifactSummary(
+                total=total,
+                missed=sum(result.missed for result in self.results),
+                semantic_degraded_cases=sum(
                     not result.semantic_available for result in self.results
                 ),
-                "hits_at_k": hits,
-                "recall_at_k": recall_at_k,
-                "mean_reciprocal_rank": _metric(
+                hits_at_k=hits,
+                recall_at_k=recall_at_k,
+                mean_reciprocal_rank=_metric(
                     sum(result.reciprocal_rank for result in self.results) / total
                     if total
                     else 0.0
                 ),
-                "mean_reciprocal_rank_cutoff": self.effective_search_limit,
-            },
-            "results": [result.to_dict() for result in self.results],
-        }
+                mean_reciprocal_rank_cutoff=self.effective_search_limit,
+            ),
+            results=tuple(result.to_artifact() for result in self.results),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.to_artifact().model_dump(mode="json")
 
 
 KnowledgeRecallEvaluationResult = (

--- a/brain/systems/knowledge/recall_eval_comparison.py
+++ b/brain/systems/knowledge/recall_eval_comparison.py
@@ -1,0 +1,345 @@
+"""Offline comparison of serialized knowledge-recall evaluation artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from brain.systems.knowledge.recall_eval import KnowledgeRecallCorpusFingerprint
+
+
+@dataclass(frozen=True)
+class _ValidArtifact:
+    question_set_digest: str
+    org_id: str
+    k_values: tuple[int, ...]
+    effective_search_limit: int
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint | None
+    summary: Mapping[str, Any]
+    results: tuple[Mapping[str, Any], ...]
+
+
+def _mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be an object")
+    return value
+
+
+def _required_text(value: Any, *, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not clean:
+        raise ValueError(f"{field_name} is required")
+    return clean
+
+
+def _result_type(artifact: Mapping[str, Any], *, label: str) -> str:
+    result_type = artifact.get("result_type")
+    if result_type not in {"valid", "invalid"}:
+        raise ValueError(f"{label}.result_type must be valid or invalid")
+    return str(result_type)
+
+
+def _load_valid_artifact(
+    artifact: Mapping[str, Any],
+    *,
+    label: str,
+) -> _ValidArtifact:
+    question_set = _mapping(
+        artifact.get("question_set"),
+        field_name=f"{label}.question_set",
+    )
+    configuration = _mapping(
+        artifact.get("configuration"),
+        field_name=f"{label}.configuration",
+    )
+    raw_k_values = configuration.get("k_values")
+    if not isinstance(raw_k_values, list):
+        raise ValueError(f"{label}.configuration.k_values must be a list")
+    try:
+        k_values = tuple(int(value) for value in raw_k_values)
+        effective_search_limit = int(configuration["effective_search_limit"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"invalid {label} search configuration: {exc}") from exc
+
+    raw_fingerprint = artifact.get("corpus_fingerprint")
+    corpus_fingerprint = None
+    if raw_fingerprint is not None:
+        corpus_fingerprint = KnowledgeRecallCorpusFingerprint.from_dict(
+            _mapping(
+                raw_fingerprint,
+                field_name=f"{label}.corpus_fingerprint",
+            )
+        )
+
+    raw_results = artifact.get("results")
+    if not isinstance(raw_results, list):
+        raise ValueError(f"{label}.results must be a list")
+    return _ValidArtifact(
+        question_set_digest=_required_text(
+            question_set.get("digest"),
+            field_name=f"{label}.question_set.digest",
+        ),
+        org_id=_required_text(
+            configuration.get("org_id"),
+            field_name=f"{label}.configuration.org_id",
+        ),
+        k_values=k_values,
+        effective_search_limit=effective_search_limit,
+        corpus_fingerprint=corpus_fingerprint,
+        summary=_mapping(
+            artifact.get("summary"),
+            field_name=f"{label}.summary",
+        ),
+        results=tuple(
+            _mapping(result, field_name=f"{label}.results[{index}]")
+            for index, result in enumerate(raw_results)
+        ),
+    )
+
+
+def _check(baseline: Any, candidate: Any) -> dict[str, Any]:
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "matches": baseline == candidate,
+    }
+
+
+def _invalid_comparison(
+    *,
+    verdict: Literal["invalid-artifact", "not-comparable"],
+    reason: str,
+    differences: Sequence[str] = (),
+    checks: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "comparison_type": "knowledge-recall",
+        "comparability": {
+            "comparable": False,
+            "computed": False,
+            "verdict": verdict,
+            "reason": reason,
+            "differences": list(differences),
+            "checks": dict(checks or {}),
+            "corpus_changed_fields": {},
+        },
+    }
+
+
+def _delta(baseline: float, candidate: float) -> dict[str, float]:
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "delta": round(candidate - baseline, 8),
+    }
+
+
+def _case_rank_deltas(
+    baseline_results: Sequence[Mapping[str, Any]],
+    candidate_results: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    candidate_by_case = {
+        _required_text(result.get("case_id"), field_name="candidate case_id"): result
+        for result in candidate_results
+    }
+    if len(candidate_by_case) != len(candidate_results):
+        raise ValueError("candidate results contain duplicate case_id values")
+
+    comparisons: list[dict[str, Any]] = []
+    baseline_case_ids: set[str] = set()
+    for result in baseline_results:
+        case_id = _required_text(result.get("case_id"), field_name="baseline case_id")
+        if case_id in baseline_case_ids:
+            raise ValueError("baseline results contain duplicate case_id values")
+        baseline_case_ids.add(case_id)
+        if case_id not in candidate_by_case:
+            raise ValueError(f"candidate artifact is missing case_id {case_id}")
+        baseline_rank = result.get("best_evidence_rank")
+        candidate_rank = candidate_by_case[case_id].get("best_evidence_rank")
+        if baseline_rank is not None:
+            baseline_rank = int(baseline_rank)
+        if candidate_rank is not None:
+            candidate_rank = int(candidate_rank)
+        if baseline_rank is None and candidate_rank is not None:
+            change = "miss-to-hit"
+        elif baseline_rank is not None and candidate_rank is None:
+            change = "hit-to-miss"
+        elif baseline_rank == candidate_rank:
+            change = "unchanged"
+        else:
+            change = "rank-changed"
+        comparisons.append(
+            {
+                "case_id": case_id,
+                "best_evidence_rank": {
+                    "baseline": baseline_rank,
+                    "candidate": candidate_rank,
+                    "delta": (
+                        candidate_rank - baseline_rank
+                        if baseline_rank is not None and candidate_rank is not None
+                        else None
+                    ),
+                    "change": change,
+                },
+            }
+        )
+    extra_cases = sorted(set(candidate_by_case) - baseline_case_ids)
+    if extra_cases:
+        raise ValueError(
+            "candidate artifact contains unexpected case_id values: "
+            + ", ".join(extra_cases)
+        )
+    return comparisons
+
+
+def _metric_deltas(
+    baseline: _ValidArtifact,
+    candidate: _ValidArtifact,
+) -> dict[str, Any]:
+    baseline_recall = _mapping(
+        baseline.summary.get("recall_at_k"),
+        field_name="baseline.summary.recall_at_k",
+    )
+    candidate_recall = _mapping(
+        candidate.summary.get("recall_at_k"),
+        field_name="candidate.summary.recall_at_k",
+    )
+    shared_k_values = sorted(set(baseline.k_values) & set(candidate.k_values))
+    recall_at_k = {
+        str(k): _delta(
+            float(baseline_recall[str(k)]),
+            float(candidate_recall[str(k)]),
+        )
+        for k in shared_k_values
+    }
+    return {
+        "recall_at_k": recall_at_k,
+        "mean_reciprocal_rank": _delta(
+            float(baseline.summary["mean_reciprocal_rank"]),
+            float(candidate.summary["mean_reciprocal_rank"]),
+        ),
+    }
+
+
+def compare_knowledge_recall_artifacts(
+    baseline_artifact: Mapping[str, Any],
+    candidate_artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compare two eval reports without accessing the knowledge database."""
+
+    baseline_type = _result_type(baseline_artifact, label="baseline")
+    candidate_type = _result_type(candidate_artifact, label="candidate")
+    invalid_labels = [
+        label
+        for label, result_type in (
+            ("baseline", baseline_type),
+            ("candidate", candidate_type),
+        )
+        if result_type == "invalid"
+    ]
+    if invalid_labels:
+        if len(invalid_labels) == 1:
+            invalid_reason = f"{invalid_labels[0]} artifact is invalid."
+        else:
+            invalid_reason = "baseline and candidate artifacts are invalid."
+        return _invalid_comparison(
+            verdict="invalid-artifact",
+            reason=(
+                "Metric deltas were not computed because "
+                + invalid_reason
+            ),
+        )
+
+    baseline = _load_valid_artifact(baseline_artifact, label="baseline")
+    candidate = _load_valid_artifact(candidate_artifact, label="candidate")
+    baseline_fingerprint = (
+        baseline.corpus_fingerprint.fingerprint
+        if baseline.corpus_fingerprint is not None
+        else None
+    )
+    candidate_fingerprint = (
+        candidate.corpus_fingerprint.fingerprint
+        if candidate.corpus_fingerprint is not None
+        else None
+    )
+    checks = {
+        "question_set_digest": _check(
+            baseline.question_set_digest,
+            candidate.question_set_digest,
+        ),
+        "org_id": _check(baseline.org_id, candidate.org_id),
+        "k_values": _check(list(baseline.k_values), list(candidate.k_values)),
+        "effective_search_limit": _check(
+            baseline.effective_search_limit,
+            candidate.effective_search_limit,
+        ),
+        "corpus_fingerprint": _check(
+            baseline_fingerprint,
+            candidate_fingerprint,
+        ),
+    }
+    differences = [name for name, check in checks.items() if not check["matches"]]
+    blocking_differences = [
+        name
+        for name in ("question_set_digest", "org_id")
+        if name in differences
+    ]
+    if blocking_differences:
+        return _invalid_comparison(
+            verdict="not-comparable",
+            reason=(
+                "Metric deltas were not computed because the runs differ in "
+                + " and ".join(blocking_differences)
+                + "."
+            ),
+            differences=differences,
+            checks=checks,
+        )
+    if baseline.corpus_fingerprint is None or candidate.corpus_fingerprint is None:
+        return _invalid_comparison(
+            verdict="not-comparable",
+            reason=(
+                "Metric deltas were not computed because both artifacts need a "
+                "corpus fingerprint."
+            ),
+            differences=differences,
+            checks=checks,
+        )
+
+    corpus_changed_fields = candidate.corpus_fingerprint.changed_fields_from(
+        baseline.corpus_fingerprint
+    )
+    if corpus_changed_fields:
+        verdict = "corpus-attributable"
+        reason = (
+            "Metric deltas were computed, but they are not attributable to code "
+            "or ranking because the corpus moved."
+        )
+    else:
+        verdict = "ranking-attributable"
+        reason = (
+            "The question set, organization, and corpus match. Metric deltas are "
+            "attributable to code or ranking."
+        )
+
+    return {
+        "comparison_type": "knowledge-recall",
+        "comparability": {
+            "comparable": True,
+            "computed": True,
+            "verdict": verdict,
+            "reason": reason,
+            "differences": differences,
+            "checks": checks,
+            "corpus_changed_fields": corpus_changed_fields,
+        },
+        "case_rank_deltas": _case_rank_deltas(
+            baseline.results,
+            candidate.results,
+        ),
+        "metric_deltas": _metric_deltas(baseline, candidate),
+    }
+
+
+__all__ = ["compare_knowledge_recall_artifacts"]

--- a/brain/systems/knowledge/recall_eval_comparison.py
+++ b/brain/systems/knowledge/recall_eval_comparison.py
@@ -3,106 +3,31 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from typing import Any, Literal
 
-from brain.systems.knowledge.recall_eval import KnowledgeRecallCorpusFingerprint
-
-
-@dataclass(frozen=True)
-class _ValidArtifact:
-    question_set_digest: str
-    org_id: str
-    k_values: tuple[int, ...]
-    effective_search_limit: int
-    corpus_fingerprint: KnowledgeRecallCorpusFingerprint | None
-    summary: Mapping[str, Any]
-    results: tuple[Mapping[str, Any], ...]
-
-
-def _mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
-        raise ValueError(f"{field_name} must be an object")
-    return value
-
-
-def _required_text(value: Any, *, field_name: str) -> str:
-    clean = str(value or "").strip()
-    if not clean:
-        raise ValueError(f"{field_name} is required")
-    return clean
-
-
-def _result_type(artifact: Mapping[str, Any], *, label: str) -> str:
-    result_type = artifact.get("result_type")
-    if result_type not in {"valid", "invalid"}:
-        raise ValueError(f"{label}.result_type must be valid or invalid")
-    return str(result_type)
-
-
-def _load_valid_artifact(
-    artifact: Mapping[str, Any],
-    *,
-    label: str,
-) -> _ValidArtifact:
-    question_set = _mapping(
-        artifact.get("question_set"),
-        field_name=f"{label}.question_set",
-    )
-    configuration = _mapping(
-        artifact.get("configuration"),
-        field_name=f"{label}.configuration",
-    )
-    raw_k_values = configuration.get("k_values")
-    if not isinstance(raw_k_values, list):
-        raise ValueError(f"{label}.configuration.k_values must be a list")
-    try:
-        k_values = tuple(int(value) for value in raw_k_values)
-        effective_search_limit = int(configuration["effective_search_limit"])
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ValueError(f"invalid {label} search configuration: {exc}") from exc
-
-    raw_fingerprint = artifact.get("corpus_fingerprint")
-    corpus_fingerprint = None
-    if raw_fingerprint is not None:
-        corpus_fingerprint = KnowledgeRecallCorpusFingerprint.from_dict(
-            _mapping(
-                raw_fingerprint,
-                field_name=f"{label}.corpus_fingerprint",
-            )
-        )
-
-    raw_results = artifact.get("results")
-    if not isinstance(raw_results, list):
-        raise ValueError(f"{label}.results must be a list")
-    return _ValidArtifact(
-        question_set_digest=_required_text(
-            question_set.get("digest"),
-            field_name=f"{label}.question_set.digest",
-        ),
-        org_id=_required_text(
-            configuration.get("org_id"),
-            field_name=f"{label}.configuration.org_id",
-        ),
-        k_values=k_values,
-        effective_search_limit=effective_search_limit,
-        corpus_fingerprint=corpus_fingerprint,
-        summary=_mapping(
-            artifact.get("summary"),
-            field_name=f"{label}.summary",
-        ),
-        results=tuple(
-            _mapping(result, field_name=f"{label}.results[{index}]")
-            for index, result in enumerate(raw_results)
-        ),
-    )
+from brain.systems.knowledge.recall_eval_contract import (
+    KnowledgeRecallArtifact,
+    KnowledgeRecallArtifactCaseResult,
+    KnowledgeRecallCorpusFingerprint,
+    KnowledgeRecallInvalidArtifact,
+    KnowledgeRecallLegacyInvalidArtifact,
+    KnowledgeRecallLegacyValidArtifact,
+    KnowledgeRecallValidArtifact,
+    KnowledgeRecallValidArtifactContract,
+)
 
 
 def _check(baseline: Any, candidate: Any) -> dict[str, Any]:
+    if baseline is None or candidate is None:
+        state = "unknown"
+    elif baseline == candidate:
+        state = "match"
+    else:
+        state = "different"
     return {
         "baseline": baseline,
         "candidate": candidate,
-        "matches": baseline == candidate,
+        "state": state,
     }
 
 
@@ -136,31 +61,24 @@ def _delta(baseline: float, candidate: float) -> dict[str, float]:
 
 
 def _case_rank_deltas(
-    baseline_results: Sequence[Mapping[str, Any]],
-    candidate_results: Sequence[Mapping[str, Any]],
+    baseline_results: Sequence[KnowledgeRecallArtifactCaseResult],
+    candidate_results: Sequence[KnowledgeRecallArtifactCaseResult],
 ) -> list[dict[str, Any]]:
-    candidate_by_case = {
-        _required_text(result.get("case_id"), field_name="candidate case_id"): result
-        for result in candidate_results
-    }
+    candidate_by_case = {result.case_id: result for result in candidate_results}
     if len(candidate_by_case) != len(candidate_results):
         raise ValueError("candidate results contain duplicate case_id values")
 
     comparisons: list[dict[str, Any]] = []
     baseline_case_ids: set[str] = set()
     for result in baseline_results:
-        case_id = _required_text(result.get("case_id"), field_name="baseline case_id")
+        case_id = result.case_id
         if case_id in baseline_case_ids:
             raise ValueError("baseline results contain duplicate case_id values")
         baseline_case_ids.add(case_id)
         if case_id not in candidate_by_case:
             raise ValueError(f"candidate artifact is missing case_id {case_id}")
-        baseline_rank = result.get("best_evidence_rank")
-        candidate_rank = candidate_by_case[case_id].get("best_evidence_rank")
-        if baseline_rank is not None:
-            baseline_rank = int(baseline_rank)
-        if candidate_rank is not None:
-            candidate_rank = int(candidate_rank)
+        baseline_rank = result.best_evidence_rank
+        candidate_rank = candidate_by_case[case_id].best_evidence_rank
         if baseline_rank is None and candidate_rank is not None:
             change = "miss-to-hit"
         elif baseline_rank is not None and candidate_rank is None:
@@ -194,95 +112,146 @@ def _case_rank_deltas(
 
 
 def _metric_deltas(
-    baseline: _ValidArtifact,
-    candidate: _ValidArtifact,
+    baseline: KnowledgeRecallValidArtifactContract,
+    candidate: KnowledgeRecallValidArtifactContract,
 ) -> dict[str, Any]:
-    baseline_recall = _mapping(
-        baseline.summary.get("recall_at_k"),
-        field_name="baseline.summary.recall_at_k",
-    )
-    candidate_recall = _mapping(
-        candidate.summary.get("recall_at_k"),
-        field_name="candidate.summary.recall_at_k",
-    )
-    shared_k_values = sorted(set(baseline.k_values) & set(candidate.k_values))
     recall_at_k = {
         str(k): _delta(
-            float(baseline_recall[str(k)]),
-            float(candidate_recall[str(k)]),
+            baseline.summary.recall_at_k[k],
+            candidate.summary.recall_at_k[k],
         )
-        for k in shared_k_values
+        for k in baseline.configuration.k_values
     }
     return {
         "recall_at_k": recall_at_k,
         "mean_reciprocal_rank": _delta(
-            float(baseline.summary["mean_reciprocal_rank"]),
-            float(candidate.summary["mean_reciprocal_rank"]),
+            baseline.summary.mean_reciprocal_rank,
+            candidate.summary.mean_reciprocal_rank,
         ),
+    }
+
+
+def _fingerprint(
+    artifact: KnowledgeRecallValidArtifactContract,
+) -> KnowledgeRecallCorpusFingerprint | None:
+    if isinstance(artifact, KnowledgeRecallValidArtifact):
+        return artifact.corpus_fingerprint
+    return None
+
+
+def _computed_comparison(
+    *,
+    baseline: KnowledgeRecallValidArtifactContract,
+    candidate: KnowledgeRecallValidArtifactContract,
+    verdict: Literal["corpus-unknown", "corpus-changed", "ranking-attributable"],
+    reason: str,
+    differences: Sequence[str],
+    checks: Mapping[str, Any],
+    corpus_changed_fields: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "comparison_type": "knowledge-recall",
+        "comparability": {
+            "comparable": True,
+            "computed": True,
+            "verdict": verdict,
+            "reason": reason,
+            "differences": list(differences),
+            "checks": dict(checks),
+            "corpus_changed_fields": dict(corpus_changed_fields or {}),
+        },
+        "case_rank_deltas": _case_rank_deltas(
+            baseline.results,
+            candidate.results,
+        ),
+        "metric_deltas": _metric_deltas(baseline, candidate),
     }
 
 
 def compare_knowledge_recall_artifacts(
-    baseline_artifact: Mapping[str, Any],
-    candidate_artifact: Mapping[str, Any],
+    baseline_artifact: KnowledgeRecallArtifact,
+    candidate_artifact: KnowledgeRecallArtifact,
 ) -> dict[str, Any]:
-    """Compare two eval reports without accessing the knowledge database."""
+    """Compare two strict artifacts without accessing the knowledge database.
 
-    baseline_type = _result_type(baseline_artifact, label="baseline")
-    candidate_type = _result_type(candidate_artifact, label="candidate")
+    A corpus change is a confounder, not proof of causation. True corpus-versus-
+    ranking attribution needs a controlled comparison that holds the ranker
+    constant across two corpus snapshots.
+    """
+
+    invalid_types = (
+        KnowledgeRecallInvalidArtifact,
+        KnowledgeRecallLegacyInvalidArtifact,
+    )
     invalid_labels = [
         label
-        for label, result_type in (
-            ("baseline", baseline_type),
-            ("candidate", candidate_type),
+        for label, artifact in (
+            ("baseline", baseline_artifact),
+            ("candidate", candidate_artifact),
         )
-        if result_type == "invalid"
+        if isinstance(artifact, invalid_types)
     ]
     if invalid_labels:
-        if len(invalid_labels) == 1:
-            invalid_reason = f"{invalid_labels[0]} artifact is invalid."
-        else:
-            invalid_reason = "baseline and candidate artifacts are invalid."
+        invalid_reason = (
+            f"{invalid_labels[0]} artifact is invalid."
+            if len(invalid_labels) == 1
+            else "baseline and candidate artifacts are invalid."
+        )
         return _invalid_comparison(
             verdict="invalid-artifact",
-            reason=(
-                "Metric deltas were not computed because "
-                + invalid_reason
-            ),
+            reason="Metric deltas were not computed because " + invalid_reason,
         )
 
-    baseline = _load_valid_artifact(baseline_artifact, label="baseline")
-    candidate = _load_valid_artifact(candidate_artifact, label="candidate")
-    baseline_fingerprint = (
-        baseline.corpus_fingerprint.fingerprint
-        if baseline.corpus_fingerprint is not None
-        else None
-    )
-    candidate_fingerprint = (
-        candidate.corpus_fingerprint.fingerprint
-        if candidate.corpus_fingerprint is not None
-        else None
-    )
+    if not isinstance(
+        baseline_artifact,
+        (KnowledgeRecallValidArtifact, KnowledgeRecallLegacyValidArtifact),
+    ) or not isinstance(
+        candidate_artifact,
+        (KnowledgeRecallValidArtifact, KnowledgeRecallLegacyValidArtifact),
+    ):
+        raise TypeError("comparison requires knowledge-recall artifacts")
+    baseline = baseline_artifact
+    candidate = candidate_artifact
+    baseline_corpus = _fingerprint(baseline)
+    candidate_corpus = _fingerprint(candidate)
     checks = {
         "question_set_digest": _check(
-            baseline.question_set_digest,
-            candidate.question_set_digest,
+            baseline.question_set.digest,
+            candidate.question_set.digest,
         ),
-        "org_id": _check(baseline.org_id, candidate.org_id),
-        "k_values": _check(list(baseline.k_values), list(candidate.k_values)),
+        "org_id": _check(
+            baseline.configuration.org_id,
+            candidate.configuration.org_id,
+        ),
+        "k_values": _check(
+            list(baseline.configuration.k_values),
+            list(candidate.configuration.k_values),
+        ),
+        "requested_search_limit": _check(
+            baseline.configuration.requested_search_limit,
+            candidate.configuration.requested_search_limit,
+        ),
         "effective_search_limit": _check(
-            baseline.effective_search_limit,
-            candidate.effective_search_limit,
+            baseline.configuration.effective_search_limit,
+            candidate.configuration.effective_search_limit,
         ),
         "corpus_fingerprint": _check(
-            baseline_fingerprint,
-            candidate_fingerprint,
+            baseline_corpus.fingerprint if baseline_corpus is not None else None,
+            candidate_corpus.fingerprint if candidate_corpus is not None else None,
         ),
     }
-    differences = [name for name, check in checks.items() if not check["matches"]]
+    differences = [
+        name for name, check in checks.items() if check["state"] == "different"
+    ]
     blocking_differences = [
         name
-        for name in ("question_set_digest", "org_id")
+        for name in (
+            "question_set_digest",
+            "org_id",
+            "k_values",
+            "requested_search_limit",
+            "effective_search_limit",
+        )
         if name in differences
     ]
     if blocking_differences:
@@ -296,50 +265,49 @@ def compare_knowledge_recall_artifacts(
             differences=differences,
             checks=checks,
         )
-    if baseline.corpus_fingerprint is None or candidate.corpus_fingerprint is None:
-        return _invalid_comparison(
-            verdict="not-comparable",
+
+    if baseline_corpus is None or candidate_corpus is None:
+        return _computed_comparison(
+            baseline=baseline,
+            candidate=candidate,
+            verdict="corpus-unknown",
             reason=(
-                "Metric deltas were not computed because both artifacts need a "
-                "corpus fingerprint."
+                "Metric deltas were computed, but one or both artifacts have no "
+                "corpus fingerprint. The corpus state is unknown, so no "
+                "attribution is possible."
             ),
             differences=differences,
             checks=checks,
         )
 
-    corpus_changed_fields = candidate.corpus_fingerprint.changed_fields_from(
-        baseline.corpus_fingerprint
-    )
-    if corpus_changed_fields:
-        verdict = "corpus-attributable"
-        reason = (
-            "Metric deltas were computed, but they are not attributable to code "
-            "or ranking because the corpus moved."
+    if baseline_corpus.fingerprint != candidate_corpus.fingerprint:
+        corpus_changed_fields = candidate_corpus.changed_fields_from(
+            baseline_corpus
         )
-    else:
-        verdict = "ranking-attributable"
-        reason = (
-            "The question set, organization, and corpus match. Metric deltas are "
-            "attributable to code or ranking."
+        return _computed_comparison(
+            baseline=baseline,
+            candidate=candidate,
+            verdict="corpus-changed",
+            reason=(
+                "The corpus changed. Metric deltas may combine corpus and code "
+                "movement, so these runs cannot separate them."
+            ),
+            differences=differences,
+            checks=checks,
+            corpus_changed_fields=corpus_changed_fields,
         )
 
-    return {
-        "comparison_type": "knowledge-recall",
-        "comparability": {
-            "comparable": True,
-            "computed": True,
-            "verdict": verdict,
-            "reason": reason,
-            "differences": differences,
-            "checks": checks,
-            "corpus_changed_fields": corpus_changed_fields,
-        },
-        "case_rank_deltas": _case_rank_deltas(
-            baseline.results,
-            candidate.results,
+    return _computed_comparison(
+        baseline=baseline,
+        candidate=candidate,
+        verdict="ranking-attributable",
+        reason=(
+            "The question set, organization, measurement configuration, and "
+            "corpus match. Metric deltas are attributable to code or ranking."
         ),
-        "metric_deltas": _metric_deltas(baseline, candidate),
-    }
+        differences=differences,
+        checks=checks,
+    )
 
 
 __all__ = ["compare_knowledge_recall_artifacts"]

--- a/brain/systems/knowledge/recall_eval_contract.py
+++ b/brain/systems/knowledge/recall_eval_contract.py
@@ -1,0 +1,188 @@
+"""Strict serialized contract for knowledge-recall evaluation artifacts."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+from brain.systems.knowledge.search_contract import KnowledgeSearchScores
+
+KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION = 1
+
+
+class _StrictKnowledgeRecallArtifactModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class KnowledgeRecallArtifactQuestionSet(_StrictKnowledgeRecallArtifactModel):
+    id: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    digest: str = Field(min_length=1)
+    case_count: int = Field(ge=0)
+
+
+class KnowledgeRecallInvalidArtifactConfiguration(
+    _StrictKnowledgeRecallArtifactModel
+):
+    org_id: str = Field(min_length=1)
+    k_values: tuple[int, ...]
+    requested_search_limit: int
+
+
+class KnowledgeRecallArtifactConfiguration(
+    KnowledgeRecallInvalidArtifactConfiguration
+):
+    requested_search_limit: int = Field(ge=1)
+    effective_search_limit: int = Field(ge=1)
+
+
+class KnowledgeRecallCorpusFingerprint(_StrictKnowledgeRecallArtifactModel):
+    """Digest and diagnostics for all knowledge rows visible to one org."""
+
+    total_item_count: int = Field(ge=0)
+    source_counts: dict[str, int]
+    newest_source_updated_at: str | None
+    newest_ingested_at: str | None
+    fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    def changed_fields_from(
+        self,
+        baseline: KnowledgeRecallCorpusFingerprint,
+    ) -> dict[str, dict[str, Any]]:
+        """Return diagnostic and digest changes between two corpora."""
+
+        baseline_values = baseline.model_dump(mode="json")
+        candidate_values = self.model_dump(mode="json")
+        return {
+            field_name: {
+                "baseline": baseline_value,
+                "candidate": candidate_values[field_name],
+            }
+            for field_name, baseline_value in baseline_values.items()
+            if baseline_value != candidate_values[field_name]
+        }
+
+
+class KnowledgeRecallArtifactEvidence(_StrictKnowledgeRecallArtifactModel):
+    source: str = Field(min_length=1)
+    source_ref: str = Field(min_length=1)
+
+
+class KnowledgeRecallArtifactRankedResult(_StrictKnowledgeRecallArtifactModel):
+    rank: int = Field(ge=1)
+    evidence: KnowledgeRecallArtifactEvidence
+    kind: str = Field(min_length=1)
+    title: str
+    matched: bool
+    scores: KnowledgeSearchScores
+
+
+class KnowledgeRecallArtifactCaseResult(_StrictKnowledgeRecallArtifactModel):
+    case_id: str = Field(min_length=1)
+    question: str = Field(min_length=1)
+    acceptable_evidence: tuple[KnowledgeRecallArtifactEvidence, ...]
+    origin: dict[str, Any]
+    best_evidence_rank: int | None
+    missed: bool
+    reciprocal_rank: float
+    hits_at_k: dict[int, bool]
+    semantic_available: bool
+    semantic_degraded_reason: str | None
+    ranked_results: tuple[KnowledgeRecallArtifactRankedResult, ...]
+
+
+class KnowledgeRecallArtifactSummary(_StrictKnowledgeRecallArtifactModel):
+    total: int = Field(ge=0)
+    missed: int = Field(ge=0)
+    semantic_degraded_cases: int = Field(ge=0)
+    hits_at_k: dict[int, int]
+    recall_at_k: dict[int, float]
+    mean_reciprocal_rank: float
+    mean_reciprocal_rank_cutoff: int = Field(ge=1)
+
+
+class KnowledgeRecallArtifactCaseError(_StrictKnowledgeRecallArtifactModel):
+    case_id: str = Field(min_length=1)
+    cause: str = Field(min_length=1)
+
+
+class _KnowledgeRecallLegacyArtifact(_StrictKnowledgeRecallArtifactModel):
+    suite: Literal["knowledge-recall"]
+    generated_at: str = Field(min_length=1)
+    live_database: bool
+    question_set: KnowledgeRecallArtifactQuestionSet
+
+
+class KnowledgeRecallLegacyValidArtifact(_KnowledgeRecallLegacyArtifact):
+    """Strict format emitted before corpus fingerprints were introduced."""
+
+    result_type: Literal["valid"]
+    configuration: KnowledgeRecallArtifactConfiguration
+    semantic_available: bool
+    semantic_degraded_reason: str | None
+    summary: KnowledgeRecallArtifactSummary
+    results: tuple[KnowledgeRecallArtifactCaseResult, ...]
+
+
+class KnowledgeRecallValidArtifact(KnowledgeRecallLegacyValidArtifact):
+    """Current valid evaluation artifact."""
+
+    schema_version: Literal[KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION]
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+
+
+class KnowledgeRecallLegacyInvalidArtifact(_KnowledgeRecallLegacyArtifact):
+    """Strict invalid format emitted before corpus fingerprints existed."""
+
+    result_type: Literal["invalid"]
+    configuration: KnowledgeRecallInvalidArtifactConfiguration
+    errors: tuple[KnowledgeRecallArtifactCaseError, ...]
+
+
+class KnowledgeRecallInvalidArtifact(KnowledgeRecallLegacyInvalidArtifact):
+    """Current invalid evaluation artifact."""
+
+    schema_version: Literal[KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION]
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+
+
+KnowledgeRecallValidArtifactContract = Union[
+    KnowledgeRecallValidArtifact,
+    KnowledgeRecallLegacyValidArtifact,
+]
+KnowledgeRecallArtifact = Union[
+    KnowledgeRecallValidArtifact,
+    KnowledgeRecallLegacyValidArtifact,
+    KnowledgeRecallInvalidArtifact,
+    KnowledgeRecallLegacyInvalidArtifact,
+]
+
+_ARTIFACT_ADAPTER = TypeAdapter(KnowledgeRecallArtifact)
+
+
+def parse_knowledge_recall_artifact_json(payload: str) -> KnowledgeRecallArtifact:
+    """Parse one JSON artifact through the canonical strict contract."""
+
+    return _ARTIFACT_ADAPTER.validate_json(payload)
+
+
+__all__ = [
+    "KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION",
+    "KnowledgeRecallArtifact",
+    "KnowledgeRecallArtifactCaseError",
+    "KnowledgeRecallArtifactCaseResult",
+    "KnowledgeRecallArtifactConfiguration",
+    "KnowledgeRecallArtifactEvidence",
+    "KnowledgeRecallArtifactQuestionSet",
+    "KnowledgeRecallArtifactRankedResult",
+    "KnowledgeRecallArtifactSummary",
+    "KnowledgeRecallCorpusFingerprint",
+    "KnowledgeRecallInvalidArtifact",
+    "KnowledgeRecallInvalidArtifactConfiguration",
+    "KnowledgeRecallLegacyInvalidArtifact",
+    "KnowledgeRecallLegacyValidArtifact",
+    "KnowledgeRecallValidArtifact",
+    "KnowledgeRecallValidArtifactContract",
+    "parse_knowledge_recall_artifact_json",
+]

--- a/brain/systems/knowledge/search.py
+++ b/brain/systems/knowledge/search.py
@@ -138,7 +138,7 @@ def reciprocal_rank_fusion(
     return ordered, debug
 
 
-def _item_filters(
+def knowledge_item_filters(
     *,
     org_id: str,
     sources: Sequence[str] | None,
@@ -371,7 +371,7 @@ async def search_knowledge(
     max_results = normalize_knowledge_search_limit(limit)
     channel_limit = min(200, max(20, max_results * 4))
     clean_org_id = str(org_id or "").strip()
-    filters = _item_filters(
+    filters = knowledge_item_filters(
         org_id=clean_org_id,
         sources=sources,
         kinds=kinds,
@@ -435,6 +435,7 @@ __all__ = [
     "RECENCY_WEIGHT",
     "RRF_K",
     "SEMANTIC_WEIGHT",
+    "knowledge_item_filters",
     "reciprocal_rank_fusion",
     "search_knowledge",
 ]

--- a/tests/test_knowledge_recall_eval.py
+++ b/tests/test_knowledge_recall_eval.py
@@ -11,6 +11,8 @@ from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.knowledge import KnowledgeItem
 from brain.systems.knowledge.recall_eval import (
     EvidencePointer,
+    KnowledgeRecallCaseError,
+    KnowledgeRecallCaseResult,
     KnowledgeRecallCorpusFingerprint,
     KnowledgeRecallInvalidResult,
     KnowledgeRecallQuestion,
@@ -19,6 +21,10 @@ from brain.systems.knowledge.recall_eval import (
     build_knowledge_recall_corpus_fingerprint,
     load_knowledge_recall_question_set,
     run_knowledge_recall_eval,
+)
+from brain.systems.knowledge.recall_eval_contract import (
+    KnowledgeRecallArtifact,
+    parse_knowledge_recall_artifact_json,
 )
 from brain.systems.knowledge.recall_eval_harvester import (
     harvest_knowledge_recall_candidates,
@@ -35,6 +41,28 @@ from brain.systems.knowledge.search_contract import (
 
 _ORG_ID = "11111111-1111-4111-8111-111111111111"
 _FIXED_TIME = "2026-07-30T12:00:00+00:00"
+
+
+def _corpus_fingerprint(
+    *,
+    fingerprint: str = "0" * 64,
+    total_item_count: int = 2,
+    source_counts: dict[str, int] | None = None,
+    newest_source_updated_at: str | None = "2026-07-30T12:00:00+00:00",
+    newest_ingested_at: str | None = "2026-07-30T12:05:00+00:00",
+) -> KnowledgeRecallCorpusFingerprint:
+    counts = (
+        source_counts
+        if source_counts is not None
+        else ({"github": total_item_count} if total_item_count else {})
+    )
+    return KnowledgeRecallCorpusFingerprint(
+        total_item_count=total_item_count,
+        source_counts=counts,
+        newest_source_updated_at=newest_source_updated_at,
+        newest_ingested_at=newest_ingested_at,
+        fingerprint=fingerprint,
+    )
 
 
 def _item(item_id: int, source_ref: str, title: str) -> KnowledgeItem:
@@ -186,12 +214,14 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
     payload = report.to_dict()
 
     assert payload["result_type"] == "valid"
-    assert payload["corpus_fingerprint"] == KnowledgeRecallCorpusFingerprint(
+    assert payload["schema_version"] == 1
+    assert payload["corpus_fingerprint"] == _corpus_fingerprint(
+        fingerprint=payload["corpus_fingerprint"]["fingerprint"],
         total_item_count=0,
-        source_counts=(),
         newest_source_updated_at=None,
         newest_ingested_at=None,
-    ).to_dict()
+    ).model_dump(mode="json")
+    assert len(payload["corpus_fingerprint"]["fingerprint"]) == 64
     assert payload["summary"] == {
         "total": 3,
         "missed": 1,
@@ -293,12 +323,12 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss(
     payload = report.to_dict()
 
     assert payload["result_type"] == "invalid"
-    assert payload["corpus_fingerprint"] == KnowledgeRecallCorpusFingerprint(
+    assert payload["corpus_fingerprint"] == _corpus_fingerprint(
+        fingerprint=payload["corpus_fingerprint"]["fingerprint"],
         total_item_count=0,
-        source_counts=(),
         newest_source_updated_at=None,
         newest_ingested_at=None,
-    ).to_dict()
+    ).model_dump(mode="json")
     assert "summary" not in payload
     assert "results" not in payload
     assert payload["errors"][0]["case_id"] == "rank-one"
@@ -483,69 +513,87 @@ def test_cli_emits_invalid_result_and_returns_nonzero(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out) == invalid_payload
 
 
-def _comparison_artifact(
+def _comparison_report(
     *,
     corpus_fingerprint: KnowledgeRecallCorpusFingerprint,
-    digest: str = "question-set-digest",
+    question_set_marker: str = "same-question-set",
     org_id: str = _ORG_ID,
     k_values: tuple[int, ...] = (3, 10),
+    requested_search_limit: int = 50,
     effective_search_limit: int = 50,
     ranks: tuple[int | None, ...] = (1, 4),
-    recall_at_k: tuple[float, ...] = (0.5, 1.0),
-    mean_reciprocal_rank: float = 0.625,
-) -> dict:
-    return {
-        "result_type": "valid",
-        "suite": "knowledge-recall",
-        "generated_at": _FIXED_TIME,
-        "question_set": {"digest": digest},
-        "configuration": {
-            "org_id": org_id,
-            "k_values": list(k_values),
-            "requested_search_limit": effective_search_limit,
-            "effective_search_limit": effective_search_limit,
-        },
-        "corpus_fingerprint": corpus_fingerprint.to_dict(),
-        "summary": {
-            "recall_at_k": {
-                str(k): value for k, value in zip(k_values, recall_at_k, strict=True)
+) -> KnowledgeRecallSuiteResult:
+    questions = tuple(
+        KnowledgeRecallQuestion(
+            case_id=f"case-{index}",
+            question=f"Question {index}?",
+            acceptable_evidence=(
+                EvidencePointer("github", f"github:example/repo#{index}"),
+            ),
+        )
+        for index in range(1, len(ranks) + 1)
+    )
+    results = tuple(
+        KnowledgeRecallCaseResult(
+            case_id=question.case_id,
+            question=question.question,
+            acceptable_evidence=question.acceptable_evidence,
+            origin={},
+            best_evidence_rank=rank,
+            reciprocal_rank=round(1.0 / rank, 8) if rank is not None else 0.0,
+            hits_at_k={
+                k: rank is not None and rank <= k for k in k_values
             },
-            "mean_reciprocal_rank": mean_reciprocal_rank,
-        },
-        "results": [
-            {
-                "case_id": f"case-{index}",
-                "best_evidence_rank": rank,
-            }
-            for index, rank in enumerate(ranks, start=1)
-        ],
-    }
+            semantic_available=True,
+            semantic_degraded_reason=None,
+            ranked_results=(),
+        )
+        for question, rank in zip(questions, ranks, strict=True)
+    )
+    return KnowledgeRecallSuiteResult(
+        suite="knowledge-recall",
+        generated_at=_FIXED_TIME,
+        live_database=True,
+        org_id=org_id,
+        question_set=KnowledgeRecallQuestionSet(
+            question_set_id="comparison-fixture",
+            version="1",
+            description=question_set_marker,
+            cases=questions,
+        ),
+        k_values=k_values,
+        requested_search_limit=requested_search_limit,
+        effective_search_limit=effective_search_limit,
+        corpus_fingerprint=corpus_fingerprint,
+        results=results,
+    )
 
 
-def _write_artifact(path, payload: dict) -> None:
-    path.write_text(json.dumps(payload), encoding="utf-8")
+def _legacy_artifact(report: KnowledgeRecallSuiteResult) -> KnowledgeRecallArtifact:
+    payload = report.to_dict()
+    payload.pop("schema_version")
+    payload.pop("corpus_fingerprint")
+    return parse_knowledge_recall_artifact_json(json.dumps(payload))
+
+
+def _write_artifact(path, artifact) -> None:
+    contract = artifact.to_artifact() if hasattr(artifact, "to_artifact") else artifact
+    path.write_text(contract.model_dump_json(indent=2), encoding="utf-8")
 
 
 def test_compare_labels_same_corpus_metric_change_as_ranking_attributable(
     tmp_path,
     capsys,
 ):
-    corpus = KnowledgeRecallCorpusFingerprint(
-        total_item_count=2,
-        source_counts=(("github", 2),),
-        newest_source_updated_at="2026-07-30T12:00:00+00:00",
-        newest_ingested_at="2026-07-30T12:05:00+00:00",
-    )
+    corpus = _corpus_fingerprint()
     baseline_path = tmp_path / "baseline.json"
     candidate_path = tmp_path / "candidate.json"
-    _write_artifact(baseline_path, _comparison_artifact(corpus_fingerprint=corpus))
+    _write_artifact(baseline_path, _comparison_report(corpus_fingerprint=corpus))
     _write_artifact(
         candidate_path,
-        _comparison_artifact(
+        _comparison_report(
             corpus_fingerprint=corpus,
             ranks=(4, 2),
-            recall_at_k=(0.5, 1.0),
-            mean_reciprocal_rank=0.375,
         ),
     )
 
@@ -563,6 +611,7 @@ def test_compare_labels_same_corpus_metric_change_as_ranking_attributable(
     assert exit_code == 0
     assert payload["comparability"]["verdict"] == "ranking-attributable"
     assert payload["comparability"]["differences"] == []
+    assert payload["comparability"]["checks"]["corpus_fingerprint"]["state"] == "match"
     assert payload["case_rank_deltas"][0]["best_evidence_rank"] == {
         "baseline": 1,
         "candidate": 4,
@@ -572,16 +621,12 @@ def test_compare_labels_same_corpus_metric_change_as_ranking_attributable(
     assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.25
 
 
-def test_compare_labels_changed_corpus_and_names_changed_fields(tmp_path, capsys):
-    baseline_corpus = KnowledgeRecallCorpusFingerprint(
-        total_item_count=2,
-        source_counts=(("github", 2),),
-        newest_source_updated_at="2026-07-30T12:00:00+00:00",
-        newest_ingested_at="2026-07-30T12:05:00+00:00",
-    )
-    candidate_corpus = KnowledgeRecallCorpusFingerprint(
+def test_compare_reports_changed_corpus_without_claiming_causation(tmp_path, capsys):
+    baseline_corpus = _corpus_fingerprint()
+    candidate_corpus = _corpus_fingerprint(
+        fingerprint="1" * 64,
         total_item_count=3,
-        source_counts=(("github", 2), ("slack", 1)),
+        source_counts={"github": 2, "slack": 1},
         newest_source_updated_at="2026-07-30T12:00:00+00:00",
         newest_ingested_at="2026-07-31T09:00:00+00:00",
     )
@@ -589,15 +634,13 @@ def test_compare_labels_changed_corpus_and_names_changed_fields(tmp_path, capsys
     candidate_path = tmp_path / "candidate.json"
     _write_artifact(
         baseline_path,
-        _comparison_artifact(corpus_fingerprint=baseline_corpus),
+        _comparison_report(corpus_fingerprint=baseline_corpus),
     )
     _write_artifact(
         candidate_path,
-        _comparison_artifact(
+        _comparison_report(
             corpus_fingerprint=candidate_corpus,
             ranks=(2, 6),
-            recall_at_k=(0.5, 1.0),
-            mean_reciprocal_rank=0.33333333,
         ),
     )
 
@@ -612,34 +655,64 @@ def test_compare_labels_changed_corpus_and_names_changed_fields(tmp_path, capsys
     )
     payload = json.loads(capsys.readouterr().out)
 
-    assert exit_code == 0
+    assert exit_code == 1
     comparability = payload["comparability"]
-    assert comparability["verdict"] == "corpus-attributable"
+    assert comparability["verdict"] == "corpus-changed"
     assert comparability["differences"] == ["corpus_fingerprint"]
+    assert comparability["checks"]["corpus_fingerprint"]["state"] == "different"
+    assert "may combine corpus and code movement" in comparability["reason"]
     assert set(comparability["corpus_changed_fields"]) == {
         "total_item_count",
         "source_counts",
         "newest_ingested_at",
         "fingerprint",
     }
-    assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.29166667
+    assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.29166666
 
 
-def test_compare_refuses_question_set_digest_mismatch(tmp_path, capsys):
-    corpus = KnowledgeRecallCorpusFingerprint(
-        total_item_count=0,
-        source_counts=(),
-        newest_source_updated_at=None,
-        newest_ingested_at=None,
+def test_compare_uses_digest_not_diagnostics_for_corpus_match(tmp_path, capsys):
+    baseline_corpus = _corpus_fingerprint()
+    candidate_corpus = _corpus_fingerprint(
+        newest_ingested_at="2026-07-31T09:00:00+00:00",
     )
     baseline_path = tmp_path / "baseline.json"
     candidate_path = tmp_path / "candidate.json"
-    _write_artifact(baseline_path, _comparison_artifact(corpus_fingerprint=corpus))
+    _write_artifact(
+        baseline_path,
+        _comparison_report(corpus_fingerprint=baseline_corpus),
+    )
     _write_artifact(
         candidate_path,
-        _comparison_artifact(
+        _comparison_report(corpus_fingerprint=candidate_corpus),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["comparability"]["verdict"] == "ranking-attributable"
+    assert payload["comparability"]["checks"]["corpus_fingerprint"]["state"] == "match"
+    assert payload["comparability"]["corpus_changed_fields"] == {}
+
+
+def test_compare_refuses_question_set_digest_mismatch(tmp_path, capsys):
+    corpus = _corpus_fingerprint()
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(baseline_path, _comparison_report(corpus_fingerprint=corpus))
+    _write_artifact(
+        candidate_path,
+        _comparison_report(
             corpus_fingerprint=corpus,
-            digest="different-question-set-digest",
+            question_set_marker="different-question-set",
         ),
     )
 
@@ -661,24 +734,169 @@ def test_compare_refuses_question_set_digest_mismatch(tmp_path, capsys):
     assert "case_rank_deltas" not in payload
 
 
-def test_compare_refuses_invalid_artifact(tmp_path, capsys):
-    corpus = KnowledgeRecallCorpusFingerprint(
-        total_item_count=0,
-        source_counts=(),
-        newest_source_updated_at=None,
-        newest_ingested_at=None,
+@pytest.mark.parametrize(
+    ("candidate_configuration", "different_fields"),
+    [
+        ({"k_values": (3,)}, ["k_values"]),
+        ({"effective_search_limit": 25}, ["effective_search_limit"]),
+        (
+            {"requested_search_limit": 25, "effective_search_limit": 25},
+            ["requested_search_limit", "effective_search_limit"],
+        ),
+    ],
+)
+def test_compare_refuses_measurement_configuration_mismatch(
+    tmp_path,
+    capsys,
+    candidate_configuration,
+    different_fields,
+):
+    corpus = _corpus_fingerprint()
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(baseline_path, _comparison_report(corpus_fingerprint=corpus))
+    _write_artifact(
+        candidate_path,
+        _comparison_report(
+            corpus_fingerprint=corpus,
+            **candidate_configuration,
+        ),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["comparability"]["verdict"] == "not-comparable"
+    assert payload["comparability"]["differences"] == different_fields
+    assert all(
+        field in payload["comparability"]["reason"] for field in different_fields
+    )
+    assert "metric_deltas" not in payload
+    assert "case_rank_deltas" not in payload
+
+
+def test_compare_emits_deltas_without_attribution_when_corpus_is_unknown(
+    tmp_path,
+    capsys,
+):
+    corpus = _corpus_fingerprint()
+    baseline = _legacy_artifact(
+        _comparison_report(
+            corpus_fingerprint=corpus,
+            ranks=(1, 1, None),
+        )
+    )
+    candidate = _legacy_artifact(
+        _comparison_report(
+            corpus_fingerprint=corpus,
+            ranks=(4, 6, 2),
+        )
     )
     baseline_path = tmp_path / "baseline.json"
     candidate_path = tmp_path / "candidate.json"
-    invalid_baseline = _comparison_artifact(corpus_fingerprint=corpus)
-    invalid_baseline["result_type"] = "invalid"
-    invalid_baseline.pop("summary")
-    invalid_baseline.pop("results")
-    invalid_baseline["errors"] = [
-        {"case_id": "case-1", "cause": "RuntimeError: search failed"}
+    _write_artifact(baseline_path, baseline)
+    _write_artifact(candidate_path, candidate)
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    comparability = payload["comparability"]
+    assert comparability["comparable"] is True
+    assert comparability["computed"] is True
+    assert comparability["verdict"] == "corpus-unknown"
+    assert comparability["differences"] == []
+    assert comparability["checks"]["corpus_fingerprint"] == {
+        "baseline": None,
+        "candidate": None,
+        "state": "unknown",
+    }
+    assert "no attribution is possible" in comparability["reason"]
+    assert [
+        delta["best_evidence_rank"] for delta in payload["case_rank_deltas"]
+    ] == [
+        {"baseline": 1, "candidate": 4, "delta": 3, "change": "rank-changed"},
+        {"baseline": 1, "candidate": 6, "delta": 5, "change": "rank-changed"},
+        {"baseline": None, "candidate": 2, "delta": None, "change": "miss-to-hit"},
     ]
+    assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.36111111
+
+
+def test_compare_rejects_a_renamed_producer_field_instead_of_scoring_a_miss(
+    tmp_path,
+    capsys,
+):
+    corpus = _corpus_fingerprint()
+    malformed = _comparison_report(corpus_fingerprint=corpus).to_dict()
+    rank = malformed["results"][0].pop("best_evidence_rank")
+    malformed["results"][0]["renamed_best_evidence_rank"] = rank
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    baseline_path.write_text(json.dumps(malformed), encoding="utf-8")
+    _write_artifact(
+        candidate_path,
+        _comparison_report(corpus_fingerprint=corpus),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "best_evidence_rank" in captured.err
+    assert "Field required" in captured.err
+    assert "renamed_best_evidence_rank" in captured.err
+    assert "Extra inputs are not permitted" in captured.err
+
+
+def test_compare_refuses_invalid_artifact(tmp_path, capsys):
+    corpus = _corpus_fingerprint()
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    question_set = _question_set()
+    invalid_baseline = KnowledgeRecallInvalidResult(
+        suite="knowledge-recall",
+        generated_at=_FIXED_TIME,
+        live_database=True,
+        org_id=_ORG_ID,
+        question_set=question_set,
+        k_values=(3, 10),
+        requested_search_limit=50,
+        corpus_fingerprint=corpus,
+        errors=(
+            KnowledgeRecallCaseError(
+                case_id=question_set.cases[0].case_id,
+                cause="RuntimeError: search failed",
+            ),
+        ),
+    )
     _write_artifact(baseline_path, invalid_baseline)
-    _write_artifact(candidate_path, _comparison_artifact(corpus_fingerprint=corpus))
+    _write_artifact(candidate_path, _comparison_report(corpus_fingerprint=corpus))
 
     exit_code = knowledge_recall_cli.main(
         [
@@ -791,13 +1009,43 @@ async def test_corpus_fingerprint_uses_the_same_visible_rows_as_search(
     )
 
     assert {result["id"] for result in response["results"]} == {1, 2}
-    assert fingerprint.to_dict() == {
+    assert fingerprint.model_dump(mode="json") == {
         "total_item_count": 2,
         "source_counts": {"github": 1, "slack": 1},
         "newest_source_updated_at": "2026-07-30T13:00:00+00:00",
         "newest_ingested_at": "2026-07-30T14:00:00+00:00",
         "fingerprint": fingerprint.fingerprint,
     }
+    assert len(fingerprint.fingerprint) == 64
+
+
+async def test_corpus_fingerprint_changes_for_content_only_corpus_move(
+    knowledge_session,
+):
+    item = _item(1, "same-ref", "Original searchable content")
+    knowledge_session.add(item)
+    await knowledge_session.flush()
+
+    baseline = await build_knowledge_recall_corpus_fingerprint(
+        knowledge_session,
+        org_id=_ORG_ID,
+    )
+    item.content_digest = "redistilled-content-digest"
+    item.search_text = "Replacement searchable content"
+    await knowledge_session.flush()
+    candidate = await build_knowledge_recall_corpus_fingerprint(
+        knowledge_session,
+        org_id=_ORG_ID,
+    )
+
+    assert candidate.total_item_count == baseline.total_item_count
+    assert candidate.source_counts == baseline.source_counts
+    assert (
+        candidate.newest_source_updated_at
+        == baseline.newest_source_updated_at
+    )
+    assert candidate.newest_ingested_at == baseline.newest_ingested_at
+    assert candidate.fingerprint != baseline.fingerprint
 
 
 async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_review(

--- a/tests/test_knowledge_recall_eval.py
+++ b/tests/test_knowledge_recall_eval.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
@@ -11,10 +11,12 @@ from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.knowledge import KnowledgeItem
 from brain.systems.knowledge.recall_eval import (
     EvidencePointer,
+    KnowledgeRecallCorpusFingerprint,
     KnowledgeRecallInvalidResult,
     KnowledgeRecallQuestion,
     KnowledgeRecallQuestionSet,
     KnowledgeRecallSuiteResult,
+    build_knowledge_recall_corpus_fingerprint,
     load_knowledge_recall_question_set,
     run_knowledge_recall_eval,
 )
@@ -25,6 +27,7 @@ from brain.systems.knowledge.search import (
     LEXICAL_WEIGHT,
     RECENCY_WEIGHT,
     SEMANTIC_WEIGHT,
+    search_knowledge,
 )
 from brain.systems.knowledge.search_contract import (
     KNOWLEDGE_SEARCH_MAX_RESULTS,
@@ -149,7 +152,9 @@ def _question_set() -> KnowledgeRecallQuestionSet:
     )
 
 
-async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denominator():
+async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denominator(
+    knowledge_session,
+):
     distractors = [
         _item(index + 10, f"github:Illospace/illospace#{index + 10}", f"Noise {index}")
         for index in range(5)
@@ -169,7 +174,7 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
         return _search_response(query, rows, requested_limit=limit)
 
     report = await run_knowledge_recall_eval(
-        object(),
+        knowledge_session,
         org_id=_ORG_ID,
         question_set=_question_set(),
         k_values=(1, 5),
@@ -181,6 +186,12 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
     payload = report.to_dict()
 
     assert payload["result_type"] == "valid"
+    assert payload["corpus_fingerprint"] == KnowledgeRecallCorpusFingerprint(
+        total_item_count=0,
+        source_counts=(),
+        newest_source_updated_at=None,
+        newest_ingested_at=None,
+    ).to_dict()
     assert payload["summary"] == {
         "total": 3,
         "missed": 1,
@@ -199,7 +210,9 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
     assert missed["hits_at_k"] == {"1": False, "5": False}
 
 
-async def test_report_preserves_channel_attribution_and_marks_semantic_degradation():
+async def test_report_preserves_channel_attribution_and_marks_semantic_degradation(
+    knowledge_session,
+):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def degraded_search(_session, query, *, org_id, limit):
@@ -221,7 +234,7 @@ async def test_report_preserves_channel_attribution_and_marks_semantic_degradati
     )
     payload = (
         await run_knowledge_recall_eval(
-            object(),
+            knowledge_session,
             org_id=_ORG_ID,
             question_set=single_case,
             search=degraded_search,
@@ -248,7 +261,9 @@ async def test_report_preserves_channel_attribution_and_marks_semantic_degradati
     }
 
 
-async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss():
+async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss(
+    knowledge_session,
+):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def malformed_search(_session, query, *, org_id, limit):
@@ -266,7 +281,7 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss():
         cases=(_question_set().cases[0],),
     )
     report = await run_knowledge_recall_eval(
-        object(),
+        knowledge_session,
         org_id=_ORG_ID,
         question_set=single_case,
         k_values=(1,),
@@ -278,6 +293,12 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss():
     payload = report.to_dict()
 
     assert payload["result_type"] == "invalid"
+    assert payload["corpus_fingerprint"] == KnowledgeRecallCorpusFingerprint(
+        total_item_count=0,
+        source_counts=(),
+        newest_source_updated_at=None,
+        newest_ingested_at=None,
+    ).to_dict()
     assert "summary" not in payload
     assert "results" not in payload
     assert payload["errors"][0]["case_id"] == "rank-one"
@@ -285,7 +306,9 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss():
     assert "renamed_source_ref" in payload["errors"][0]["cause"]
 
 
-async def test_one_search_failure_invalidates_the_whole_question_set():
+async def test_one_search_failure_invalidates_the_whole_question_set(
+    knowledge_session,
+):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def partly_failing_search(_session, query, *, org_id, limit):
@@ -295,7 +318,7 @@ async def test_one_search_failure_invalidates_the_whole_question_set():
         return _search_response(query, [evidence], requested_limit=limit)
 
     report = await run_knowledge_recall_eval(
-        object(),
+        knowledge_session,
         org_id=_ORG_ID,
         question_set=_question_set(),
         k_values=(1,),
@@ -316,7 +339,9 @@ async def test_one_search_failure_invalidates_the_whole_question_set():
     ]
 
 
-async def test_eval_rejects_effective_depth_that_cannot_support_requested_k():
+async def test_eval_rejects_effective_depth_that_cannot_support_requested_k(
+    knowledge_session,
+):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def shallow_search(_session, query, *, org_id, limit):
@@ -335,7 +360,7 @@ async def test_eval_rejects_effective_depth_that_cannot_support_requested_k():
         cases=(_question_set().cases[0],),
     )
     report = await run_knowledge_recall_eval(
-        object(),
+        knowledge_session,
         org_id=_ORG_ID,
         question_set=single_case,
         k_values=(3,),
@@ -356,7 +381,9 @@ async def test_eval_rejects_effective_depth_that_cannot_support_requested_k():
     ]
 
 
-async def test_inconsistent_effective_depths_return_one_invalid_result():
+async def test_inconsistent_effective_depths_return_one_invalid_result(
+    knowledge_session,
+):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
     cases = _question_set().cases[:2]
 
@@ -371,7 +398,7 @@ async def test_inconsistent_effective_depths_return_one_invalid_result():
         )
 
     report = await run_knowledge_recall_eval(
-        object(),
+        knowledge_session,
         org_id=_ORG_ID,
         question_set=KnowledgeRecallQuestionSet(
             question_set_id="inconsistent-depth",
@@ -398,7 +425,7 @@ async def test_inconsistent_effective_depths_return_one_invalid_result():
     )
 
 
-async def test_mrr_cutoff_uses_effective_retrieval_depth():
+async def test_mrr_cutoff_uses_effective_retrieval_depth(knowledge_session):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def shallower_search(_session, query, *, org_id, limit):
@@ -418,7 +445,7 @@ async def test_mrr_cutoff_uses_effective_retrieval_depth():
     )
     payload = (
         await run_knowledge_recall_eval(
-            object(),
+            knowledge_session,
             org_id=_ORG_ID,
             question_set=single_case,
             k_values=(3,),
@@ -454,6 +481,221 @@ def test_cli_emits_invalid_result_and_returns_nonzero(monkeypatch, capsys):
 
     assert exit_code == 1
     assert json.loads(capsys.readouterr().out) == invalid_payload
+
+
+def _comparison_artifact(
+    *,
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint,
+    digest: str = "question-set-digest",
+    org_id: str = _ORG_ID,
+    k_values: tuple[int, ...] = (3, 10),
+    effective_search_limit: int = 50,
+    ranks: tuple[int | None, ...] = (1, 4),
+    recall_at_k: tuple[float, ...] = (0.5, 1.0),
+    mean_reciprocal_rank: float = 0.625,
+) -> dict:
+    return {
+        "result_type": "valid",
+        "suite": "knowledge-recall",
+        "generated_at": _FIXED_TIME,
+        "question_set": {"digest": digest},
+        "configuration": {
+            "org_id": org_id,
+            "k_values": list(k_values),
+            "requested_search_limit": effective_search_limit,
+            "effective_search_limit": effective_search_limit,
+        },
+        "corpus_fingerprint": corpus_fingerprint.to_dict(),
+        "summary": {
+            "recall_at_k": {
+                str(k): value for k, value in zip(k_values, recall_at_k, strict=True)
+            },
+            "mean_reciprocal_rank": mean_reciprocal_rank,
+        },
+        "results": [
+            {
+                "case_id": f"case-{index}",
+                "best_evidence_rank": rank,
+            }
+            for index, rank in enumerate(ranks, start=1)
+        ],
+    }
+
+
+def _write_artifact(path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_compare_labels_same_corpus_metric_change_as_ranking_attributable(
+    tmp_path,
+    capsys,
+):
+    corpus = KnowledgeRecallCorpusFingerprint(
+        total_item_count=2,
+        source_counts=(("github", 2),),
+        newest_source_updated_at="2026-07-30T12:00:00+00:00",
+        newest_ingested_at="2026-07-30T12:05:00+00:00",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(baseline_path, _comparison_artifact(corpus_fingerprint=corpus))
+    _write_artifact(
+        candidate_path,
+        _comparison_artifact(
+            corpus_fingerprint=corpus,
+            ranks=(4, 2),
+            recall_at_k=(0.5, 1.0),
+            mean_reciprocal_rank=0.375,
+        ),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["comparability"]["verdict"] == "ranking-attributable"
+    assert payload["comparability"]["differences"] == []
+    assert payload["case_rank_deltas"][0]["best_evidence_rank"] == {
+        "baseline": 1,
+        "candidate": 4,
+        "delta": 3,
+        "change": "rank-changed",
+    }
+    assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.25
+
+
+def test_compare_labels_changed_corpus_and_names_changed_fields(tmp_path, capsys):
+    baseline_corpus = KnowledgeRecallCorpusFingerprint(
+        total_item_count=2,
+        source_counts=(("github", 2),),
+        newest_source_updated_at="2026-07-30T12:00:00+00:00",
+        newest_ingested_at="2026-07-30T12:05:00+00:00",
+    )
+    candidate_corpus = KnowledgeRecallCorpusFingerprint(
+        total_item_count=3,
+        source_counts=(("github", 2), ("slack", 1)),
+        newest_source_updated_at="2026-07-30T12:00:00+00:00",
+        newest_ingested_at="2026-07-31T09:00:00+00:00",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(
+        baseline_path,
+        _comparison_artifact(corpus_fingerprint=baseline_corpus),
+    )
+    _write_artifact(
+        candidate_path,
+        _comparison_artifact(
+            corpus_fingerprint=candidate_corpus,
+            ranks=(2, 6),
+            recall_at_k=(0.5, 1.0),
+            mean_reciprocal_rank=0.33333333,
+        ),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    comparability = payload["comparability"]
+    assert comparability["verdict"] == "corpus-attributable"
+    assert comparability["differences"] == ["corpus_fingerprint"]
+    assert set(comparability["corpus_changed_fields"]) == {
+        "total_item_count",
+        "source_counts",
+        "newest_ingested_at",
+        "fingerprint",
+    }
+    assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.29166667
+
+
+def test_compare_refuses_question_set_digest_mismatch(tmp_path, capsys):
+    corpus = KnowledgeRecallCorpusFingerprint(
+        total_item_count=0,
+        source_counts=(),
+        newest_source_updated_at=None,
+        newest_ingested_at=None,
+    )
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(baseline_path, _comparison_artifact(corpus_fingerprint=corpus))
+    _write_artifact(
+        candidate_path,
+        _comparison_artifact(
+            corpus_fingerprint=corpus,
+            digest="different-question-set-digest",
+        ),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["comparability"]["verdict"] == "not-comparable"
+    assert payload["comparability"]["differences"] == ["question_set_digest"]
+    assert "metric_deltas" not in payload
+    assert "case_rank_deltas" not in payload
+
+
+def test_compare_refuses_invalid_artifact(tmp_path, capsys):
+    corpus = KnowledgeRecallCorpusFingerprint(
+        total_item_count=0,
+        source_counts=(),
+        newest_source_updated_at=None,
+        newest_ingested_at=None,
+    )
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    invalid_baseline = _comparison_artifact(corpus_fingerprint=corpus)
+    invalid_baseline["result_type"] = "invalid"
+    invalid_baseline.pop("summary")
+    invalid_baseline.pop("results")
+    invalid_baseline["errors"] = [
+        {"case_id": "case-1", "cause": "RuntimeError: search failed"}
+    ]
+    _write_artifact(baseline_path, invalid_baseline)
+    _write_artifact(candidate_path, _comparison_artifact(corpus_fingerprint=corpus))
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["comparability"]["verdict"] == "invalid-artifact"
+    assert "baseline artifact is invalid" in payload["comparability"]["reason"]
+    assert "metric_deltas" not in payload
+    assert "case_rank_deltas" not in payload
 
 
 def test_question_set_is_data_backed_versioned_and_supports_multiple_evidence():
@@ -494,7 +736,7 @@ def test_question_set_rejects_a_case_without_known_best_evidence(tmp_path):
 
 
 @pytest.fixture
-async def harvest_session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+async def knowledge_session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
     del sqlite_postgres_ddl_patch
     SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "VARCHAR(36)"
     return await async_sqlite_session_factory(
@@ -505,8 +747,61 @@ async def harvest_session(async_sqlite_session_factory, sqlite_postgres_ddl_patc
     )
 
 
+async def test_corpus_fingerprint_uses_the_same_visible_rows_as_search(
+    knowledge_session,
+    monkeypatch,
+):
+    now = datetime(2026, 7, 30, 12, tzinfo=timezone.utc)
+    visible_github = _item(1, "visible-github", "Shared corpus token one")
+    visible_slack = _item(2, "visible-slack", "Shared corpus token two")
+    visible_slack.source = "slack"
+    visible_slack.source_updated_at = now + timedelta(hours=1)
+    visible_slack.ingested_at = now + timedelta(hours=2)
+
+    archived = _item(3, "archived", "Shared corpus token archived")
+    archived.archived_at = now + timedelta(days=1)
+    archived.source_updated_at = now + timedelta(days=10)
+    archived.ingested_at = now + timedelta(days=10)
+
+    other_org = _item(4, "other-org", "Shared corpus token other org")
+    other_org.extra = {"org_id": "22222222-2222-4222-8222-222222222222"}
+    other_org.source_updated_at = now + timedelta(days=20)
+    other_org.ingested_at = now + timedelta(days=20)
+    knowledge_session.add_all(
+        [visible_github, visible_slack, archived, other_org]
+    )
+    await knowledge_session.flush()
+
+    async def no_semantic_channel(*_args, **_kwargs):
+        return [], {}, "semantic disabled for visibility test"
+
+    monkeypatch.setattr(
+        "brain.systems.knowledge.search._semantic_channel",
+        no_semantic_channel,
+    )
+    fingerprint = await build_knowledge_recall_corpus_fingerprint(
+        knowledge_session,
+        org_id=_ORG_ID,
+    )
+    response = await search_knowledge(
+        knowledge_session,
+        "shared corpus token",
+        org_id=_ORG_ID,
+        limit=10,
+    )
+
+    assert {result["id"] for result in response["results"]} == {1, 2}
+    assert fingerprint.to_dict() == {
+        "total_item_count": 2,
+        "source_counts": {"github": 1, "slack": 1},
+        "newest_source_updated_at": "2026-07-30T13:00:00+00:00",
+        "newest_ingested_at": "2026-07-30T14:00:00+00:00",
+        "fingerprint": fingerprint.fingerprint,
+    }
+
+
 async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_review(
-    harvest_session,
+    knowledge_session,
 ):
     issue = _item(586, "github:Illospace/illospace#586", "Mirror the produced kind")
     issue.extra = {
@@ -523,8 +818,8 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
         ],
     }
     issue.resolution = "Resolved by merged PR Illospace/illospace#607"
-    harvest_session.add(issue)
-    harvest_session.add(
+    knowledge_session.add(issue)
+    knowledge_session.add(
         AgentRunRow(
             id=44,
             org_id=_ORG_ID,
@@ -539,11 +834,11 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
             metadata_={},
         )
     )
-    await harvest_session.flush()
+    await knowledge_session.flush()
 
     payload = (
         await harvest_knowledge_recall_candidates(
-            harvest_session,
+            knowledge_session,
             org_id=_ORG_ID,
             limit_per_source=5,
             generated_at=_FIXED_TIME,
@@ -581,10 +876,10 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
 
 
 async def test_harvester_caps_run_candidates_independently(
-    harvest_session,
+    knowledge_session,
 ):
     for run_id in range(1, 4):
-        harvest_session.add(
+        knowledge_session.add(
             AgentRunRow(
                 id=run_id,
                 org_id=_ORG_ID,
@@ -599,11 +894,11 @@ async def test_harvester_caps_run_candidates_independently(
                 metadata_={},
             )
         )
-    await harvest_session.flush()
+    await knowledge_session.flush()
 
     payload = (
         await harvest_knowledge_recall_candidates(
-            harvest_session,
+            knowledge_session,
             org_id=_ORG_ID,
             limit_per_source=2,
             generated_at=_FIXED_TIME,


### PR DESCRIPTION
> *This was generated by AI during an autonomous routine run (R3).*

Part of #578 (knowledge slice 3, **item 1 only**). Does **not** touch item 2 (R2 retarget) or item 3 (the memory strangler swap).

## Why

Item 1's definition of done is *"a repeatable score against the north star that can be re-run after any connector change."* It was not repeatable. Two live runs against the same org, with **identical code and an identical question-set digest**, disagreed:

| run | recall@3 | recall@10 | MRR | missed |
|---|---|---|---|---|
| 2026-07-31 13:00Z | 0.80 | 0.80 | 0.80 | 1 |
| 2026-08-01 15:39Z | **0.60** | **1.00** | **0.58** | 0 |

Nothing in the code changed. The corpus did: new documents on the same topics outranked the pinned best-evidence refs. The artifact recorded **nothing at all about the corpus**, so both times a human had to hand-run SQL against `knowledge_items` to work out why the number moved — and the metric moved in *both directions at once* from corpus drift alone.

That number is meant to gate a destructive change (deleting the duplicate memory recall path). A gate metric that cannot say *why* it moved cannot do that job. This PR makes it say why.

## What it does

1. **Corpus fingerprint on every eval artifact** (valid *and* invalid runs). A canonical SHA-256 over every retrievable row — `source`, `source_ref`, `content_digest`, recency — plus human-readable diagnostics (per-source counts, newest timestamps). It reuses `knowledge_item_filters`, the *same* predicate `search_knowledge` uses, so it counts exactly the rows search can see. There is one owner of that visibility rule, not two.
2. **A `compare` subcommand** that reads two artifacts off disk (no database, no org id) and reports per-case rank movement, metric deltas, and an explicit verdict: `ranking-attributable`, `corpus-changed`, `corpus-unknown`, or `not-comparable`.
3. **One strict versioned artifact contract** (`recall_eval_contract.py`, Pydantic `extra="forbid"`, frozen, strict) shared by the producer, the comparator and the tests.

## Review surface — run this, no database needed

```bash
python -m brain.app.cli.knowledge_recall compare \
  --baseline knowledge-recall-20260731T1300.json \
  --candidate knowledge-recall-20260801T1539.json
```

Against the two real artifacts above it now prints:

```
verdict:  corpus-unknown
reason:   Metric deltas were computed, but one or both artifacts have no corpus
          fingerprint. The corpus state is unknown, so no attribution is possible.
corpus_fingerprint: {"baseline": null, "candidate": null, "state": "unknown"}

  memory-mirror-produced-node-kind    1 -> 1     unchanged
  agent-run-zero-capacity-detection   1 -> 1     unchanged
  tool-event-transaction-boundary  miss -> 2     miss-to-hit
  agent-run-deadline-contract         1 -> 4     rank-changed
  sibling-agent-run-deadlock          1 -> 6     rank-changed

  recall@3  0.80 -> 0.60  (-0.20)   recall@10  0.80 -> 1.00  (+0.20)
  MRR       0.80 -> 0.58  (-0.22)
```

Exit code 1 — attribution is unavailable. That is the whole point: it shows you the movement, and refuses to tell you a cause it cannot know.

## Acceptance checks

1. **It answers "why did the number move?"** Two runs with the same corpus digest → `ranking-attributable`. A changed digest → `corpus-changed`. It never claims the corpus *caused* the delta, only that the corpus is a confounder.
2. **A content-only corpus change is detected.** Re-distilling an item leaves row counts and max timestamps identical; the digest still changes, so a false `ranking-attributable` cannot be produced.
3. **Unknown is never reported as agreement.** Two artifacts with no fingerprint report `state: "unknown"`, not `matches: true`.
4. **Producer drift fails loudly.** Rename a field in the artifact and `compare` raises `extra_forbidden` instead of silently scoring every case as a miss. Verified by hand against a mutated real artifact.

## Assumptions and what I deliberately did not do

- **The seed question set is untouched** (still 5 cases, digest `988b7a9f`). Whether to grow it is an open call for you — and editing it would change the digest and invalidate the two artifacts this work exists to compare.
- **No ranking change.** Weights, `RRF_K`, `reciprocal_rank_fusion`, the lexical/semantic/recency channels, `order_by` and `ordered_ids` diff **empty** against `main`. The only change in `search.py` is renaming `_item_filters` → `knowledge_item_filters` so the fingerprint can share it.
- **No schema change, no migration**, and `tests/fixtures/architecture-boundary-allowlist.json` is untouched.
- This does **not** make the 5-case score trustworthy enough to gate the memory deletion. It makes the score *legible*. Whether 5 cases is enough is still an open question — see the issue thread.

## Verification

- Full repo CI selection, run outside the agent sandbox: **4669 passed, 11 skipped, 82 deselected, 0 failed** (72s). Baseline on `main` measured the same way: 4662 passed.
- A thermo-nuclear maintainability review (Codex) returned **4 blocking findings** on the first implementation; all four, plus one I found, were fixed before this PR was opened. Notes: `state/evidence/578-thermo-review-20260803T1510.md`.
