### PR TITLE
fix(meetings): meetbot env passthrough + census updates stranded by the early #644 merge

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -26,6 +26,8 @@ x-illo-env: &illo-env
   EMBEDDING_API_MODEL: ${EMBEDDING_API_MODEL:-gemini-embedding-2}
   EMBEDDING_DIM: ${EMBEDDING_DIM:-768}
   WORKSPACE_ROOT: /workspaces
+  ILLO_MEETBOT_URL: ${ILLO_MEETBOT_URL:-}
+  ILLO_MEETBOT_TOKEN: ${ILLO_MEETBOT_TOKEN:-}
   ILLO_PRIVATE_HOME: /data/private
   JOURNAL_DIR: /data/private/journal
   AGENT_CONTEXT_DIR: /data/private/agent-context

--- a/tests/test_cycle_context_admission_gate.py
+++ b/tests/test_cycle_context_admission_gate.py
@@ -12,7 +12,7 @@ def test_enabled_cycle_fixture_gate_passes_with_healthy_catalog(monkeypatch):
     assert report["ok"] is True
     assert {item["cycle_id"] for item in report["results"]} == {2, 8, 9}
     assert all(item["status"] == "passed" for item in report["results"])
-    assert all(item["tools"] == 87 for item in report["results"])
+    assert all(item["tools"] == 91 for item in report["results"])
 
 
 def test_enabled_cycle_fixture_gate_names_cycles_killed_by_128k_regression(monkeypatch):
@@ -31,7 +31,7 @@ def test_enabled_cycle_fixture_gate_names_cycles_killed_by_128k_regression(monke
     assert all("floor=" in item["diagnostic"] for item in failures.values())
     assert "ceiling=50486" in failures[2]["diagnostic"]
     assert "ceiling=57859" in failures[9]["diagnostic"]
-    assert all("tools=87" in item["diagnostic"] for item in failures.values())
+    assert all("tools=91" in item["diagnostic"] for item in failures.values())
 
 
 def test_compose_upgrade_runs_live_cycle_gate_after_doctor():

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -309,12 +309,16 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
         "worker",
         "scheduler",
         "slack-connector",
+        "meetbot",
         "updater",
         "web",
     ]
-    slack_section = services_section.split("  slack-connector:", 1)[1].split("\n  updater:", 1)[0]
+    slack_section = services_section.split("  slack-connector:", 1)[1].split("\n  meetbot:", 1)[0]
     assert 'profiles: ["slack"]' in slack_section
     assert "\n    ports:" not in slack_section
+    meetbot_section = services_section.split("  meetbot:", 1)[1].split("\n  updater:", 1)[0]
+    assert 'profiles: ["meetbot"]' in meetbot_section
+    assert "\n    ports:" not in meetbot_section
     assert "127.0.0.1:${ILLO_WEB_PORT:-8080}:8080" in compose
     assert "ILLO_SELF_UPDATE_REQUEST_FILE" in compose
     assert "ILLO_SELF_UPDATE_HEARTBEAT_FILE" in compose


### PR DESCRIPTION
#644 was merged two minutes before these two commits landed on its branch:

- pass ILLO_MEETBOT_URL / ILLO_MEETBOT_TOKEN through the illo-env anchor (without this, join_meeting reports the service as unconfigured on every deploy)
- update the tool-count census (87 → 91) and add meetbot to the private-deploy compose census with the same profile+no-ports assertions as slack-connector — this is what turns main CI green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)