### PR TITLE
fix(meetings): capture the real caption menu DOM when fr-FR cannot be confirmed (#652)

### DIFF
--- a/meetbot/browser_diagnostics.py
+++ b/meetbot/browser_diagnostics.py
@@ -1,0 +1,86 @@
+"""Best-effort browser diagnostics for live UI failures."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CONTROL_INVENTORY_SCRIPT = r"""
+() => {
+  const limit = 250;
+  const selectors = [
+    'button',
+    '[role="button"]',
+    '[role="menuitem"]',
+    '[role="menuitemradio"]',
+    '[role="tab"]',
+    '[role="option"]',
+    'select',
+    'option'
+  ].join(',');
+  const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+  const isVisible = (node) => {
+    if (!(node instanceof Element)) return false;
+    if (node.tagName === 'OPTION') {
+      const select = node.closest('select');
+      return Boolean(select && isVisible(select));
+    }
+    const style = window.getComputedStyle(node);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
+
+  return Array.from(document.querySelectorAll(selectors))
+    .filter(isVisible)
+    .slice(0, limit)
+    .map((node) => ({
+      tag: node.tagName.toLowerCase(),
+      role: node.getAttribute('role'),
+      'aria-label': clean(node.getAttribute('aria-label')) || null,
+      'data-tooltip': clean(node.getAttribute('data-tooltip')) || null,
+      text: clean(node.textContent) || null
+    }));
+}
+"""
+
+
+async def capture_failure_evidence(
+    page: Any,
+    session_id: str,
+    label: str,
+    *,
+    debug_dir: Path,
+) -> None:
+    """Best-effort screenshot and control inventory for a live UI failure."""
+
+    try:
+        debug_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        logger.debug("Meetbot could not create its diagnostic directory", exc_info=True)
+        return
+
+    artifact_stem = f"{session_id}-{label}"
+    screenshot_path = debug_dir / f"{artifact_stem}.png"
+    inventory_path = debug_dir / f"{artifact_stem}.json"
+    try:
+        await page.screenshot(path=str(screenshot_path), full_page=True)
+        logger.info("Meetbot saved a failure screenshot to %s", screenshot_path)
+    except Exception:
+        logger.debug("Meetbot could not capture a failure screenshot", exc_info=True)
+
+    try:
+        inventory = await page.evaluate(_CONTROL_INVENTORY_SCRIPT)
+        if not isinstance(inventory, list):
+            inventory = []
+        inventory_path.write_text(
+            json.dumps(inventory, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        logger.info("Meetbot saved a failure control inventory to %s", inventory_path)
+    except Exception:
+        logger.debug("Meetbot could not capture a failure control inventory", exc_info=True)

--- a/meetbot/config.py
+++ b/meetbot/config.py
@@ -24,6 +24,12 @@ class MeetbotConfig:
     storage_state_path: Path = Path("/data/private/meetbot/google-storage-state.json")
     caption_warning_seconds: int = 90
 
+    @property
+    def debug_dir(self) -> Path:
+        """Return the private directory for live browser diagnostics."""
+
+        return self.private_root / "debug"
+
     @classmethod
     def from_env(cls) -> MeetbotConfig:
         """Build configuration from the public meetbot environment contract."""

--- a/meetbot/engine.py
+++ b/meetbot/engine.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from meetbot.browser_diagnostics import capture_failure_evidence
 from meetbot.config import MeetbotConfig
 from meetbot.models import EngineResult, SessionEvents
 
@@ -238,10 +239,15 @@ class PlaywrightMeetEngine:
                     return admission_result
                 await events.status("admitted")
                 await self._attach_caption_observer(page, events)
-                await self._enable_captions(page, events)
+                await self._enable_captions(page, events, session_id)
                 return await self._monitor_call(page, runtime.leave_requested, events)
             except Exception:
-                await _capture_failure_screenshot(page, session_id)
+                await capture_failure_evidence(
+                    page,
+                    session_id,
+                    "join-failure",
+                    debug_dir=self._config.debug_dir,
+                )
                 raise
             finally:
                 self._runtimes.pop(session_id, None)
@@ -412,7 +418,12 @@ class PlaywrightMeetEngine:
         await page.expose_function("__illoMeetbotCaption", on_caption)
         await page.evaluate(_CAPTION_OBSERVER_SCRIPT)
 
-    async def _enable_captions(self, page: Any, events: SessionEvents) -> None:
+    async def _enable_captions(
+        self,
+        page: Any,
+        events: SessionEvents,
+        session_id: str,
+    ) -> None:
         await page.keyboard.press("c")
         await asyncio.sleep(1.0)
         enabled = await _first_visible(
@@ -434,7 +445,7 @@ class PlaywrightMeetEngine:
             if not clicked:
                 logger.warning("Meetbot could not verify or click the Google Meet captions control")
 
-        strategy = await self._set_caption_language(page)
+        strategy = await self._set_caption_language(page, session_id)
         if strategy:
             logger.info(
                 "Meetbot confirmed caption language %s with selector strategy %s",
@@ -447,9 +458,14 @@ class PlaywrightMeetEngine:
             "the transcript may be translated or empty."
         )
         logger.warning("%s", warning)
+        logger.info(
+            "Meetbot caption-language diagnostic evidence for session %s is under %s",
+            session_id,
+            self._config.debug_dir,
+        )
         await events.warning(warning)
 
-    async def _set_caption_language(self, page: Any) -> str | None:
+    async def _set_caption_language(self, page: Any, session_id: str) -> str | None:
         strategies = (
             ("visible-language-control", self._set_visible_caption_language),
             ("caption-settings-control", self._set_via_caption_settings_control),
@@ -465,6 +481,14 @@ class PlaywrightMeetEngine:
                     name,
                     exc_info=True,
                 )
+            # Meet closes the menu on Escape, so live selector evidence must be
+            # recorded while the failed strategy's last overlay is still open.
+            await capture_failure_evidence(
+                page,
+                session_id,
+                name,
+                debug_dir=self._config.debug_dir,
+            )
             try:
                 await page.keyboard.press("Escape")
             except Exception:
@@ -576,20 +600,6 @@ async def _click_leave(page: Any) -> None:
             '[role="button"][data-tooltip*="Leave call" i]',
         ),
     )
-
-
-async def _capture_failure_screenshot(page: Any, session_id: str) -> None:
-    """Best-effort page snapshot so a live selector failure diagnoses itself."""
-
-    from pathlib import Path
-
-    try:
-        debug_dir = Path("/data/private/meetbot/debug")
-        debug_dir.mkdir(parents=True, exist_ok=True)
-        await page.screenshot(path=str(debug_dir / f"{session_id}.png"), full_page=True)
-        logger.info("Meetbot saved a failure screenshot for session %s", session_id)
-    except Exception:
-        logger.debug("Meetbot could not capture a failure screenshot", exc_info=True)
 
 
 JOIN_BLOCKED_ERROR = (

--- a/meetbot/tests/test_config.py
+++ b/meetbot/tests/test_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from meetbot.config import MeetbotConfig
@@ -28,6 +30,13 @@ def test_config_uses_the_spec_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.caption_language == "fr-FR"
     assert config.ui_locale == "en-US"
     assert config.lobby_timeout_seconds == 600
+    assert config.debug_dir == Path("/data/private/meetbot/debug")
+
+
+def test_debug_directory_resolves_from_private_root(tmp_path: Path) -> None:
+    config = MeetbotConfig(private_root=tmp_path / "private")
+
+    assert config.debug_dir == tmp_path / "private" / "debug"
 
 
 def test_config_reads_language_locale_and_lobby_timeout_overrides(

--- a/meetbot/tests/test_engine.py
+++ b/meetbot/tests/test_engine.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
+from typing import Any
 
 import pytest
 
+from meetbot.browser_diagnostics import capture_failure_evidence
 from meetbot.config import MeetbotConfig
 from meetbot.engine import (
     PlaywrightMeetEngine,
@@ -95,16 +99,181 @@ async def test_lobby_wait_is_bounded_and_returns_not_admitted_failure() -> None:
 @pytest.mark.asyncio
 async def test_caption_language_failure_emits_transcript_risk_warning(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     async def no_sleep(_: float) -> None:
         return None
 
     monkeypatch.setattr("meetbot.engine.asyncio.sleep", no_sleep)
     events = _WarningEvents()
-    engine = PlaywrightMeetEngine(MeetbotConfig(caption_language="fr-FR"))
+    engine = PlaywrightMeetEngine(
+        MeetbotConfig(caption_language="fr-FR", private_root=tmp_path)
+    )
 
-    await engine._enable_captions(_NeverAdmittedPage(), events)
+    await engine._enable_captions(_NeverAdmittedPage(), events, "session-1")
 
+    assert events.messages == [
+        "Could not confirm the caption language is fr-FR; "
+        "the transcript may be translated or empty."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_caption_failure_capture_precedes_each_strategy_escape(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captures: list[tuple[str, bool]] = []
+
+    class _RecordingPage(_NeverAdmittedPage):
+        def __init__(self) -> None:
+            self.overlay_open = False
+
+        class _RecordingKeyboard:
+            def __init__(self, page: _RecordingPage) -> None:
+                self.page = page
+
+            async def press(self, key: str) -> None:
+                assert key == "Escape"
+                self.page.overlay_open = False
+
+        @property
+        def keyboard(self) -> _RecordingKeyboard:
+            return self._RecordingKeyboard(self)
+
+    async def failed_strategy(page: Any) -> bool:
+        assert not page.overlay_open
+        page.overlay_open = True
+        return False
+
+    async def capture(
+        page: Any,
+        session_id: str,
+        label: str,
+        *,
+        debug_dir: Path,
+    ) -> None:
+        assert session_id == "session-1"
+        assert debug_dir == tmp_path / "debug"
+        captures.append((label, page.overlay_open))
+
+    engine = PlaywrightMeetEngine(MeetbotConfig(private_root=tmp_path))
+    monkeypatch.setattr(engine, "_set_visible_caption_language", failed_strategy)
+    monkeypatch.setattr(engine, "_set_via_caption_settings_control", failed_strategy)
+    monkeypatch.setattr(engine, "_set_via_meet_settings", failed_strategy)
+    monkeypatch.setattr("meetbot.engine.capture_failure_evidence", capture)
+
+    result = await engine._set_caption_language(_RecordingPage(), "session-1")
+
+    assert result is None
+    assert all(overlay_open for _, overlay_open in captures)
+    labels = {label for label, _ in captures}
+    assert "visible-language-control" in labels
+    assert "caption-settings-control" in labels
+    assert "more-options-settings-captions" in labels
+
+
+@pytest.mark.asyncio
+async def test_failure_capture_names_are_distinct_by_session_and_label(
+    tmp_path: Path,
+) -> None:
+    class _CapturePage:
+        def __init__(self) -> None:
+            self.screenshot_paths: list[Path] = []
+
+        async def screenshot(self, *, path: str, full_page: bool) -> None:
+            assert full_page
+            self.screenshot_paths.append(Path(path))
+
+        async def evaluate(self, script: str) -> list[dict[str, str | None]]:
+            assert "menuitemradio" in script
+            return [
+                {
+                    "tag": "button",
+                    "role": None,
+                    "aria-label": "Caption settings",
+                    "data-tooltip": None,
+                    "text": "",
+                }
+            ]
+
+    page = _CapturePage()
+    debug_dir = tmp_path / "debug"
+    captures = (
+        ("session-1", "join-failure"),
+        ("session-1", "visible-language-control"),
+        ("session-1", "caption-settings-control"),
+        ("session-2", "caption-settings-control"),
+    )
+
+    for session_id, label in captures:
+        await capture_failure_evidence(
+            page,
+            session_id,
+            label,
+            debug_dir=debug_dir,
+        )
+
+    expected_stems = {f"{session_id}-{label}" for session_id, label in captures}
+    assert {path.stem for path in page.screenshot_paths} == expected_stems
+    assert {path.stem for path in debug_dir.glob("*.json")} == expected_stems
+    assert len(page.screenshot_paths) == len(captures)
+    assert len(list(debug_dir.glob("*.json"))) == len(captures)
+    inventory = json.loads(
+        (debug_dir / "session-1-visible-language-control.json").read_text()
+    )
+    assert inventory == [
+        {
+            "tag": "button",
+            "role": None,
+            "aria-label": "Caption settings",
+            "data-tooltip": None,
+            "text": "",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_capture_errors_do_not_interrupt_caption_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _BrokenCapturePage(_NeverAdmittedPage):
+        def __init__(self) -> None:
+            self.escape_count = 0
+            self.screenshot_count = 0
+            self.evaluate_count = 0
+
+            class _Keyboard:
+                async def press(inner_self, key: str) -> None:
+                    if key == "Escape":
+                        self.escape_count += 1
+
+            self.keyboard = _Keyboard()
+
+        async def screenshot(self, *, path: str, full_page: bool) -> None:
+            self.screenshot_count += 1
+            raise RuntimeError("screenshot failed")
+
+        async def evaluate(self, script: str) -> object:
+            self.evaluate_count += 1
+            raise RuntimeError("evaluate failed")
+
+    async def no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("meetbot.engine.asyncio.sleep", no_sleep)
+    page = _BrokenCapturePage()
+    events = _WarningEvents()
+    engine = PlaywrightMeetEngine(
+        MeetbotConfig(caption_language="fr-FR", private_root=tmp_path)
+    )
+
+    await engine._enable_captions(page, events, "session-1")
+
+    assert page.escape_count == 3
+    assert page.screenshot_count == 3
+    assert page.evaluate_count == 3
     assert events.messages == [
         "Could not confirm the caption language is fr-FR; "
         "the transcript may be translated or empty."


### PR DESCRIPTION
Closes #652

## What this does — and what it deliberately does not

The first live meetbot session (2026-08-03) got captions but never
confirmed they were French. All three caption-language selector
strategies missed, and the session carried its designed warning.

The strategies were written blind against a documented UI flow. Nobody
has ever seen Google Meet's real settings-menu DOM at runtime. **So this
PR does not touch the selectors.** A fourth blind guess is the same
mistake a fourth time. It buys the evidence a correct selector needs.

## How

- Each failed strategy writes a screenshot **and** a JSON inventory of
  the visible interactive controls (tag, role, `aria-label`,
  `data-tooltip`, text).
- The capture happens **before** the `Escape` that closes that strategy's
  overlay. This is the whole point: `_set_caption_language` presses Escape
  after every failed strategy, so a capture taken after the loop would
  only ever photograph a closed menu.
- Artifacts are labelled per session **and** per strategy, so
  join-failure evidence can no longer overwrite caption evidence.
- The writer lives in a new `meetbot/browser_diagnostics.py`, not in
  `engine.py` — #645 is about to split that module, and growing it here
  would have made the split harder. `engine.py` nets +27 lines.
- The debug directory now comes from `MeetbotConfig.private_root`, not a
  path literal. The resolved default is unchanged.
- Every capture is best-effort. A diagnostic must never end a meeting.

## What Reda judges

There is no UI to eyeball — this only produces output when a live session
fails. The check is on the next French test meeting:

1. Run a short Meet where the first sentences are French.
2. If the caption-language warning appears, look at what landed:

```
ssh illo-dev "docker exec illospace-meetbot-1 ls -la /data/private/meetbot/debug"
```

You should see, per failed strategy, `<session-id>-<strategy>.png` and
`<session-id>-<strategy>.json` — for example
`<id>-more-options-settings-captions.json`. The JSON is what tells us
which selector to write.

3. If the warning does **not** appear, the language confirmed on its own
   and #652's selector half needs no work.

## Acceptance checks

- Each of the three strategies produces its own labelled screenshot + JSON
  when it fails, captured while its overlay is still open.
- A join failure and a caption-language failure in the same session write
  distinct files; neither overwrites the other.
- A capture that throws (screenshot or `evaluate`) is swallowed — the
  caption flow still completes and still emits its warning.
- `meetbot/tests`: 31 passed. Backend fast suite (the exact CI command):
  4686 passed, 11 skipped, 0 failed.

## Reviewed

Thermo-nuclear maintainability review (Codex, cross-family): **nothing
blocking**. Its one MAJOR and two MINOR findings are all folded in — the
module extraction above, a single owner for the 250-control cap, and an
ordering test rewritten to assert the overlay is open at capture time
rather than matching one exact call trace.

## Known gap, not fixed here

CI runs **no** meetbot tests at all — `meetbot/**` is in no paths-filter
and `pytest.ini` sets `testpaths = tests`. Filed as #654. The 31 meetbot
tests above were run by hand, as every meetbot PR before this one was.
