### PR TITLE
feat(knowledge): memory recall arm + corpus-reachability guard (#578 item 3 prerequisite)

### DIFF
--- a/brain/app/cli/knowledge_recall.py
+++ b/brain/app/cli/knowledge_recall.py
@@ -85,6 +85,12 @@ def _parser() -> argparse.ArgumentParser:
         help=f"Versioned question-set JSON (default: {DEFAULT_QUESTION_SET_PATH}).",
     )
     eval_parser.add_argument(
+        "--engine",
+        choices=("knowledge", "memory"),
+        default="knowledge",
+        help="Recall engine to evaluate (default: knowledge).",
+    )
+    eval_parser.add_argument(
         "--k",
         action="append",
         dest="k_values",
@@ -152,6 +158,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 question_set=question_set,
                 k_values=args.k_values or DEFAULT_K_VALUES,
                 search_limit=args.search_limit,
+                engine=args.engine,
                 generated_at=args.generated_at,
                 live_database=True,
             )

--- a/brain/platform/db/repositories/reconstructive_memory.py
+++ b/brain/platform/db/repositories/reconstructive_memory.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 from sqlalchemy import and_, exists, false, func, or_, select, true, update
@@ -447,6 +447,39 @@ def _lexical_relevance(node: MemoryNode, *, query: str, terms: Sequence[str]) ->
     return max(1.0 if exact else 0.0, hits / len(terms))
 
 
+class MemoryBlendWeights(NamedTuple):
+    """The weights `_blended_relevance_score` applies, for one query's regime."""
+
+    semantic: float
+    lexical: float
+    storage_confidence: float
+
+
+# Similarity and query-term coverage own 97% of ranking. Storage confidence is
+# only a stable tie-break signal and cannot swamp relevance.
+MEMORY_BLEND_WEIGHTS = MemoryBlendWeights(
+    semantic=0.72,
+    lexical=0.25,
+    storage_confidence=0.03,
+)
+# Missing vectors remain fully retrievable by text while backfill runs.
+MEMORY_BLEND_WEIGHTS_WITHOUT_SEMANTIC = MemoryBlendWeights(
+    semantic=0.0,
+    lexical=0.95,
+    storage_confidence=0.05,
+)
+
+
+def memory_blend_weights(*, semantic_available: bool) -> MemoryBlendWeights:
+    """Expose the ranking weights so reporters cannot drift from the ranker."""
+
+    return (
+        MEMORY_BLEND_WEIGHTS
+        if semantic_available
+        else MEMORY_BLEND_WEIGHTS_WITHOUT_SEMANTIC
+    )
+
+
 def _blended_relevance_score(
     *,
     semantic_score: float | None,
@@ -455,13 +488,18 @@ def _blended_relevance_score(
 ) -> float:
     storage_confidence = min(1.0, max(0.0, storage_confidence))
     lexical_score = min(1.0, max(0.0, lexical_score))
+    weights = memory_blend_weights(semantic_available=semantic_score is not None)
     if semantic_score is None:
-        # Missing vectors remain fully retrievable by text while backfill runs.
-        return 0.95 * lexical_score + 0.05 * storage_confidence
+        return (
+            weights.lexical * lexical_score
+            + weights.storage_confidence * storage_confidence
+        )
     semantic_score = min(1.0, max(0.0, semantic_score))
-    # Similarity and query-term coverage own 97% of ranking. Storage confidence
-    # is only a stable tie-break signal and cannot swamp relevance.
-    return 0.72 * semantic_score + 0.25 * lexical_score + 0.03 * storage_confidence
+    return (
+        weights.semantic * semantic_score
+        + weights.lexical * lexical_score
+        + weights.storage_confidence * storage_confidence
+    )
 
 
 def _rank_memory_nodes(

--- a/brain/platform/db/repositories/reconstructive_memory.py
+++ b/brain/platform/db/repositories/reconstructive_memory.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
-from sqlalchemy import and_, exists, func, or_, select, true, update
+from sqlalchemy import and_, exists, false, func, or_, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.reconstructive_memory import (
@@ -56,6 +56,42 @@ _QUERY_STOP_WORDS = {
     "with",
 }
 _MIN_SEMANTIC_CANDIDATE_SCORE = 0.35
+
+
+def memory_content_node_filters(
+    *,
+    org_id: str | None = None,
+    user_id: str | None = None,
+    allow_global: bool = False,
+) -> tuple[Any, ...]:
+    """Return the visibility and lifecycle filters used by memory recall."""
+
+    if allow_global:
+        visibility_predicate = true()
+    elif not user_id and not org_id:
+        return (false(),)
+    else:
+        visibility_predicate = or_(
+            and_(MemoryNode.visibility == "org", MemoryNode.org_id == org_id),
+            and_(MemoryNode.visibility == "team", MemoryNode.org_id == org_id),
+            and_(MemoryNode.visibility == "private", MemoryNode.user_id == user_id),
+        )
+
+    filters: list[Any] = [
+        MemoryNode.archived_at.is_(None),
+        MemoryNode.truth_status != "superseded",
+        ~exists(
+            select(MemoryEdgeNode.id).where(
+                MemoryEdgeNode.source_node_id == MemoryNode.id,
+                MemoryEdgeNode.edge_kind == "superseded_by",
+            )
+        ),
+        MemoryNode.node_kind.in_(_CONTENT_NODE_KINDS),
+        visibility_predicate,
+    ]
+    if org_id is not None:
+        filters.append(or_(MemoryNode.org_id == org_id, MemoryNode.org_id.is_(None)))
+    return tuple(filters)
 
 
 def stable_digest(value: str) -> str:
@@ -270,34 +306,16 @@ class MemoryNodeRepository(BaseRepository[MemoryNode]):
         query = query.strip()
         if not query:
             return []
-        if allow_global:
-            visibility_predicate = true()
-        elif not user_id and not org_id:
-            return []
-        else:
-            visibility_predicate = or_(
-                and_(MemoryNode.visibility == "org", MemoryNode.org_id == org_id),
-                and_(MemoryNode.visibility == "team", MemoryNode.org_id == org_id),
-                and_(MemoryNode.visibility == "private", MemoryNode.user_id == user_id),
-            )
-
         base_stmt = (
             select(MemoryNode)
-            .where(MemoryNode.archived_at.is_(None))
-            .where(MemoryNode.truth_status != "superseded")
             .where(
-                ~exists(
-                    select(MemoryEdgeNode.id).where(
-                        MemoryEdgeNode.source_node_id == MemoryNode.id,
-                        MemoryEdgeNode.edge_kind == "superseded_by",
-                    )
+                *memory_content_node_filters(
+                    org_id=org_id,
+                    user_id=user_id,
+                    allow_global=allow_global,
                 )
             )
-            .where(MemoryNode.node_kind.in_(_CONTENT_NODE_KINDS))
-            .where(visibility_predicate)
         )
-        if org_id is not None:
-            base_stmt = base_stmt.where(or_(MemoryNode.org_id == org_id, MemoryNode.org_id.is_(None)))
 
         query_vector = (
             np.asarray(query_embedding, dtype=np.float32).reshape(-1)

--- a/brain/systems/knowledge/recall_eval.py
+++ b/brain/systems/knowledge/recall_eval.py
@@ -15,6 +15,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.knowledge import KnowledgeItem
+from brain.platform.db.models.reconstructive_memory import MemoryNode
+from brain.platform.db.repositories.reconstructive_memory import (
+    MemoryNodeRepository,
+    memory_content_node_filters,
+)
 from brain.systems.knowledge.recall_eval_contract import (
     KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION,
     KnowledgeRecallArtifactCaseError,
@@ -35,7 +40,11 @@ from brain.systems.knowledge.search import (
 )
 from brain.systems.knowledge.search_contract import (
     KNOWLEDGE_SEARCH_MAX_RESULTS,
+    KnowledgeSearchChannelScore,
+    KnowledgeSearchChannelWeights,
+    KnowledgeSearchHit,
     KnowledgeSearchResponse,
+    KnowledgeSearchScoreChannels,
     KnowledgeSearchScores,
     normalize_knowledge_search_limit,
 )
@@ -46,6 +55,7 @@ DEFAULT_QUESTION_SET_PATH = (
 )
 
 KnowledgeSearch = Callable[..., Awaitable[Any]]
+KnowledgeRecallEngine = Literal["knowledge", "memory"]
 
 
 def _iso_utc(value: datetime | None) -> str | None:
@@ -119,6 +129,104 @@ async def build_knowledge_recall_corpus_fingerprint(
         ),
         fingerprint=hashlib.sha256(encoded_rows).hexdigest(),
     )
+
+
+async def _visible_memory_content_nodes(
+    session: AsyncSession,
+    *,
+    org_id: str,
+) -> list[MemoryNode]:
+    return list(
+        (
+            await session.scalars(
+                select(MemoryNode)
+                .where(*memory_content_node_filters(org_id=org_id))
+                .order_by(MemoryNode.id.asc())
+            )
+        ).all()
+    )
+
+
+async def build_memory_recall_corpus_fingerprint(
+    session: AsyncSession,
+    *,
+    org_id: str,
+) -> KnowledgeRecallCorpusFingerprint:
+    """Summarize the visible content nodes used by reconstructive memory."""
+
+    rows = await _visible_memory_content_nodes(session, org_id=org_id)
+    canonical_rows = [
+        {
+            "id": int(row.id),
+            "node_kind": str(row.node_kind),
+            "content_kind": str(row.content_kind) if row.content_kind else None,
+            "canonical_label": str(row.canonical_label),
+            "text": str(row.text) if row.text is not None else None,
+            "normalized_key": str(row.normalized_key),
+            "scope_key": str(row.scope_key),
+            "confidence": float(row.confidence),
+            "truth_status": str(row.truth_status),
+            "freshness_status": str(row.freshness_status),
+            "created_at": _iso_utc(row.created_at),
+            "updated_at": _iso_utc(row.updated_at),
+        }
+        for row in rows
+    ]
+    encoded_rows = json.dumps(
+        canonical_rows,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    updated_values = [row.updated_at for row in rows if row.updated_at is not None]
+    created_values = [row.created_at for row in rows if row.created_at is not None]
+    return KnowledgeRecallCorpusFingerprint(
+        total_item_count=len(rows),
+        source_counts={"memory": len(rows)} if rows else {},
+        newest_source_updated_at=_iso_utc(
+            max(updated_values) if updated_values else None
+        ),
+        newest_ingested_at=_iso_utc(
+            max(created_values) if created_values else None
+        ),
+        fingerprint=hashlib.sha256(encoded_rows).hexdigest(),
+    )
+
+
+async def _recall_corpus(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    engine: KnowledgeRecallEngine,
+) -> tuple[KnowledgeRecallCorpusFingerprint, set[tuple[str, str]]]:
+    if engine == "knowledge":
+        fingerprint = await build_knowledge_recall_corpus_fingerprint(
+            session,
+            org_id=org_id,
+        )
+        pointers = set(
+            (
+                await session.execute(
+                    select(KnowledgeItem.source, KnowledgeItem.source_ref).where(
+                        *knowledge_item_filters(
+                            org_id=org_id,
+                            sources=None,
+                            kinds=None,
+                        )
+                    )
+                )
+            ).all()
+        )
+        return fingerprint, {
+            (str(source), str(source_ref)) for source, source_ref in pointers
+        }
+
+    rows = await _visible_memory_content_nodes(session, org_id=org_id)
+    fingerprint = await build_memory_recall_corpus_fingerprint(
+        session,
+        org_id=org_id,
+    )
+    return fingerprint, {("memory", f"memory_node:{row.id}") for row in rows}
 
 
 @dataclass(frozen=True)
@@ -273,6 +381,7 @@ class KnowledgeRecallInvalidResult:
     suite: str
     generated_at: str
     live_database: bool
+    engine: KnowledgeRecallEngine
     org_id: str
     question_set: KnowledgeRecallQuestionSet
     k_values: tuple[int, ...]
@@ -287,6 +396,7 @@ class KnowledgeRecallInvalidResult:
             suite=self.suite,
             generated_at=self.generated_at,
             live_database=self.live_database,
+            engine=self.engine,
             question_set=self.question_set.to_artifact(),
             configuration=KnowledgeRecallInvalidArtifactConfiguration(
                 org_id=self.org_id,
@@ -310,6 +420,7 @@ class KnowledgeRecallSuiteResult:
     suite: str
     generated_at: str
     live_database: bool
+    engine: KnowledgeRecallEngine
     org_id: str
     question_set: KnowledgeRecallQuestionSet
     k_values: tuple[int, ...]
@@ -351,6 +462,7 @@ class KnowledgeRecallSuiteResult:
             suite=self.suite,
             generated_at=self.generated_at,
             live_database=self.live_database,
+            engine=self.engine,
             question_set=self.question_set.to_artifact(),
             configuration=KnowledgeRecallArtifactConfiguration(
                 org_id=self.org_id,
@@ -504,6 +616,116 @@ def _metric(value: float) -> float:
     return round(float(value), 8)
 
 
+async def _embed_memory_recall_query(
+    session: AsyncSession,
+    query: str,
+) -> Any:
+    from brain.systems.reconstructive_memory.embeddings import embed_recall_query
+
+    return await embed_recall_query(session, query)
+
+
+async def search_memory_recall(
+    session: AsyncSession,
+    query: str,
+    *,
+    org_id: str,
+    limit: int,
+) -> KnowledgeSearchResponse:
+    """Adapt reconstructive memory's own ranker to the recall harness contract."""
+
+    requested_limit = int(limit)
+    effective_limit = normalize_knowledge_search_limit(
+        requested_limit,
+        default=KNOWLEDGE_SEARCH_MAX_RESULTS,
+    )
+    query_embedding = await _embed_memory_recall_query(session, query)
+    nodes = await MemoryNodeRepository(session).search_content_nodes(
+        query=query,
+        org_id=org_id,
+        limit=effective_limit,
+        query_embedding=(
+            query_embedding.vector if query_embedding is not None else None
+        ),
+        embedding_model=(
+            query_embedding.model if query_embedding is not None else None
+        ),
+    )
+    semantic_available = query_embedding is not None
+    lexical_weight = 0.25 if semantic_available else 0.95
+    semantic_weight = 0.72 if semantic_available else 0.0
+    storage_weight = 0.03 if semantic_available else 0.05
+    hits: list[KnowledgeSearchHit] = []
+    for rank, node in enumerate(nodes, start=1):
+        lexical_score = float(getattr(node, "lexical_score", 0.0))
+        semantic_score = getattr(node, "semantic_score", None)
+        semantic_value = (
+            float(semantic_score) if semantic_score is not None else None
+        )
+        hits.append(
+            KnowledgeSearchHit(
+                id=int(node.id),
+                source="memory",
+                kind=str(node.content_kind or node.node_kind),
+                source_ref=f"memory_node:{node.id}",
+                title=str(node.canonical_label),
+                summary=str(node.text or node.canonical_label),
+                resolution=None,
+                entities=[],
+                extra={
+                    "confidence": float(node.confidence or 0.0),
+                    "freshness_status": str(node.freshness_status),
+                    "node_kind": str(node.node_kind),
+                    "scope": str(node.scope_key),
+                    "truth_status": str(node.truth_status),
+                    "visibility": str(node.visibility),
+                },
+                source_created_at=_iso_utc(node.created_at),
+                source_updated_at=_iso_utc(node.updated_at),
+                scores=KnowledgeSearchScores(
+                    rrf=float(getattr(node, "retrieval_score", 0.0)),
+                    channels=KnowledgeSearchScoreChannels(
+                        lexical=KnowledgeSearchChannelScore(
+                            rank=rank,
+                            score=lexical_score,
+                            weight=lexical_weight,
+                            contribution=lexical_weight * lexical_score,
+                        ),
+                        semantic=(
+                            KnowledgeSearchChannelScore(
+                                rank=rank,
+                                score=semantic_value,
+                                weight=semantic_weight,
+                                contribution=semantic_weight * semantic_value,
+                            )
+                            if semantic_value is not None
+                            else None
+                        ),
+                        recency=None,
+                    ),
+                ),
+            )
+        )
+    return KnowledgeSearchResponse(
+        query=query,
+        org_id=org_id,
+        sources=["memory"],
+        kinds=[],
+        semantic_available=semantic_available,
+        semantic_degraded_reason=(
+            None if semantic_available else "memory query embedding unavailable"
+        ),
+        weights=KnowledgeSearchChannelWeights(
+            lexical=lexical_weight,
+            semantic=semantic_weight,
+            recency=storage_weight,
+        ),
+        requested_limit=requested_limit,
+        effective_limit=effective_limit,
+        results=hits,
+    )
+
+
 def _ranked_results(
     response: KnowledgeSearchResponse,
     *,
@@ -538,7 +760,8 @@ async def run_knowledge_recall_eval(
     question_set: KnowledgeRecallQuestionSet | None = None,
     k_values: Sequence[int] = DEFAULT_K_VALUES,
     search_limit: int = KNOWLEDGE_SEARCH_MAX_RESULTS,
-    search: KnowledgeSearch = search_knowledge,
+    engine: KnowledgeRecallEngine = "knowledge",
+    search: KnowledgeSearch | None = None,
     generated_at: str | None = None,
     live_database: bool = False,
 ) -> KnowledgeRecallEvaluationResult:
@@ -550,19 +773,26 @@ async def run_knowledge_recall_eval(
     """
 
     clean_org_id = _required_text(org_id, field_name="org_id")
+    if engine not in ("knowledge", "memory"):
+        raise ValueError("engine must be 'knowledge' or 'memory'")
+    selected_search = search or (
+        search_knowledge if engine == "knowledge" else search_memory_recall
+    )
     loaded_question_set = question_set or load_knowledge_recall_question_set()
     normalized_k = normalize_k_values(k_values)
     requested_search_limit = int(search_limit)
     report_generated_at = generated_at or datetime.now(timezone.utc).isoformat()
-    corpus_fingerprint = await build_knowledge_recall_corpus_fingerprint(
+    corpus_fingerprint, reachable_pointers = await _recall_corpus(
         session,
         org_id=clean_org_id,
+        engine=engine,
     )
     if not loaded_question_set.cases:
         return KnowledgeRecallInvalidResult(
             suite="knowledge-recall",
             generated_at=report_generated_at,
             live_database=live_database,
+            engine=engine,
             org_id=clean_org_id,
             question_set=loaded_question_set,
             k_values=normalized_k,
@@ -592,6 +822,7 @@ async def run_knowledge_recall_eval(
             suite="knowledge-recall",
             generated_at=report_generated_at,
             live_database=live_database,
+            engine=engine,
             org_id=clean_org_id,
             question_set=loaded_question_set,
             k_values=normalized_k,
@@ -603,13 +834,52 @@ async def run_knowledge_recall_eval(
             ),
         )
 
+    evidence_pointers = [
+        pointer
+        for case in loaded_question_set.cases
+        for pointer in case.acceptable_evidence
+    ]
+    reachable_count = sum(
+        (pointer.source, pointer.source_ref) in reachable_pointers
+        for pointer in evidence_pointers
+    )
+    if evidence_pointers and reachable_count == 0:
+        evidence_source_counts = Counter(
+            pointer.source for pointer in evidence_pointers
+        )
+        source_breakdown = ", ".join(
+            f"{count}/{len(evidence_pointers)} `{source}`"
+            for source, count in sorted(evidence_source_counts.items())
+        )
+        return KnowledgeRecallInvalidResult(
+            suite="knowledge-recall",
+            generated_at=report_generated_at,
+            live_database=live_database,
+            engine=engine,
+            org_id=clean_org_id,
+            question_set=loaded_question_set,
+            k_values=normalized_k,
+            requested_search_limit=requested_search_limit,
+            corpus_fingerprint=corpus_fingerprint,
+            errors=(
+                KnowledgeRecallCaseError(
+                    case_id=loaded_question_set.question_set_id,
+                    cause=(
+                        f"0 of {len(evidence_pointers)} acceptable evidence refs "
+                        f"are reachable in the {engine} corpus; the question set "
+                        f"evidence is {source_breakdown}"
+                    ),
+                ),
+            ),
+        )
+
     case_results: list[KnowledgeRecallCaseResult] = []
     case_errors: list[KnowledgeRecallCaseError] = []
     observed_depths: list[tuple[str, int]] = []
 
     for case in loaded_question_set.cases:
         try:
-            raw_response = await search(
+            raw_response = await selected_search(
                 session,
                 case.question,
                 org_id=clean_org_id,
@@ -687,6 +957,7 @@ async def run_knowledge_recall_eval(
             suite="knowledge-recall",
             generated_at=report_generated_at,
             live_database=live_database,
+            engine=engine,
             org_id=clean_org_id,
             question_set=loaded_question_set,
             k_values=normalized_k,
@@ -699,6 +970,7 @@ async def run_knowledge_recall_eval(
         suite="knowledge-recall",
         generated_at=report_generated_at,
         live_database=live_database,
+        engine=engine,
         org_id=clean_org_id,
         question_set=loaded_question_set,
         k_values=normalized_k,
@@ -723,7 +995,9 @@ __all__ = [
     "KnowledgeRecallSuiteResult",
     "RankedKnowledgeResult",
     "build_knowledge_recall_corpus_fingerprint",
+    "build_memory_recall_corpus_fingerprint",
     "load_knowledge_recall_question_set",
     "normalize_k_values",
     "run_knowledge_recall_eval",
+    "search_memory_recall",
 ]

--- a/brain/systems/knowledge/recall_eval.py
+++ b/brain/systems/knowledge/recall_eval.py
@@ -18,6 +18,7 @@ from brain.platform.db.models.knowledge import KnowledgeItem
 from brain.platform.db.models.reconstructive_memory import MemoryNode
 from brain.platform.db.repositories.reconstructive_memory import (
     MemoryNodeRepository,
+    memory_blend_weights,
     memory_content_node_filters,
 )
 from brain.systems.knowledge.recall_eval_contract import (
@@ -652,9 +653,11 @@ async def search_memory_recall(
         ),
     )
     semantic_available = query_embedding is not None
-    lexical_weight = 0.25 if semantic_available else 0.95
-    semantic_weight = 0.72 if semantic_available else 0.0
-    storage_weight = 0.03 if semantic_available else 0.05
+    # The ranker owns these numbers; reporting them from anywhere else drifts.
+    weights = memory_blend_weights(semantic_available=semantic_available)
+    lexical_weight = weights.lexical
+    semantic_weight = weights.semantic
+    storage_weight = weights.storage_confidence
     hits: list[KnowledgeSearchHit] = []
     for rank, node in enumerate(nodes, start=1):
         lexical_score = float(getattr(node, "lexical_score", 0.0))

--- a/brain/systems/knowledge/recall_eval_comparison.py
+++ b/brain/systems/knowledge/recall_eval_comparison.py
@@ -12,6 +12,8 @@ from brain.systems.knowledge.recall_eval_contract import (
     KnowledgeRecallInvalidArtifact,
     KnowledgeRecallLegacyInvalidArtifact,
     KnowledgeRecallLegacyValidArtifact,
+    KnowledgeRecallV1InvalidArtifact,
+    KnowledgeRecallV1ValidArtifact,
     KnowledgeRecallValidArtifact,
     KnowledgeRecallValidArtifactContract,
 )
@@ -134,9 +136,18 @@ def _metric_deltas(
 def _fingerprint(
     artifact: KnowledgeRecallValidArtifactContract,
 ) -> KnowledgeRecallCorpusFingerprint | None:
-    if isinstance(artifact, KnowledgeRecallValidArtifact):
+    if isinstance(
+        artifact,
+        (KnowledgeRecallValidArtifact, KnowledgeRecallV1ValidArtifact),
+    ):
         return artifact.corpus_fingerprint
     return None
+
+
+def _engine(artifact: KnowledgeRecallValidArtifactContract) -> str:
+    if isinstance(artifact, KnowledgeRecallValidArtifact):
+        return artifact.engine
+    return "knowledge"
 
 
 def _computed_comparison(
@@ -181,6 +192,7 @@ def compare_knowledge_recall_artifacts(
 
     invalid_types = (
         KnowledgeRecallInvalidArtifact,
+        KnowledgeRecallV1InvalidArtifact,
         KnowledgeRecallLegacyInvalidArtifact,
     )
     invalid_labels = [
@@ -204,10 +216,18 @@ def compare_knowledge_recall_artifacts(
 
     if not isinstance(
         baseline_artifact,
-        (KnowledgeRecallValidArtifact, KnowledgeRecallLegacyValidArtifact),
+        (
+            KnowledgeRecallValidArtifact,
+            KnowledgeRecallV1ValidArtifact,
+            KnowledgeRecallLegacyValidArtifact,
+        ),
     ) or not isinstance(
         candidate_artifact,
-        (KnowledgeRecallValidArtifact, KnowledgeRecallLegacyValidArtifact),
+        (
+            KnowledgeRecallValidArtifact,
+            KnowledgeRecallV1ValidArtifact,
+            KnowledgeRecallLegacyValidArtifact,
+        ),
     ):
         raise TypeError("comparison requires knowledge-recall artifacts")
     baseline = baseline_artifact
@@ -215,6 +235,10 @@ def compare_knowledge_recall_artifacts(
     baseline_corpus = _fingerprint(baseline)
     candidate_corpus = _fingerprint(candidate)
     checks = {
+        "engine": _check(
+            _engine(baseline),
+            _engine(candidate),
+        ),
         "question_set_digest": _check(
             baseline.question_set.digest,
             candidate.question_set.digest,
@@ -246,6 +270,7 @@ def compare_knowledge_recall_artifacts(
     blocking_differences = [
         name
         for name in (
+            "engine",
             "question_set_digest",
             "org_id",
             "k_values",

--- a/brain/systems/knowledge/recall_eval_contract.py
+++ b/brain/systems/knowledge/recall_eval_contract.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from brain.systems.knowledge.search_contract import KnowledgeSearchScores
 
-KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION = 1
+KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION = 2
 
 
 class _StrictKnowledgeRecallArtifactModel(BaseModel):
@@ -125,11 +125,18 @@ class KnowledgeRecallLegacyValidArtifact(_KnowledgeRecallLegacyArtifact):
     results: tuple[KnowledgeRecallArtifactCaseResult, ...]
 
 
-class KnowledgeRecallValidArtifact(KnowledgeRecallLegacyValidArtifact):
+class KnowledgeRecallV1ValidArtifact(KnowledgeRecallLegacyValidArtifact):
+    """Valid artifact emitted before recall engines were recorded."""
+
+    schema_version: Literal[1]
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+
+
+class KnowledgeRecallValidArtifact(KnowledgeRecallV1ValidArtifact):
     """Current valid evaluation artifact."""
 
     schema_version: Literal[KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION]
-    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+    engine: Literal["knowledge", "memory"]
 
 
 class KnowledgeRecallLegacyInvalidArtifact(_KnowledgeRecallLegacyArtifact):
@@ -140,21 +147,31 @@ class KnowledgeRecallLegacyInvalidArtifact(_KnowledgeRecallLegacyArtifact):
     errors: tuple[KnowledgeRecallArtifactCaseError, ...]
 
 
-class KnowledgeRecallInvalidArtifact(KnowledgeRecallLegacyInvalidArtifact):
+class KnowledgeRecallV1InvalidArtifact(KnowledgeRecallLegacyInvalidArtifact):
+    """Invalid artifact emitted before recall engines were recorded."""
+
+    schema_version: Literal[1]
+    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+
+
+class KnowledgeRecallInvalidArtifact(KnowledgeRecallV1InvalidArtifact):
     """Current invalid evaluation artifact."""
 
     schema_version: Literal[KNOWLEDGE_RECALL_ARTIFACT_SCHEMA_VERSION]
-    corpus_fingerprint: KnowledgeRecallCorpusFingerprint
+    engine: Literal["knowledge", "memory"]
 
 
 KnowledgeRecallValidArtifactContract = Union[
     KnowledgeRecallValidArtifact,
+    KnowledgeRecallV1ValidArtifact,
     KnowledgeRecallLegacyValidArtifact,
 ]
 KnowledgeRecallArtifact = Union[
     KnowledgeRecallValidArtifact,
+    KnowledgeRecallV1ValidArtifact,
     KnowledgeRecallLegacyValidArtifact,
     KnowledgeRecallInvalidArtifact,
+    KnowledgeRecallV1InvalidArtifact,
     KnowledgeRecallLegacyInvalidArtifact,
 ]
 
@@ -182,6 +199,8 @@ __all__ = [
     "KnowledgeRecallInvalidArtifactConfiguration",
     "KnowledgeRecallLegacyInvalidArtifact",
     "KnowledgeRecallLegacyValidArtifact",
+    "KnowledgeRecallV1InvalidArtifact",
+    "KnowledgeRecallV1ValidArtifact",
     "KnowledgeRecallValidArtifact",
     "KnowledgeRecallValidArtifactContract",
     "parse_knowledge_recall_artifact_json",

--- a/tests/test_knowledge_recall_eval.py
+++ b/tests/test_knowledge_recall_eval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
@@ -9,6 +10,7 @@ from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 from brain.app.cli import knowledge_recall as knowledge_recall_cli
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.knowledge import KnowledgeItem
+from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.recall_eval import (
     EvidencePointer,
     KnowledgeRecallCaseError,
@@ -21,6 +23,7 @@ from brain.systems.knowledge.recall_eval import (
     build_knowledge_recall_corpus_fingerprint,
     load_knowledge_recall_question_set,
     run_knowledge_recall_eval,
+    search_memory_recall,
 )
 from brain.systems.knowledge.recall_eval_contract import (
     KnowledgeRecallArtifact,
@@ -180,9 +183,27 @@ def _question_set() -> KnowledgeRecallQuestionSet:
     )
 
 
+async def _seed_question_set_evidence(
+    session,
+    question_set: KnowledgeRecallQuestionSet,
+) -> None:
+    pointers = {
+        (pointer.source, pointer.source_ref)
+        for case in question_set.cases
+        for pointer in case.acceptable_evidence
+    }
+    for item_id, (source, source_ref) in enumerate(sorted(pointers), start=1000):
+        item = _item(item_id, source_ref, f"Reachable evidence {item_id}")
+        item.source = source
+        session.add(item)
+    await session.flush()
+
+
 async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denominator(
     knowledge_session,
 ):
+    question_set = _question_set()
+    await _seed_question_set_evidence(knowledge_session, question_set)
     distractors = [
         _item(index + 10, f"github:Illospace/illospace#{index + 10}", f"Noise {index}")
         for index in range(5)
@@ -204,7 +225,7 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
     report = await run_knowledge_recall_eval(
         knowledge_session,
         org_id=_ORG_ID,
-        question_set=_question_set(),
+        question_set=question_set,
         k_values=(1, 5),
         search_limit=5,
         search=stub_search,
@@ -214,12 +235,13 @@ async def test_known_rankings_compute_recall_at_k_and_mrr_with_misses_in_denomin
     payload = report.to_dict()
 
     assert payload["result_type"] == "valid"
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
+    assert payload["engine"] == "knowledge"
     assert payload["corpus_fingerprint"] == _corpus_fingerprint(
         fingerprint=payload["corpus_fingerprint"]["fingerprint"],
-        total_item_count=0,
-        newest_source_updated_at=None,
-        newest_ingested_at=None,
+        total_item_count=4,
+        newest_source_updated_at="2026-07-30T00:00:00+00:00",
+        newest_ingested_at="2026-07-30T00:00:00+00:00",
     ).model_dump(mode="json")
     assert len(payload["corpus_fingerprint"]["fingerprint"]) == 64
     assert payload["summary"] == {
@@ -262,6 +284,7 @@ async def test_report_preserves_channel_attribution_and_marks_semantic_degradati
         description="Semantic degradation fixture.",
         cases=(_question_set().cases[0],),
     )
+    await _seed_question_set_evidence(knowledge_session, single_case)
     payload = (
         await run_knowledge_recall_eval(
             knowledge_session,
@@ -310,6 +333,7 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss(
         description="Producer drift fixture.",
         cases=(_question_set().cases[0],),
     )
+    await _seed_question_set_evidence(knowledge_session, single_case)
     report = await run_knowledge_recall_eval(
         knowledge_session,
         org_id=_ORG_ID,
@@ -325,9 +349,9 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss(
     assert payload["result_type"] == "invalid"
     assert payload["corpus_fingerprint"] == _corpus_fingerprint(
         fingerprint=payload["corpus_fingerprint"]["fingerprint"],
-        total_item_count=0,
-        newest_source_updated_at=None,
-        newest_ingested_at=None,
+        total_item_count=1,
+        newest_source_updated_at="2026-07-30T00:00:00+00:00",
+        newest_ingested_at="2026-07-30T00:00:00+00:00",
     ).model_dump(mode="json")
     assert "summary" not in payload
     assert "results" not in payload
@@ -339,6 +363,8 @@ async def test_malformed_search_hit_is_an_evaluation_error_not_a_miss(
 async def test_one_search_failure_invalidates_the_whole_question_set(
     knowledge_session,
 ):
+    question_set = _question_set()
+    await _seed_question_set_evidence(knowledge_session, question_set)
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
 
     async def partly_failing_search(_session, query, *, org_id, limit):
@@ -350,7 +376,7 @@ async def test_one_search_failure_invalidates_the_whole_question_set(
     report = await run_knowledge_recall_eval(
         knowledge_session,
         org_id=_ORG_ID,
-        question_set=_question_set(),
+        question_set=question_set,
         k_values=(1,),
         search_limit=1,
         search=partly_failing_search,
@@ -389,6 +415,7 @@ async def test_eval_rejects_effective_depth_that_cannot_support_requested_k(
         description="Retrieval-depth fixture.",
         cases=(_question_set().cases[0],),
     )
+    await _seed_question_set_evidence(knowledge_session, single_case)
     report = await run_knowledge_recall_eval(
         knowledge_session,
         org_id=_ORG_ID,
@@ -416,6 +443,13 @@ async def test_inconsistent_effective_depths_return_one_invalid_result(
 ):
     evidence = _item(1, "github:Illospace/illospace#1", "Alpha evidence")
     cases = _question_set().cases[:2]
+    question_set = KnowledgeRecallQuestionSet(
+        question_set_id="inconsistent-depth",
+        version="1",
+        description="Inconsistent retrieval-depth fixture.",
+        cases=cases,
+    )
+    await _seed_question_set_evidence(knowledge_session, question_set)
 
     async def inconsistent_search(_session, query, *, org_id, limit):
         assert org_id == _ORG_ID
@@ -430,12 +464,7 @@ async def test_inconsistent_effective_depths_return_one_invalid_result(
     report = await run_knowledge_recall_eval(
         knowledge_session,
         org_id=_ORG_ID,
-        question_set=KnowledgeRecallQuestionSet(
-            question_set_id="inconsistent-depth",
-            version="1",
-            description="Inconsistent retrieval-depth fixture.",
-            cases=cases,
-        ),
+        question_set=question_set,
         k_values=(3,),
         search_limit=5,
         search=inconsistent_search,
@@ -473,6 +502,7 @@ async def test_mrr_cutoff_uses_effective_retrieval_depth(knowledge_session):
         description="Actual MRR cutoff fixture.",
         cases=(_question_set().cases[0],),
     )
+    await _seed_question_set_evidence(knowledge_session, single_case)
     payload = (
         await run_knowledge_recall_eval(
             knowledge_session,
@@ -490,6 +520,206 @@ async def test_mrr_cutoff_uses_effective_retrieval_depth(knowledge_session):
     assert payload["summary"]["mean_reciprocal_rank_cutoff"] == 4
 
 
+async def test_memory_adapter_maps_memory_retrieval_scores(monkeypatch):
+    node = SimpleNamespace(
+        id=41,
+        node_kind="content",
+        content_kind="decision",
+        canonical_label="Use the memory recall arm",
+        text="The harness should use memory's own blended ranker.",
+        confidence=0.8,
+        freshness_status="fresh",
+        scope_key="default",
+        truth_status="active",
+        visibility="org",
+        created_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 8, 2, tzinfo=timezone.utc),
+        retrieval_score=0.734,
+        semantic_score=0.81,
+        lexical_score=0.55,
+    )
+
+    async def fake_embed(_session, query):
+        assert query == "How does memory recall rank?"
+        return SimpleNamespace(vector=[0.1, 0.2], model="test:model")
+
+    async def fake_search(
+        _repository,
+        *,
+        query,
+        org_id,
+        limit,
+        query_embedding,
+        embedding_model,
+    ):
+        assert query == "How does memory recall rank?"
+        assert org_id == _ORG_ID
+        assert limit == 10
+        assert query_embedding == [0.1, 0.2]
+        assert embedding_model == "test:model"
+        return [node]
+
+    monkeypatch.setattr(
+        "brain.systems.knowledge.recall_eval._embed_memory_recall_query",
+        fake_embed,
+    )
+    monkeypatch.setattr(
+        "brain.systems.knowledge.recall_eval.MemoryNodeRepository.search_content_nodes",
+        fake_search,
+    )
+
+    response = await search_memory_recall(
+        SimpleNamespace(),
+        "How does memory recall rank?",
+        org_id=_ORG_ID,
+        limit=10,
+    )
+
+    hit = response.results[0]
+    assert hit.source == "memory"
+    assert hit.source_ref == "memory_node:41"
+    assert hit.scores.rrf == 0.734
+    assert hit.scores.channels.semantic.score == 0.81
+    assert hit.scores.channels.lexical.score == 0.55
+
+
+async def test_memory_guard_rejects_github_only_evidence_with_counts(
+    knowledge_session,
+):
+    question_set = load_knowledge_recall_question_set()
+    evidence_count = sum(
+        len(case.acceptable_evidence) for case in question_set.cases
+    )
+    assert evidence_count == 58
+    assert {
+        pointer.source
+        for case in question_set.cases
+        for pointer in case.acceptable_evidence
+    } == {"github"}
+
+    async def search_must_not_run(*_args, **_kwargs):
+        raise AssertionError("search ran before the corpus guard")
+
+    report = await run_knowledge_recall_eval(
+        knowledge_session,
+        org_id=_ORG_ID,
+        question_set=question_set,
+        k_values=(1,),
+        search_limit=1,
+        engine="memory",
+        search=search_must_not_run,
+        generated_at=_FIXED_TIME,
+    )
+
+    assert isinstance(report, KnowledgeRecallInvalidResult)
+    payload = report.to_dict()
+    assert payload["engine"] == "memory"
+    assert payload["errors"] == [
+        {
+            "case_id": question_set.question_set_id,
+            "cause": (
+                "0 of 58 acceptable evidence refs are reachable in the memory "
+                "corpus; the question set evidence is 58/58 `github`"
+            ),
+        }
+    ]
+    assert "summary" not in payload
+
+
+async def test_knowledge_guard_accepts_reachable_github_evidence(
+    knowledge_session,
+):
+    case = _question_set().cases[0]
+    question_set = KnowledgeRecallQuestionSet(
+        question_set_id="reachable-github",
+        version="1",
+        description="Knowledge reachability fixture.",
+        cases=(case,),
+    )
+    await _seed_question_set_evidence(knowledge_session, question_set)
+    evidence = _item(1, case.acceptable_evidence[0].source_ref, "Alpha evidence")
+
+    async def stub_search(_session, query, *, org_id, limit):
+        return _search_response(query, [evidence], requested_limit=limit)
+
+    report = await run_knowledge_recall_eval(
+        knowledge_session,
+        org_id=_ORG_ID,
+        question_set=question_set,
+        k_values=(1,),
+        search_limit=1,
+        engine="knowledge",
+        search=stub_search,
+        generated_at=_FIXED_TIME,
+    )
+
+    assert isinstance(report, KnowledgeRecallSuiteResult)
+    assert report.to_dict()["summary"]["recall_at_k"] == {"1": 1.0}
+
+
+async def test_memory_arm_scores_memory_reachable_evidence(
+    knowledge_session,
+    monkeypatch,
+):
+    node = MemoryNode(
+        id=77,
+        node_kind="content",
+        content_kind="decision",
+        canonical_label="Memory corpus comparison guard",
+        text="The memory corpus comparison guard prevents a fake recall win.",
+        normalized_key="memory corpus comparison guard",
+        scope_key="default",
+        org_id=_ORG_ID,
+        visibility="org",
+        confidence=0.9,
+        truth_status="active",
+        freshness_status="fresh",
+    )
+    knowledge_session.add(node)
+    await knowledge_session.flush()
+
+    async def no_query_embedding(_session, _query):
+        return None
+
+    monkeypatch.setattr(
+        "brain.systems.knowledge.recall_eval._embed_memory_recall_query",
+        no_query_embedding,
+    )
+    question_set = KnowledgeRecallQuestionSet(
+        question_set_id="reachable-memory",
+        version="1",
+        description="Memory reachability fixture.",
+        cases=(
+            KnowledgeRecallQuestion(
+                case_id="memory-hit",
+                question="What prevents a fake recall win?",
+                acceptable_evidence=(
+                    EvidencePointer("memory", "memory_node:77"),
+                ),
+            ),
+        ),
+    )
+
+    report = await run_knowledge_recall_eval(
+        knowledge_session,
+        org_id=_ORG_ID,
+        question_set=question_set,
+        k_values=(1,),
+        search_limit=1,
+        engine="memory",
+        generated_at=_FIXED_TIME,
+    )
+
+    assert isinstance(report, KnowledgeRecallSuiteResult)
+    payload = report.to_dict()
+    assert payload["engine"] == "memory"
+    assert payload["summary"]["recall_at_k"] == {"1": 1.0}
+    scores = payload["results"][0]["ranked_results"][0]["scores"]
+    assert scores["rrf"] == 0.995
+    assert scores["channels"]["lexical"]["score"] == 1.0
+    assert scores["channels"]["semantic"] is None
+
+
 def test_cli_emits_invalid_result_and_returns_nonzero(monkeypatch, capsys):
     invalid_payload = {
         "result_type": "invalid",
@@ -502,7 +732,8 @@ def test_cli_emits_invalid_result_and_returns_nonzero(monkeypatch, capsys):
         ],
     }
 
-    async def fake_run(_args):
+    async def fake_run(args):
+        assert args.engine == "knowledge"
         return invalid_payload
 
     monkeypatch.setattr(knowledge_recall_cli, "_run", fake_run)
@@ -511,6 +742,21 @@ def test_cli_emits_invalid_result_and_returns_nonzero(monkeypatch, capsys):
 
     assert exit_code == 1
     assert json.loads(capsys.readouterr().out) == invalid_payload
+
+
+def test_cli_accepts_memory_engine(monkeypatch, capsys):
+    async def fake_run(args):
+        assert args.engine == "memory"
+        return {"result_type": "invalid", "engine": args.engine, "errors": []}
+
+    monkeypatch.setattr(knowledge_recall_cli, "_run", fake_run)
+
+    exit_code = knowledge_recall_cli.main(
+        ["eval", "--org-id", _ORG_ID, "--engine", "memory"]
+    )
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out)["engine"] == "memory"
 
 
 def _comparison_report(
@@ -522,6 +768,7 @@ def _comparison_report(
     requested_search_limit: int = 50,
     effective_search_limit: int = 50,
     ranks: tuple[int | None, ...] = (1, 4),
+    engine: str = "knowledge",
 ) -> KnowledgeRecallSuiteResult:
     questions = tuple(
         KnowledgeRecallQuestion(
@@ -554,6 +801,7 @@ def _comparison_report(
         suite="knowledge-recall",
         generated_at=_FIXED_TIME,
         live_database=True,
+        engine=engine,
         org_id=org_id,
         question_set=KnowledgeRecallQuestionSet(
             question_set_id="comparison-fixture",
@@ -573,6 +821,14 @@ def _legacy_artifact(report: KnowledgeRecallSuiteResult) -> KnowledgeRecallArtif
     payload = report.to_dict()
     payload.pop("schema_version")
     payload.pop("corpus_fingerprint")
+    payload.pop("engine")
+    return parse_knowledge_recall_artifact_json(json.dumps(payload))
+
+
+def _v1_artifact(report: KnowledgeRecallSuiteResult) -> KnowledgeRecallArtifact:
+    payload = report.to_dict()
+    payload["schema_version"] = 1
+    payload.pop("engine")
     return parse_knowledge_recall_artifact_json(json.dumps(payload))
 
 
@@ -619,6 +875,73 @@ def test_compare_labels_same_corpus_metric_change_as_ranking_attributable(
         "change": "rank-changed",
     }
     assert payload["metric_deltas"]["mean_reciprocal_rank"]["delta"] == -0.25
+
+
+def test_compare_refuses_cross_engine_artifacts(tmp_path, capsys):
+    corpus = _corpus_fingerprint()
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(
+        baseline_path,
+        _comparison_report(corpus_fingerprint=corpus, engine="knowledge"),
+    )
+    _write_artifact(
+        candidate_path,
+        _comparison_report(corpus_fingerprint=corpus, engine="memory"),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["comparability"]["verdict"] == "not-comparable"
+    assert payload["comparability"]["differences"] == ["engine"]
+    assert payload["comparability"]["checks"]["engine"] == {
+        "baseline": "knowledge",
+        "candidate": "memory",
+        "state": "different",
+    }
+    assert "metric_deltas" not in payload
+
+
+def test_compare_loads_version_one_artifacts_as_knowledge_engine(tmp_path, capsys):
+    corpus = _corpus_fingerprint()
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_artifact(
+        baseline_path,
+        _v1_artifact(_comparison_report(corpus_fingerprint=corpus)),
+    )
+    _write_artifact(
+        candidate_path,
+        _v1_artifact(_comparison_report(corpus_fingerprint=corpus)),
+    )
+
+    exit_code = knowledge_recall_cli.main(
+        [
+            "compare",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["comparability"]["checks"]["engine"] == {
+        "baseline": "knowledge",
+        "candidate": "knowledge",
+        "state": "match",
+    }
 
 
 def test_compare_reports_changed_corpus_without_claiming_causation(tmp_path, capsys):
@@ -883,6 +1206,7 @@ def test_compare_refuses_invalid_artifact(tmp_path, capsys):
         suite="knowledge-recall",
         generated_at=_FIXED_TIME,
         live_database=True,
+        engine="knowledge",
         org_id=_ORG_ID,
         question_set=question_set,
         k_values=(3, 10),
@@ -972,6 +1296,8 @@ async def knowledge_session(async_sqlite_session_factory, sqlite_postgres_ddl_pa
         [
             AgentRunRow.__table__,
             KnowledgeItem.__table__,
+            MemoryNode.__table__,
+            MemoryEdgeNode.__table__,
         ]
     )
 


### PR DESCRIPTION
Closes nothing on its own — this is a prerequisite for [#578](https://github.com/Illospace/illospace/issues/578) item 3, which stays open.

## Why

Item 3 gates deleting the memory recall path on a measured comparison: knowledge search must beat "memory's own lexical+vector recall on the harness."

**That comparison could not be run, and forcing it produced a fake win.** Measured against the live database on 2026-08-04:

| fact | value |
|---|---|
| `acceptable_evidence` refs in the 29-case set | **58 of 58 are `github:…#N`** |
| `knowledge_items` by source | slack 7045 · **github 3299** · domain_records 3269 · memory 207 |
| memory `content` nodes (whole subsystem) | **313** |
| of those, nodes mentioning any `illospace#` ref | **3** |

The memory subsystem has no GitHub connector. So a memory run scores ~0.00 on every case because the documents are **absent from its corpus**, not because the ranker is worse. A `0.86 vs 0.00` result reads as "delete memory" while proving nothing about what the deletion would lose — and the action it licenses is irreversible.

## What this adds

- **A memory engine.** Adapts memory's own ranker (`_rank_memory_nodes` — semantic cosine, lexical coverage, storage confidence) to the harness search contract, via the pluggable `search` seam that already existed. Neither ranker changes.
- **A reachability guard.** When none of a question set's evidence refs exist in an engine's corpus, the run returns an invalid result naming the counts — `0 of 58 acceptable evidence refs are reachable in the memory corpus; the question set evidence is 58/58 github` — instead of a score. This follows the module's existing rule that metrics which are not comparable must not be emitted.
- **`memory_content_node_filters`**, extracted so the corpus fingerprint counts exactly the rows memory search sees. Mirrors the existing `knowledge_item_filters`.
- **`--engine knowledge|memory`** on the CLI, defaulting to `knowledge` so today's invocation is unchanged. Artifacts record the engine; `compare` refuses cross-engine and invalid artifacts. Existing 07-31 and 08-01 artifacts still load.

## Review surface

No UI. Judge it from these:

```bash
cd <repo> && python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

- **Full CI selection: 4724 passed, 11 skipped, 0 failed** (67s, run outside the sandbox — the workflow's exact command from `.github/workflows/brain-ci.yml`, which since #656 includes `meetbot/tests`).
- The guard's behaviour is pinned by 7 tests in `tests/test_knowledge_recall_eval.py`: it fires for the memory engine on a github-only set, does **not** fire for the knowledge engine on the same set, and does not fire when evidence *is* reachable — so it keys on reachability, not on which engine is running.

**Acceptance checks:**
1. `--engine memory` on seed v2 returns INVALID naming `0 of 58`, never a 0.00 score.
2. `--engine knowledge` on seed v2 behaves exactly as before this PR.
3. `compare` rejects a knowledge artifact against a memory artifact, and rejects any invalid artifact.
4. Memory ranking and knowledge ranking are byte-for-byte unchanged in behaviour.

## Named, not fixed — one is a real design call

1. **The guard triggers on a hard zero (`reachable_count == 0`).** If 4 of 58 refs were reachable, the run scores and emits a near-zero metric — the exact misleading artifact the guard exists to prevent. This is **weaker than the standard this module already sets for itself**: a single case failure invalidates the whole run, on the stated grounds that partial-subset metrics are not comparable.

   The design I would defend is stricter *and* simpler: treat a case whose entire evidence set is unreachable in this engine's corpus as a **case error**, and let the existing "any case error invalidates the run" rule do the work — the hard-zero special case then disappears. I did not make that change here because it decides **which cases count toward a score**, i.e. metric semantics on a deletion gate. That is the same class of call as the "one incident, two entry points" finding from the seed-v2 review, which was also left to the owner.

2. **`suite` stays `"knowledge-recall"` for both engines.** Slightly misleading inside a memory-engine artifact. Cosmetic, but it is what a reader greps for.

## Review provenance — one caveat, stated plainly

The guardrail requires the thermo-nuclear maintainability pass to run through **Codex**, so the review crosses model families. **It could not.** Codex hit its usage limit mid-run — credits are exhausted until **Aug 8**, not the usual 5-hour window. The implementation worker consumed the last of them.

Per the Codex-unavailable fallback, the maintainability review was done by the Claude director instead. Finding 1 above and the weight-duplication fix below both came out of it. **But it is a same-family review, so it carries the blind spots of the family that wrote the code.** Worth a second pass after Aug 8 if this is going to gate the deletion.

One finding from that review **was** fixed, because it needed no judgement call: `search_memory_recall` had re-declared the ranker's weights (`0.72 / 0.25 / 0.03`, and `0.95 / 0.05` degraded) as local literals in order to report channel contributions. Retuning memory's blend would have silently desynced the reported contributions from the actual ranking. The weights now have one owner — `memory_blend_weights()` in the memory repository — and the adapter imports them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
