### PR TITLE
ci: run the meetbot test suite in CI (#654)

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -43,6 +43,8 @@ jobs:
               # script-only change that breaks its own guard test would otherwise
               # skip the suite that guards it and only fail once it reaches main.
               - "brain/**"
+              # meetbot/** is backend surface covered by the fast fake-based suite.
+              - "meetbot/**"
               - "deploy/**"
               - "tests/**"
               - "scripts/**"
@@ -110,7 +112,7 @@ jobs:
 
       - name: Run backend fast suite
         run: >-
-          python3 -m pytest tests/
+          python3 -m pytest
           -m "not requires_db and not requires_browser and not live_provider"
           -q
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,10 @@ start:
 	uvicorn brain.app.api.main:app --host 0.0.0.0 --port 8000
 
 ## Run fast tests only (no Docker, no DB)
+# No explicit path: pytest.ini's testpaths owns the selection, so this runs the
+# same suite CI runs. Naming tests/ here would silently drop meetbot/tests again.
 test:
-	python3 -m pytest tests/ -m "not requires_db" -q
+	python3 -m pytest -m "not requires_db" -q
 
 ## Run backend architecture boundary guardrails
 architecture-check:

--- a/illo
+++ b/illo
@@ -2682,7 +2682,9 @@ case "${1:-}" in
     ;;
   test)
     [ -f "venv/bin/activate" ] && source venv/bin/activate
-    "$ROOT/venv/bin/python3" -m pytest tests/ -m "not requires_db" -q "${@:2}"
+    # No explicit path: pytest.ini's testpaths owns the selection, so this runs
+    # the same suite CI runs. An explicit path in "${@:2}" still overrides it.
+    "$ROOT/venv/bin/python3" -m pytest -m "not requires_db" -q "${@:2}"
     ;;
   help|-h|--help)
     usage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = tests
+testpaths = tests meetbot/tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
Closes #654

## What was broken

A pull request that only changed `meetbot/**` ran **zero** tests. The whole meetbot service — browser lifecycle, caption observation, transcript assembly, auth, callback — reached `main` unguarded. Two independent gaps, and both had to be closed:

1. `meetbot/**` was in no paths-filter, so `backend-fast` (gated on `needs.changes.outputs.backend == 'true'`) never even started.
2. Even when the job did run, `pytest.ini` set `testpaths = tests` **and** the workflow step passed `tests/` explicitly, so `meetbot/tests/` was never collected.

PRs #644, #646, #647, #648, #649, #651 and #655 all landed meetbot code on `main` with its suite never executed by CI.

## What changed (4 files, small)

- **`.github/workflows/brain-ci.yml`** — `meetbot/**` added to the `backend` filter. Deliberately **not** added to the `db` filter: the meetbot tests are pure fakes and need no Postgres, so adding it there would spin a database job for nothing.
- **`pytest.ini`** — `testpaths = tests meetbot/tests`.
- **`.github/workflows/brain-ci.yml`** (same file, second hunk) — the fast-suite step now runs `pytest` with **no explicit path**. This matters: the explicit `tests/` argument *overrides* `testpaths`, so without this the `pytest.ini` change would have been dead code.
- **`Makefile`** and **`illo`** — `make test` and `illo test` also stop naming `tests/`, so they inherit the same selection. Without this the change would have created a new split: CI running one suite and the documented local command running another.

The design point the ticket asked for — **one owner for the test selection** — is `pytest.ini`. Every human-facing entry point now defers to it.

## Evidence

| check | result |
|---|---|
| fast suite before | 4,697 selected |
| fast suite after | 4,728 selected — **exactly +31**, the meetbot suite |
| full CI command, outside any sandbox | see the run recorded on this PR |
| meetbot suite alone | 31 passed |
| `make test` collects meetbot | confirmed — `testpaths: tests, meetbot/tests`, `<Package meetbot>` collected |
| dependency safety | `playwright` is **not** installed and is not needed: all 7 meetbot test modules import cleanly with a blocker rejecting any Playwright import. `meetbot/engine.py` types the browser as `Any` and has no top-level Playwright import. `fastapi`, `httpx`, `uvicorn` are already in root `requirements.txt`, which is what the fast job installs. |
| collection collisions | none — no duplicate basenames, no fixture leakage from `tests/conftest.py`, async meetbot tests run under `asyncio_mode = auto` |
| markers | no meetbot test carries `requires_db` / `requires_browser` / `live_provider`; all 31 survive the CI marker expression |

**Deliberate-break check** (the ticket's third acceptance criterion, which normally needs a scratch CI run): one assertion in `meetbot/tests/test_captions.py` was broken locally, the new command went red on exactly that test, the edit was reverted in full, and the suite returned to green. No trace of it is in this commit.

## Assumptions and what is deliberately left out

- **The `db-contract` job still passes `tests/` explicitly** and is unchanged. Correct: meetbot has no `requires_db` tests.
- **Left alone on purpose, and worth a look later:** `ops/test-with-db.sh:42`, `brain/jobs/pipelines/nightly_assess.py:169` and `brain/jobs/pipelines/nightly_implement.py:228` still name `tests/`. Those are the DB script and Illo's own autonomy pipelines — changing what they run is a behaviour change beyond a CI-selection fix, so I named it instead of doing it.
- **`.github/workflows/container-images.yml` also uses `paths-filter`.** Not touched — this ticket is about test selection, not image builds.
- The first acceptance check ("a PR touching only `meetbot/engine.py` selects the backend job") is proven by the filter change plus this PR's own run; it cannot be fully demonstrated without pushing a meetbot-only scratch branch, which I did not do.

## Review surface

No UI. Run it yourself:

```
cd <repo> && make test
```

Expect the meetbot package in the collection and the count up by 31 versus `main`.

Acceptance checks to judge this by:
1. A meetbot-only change now selects `Backend fast suite` instead of skipping every job.
2. The fast suite count grows by exactly 31 and stays green.
3. `make test`, `illo test` and CI all run the same set — one owner, `pytest.ini`.
4. No new dependency is installed into the fast CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
