### PR TITLE
test(scheduler): drive the drain admission budget with an injected clock, not wall time

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -1242,6 +1242,7 @@ async def async_drain_scheduler(
     now: datetime | None = None,
     allowed_owner_modes: tuple[str, ...] | None = None,
     admission_budget_seconds: float | None = None,
+    clock: Callable[[], float] | None = None,
 ) -> dict[str, Any]:
     """Start due runs within one bounded scheduler-tick admission budget."""
     now = _utcnow(now)
@@ -1253,8 +1254,8 @@ async def async_drain_scheduler(
     )
     if budget_seconds <= 0:
         raise ValueError("admission_budget_seconds must be greater than zero")
-    loop = asyncio.get_running_loop()
-    admission_deadline = loop.time() + budget_seconds
+    clock = asyncio.get_running_loop().time if clock is None else clock
+    admission_deadline = clock() + budget_seconds
 
     await async_reconcile_detached_runs(
         session,
@@ -1274,7 +1275,7 @@ async def async_drain_scheduler(
     executed = 0
     budget_exhausted = False
     while executed < max_runs:
-        if loop.time() >= admission_deadline:
+        if clock() >= admission_deadline:
             budget_exhausted = True
             break
         candidate = await async_claim_next_due_run(

--- a/tests/test_scheduler_drain_budget.py
+++ b/tests/test_scheduler_drain_budget.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from sqlalchemy import select
@@ -72,6 +72,10 @@ def _due_job(job_key: str, *, priority: int) -> SchedulerJob:
     )
 
 
+def _frozen_clock() -> float:
+    return 0.0
+
+
 async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
     blocker = _due_job("blocking_job", priority=200)
     blocker.timeout_seconds = 60
@@ -81,22 +85,19 @@ async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
 
     runner_timeouts = []
 
-    async def runner(command, **_kwargs):
+    async def runner(_command, **_kwargs):
         runner_timeouts.append(_kwargs["timeout_seconds"])
-        if command == ["blocking_job"]:
-            await asyncio.sleep(0.3)
         return SimpleNamespace(returncode=0, stdout="ok", stderr="")
 
     now = datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc)
-    first = await asyncio.wait_for(
-        async_drain_scheduler(
-            session,
-            max_runs=2,
-            runner=runner,
-            admission_budget_seconds=0.25,
-            now=now,
-        ),
-        timeout=1.5,
+    clock = Mock(side_effect=[0.0, 0.0, 1.0])
+    first = await async_drain_scheduler(
+        session,
+        max_runs=2,
+        runner=runner,
+        admission_budget_seconds=0.25,
+        clock=clock,
+        now=now,
     )
 
     assert first["executed"] == 1
@@ -123,6 +124,7 @@ async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
         max_runs=2,
         runner=runner,
         admission_budget_seconds=1,
+        clock=_frozen_clock,
         now=now,
     )
 
@@ -147,6 +149,7 @@ async def test_healthy_drain_keeps_existing_result_shape(session):
         session,
         runner=runner,
         admission_budget_seconds=1,
+        clock=_frozen_clock,
         now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
     )
 
@@ -180,6 +183,7 @@ async def test_undeclared_command_output_cannot_activate_detached_lifecycle(sess
         session,
         runner=runner,
         admission_budget_seconds=1,
+        clock=_frozen_clock,
         now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
     )
 
@@ -221,6 +225,7 @@ async def test_declared_detached_command_rejects_malformed_handoff(session):
         session,
         runner=runner,
         admission_budget_seconds=1,
+        clock=_frozen_clock,
         now=now,
     )
 
@@ -322,6 +327,7 @@ async def test_later_drain_reconciles_detached_agent_run_and_step(
         job_key=job.job_key,
         runner=runner,
         admission_budget_seconds=1,
+        clock=_frozen_clock,
         now=now,
     )
     assert first_drain["executed"] == 1


### PR DESCRIPTION
Closes #657.

`test_drain_budget_bounds_admission_not_in_flight_execution` decided pass/fail by reading a real clock, so machine load — not the code — chose the outcome. This takes real time out of the assertion path instead of widening the margin.

## What changed

`async_drain_scheduler` gains a keyword-only `clock: Callable[[], float] | None`, defaulting to the running loop's `time`. The deadline stays exactly where it was; only the source of the number moves. Omit the argument and production runs the same instructions as before.

The test then drives the budget directly: `Mock(side_effect=[0.0, 0.0, 1.0])` — arm the deadline at 0.0, admit the first job at 0.0, exhaust at 1.0. The 0.3s `asyncio.sleep` and the `asyncio.wait_for(..., timeout=1.5)` wrapper are both deleted, because with a driven clock there is nothing left for them to guard. Five sibling cases that need a successful admission get a frozen clock for the same reason.

## Verification

| check | result |
|---|---|
| full CI selection on the branch, quiet machine | **4717 passed, 0 failed** (70.5s) |
| same on `origin/main` — baseline | 4717 passed, 0 failed |
| **3 concurrent full suites**, branch | 4717 / 4717 / 4717, all green (81s each) |
| drain-budget file run as a 4th process during those three | 10 passed |

Same command CI runs: `pytest -m "not requires_db and not requires_browser and not live_provider"`.

## What I could not prove

**I never reproduced the original failure on the old code**, so this is not a differential result. I tried hard: 3 concurrent full suites plus 20 CPU spinners, load average ~22, suite wall-clock stretched from 70s to 250s — `origin/main` still returned 4717 passed, three times over, and the flaky test alone passed 8/8 under starvation.

So "the branch is green under load" is not by itself evidence, because `main` is green under the same load. The case for this change rests on the structural argument instead, which is checkable by reading the diff rather than by trusting a run: after it, **no assertion in the admission path reads a real clock**. The test cannot be load-sensitive by construction, whatever the machine is doing. The recorded failure from 2026-08-03 stays the evidence that the flake is real.

## Named, not fixed

- **`test_aws_health_scan_returns_immediately_after_dispatch` (line ~382) still wraps a fully-mocked call in `asyncio.wait_for(..., timeout=0.1)`.** Same family — a wall-clock assertion in this file — but a different mechanism (an over-tight timeout, not a budget race), and it is outside what #657 describes. Left deliberately.
- **The second drain in `test_later_drain_reconciles_detached_agent_run_and_step` keeps the real clock on purpose.** It asserts `executed == 0`, and budget exhaustion also yields 0, so the assertion holds either way; every later assertion in it covers reconciliation state, which completes before the deadline check runs.

## The production shape underneath, deliberately untouched

The deadline is armed *before* `async_reconcile_detached_runs` and `async_materialize_due_runs`, so setup time is charged against the budget it precedes. With the production default of 30s (`executor.py:110`) a slow enough reconcile would make a tick admit zero jobs while looking healthy — and nothing logs `budget_exhausted`, so it would be invisible.

That is a scheduler-semantics question, not a test fix, so this PR does not move the deadline. Raised as a hypothesis on #632 (with #576 cross-referenced — its "after a deploy" timing is the strongest fit, since a deploy is when reconcile has the most orphaned runs to clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
