### PR TITLE
fix(meetings): transcript completions are not human asks + never fabricate Slack timestamps

### DIFF
--- a/brain/systems/meetings/inbound.py
+++ b/brain/systems/meetings/inbound.py
@@ -334,6 +334,7 @@ def _build_meeting_work_intake_payload(
     metadata = {
         "execution_profile": "fast",
         "origin": "meeting_transcript",
+        "obligation": "none",
         "inbound_event": {
             "event_id": str(event.id),
             "origin": normalized.get("origin"),
@@ -363,9 +364,7 @@ def _build_meeting_work_intake_payload(
     if slack_route:
         delivery_trigger = build_delivery_trigger(
             slack_route,
-            message_ts=str(
-                slack_route.thread_ts or f"meeting-{payload['session_id']}"
-            ),
+            message_ts=slack_route.thread_ts,
             slack_user_id=payload.get("requested_by"),
             text="Meetbot transcript completion",
             triggering_surface="meeting",

--- a/brain/systems/runs/open_asks.py
+++ b/brain/systems/runs/open_asks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import re
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -27,6 +29,10 @@ from brain.systems.runs.obligation_specs import (
 OPEN_ASK_STATUS = "open"
 ANSWERED_ASK_STATUS = "answered"
 OPEN_ASK_STRAGGLER_AFTER = timedelta(hours=1)
+SLACK_TIMESTAMP_MAX_LENGTH = 40
+_SLACK_TIMESTAMP = re.compile(r"^[0-9]+\.[0-9]+$")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +96,37 @@ def _slack_trigger_for_request(request: AgentRunRequest) -> dict[str, Any]:
     return {}
 
 
+def _normalize_open_ask_timestamp(value: Any, *, field: str) -> str | None:
+    timestamp = _clean(value)
+    if not timestamp:
+        return None
+    if (
+        len(timestamp) > SLACK_TIMESTAMP_MAX_LENGTH
+        or _SLACK_TIMESTAMP.fullmatch(timestamp) is None
+    ):
+        logger.warning(
+            "Ignoring invalid Slack %s for open-ask anchoring",
+            field,
+            extra={
+                "event": "invalid_open_ask_slack_timestamp",
+                "slack_timestamp_field": field,
+                "slack_timestamp_length": len(timestamp),
+            },
+        )
+        return None
+    return timestamp
+
+
+def _validated_open_ask_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
+    validated = dict(trigger)
+    for field in ("thread_ts", "message_ts"):
+        validated[field] = _normalize_open_ask_timestamp(
+            trigger.get(field),
+            field=field,
+        )
+    return validated
+
+
 def slack_origin_ref(trigger: dict[str, Any]) -> str | None:
     team_id = _clean(trigger.get("team_id"))
     channel_id = _clean(trigger.get("channel_id"))
@@ -117,14 +154,17 @@ def slack_thread_permalink(trigger: dict[str, Any]) -> str | None:
 def open_ask_context_for_request(request: AgentRunRequest) -> dict[str, Any] | None:
     target_ref, metadata = _request_maps(request)
     trigger = _slack_trigger_for_request(request)
+    if not trigger or _clean(metadata.get("obligation")).lower() == "none":
+        return None
     obligation_spec = obligation_spec_from_metadata(
         metadata.get("obligation_spec")
     )
-    if not trigger or (
+    if (
         obligation_spec is None
         and (metadata.get("slack_monitor") or target_ref.get("headless"))
     ):
         return None
+    trigger = _validated_open_ask_trigger(trigger)
     channel_id = _clean(trigger.get("channel_id"))
     thread_ts = _clean(trigger.get("thread_ts") or trigger.get("message_ts"))
     requester = metadata.get("obligation_requester")

--- a/brain/systems/runs/work_intake_slack.py
+++ b/brain/systems/runs/work_intake_slack.py
@@ -121,9 +121,11 @@ def _slack_thread_id(slack_trigger: dict[str, Any], target: dict[str, Any]) -> s
         or target.get("message_ts")
         or ""
     )
-    if not team_id or not channel_id or not message_ts:
-        raise ValueError("Slack run triggers require team_id, channel_id, and message timestamp")
-    return f"slack:{team_id}:{channel_id}:{message_ts}"
+    if not team_id or not channel_id:
+        raise ValueError("Slack run triggers require team_id and channel_id")
+    if message_ts:
+        return f"slack:{team_id}:{channel_id}:{message_ts}"
+    return f"slack:{team_id}:{channel_id}"
 
 
 __all__ = ["agent_run_request_for_slack"]

--- a/brain/systems/slack/delivery_routes.py
+++ b/brain/systems/slack/delivery_routes.py
@@ -94,7 +94,7 @@ async def resolve_delivery_route(
 def build_delivery_trigger(
     route: SlackDeliveryRoute,
     *,
-    message_ts: str,
+    message_ts: str | None,
     slack_user_id: str | None,
     text: str,
     triggering_surface: str,

--- a/tests/test_meeting_transcript_inbound.py
+++ b/tests/test_meeting_transcript_inbound.py
@@ -130,6 +130,7 @@ async def test_meeting_transcript_admits_same_thread_run_and_is_idempotent(
     assert first["ilo_outcome"]["routing"] == "slack_origin"
     assert second["idempotent_replay"] is True
     assert await session.scalar(select(func.count()).select_from(AgentRunRow)) == 1
+    assert await session.scalar(select(func.count()).select_from(OpenAsk)) == 0
     assert run.thread_id == "slack:T-team:C-meetings:1722700000.001"
     assert run.target_ref["slack_trigger"]["response_target"] == {
         "channel_id": "C-meetings",
@@ -142,6 +143,46 @@ async def test_meeting_transcript_admits_same_thread_run_and_is_idempotent(
     assert event.action_type == "meeting.run_admitted"
     assert receipt.tool_use["type"] == "meeting_transcript_intake"
     assert receipt.target["thread_ts"] == "1722700000.001"
+
+
+@pytest.mark.asyncio
+async def test_unthreaded_dm_meeting_admits_without_open_ask(
+    session,
+    tmp_path,
+    monkeypatch,
+):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.meetings import inbound as meeting_inbound
+
+    meetbot = await _seed(session)
+    upload_root = tmp_path / "meetings"
+    monkeypatch.setattr(meeting_inbound, "MEETING_UPLOAD_ROOT", upload_root)
+    session_id = "1eebef49-253a-4c59-830a-0b18f33f417d"
+    payload = _ended_payload(upload_root, session_id=session_id)
+    payload["origin"] = {"channel": "D-meeting-dm", "thread_ts": ""}
+    payload["requested_by"] = "U04R1A6MZST"
+
+    result = await submit_inbound_envelope(
+        session,
+        connection=meetbot,
+        envelope={
+            "kind": "meeting_transcript",
+            "origin": "meetbot.session_complete",
+            "payload": payload,
+            "idempotency_key": f"meeting-{session_id}",
+        },
+    )
+
+    run = (await session.scalars(select(AgentRunRow))).one()
+    assert result["status"] == "processed"
+    assert result["ilo_outcome"]["operation"] == "meeting_run_admitted"
+    assert await session.scalar(select(func.count()).select_from(OpenAsk)) == 0
+    assert run.metadata_["slack_trigger"]["message_ts"] is None
+    assert run.metadata_["slack_trigger"]["response_target"] == {
+        "channel_id": "D-meeting-dm",
+        "thread_ts": None,
+        "visibility": "public",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_open_ask_ledger.py
+++ b/tests/test_open_ask_ledger.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
@@ -292,6 +292,27 @@ async def test_admission_preserves_verbatim_ask_and_answer_requires_delivery_tim
         )
     assert ask.status == "open"
     assert ask.answered_at is None
+
+
+@pytest.mark.asyncio
+async def test_admission_rejects_fabricated_open_ask_timestamp(
+    session,
+    caplog,
+):
+    from brain.systems.runs.work_intake import admit_work
+
+    event = _slack_admission_event()
+    fabricated_ts = "meeting-1eebef49-253a-4c59-830a-0b18f33f417d"
+    event.payload["metadata"]["slack_trigger"]["message_ts"] = fabricated_ts
+    event.payload["metadata"]["slack_trigger"]["thread_ts"] = fabricated_ts
+
+    with caplog.at_level("WARNING", logger="brain.systems.runs.open_asks"):
+        result = await admit_work(session, event)
+
+    assert result.ok is True
+    assert await session.scalar(select(func.count()).select_from(OpenAsk)) == 0
+    assert "Ignoring invalid Slack thread_ts for open-ask anchoring" in caplog.text
+    assert "Ignoring invalid Slack message_ts for open-ask anchoring" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
First live completion callback failed admission (open_asks.thread_ts varchar(40) overflow from a fabricated 'meeting-<session-id>' timestamp; full chain in the commit message).

- Meeting admissions declare `obligation: none` — a transcript completion delivers output, it does not open a human ask
- `build_delivery_trigger` takes `message_ts: str | None`; the meeting path passes the real thread ts or None, never a synthetic value
- Open-ask ts values are shape-validated (`^[0-9]+\.[0-9]+$`, ≤40 chars) before any DB write — SQLite tests can't enforce Postgres column widths, so the guard lives in code
- Regression tests: unthreaded-DM transcript admission with a 44-char session ref creates no open_asks row; invalid ts normalizes to None with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)