### PR TITLE
fix(meetings): start Xvfb via entrypoint script, not xvfb-run

### DIFF
--- a/deploy/docker/meetbot-entrypoint.sh
+++ b/deploy/docker/meetbot-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Start the virtual display ourselves instead of via xvfb-run: the xvfb-run
+# readiness handshake can hang forever without output, leaving the container
+# "up" with no server bound (observed on the first illo-dev deploy). Chromium
+# only needs DISPLAY to exist; uvicorn must own PID 1 semantics via exec.
+set -eu
+
+Xvfb :99 -screen 0 1280x720x24 -nolisten tcp &
+export DISPLAY=:99
+
+exec uvicorn meetbot.app:app --host 0.0.0.0 --port 8010

--- a/deploy/docker/meetbot.Dockerfile
+++ b/deploy/docker/meetbot.Dockerfile
@@ -22,6 +22,7 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
     && rm -rf /var/lib/apt/lists/*
 
 COPY meetbot ./meetbot
+COPY deploy/docker/meetbot-entrypoint.sh /usr/local/bin/meetbot-entrypoint.sh
 
 RUN useradd --create-home --uid 10001 illo \
     && mkdir -p /data/private/meetbot /app/brain/uploads \
@@ -31,5 +32,4 @@ USER illo
 
 EXPOSE 8010
 
-ENTRYPOINT ["xvfb-run", "-a", "--server-args=-screen 0 1280x720x24"]
-CMD ["uvicorn", "meetbot.app:app", "--host", "0.0.0.0", "--port", "8010"]
+ENTRYPOINT ["/usr/local/bin/meetbot-entrypoint.sh"]


### PR DESCRIPTION
xvfb-run's readiness handshake hung silently on the first deploy — Xvfb up, uvicorn never launched, container unhealthy with zero log output. Replace with an entrypoint script that starts Xvfb, exports DISPLAY, and execs uvicorn (the pattern Attendee/meet-teams-bot use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)