### PR TITLE
feat(cycles): quota-aware admission gate for Codex-backed runs (#662)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ ILLO_PRIVATE_HOME=.illo
 # Local Codex auth fallback is convenient for single-user laptop dev only.
 # Leave this disabled in shared or production environments.
 ILLO_ALLOW_LOCAL_CODEX_AUTH_FALLBACK=0
+# Codex subscription admission reads local session usage from CODEX_HOME.
+# It defaults to ~/.codex. Unknown or unreadable usage always fails open.
+# CODEX_HOME=/absolute/path/to/.codex
+# ILLO_CODEX_QUOTA_SOFT_PERCENT=75
+# ILLO_CODEX_QUOTA_HARD_PERCENT=90
 # The launcher refuses to kill unknown processes on app ports by default.
 # Set only when you intentionally want ./illo to reclaim 8000/5173/9800.
 # ILLO_FORCE_KILL_PORTS=1

--- a/brain/platform/integrations/codex_usage.py
+++ b/brain/platform/integrations/codex_usage.py
@@ -1,0 +1,342 @@
+"""Read Codex subscription usage from local session event logs."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+
+CodexUsageStatus = Literal["ok", "unknown", "exhausted"]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexKnownUsage:
+    used_percent: float
+    observed_at: str
+    source_path: str
+    limit_id: str = "codex"
+    plan_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "used_percent": self.used_percent,
+            "observed_at": self.observed_at,
+            "source_path": self.source_path,
+            "limit_id": self.limit_id,
+            "plan_type": self.plan_type,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CodexUsageReading:
+    status: CodexUsageStatus
+    used_percent: float | None = None
+    reason: str | None = None
+    observed_at: str | None = None
+    source_path: str | None = None
+    limit_id: str | None = None
+    plan_type: str | None = None
+    last_known_good: CodexKnownUsage | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "used_percent": self.used_percent,
+            "reason": self.reason,
+            "observed_at": self.observed_at,
+            "source_path": self.source_path,
+            "limit_id": self.limit_id,
+            "plan_type": self.plan_type,
+            "last_known_good": (
+                self.last_known_good.to_dict() if self.last_known_good else None
+            ),
+        }
+
+
+def codex_home_path(path: str | Path | None = None) -> Path:
+    """Return the configured Codex home, defaulting to ``~/.codex``."""
+
+    if path is not None:
+        return Path(path).expanduser()
+    configured = str(os.environ.get("CODEX_HOME") or "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
+def _unknown(
+    reason: str,
+    *,
+    observed_at: str | None = None,
+    source_path: Path | None = None,
+    limit_id: str | None = None,
+    plan_type: str | None = None,
+) -> CodexUsageReading:
+    return CodexUsageReading(
+        status="unknown",
+        reason=reason,
+        observed_at=observed_at,
+        source_path=str(source_path) if source_path else None,
+        limit_id=limit_id,
+        plan_type=plan_type,
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _event_timestamp(data: Mapping[str, Any], source_path: Path) -> str:
+    payload = _mapping(data.get("payload"))
+    raw = data.get("timestamp") or payload.get("timestamp")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    try:
+        modified = datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        modified = datetime.now(timezone.utc)
+    return modified.isoformat()
+
+
+def _token_count_payload(data: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    if data.get("type") == "token_count":
+        return data
+    payload = _mapping(data.get("payload"))
+    if payload.get("type") == "token_count":
+        return payload
+    return None
+
+
+def _is_auth_error(data: Mapping[str, Any]) -> bool:
+    payload = _mapping(data.get("payload"))
+    event_type = str(payload.get("type") or data.get("type") or "").lower()
+    if event_type not in {"error", "auth_error", "authentication_error"}:
+        return False
+    error = payload.get("error") or data.get("error") or payload
+    text = json.dumps(error, default=str).lower()
+    return any(
+        marker in text
+        for marker in ("auth", "unauthorized", "forbidden", '"401"', '"403"')
+    )
+
+
+def _rate_limits(
+    data: Mapping[str, Any], token_payload: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    info = _mapping(token_payload.get("info"))
+    return _mapping(
+        token_payload.get("rate_limits")
+        or info.get("rate_limits")
+        or data.get("rate_limits")
+    )
+
+
+def _reading_from_event(
+    data: Mapping[str, Any],
+    *,
+    source_path: Path,
+) -> CodexUsageReading | None:
+    if _is_auth_error(data):
+        return _unknown(
+            "auth_error",
+            observed_at=_event_timestamp(data, source_path),
+            source_path=source_path,
+        )
+
+    token_payload = _token_count_payload(data)
+    if token_payload is None:
+        return None
+
+    observed_at = _event_timestamp(data, source_path)
+    if token_payload.get("error"):
+        return _unknown(
+            "auth_error",
+            observed_at=observed_at,
+            source_path=source_path,
+        )
+    rate_limits = _rate_limits(data, token_payload)
+    if not rate_limits:
+        return _unknown(
+            "rate_limits_missing",
+            observed_at=observed_at,
+            source_path=source_path,
+        )
+    if rate_limits.get("error"):
+        return _unknown(
+            "auth_error",
+            observed_at=observed_at,
+            source_path=source_path,
+        )
+
+    limit_id_value = rate_limits.get("limit_id")
+    limit_id = str(limit_id_value).strip() if limit_id_value is not None else None
+    plan_value = rate_limits.get("plan_type")
+    plan_type = str(plan_value).strip() if plan_value is not None else None
+    if limit_id != "codex":
+        return _unknown(
+            "unexpected_limit_id",
+            observed_at=observed_at,
+            source_path=source_path,
+            limit_id=limit_id,
+            plan_type=plan_type,
+        )
+
+    primary = rate_limits.get("primary")
+    if not isinstance(primary, Mapping):
+        return _unknown(
+            "primary_missing",
+            observed_at=observed_at,
+            source_path=source_path,
+            limit_id=limit_id,
+            plan_type=plan_type,
+        )
+
+    used_percent = primary.get("used_percent")
+    if isinstance(used_percent, bool) or not isinstance(used_percent, (int, float)):
+        return _unknown(
+            "used_percent_missing",
+            observed_at=observed_at,
+            source_path=source_path,
+            limit_id=limit_id,
+            plan_type=plan_type,
+        )
+    normalized_percent = float(used_percent)
+    if not math.isfinite(normalized_percent) or normalized_percent < 0:
+        return _unknown(
+            "used_percent_invalid",
+            observed_at=observed_at,
+            source_path=source_path,
+            limit_id=limit_id,
+            plan_type=plan_type,
+        )
+    return CodexUsageReading(
+        status="exhausted" if normalized_percent >= 100 else "ok",
+        used_percent=normalized_percent,
+        observed_at=observed_at,
+        source_path=str(source_path),
+        limit_id=limit_id,
+        plan_type=plan_type,
+    )
+
+
+def _session_files(sessions_path: Path) -> list[Path]:
+    files = list(sessions_path.glob("*/*/*/*.jsonl"))
+    return sorted(
+        files,
+        key=lambda item: (item.stat().st_mtime_ns, str(item)),
+        reverse=True,
+    )
+
+
+def _read_lines(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8") as handle:
+        return handle.readlines()
+
+
+def _scan_lines(
+    lines: list[str],
+    *,
+    source_path: Path,
+    malformed_is_verdict: bool,
+) -> CodexUsageReading | None:
+    for raw_line in reversed(lines):
+        if not raw_line.strip():
+            continue
+        try:
+            data = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            if malformed_is_verdict:
+                return _unknown("malformed_line", source_path=source_path)
+            continue
+        if not isinstance(data, Mapping):
+            if malformed_is_verdict:
+                return _unknown("malformed_line", source_path=source_path)
+            continue
+        reading = _reading_from_event(data, source_path=source_path)
+        if reading is not None:
+            return reading
+    return None
+
+
+def _find_last_known(files: list[Path]) -> CodexKnownUsage | None:
+    for source_path in files:
+        try:
+            lines = _read_lines(source_path)
+        except (OSError, UnicodeError):
+            continue
+        for raw_line in reversed(lines):
+            try:
+                data = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(data, Mapping):
+                continue
+            reading = _reading_from_event(data, source_path=source_path)
+            if reading is None or reading.status == "unknown":
+                continue
+            return CodexKnownUsage(
+                used_percent=float(reading.used_percent),
+                observed_at=str(reading.observed_at),
+                source_path=str(source_path),
+                plan_type=reading.plan_type,
+            )
+    return None
+
+
+def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
+    """Read the newest local Codex usage verdict and retain older known usage.
+
+    Unknown inputs always remain unknown. In particular, degenerate entitlement
+    payloads are not converted to either zero or one hundred percent.
+    """
+
+    sessions_path = codex_home_path(path) / "sessions"
+    try:
+        if not sessions_path.exists():
+            return _unknown("sessions_dir_missing")
+        if not sessions_path.is_dir():
+            return _unknown("sessions_dir_unreadable")
+        files = _session_files(sessions_path)
+    except OSError:
+        return _unknown("sessions_dir_unreadable")
+    if not files:
+        return _unknown("sessions_dir_empty")
+
+    newest = files[0]
+    try:
+        newest_lines = _read_lines(newest)
+    except (OSError, UnicodeError):
+        verdict = _unknown("session_file_unreadable", source_path=newest)
+    else:
+        if not any(line.strip() for line in newest_lines):
+            verdict = _unknown("session_file_empty", source_path=newest)
+        else:
+            verdict = _scan_lines(
+                newest_lines,
+                source_path=newest,
+                malformed_is_verdict=True,
+            ) or _unknown("token_count_missing", source_path=newest)
+
+    if verdict.status != "unknown":
+        return verdict
+    return CodexUsageReading(
+        status=verdict.status,
+        reason=verdict.reason,
+        observed_at=verdict.observed_at,
+        source_path=verdict.source_path,
+        limit_id=verdict.limit_id,
+        plan_type=verdict.plan_type,
+        last_known_good=_find_last_known(files),
+    )
+
+
+__all__ = [
+    "CodexKnownUsage",
+    "CodexUsageReading",
+    "CodexUsageStatus",
+    "codex_home_path",
+    "read_codex_usage",
+]

--- a/brain/platform/integrations/provider_quota_preflight.py
+++ b/brain/platform/integrations/provider_quota_preflight.py
@@ -1,0 +1,221 @@
+"""Neutral provider subscription-quota probing for admission boundaries."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, replace
+from typing import Any
+
+from brain.platform.integrations.codex_usage import CodexUsageReading, read_codex_usage
+from brain.platform.providers.model_policy import required_openai_auth_mode
+
+
+DEFAULT_CODEX_QUOTA_SOFT_PERCENT = 75.0
+DEFAULT_CODEX_QUOTA_HARD_PERCENT = 90.0
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderQuotaThresholds:
+    soft_percent: float
+    hard_percent: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "soft_percent": self.soft_percent,
+            "hard_percent": self.hard_percent,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderQuotaPreflightResult:
+    status: str
+    decision: str
+    provider: str
+    model: str
+    usage_status: str | None
+    thresholds: ProviderQuotaThresholds
+    used_percent: float | None = None
+    unknown_reason: str | None = None
+    observed_at: str | None = None
+    source_path: str | None = None
+    limit_id: str | None = None
+    plan_type: str | None = None
+    last_known_good: dict[str, Any] | None = None
+    explicit_request: bool = False
+    visible_message: str | None = None
+
+    @property
+    def blocked(self) -> bool:
+        return self.decision == "blocked"
+
+    @property
+    def deferred(self) -> bool:
+        return self.decision == "deferred"
+
+    def with_presentation(self, *, visible_message: str) -> ProviderQuotaPreflightResult:
+        return replace(self, visible_message=visible_message)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "decision": self.decision,
+            "provider": self.provider,
+            "model": self.model,
+            "usage_status": self.usage_status,
+            "used_percent": self.used_percent,
+            "unknown_reason": self.unknown_reason,
+            "observed_at": self.observed_at,
+            "source_path": self.source_path,
+            "limit_id": self.limit_id,
+            "plan_type": self.plan_type,
+            "last_known_good": self.last_known_good,
+            "explicit_request": self.explicit_request,
+            "thresholds": self.thresholds.to_dict(),
+            "visible_message": self.visible_message,
+        }
+
+
+def _percent_setting(name: str, default: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or not 0 <= value <= 100:
+        return default
+    return value
+
+
+def provider_quota_thresholds() -> ProviderQuotaThresholds:
+    soft = _percent_setting(
+        "ILLO_CODEX_QUOTA_SOFT_PERCENT",
+        DEFAULT_CODEX_QUOTA_SOFT_PERCENT,
+    )
+    hard = _percent_setting(
+        "ILLO_CODEX_QUOTA_HARD_PERCENT",
+        DEFAULT_CODEX_QUOTA_HARD_PERCENT,
+    )
+    if soft >= hard:
+        soft = DEFAULT_CODEX_QUOTA_SOFT_PERCENT
+        hard = DEFAULT_CODEX_QUOTA_HARD_PERCENT
+    return ProviderQuotaThresholds(soft_percent=soft, hard_percent=hard)
+
+
+def skipped_provider_quota_preflight(
+    *,
+    provider: str,
+    model: str,
+    explicit_request: bool,
+    thresholds: ProviderQuotaThresholds | None = None,
+) -> ProviderQuotaPreflightResult:
+    return ProviderQuotaPreflightResult(
+        status="skipped",
+        decision="admitted",
+        provider=provider,
+        model=model,
+        usage_status=None,
+        thresholds=thresholds or provider_quota_thresholds(),
+        explicit_request=explicit_request,
+    )
+
+
+def _result_from_usage(
+    usage: CodexUsageReading,
+    *,
+    status: str,
+    decision: str,
+    provider: str,
+    model: str,
+    explicit_request: bool,
+    thresholds: ProviderQuotaThresholds,
+) -> ProviderQuotaPreflightResult:
+    return ProviderQuotaPreflightResult(
+        status=status,
+        decision=decision,
+        provider=provider,
+        model=model,
+        usage_status=usage.status,
+        thresholds=thresholds,
+        used_percent=usage.used_percent,
+        unknown_reason=usage.reason,
+        observed_at=usage.observed_at,
+        source_path=usage.source_path,
+        limit_id=usage.limit_id,
+        plan_type=usage.plan_type,
+        last_known_good=(
+            usage.last_known_good.to_dict() if usage.last_known_good else None
+        ),
+        explicit_request=explicit_request,
+    )
+
+
+def probe_provider_quota(
+    *,
+    provider: str,
+    model: str,
+    explicit_request: bool,
+) -> ProviderQuotaPreflightResult:
+    """Probe one provider route and apply neutral quota-admission policy."""
+
+    thresholds = provider_quota_thresholds()
+    if provider != "openai" or required_openai_auth_mode(model) != "chatgpt":
+        return skipped_provider_quota_preflight(
+            provider=provider,
+            model=model,
+            explicit_request=explicit_request,
+            thresholds=thresholds,
+        )
+
+    usage = read_codex_usage()
+    if usage.status == "unknown":
+        return _result_from_usage(
+            usage,
+            status="unknown",
+            decision="admitted",
+            provider=provider,
+            model=model,
+            explicit_request=explicit_request,
+            thresholds=thresholds,
+        )
+
+    used_percent = float(usage.used_percent)
+    if used_percent >= thresholds.hard_percent:
+        return _result_from_usage(
+            usage,
+            status="quota_blocked",
+            decision="blocked",
+            provider=provider,
+            model=model,
+            explicit_request=explicit_request,
+            thresholds=thresholds,
+        )
+    if used_percent >= thresholds.soft_percent and not explicit_request:
+        return _result_from_usage(
+            usage,
+            status="quota_deferred",
+            decision="deferred",
+            provider=provider,
+            model=model,
+            explicit_request=explicit_request,
+            thresholds=thresholds,
+        )
+    return _result_from_usage(
+        usage,
+        status="passed",
+        decision="admitted",
+        provider=provider,
+        model=model,
+        explicit_request=explicit_request,
+        thresholds=thresholds,
+    )
+
+
+__all__ = [
+    "DEFAULT_CODEX_QUOTA_HARD_PERCENT",
+    "DEFAULT_CODEX_QUOTA_SOFT_PERCENT",
+    "ProviderQuotaPreflightResult",
+    "ProviderQuotaThresholds",
+    "probe_provider_quota",
+    "provider_quota_thresholds",
+    "skipped_provider_quota_preflight",
+]

--- a/brain/systems/cycles/cycle_failure_guard.py
+++ b/brain/systems/cycles/cycle_failure_guard.py
@@ -223,6 +223,9 @@ CYCLE_TERMINAL_POLICIES: Mapping[str, CycleTerminalPolicy] = MappingProxyType(
             alert_class=CYCLE_AUTH_BLOCKED_ALERT_CLASS,
             operator_action="reconnect OpenAI in Settings > Access",
         ),
+        # Quota admission owns its visible, deduplicated notice. It is not a
+        # repeated Cycle execution failure and must not trigger Slack alerts.
+        "quota_blocked": IgnoreCycleTerminalPolicy(),
     }
 )
 

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -430,7 +430,13 @@ async def record_cycle_run_evaluation(
         skip_reason=skip_reason,
         usage=usage,
     )
-    score = 1 if status == "completed" else 0 if status in {"failed", "degraded", "auth_blocked"} else None
+    score = (
+        1
+        if status == "completed"
+        else 0
+        if status in {"failed", "degraded", "auth_blocked", "quota_blocked"}
+        else None
+    )
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
     launch_tracking = json_dict(context_snapshot.get("degradation_tracking"))
     verdict = json_dict(context_snapshot.get(MISSION_RESULT_CONTRACT_VERDICT_KEY))
@@ -560,6 +566,9 @@ def cycle_run_evaluation_summary(
     if status == "auth_blocked":
         detail = error or "external auth preflight blocked the run"
         return f"Cycle run was auth-blocked and recorded in the Cycle ledger: {detail}" + burn
+    if status == "quota_blocked":
+        detail = error or "subscription quota preflight blocked the run"
+        return f"Cycle run was quota-blocked and recorded in the Cycle ledger: {detail}" + burn
     if status == "skipped":
         detail = skip_reason or "unknown skip reason"
         return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}" + burn

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -1,0 +1,76 @@
+"""Cycle adapter for neutral provider subscription-quota probing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+    probe_provider_quota,
+)
+from brain.platform.providers.model_policy import (
+    async_get_default_model,
+    infer_provider_from_model,
+)
+from brain.systems.cycles.common import (
+    SCHEDULED_CYCLE_ORIGIN,
+    cycle_run_launch_context,
+)
+
+
+def _with_cycle_presentation(
+    result: ProviderQuotaPreflightResult,
+) -> ProviderQuotaPreflightResult:
+    if result.blocked:
+        return result.with_presentation(
+            visible_message=(
+                "Cycle quota blocked: Codex usage is "
+                f"{result.used_percent:g}%, at or above the "
+                f"{result.thresholds.hard_percent:g}% hard limit. "
+                "Illo will admit new runs automatically after usage falls below the limit."
+            )
+        )
+    if result.deferred:
+        return result.with_presentation(
+            visible_message=(
+                "Scheduled Cycle quota deferred: Codex usage is "
+                f"{result.used_percent:g}%, at or above the "
+                f"{result.thresholds.soft_percent:g}% soft limit. "
+                "Illo will try again on a later scheduled run."
+            )
+        )
+    return result
+
+
+async def async_preflight_cycle_external_quota(
+    session: AsyncSession,
+    *,
+    cycle: Any,
+    run: Any,
+) -> ProviderQuotaPreflightResult:
+    """Probe subscription quota before admitting a Cycle agent run."""
+
+    user_id = str(getattr(cycle, "user_id", "") or "") or None
+    org_id = str(getattr(cycle, "org_id", "") or "") or None
+    model = str(getattr(cycle, "model_override", None) or "").strip()
+    if not model:
+        model = await async_get_default_model(
+            session,
+            include_provider_prefix=True,
+            user_id=user_id,
+            org_id=org_id,
+        )
+
+    provider = infer_provider_from_model(model)
+    origin = str(cycle_run_launch_context(run).get("origin") or "")
+    result = probe_provider_quota(
+        provider=provider,
+        model=model,
+        explicit_request=origin != SCHEDULED_CYCLE_ORIGIN,
+    )
+    return _with_cycle_presentation(result)
+
+
+__all__ = ["async_preflight_cycle_external_quota"]

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -12,12 +12,18 @@ from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
 )
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+)
 from brain.platform.providers.model_policy import EFFORT_TIER_SET, normalize_model_name
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
 from brain.systems.cycles.auth_preflight import (
     async_preflight_cycle_external_auth,
+)
+from brain.systems.cycles.quota_preflight import (
+    async_preflight_cycle_external_quota,
 )
 from brain.systems.cycles.common import (
     MANUAL_CYCLE_ORIGIN,
@@ -77,7 +83,7 @@ from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.agent_run import AgentRunEventRow
-from brain.platform.db.models.idea import Idea
+from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.db.models.org import User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
@@ -320,6 +326,56 @@ async def _async_append_cycle_auth_blocked_thread_message(
         ),
         parse_message_type=lambda _content, _role: "agent_response",
         lifecycle_trigger="cycle_auth_preflight_blocked",
+    )
+    return result.message_payload, result.status_change
+
+
+async def _async_append_cycle_quota_notice(
+    session,
+    idea: Idea,
+    cycle: Cycle,
+    cycle_run: CycleRun,
+    preflight: ProviderQuotaPreflightResult,
+) -> tuple[dict | None, dict | None]:
+    # Serialize the check and insert on the reusable thread. The quota gate can
+    # settle many scheduled runs, but the user should see one durable notice.
+    await session.scalar(
+        select(Idea.id).where(Idea.id == idea.id).with_for_update()
+    )
+    existing_notice = await session.scalar(
+        select(IdeaThread.id)
+        .where(
+            IdeaThread.idea_id == idea.id,
+            IdeaThread.metadata_.contains({"quota_notice": True}),
+        )
+        .limit(1)
+    )
+    if existing_notice:
+        return None, None
+
+    metadata = {
+        "source": "cycle",
+        "cycle_id": cycle.id,
+        "cycle_run_id": cycle_run.id,
+        "quota_notice": True,
+        "quota_preflight": preflight.to_dict(),
+    }
+    result = await post_thread_message(
+        session,
+        idea=idea,
+        command=ThreadMessageCommand(
+            idea_id=str(idea.id),
+            role="illo",
+            content=preflight.visible_message or "Cycle quota admission paused.",
+            actor={
+                "org_id": str(cycle.org_id) if cycle.org_id else None,
+                "name": "Illo",
+            },
+            attachments=[],
+            metadata=metadata,
+        ),
+        parse_message_type=lambda _content, _role: "agent_response",
+        lifecycle_trigger="cycle_quota_preflight_paused",
     )
     return result.message_payload, result.status_change
 
@@ -874,18 +930,18 @@ async def async_execute_cycle_run(run_id: int) -> None:
         )
         idea_id = idea.id
 
-        preflight = await async_preflight_cycle_external_auth(uow.session, cycle=cycle)
-        if preflight.status != "skipped":
+        auth_preflight = await async_preflight_cycle_external_auth(uow.session, cycle=cycle)
+        if auth_preflight.status != "skipped":
             context_snapshot = dict(run.context_snapshot or {})
-            context_snapshot["auth_preflight"] = preflight.to_dict()
+            context_snapshot["auth_preflight"] = auth_preflight.to_dict()
             run.context_snapshot = context_snapshot
 
-        if preflight.blocked:
+        if auth_preflight.blocked:
             await _finalize_cycle_run(
                 run,
                 cycle,
                 status="auth_blocked",
-                error=preflight.visible_message,
+                error=auth_preflight.visible_message,
                 session=uow.session,
             )
             message_payload, status_payload = await _async_append_cycle_auth_blocked_thread_message(
@@ -893,44 +949,78 @@ async def async_execute_cycle_run(run_id: int) -> None:
                 idea,
                 cycle,
                 run,
-                preflight,
+                auth_preflight,
             )
             idea_snapshot = serialize_execution_idea(idea)
         else:
-            run.started_at = datetime.now(timezone.utc)
-            run_metadata = _cycle_run_metadata(cycle, run)
-            run_message = _cycle_run_message(idea, cycle, run)
-            agent_run_id = await _async_admit_cycle_run(
+            quota_preflight = await async_preflight_cycle_external_quota(
                 uow.session,
-                idea_id=idea.id,
-                message=run_message,
-                priority=1,
-                user_id=cycle_user_id,
-                metadata=run_metadata,
-                cycle_run_id=run.id,
-                model_policy=run_model_policy,
-                deadline_at=_cycle_run_deadline_at(cycle),
+                cycle=cycle,
+                run=run,
             )
-            if agent_run_id is None:
+            context_snapshot = dict(run.context_snapshot or {})
+            context_snapshot["quota_preflight"] = quota_preflight.to_dict()
+            run.context_snapshot = context_snapshot
+
+            if quota_preflight.blocked or quota_preflight.deferred:
+                terminal_status = "quota_blocked" if quota_preflight.blocked else "skipped"
                 await _finalize_cycle_run(
                     run,
                     cycle,
-                    status="failed",
-                    error="Cycle work admission failed before an agent run was created",
+                    status=terminal_status,
+                    error=(
+                        quota_preflight.visible_message
+                        if quota_preflight.blocked
+                        else None
+                    ),
+                    skip_reason=(
+                        "quota_soft_limit" if quota_preflight.deferred else None
+                    ),
                     session=uow.session,
                 )
-                return
-            message_payload, status_payload = await _async_append_cycle_thread_message(
-                uow.session,
-                idea,
-                cycle,
-                run,
-                owner,
-            )
-            idea_snapshot = serialize_execution_idea(idea)
-            run.run_id = agent_run_id
-            cycle.last_status = "running"
-            cycle.last_error = None
+                message_payload, status_payload = await _async_append_cycle_quota_notice(
+                    uow.session,
+                    idea,
+                    cycle,
+                    run,
+                    quota_preflight,
+                )
+                idea_snapshot = serialize_execution_idea(idea)
+            else:
+                run.started_at = datetime.now(timezone.utc)
+                run_metadata = _cycle_run_metadata(cycle, run)
+                run_message = _cycle_run_message(idea, cycle, run)
+                agent_run_id = await _async_admit_cycle_run(
+                    uow.session,
+                    idea_id=idea.id,
+                    message=run_message,
+                    priority=1,
+                    user_id=cycle_user_id,
+                    metadata=run_metadata,
+                    cycle_run_id=run.id,
+                    model_policy=run_model_policy,
+                    deadline_at=_cycle_run_deadline_at(cycle),
+                )
+                if agent_run_id is None:
+                    await _finalize_cycle_run(
+                        run,
+                        cycle,
+                        status="failed",
+                        error="Cycle work admission failed before an agent run was created",
+                        session=uow.session,
+                    )
+                    return
+                message_payload, status_payload = await _async_append_cycle_thread_message(
+                    uow.session,
+                    idea,
+                    cycle,
+                    run,
+                    owner,
+                )
+                idea_snapshot = serialize_execution_idea(idea)
+                run.run_id = agent_run_id
+                cycle.last_status = "running"
+                cycle.last_error = None
     if should_publish_idea and idea_snapshot:
         publish("idea_upserted", {"idea": idea_snapshot})
     if message_payload:

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -338,20 +338,41 @@ async def _async_append_cycle_quota_notice(
     preflight: ProviderQuotaPreflightResult,
 ) -> tuple[dict | None, dict | None]:
     # Serialize the check and insert on the reusable thread. The quota gate can
-    # settle many scheduled runs, but the user should see one durable notice.
+    # settle many scheduled runs, but the user should see one durable notice
+    # for each contiguous quota-restricted episode.
     await session.scalar(
         select(Idea.id).where(Idea.id == idea.id).with_for_update()
     )
-    existing_notice = await session.scalar(
-        select(IdeaThread.id)
+    latest_notice_metadata = await session.scalar(
+        select(IdeaThread.metadata_)
         .where(
             IdeaThread.idea_id == idea.id,
             IdeaThread.metadata_.contains({"quota_notice": True}),
         )
+        .order_by(IdeaThread.id.desc())
         .limit(1)
     )
-    if existing_notice:
-        return None, None
+    if isinstance(latest_notice_metadata, dict):
+        try:
+            notice_cycle_run_id = int(latest_notice_metadata["cycle_run_id"])
+        except (KeyError, TypeError, ValueError):
+            notice_cycle_run_id = None
+
+        if notice_cycle_run_id is not None:
+            admitted_since_notice = await session.scalar(
+                select(CycleRun.id)
+                .where(
+                    CycleRun.idea_id == idea.id,
+                    CycleRun.id > notice_cycle_run_id,
+                    CycleRun.id < cycle_run.id,
+                    CycleRun.context_snapshot.contains(
+                        {"quota_preflight": {"decision": "admitted"}}
+                    ),
+                )
+                .limit(1)
+            )
+            if admitted_since_notice is None:
+                return None, None
 
     metadata = {
         "source": "cycle",

--- a/brain/systems/cycles/status.py
+++ b/brain/systems/cycles/status.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 
 CYCLE_RUN_ACTIVE_STATUS_VALUES = ("queued", "running", "pending_approval")
-CYCLE_RUN_TERMINAL_STATUS_VALUES = ("completed", "failed", "skipped", "degraded", "auth_blocked")
+CYCLE_RUN_TERMINAL_STATUS_VALUES = (
+    "completed",
+    "failed",
+    "skipped",
+    "degraded",
+    "auth_blocked",
+    "quota_blocked",
+)
 
 CYCLE_RUN_ACTIVE_STATUSES = frozenset(CYCLE_RUN_ACTIVE_STATUS_VALUES)
 CYCLE_RUN_TERMINAL_STATUSES = frozenset(CYCLE_RUN_TERMINAL_STATUS_VALUES)

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import os
+
+from brain.platform.integrations.codex_usage import read_codex_usage
+
+
+def _event(
+    used_percent=None,
+    *,
+    timestamp="2026-08-04T13:24:45Z",
+    limit_id="codex",
+    primary_marker=True,
+    plan_type="pro",
+):
+    primary = {"used_percent": used_percent} if primary_marker else None
+    return {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {},
+            "rate_limits": {
+                "limit_id": limit_id,
+                "primary": primary,
+                "secondary": None,
+                "plan_type": plan_type,
+            },
+        },
+    }
+
+
+def _session_file(tmp_path, *, name="rollout.jsonl"):
+    path = tmp_path / "sessions" / "2026" / "08" / "04" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_events(path, *events):
+    path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+
+def test_reads_newest_real_codex_usage(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(path, _event(29), _event(31, timestamp="2026-08-04T13:24:46Z"))
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "ok"
+    assert reading.used_percent == 31.0
+    assert reading.reason is None
+    assert reading.observed_at == "2026-08-04T13:24:46Z"
+    assert reading.limit_id == "codex"
+    assert reading.plan_type == "pro"
+
+
+def test_real_codex_usage_at_one_hundred_is_exhausted(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(path, _event(100))
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "exhausted"
+    assert reading.used_percent == 100.0
+    assert reading.reason is None
+
+
+def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(
+        path,
+        _event(31, timestamp="2026-08-04T13:24:45Z"),
+        _event(
+            None,
+            timestamp="2026-08-04T13:28:13Z",
+            limit_id="premium",
+            primary_marker=False,
+            plan_type=None,
+        ),
+    )
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "unexpected_limit_id"
+    assert reading.used_percent is None
+    assert reading.limit_id == "premium"
+    assert reading.last_known_good is not None
+    assert reading.last_known_good.used_percent == 31.0
+    assert reading.last_known_good.observed_at == "2026-08-04T13:24:45Z"
+
+
+def test_null_primary_on_codex_limit_is_unknown_not_zero_or_exhausted(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(path, _event(None, primary_marker=False))
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "primary_missing"
+    assert reading.used_percent is None
+    assert reading.last_known_good is None
+
+
+def test_malformed_newest_line_is_unknown_with_older_known_reading(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(path, _event(42))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("{not valid json\n")
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "malformed_line"
+    assert reading.used_percent is None
+    assert reading.last_known_good is not None
+    assert reading.last_known_good.used_percent == 42.0
+
+
+def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
+    path = _session_file(tmp_path)
+    _write_events(
+        path,
+        _event(52),
+        {
+            "timestamp": "2026-08-04T13:30:00Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "error",
+                "error": {"code": "unauthorized", "status": 401},
+            },
+        },
+    )
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "auth_error"
+    assert reading.used_percent is None
+    assert reading.last_known_good is not None
+    assert reading.last_known_good.used_percent == 52.0
+
+
+def test_missing_sessions_directory_is_unknown(tmp_path):
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "sessions_dir_missing"
+    assert reading.used_percent is None
+
+
+def test_only_newest_session_file_controls_current_verdict(tmp_path):
+    older = _session_file(tmp_path, name="older.jsonl")
+    newer = _session_file(tmp_path, name="newer.jsonl")
+    _write_events(older, _event(12, timestamp="2026-08-04T12:00:00Z"))
+    _write_events(newer, {"timestamp": "2026-08-04T13:00:00Z", "type": "response_item"})
+    os.utime(older, (1, 1))
+    os.utime(newer, (2, 2))
+
+    reading = read_codex_usage(tmp_path)
+
+    assert reading.status == "unknown"
+    assert reading.reason == "token_count_missing"
+    assert reading.last_known_good is not None
+    assert reading.last_known_good.used_percent == 12.0
+
+
+def test_codex_home_environment_selects_usage_root(tmp_path, monkeypatch):
+    path = _session_file(tmp_path)
+    _write_events(path, _event(17))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    assert read_codex_usage().used_percent == 17.0

--- a/tests/test_cycle_failure_guard.py
+++ b/tests/test_cycle_failure_guard.py
@@ -91,6 +91,7 @@ def test_cycle_terminal_policy_is_total_for_canonical_terminal_statuses():
         "skipped": cycle_failure_guard.CycleTerminalAction.IGNORE,
         "degraded": cycle_failure_guard.CycleTerminalAction.RECORD_FAILURE,
         "auth_blocked": cycle_failure_guard.CycleTerminalAction.RECORD_FAILURE,
+        "quota_blocked": cycle_failure_guard.CycleTerminalAction.IGNORE,
     }
 
 

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+    ProviderQuotaThresholds,
+)
+from brain.systems.cycles import quota_preflight
+
+
+async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
+    captured = {}
+
+    def probe(**kwargs):
+        captured.update(kwargs)
+        return ProviderQuotaPreflightResult(
+            status="quota_deferred",
+            decision="deferred",
+            provider=kwargs["provider"],
+            model=kwargs["model"],
+            usage_status="ok",
+            used_percent=80,
+            thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
+        )
+
+    monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
+    result = await quota_preflight.async_preflight_cycle_external_quota(
+        object(),
+        cycle=SimpleNamespace(
+            user_id="user-1",
+            org_id="org-1",
+            model_override="openai/gpt-5.6-sol",
+        ),
+        run=SimpleNamespace(
+            context_snapshot={"launch_context": {"origin": "scheduled_cycle"}}
+        ),
+    )
+
+    assert captured["explicit_request"] is False
+    assert result.deferred is True
+    assert "80%" in result.visible_message
+    assert "75% soft limit" in result.visible_message
+
+
+async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
+    captured = {}
+
+    def probe(**kwargs):
+        captured.update(kwargs)
+        return ProviderQuotaPreflightResult(
+            status="passed",
+            decision="admitted",
+            provider=kwargs["provider"],
+            model=kwargs["model"],
+            usage_status="ok",
+            used_percent=80,
+            thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
+            explicit_request=kwargs["explicit_request"],
+        )
+
+    monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
+    result = await quota_preflight.async_preflight_cycle_external_quota(
+        object(),
+        cycle=SimpleNamespace(
+            user_id="user-1",
+            org_id="org-1",
+            model_override="openai/gpt-5.6-sol",
+        ),
+        run=SimpleNamespace(
+            context_snapshot={"launch_context": {"origin": "manual_cycle"}}
+        ),
+    )
+
+    assert captured["explicit_request"] is True
+    assert result.decision == "admitted"
+    assert result.visible_message is None
+
+
+async def test_cycle_quota_resolves_default_model(monkeypatch):
+    captured = {}
+
+    async def default_model(_session, **kwargs):
+        captured["default"] = kwargs
+        return "openai/gpt-5.6-sol"
+
+    def probe(**kwargs):
+        captured["probe"] = kwargs
+        return ProviderQuotaPreflightResult(
+            status="unknown",
+            decision="admitted",
+            provider=kwargs["provider"],
+            model=kwargs["model"],
+            usage_status="unknown",
+            unknown_reason="sessions_dir_missing",
+            thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
+        )
+
+    monkeypatch.setattr(quota_preflight, "async_get_default_model", default_model)
+    monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
+    result = await quota_preflight.async_preflight_cycle_external_quota(
+        object(),
+        cycle=SimpleNamespace(
+            user_id="user-1",
+            org_id="org-1",
+            model_override=None,
+        ),
+        run=SimpleNamespace(context_snapshot={}),
+    )
+
+    assert captured["default"] == {
+        "include_provider_prefix": True,
+        "user_id": "user-1",
+        "org_id": "org-1",
+    }
+    assert captured["probe"]["model"] == "openai/gpt-5.6-sol"
+    assert result.status == "unknown"
+    assert result.decision == "admitted"

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -32,7 +32,8 @@ from brain.platform.db.models.cycle import (
 )
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
 from brain.platform.db.models.run import AgentRun
-from brain.platform.db.models.idea import Idea
+from brain.platform.db.models.idea import Idea, IdeaThread
+from brain.platform.db.models.org import Org, User
 from brain.platform.integrations.provider_auth_preflight import ProviderAuthPreflightResult
 from brain.platform.integrations.provider_quota_preflight import (
     ProviderQuotaPreflightResult,
@@ -2271,17 +2272,21 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
         raise AssertionError("hard-limit run must not be admitted")
 
     original_scalar = session.scalar
+    admission_since_notice = False
 
     async def scalar(statement):
+        nonlocal admission_since_notice
         if "FROM idea_threads" in str(statement):
             return next(
                 (
-                    item.id
+                    item.metadata_
                     for item in session.added
                     if item.__class__.__name__ == "IdeaThread"
                 ),
                 None,
             )
+        if "FROM cycle_runs" in str(statement):
+            return 99 if admission_since_notice else None
         return await original_scalar(statement)
 
     session.scalar = scalar
@@ -2318,6 +2323,125 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
     assert len(
         [item for item in session.added if item.__class__.__name__ == "IdeaThread"]
     ) == 1
+
+    admission_since_notice = True
+    later_run = CycleRun()
+    later_run.id = run.id + 1
+    await service._async_append_cycle_quota_notice(
+        session,
+        idea,
+        cycle,
+        later_run,
+        quota,
+    )
+    assert len(
+        [item for item in session.added if item.__class__.__name__ == "IdeaThread"]
+    ) == 2
+
+
+@pytest.mark.requires_db
+@pytest.mark.asyncio
+async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_session):
+    unique = uuid4().hex
+    org_id = str(uuid4())
+    user_id = str(uuid4())
+    idea_id = str(uuid4())
+    db_session.add(Org(id=org_id, name="Quota Episode Org", slug=f"quota-{unique}"))
+    db_session.add(
+        User(
+            id=user_id,
+            org_id=org_id,
+            name="Quota Episode Owner",
+            email=f"quota-{unique}@example.com",
+        )
+    )
+    cycle = Cycle(
+        user_id=user_id,
+        org_id=org_id,
+        name="Quota episode Cycle",
+        prompt="Run a scheduled coding-agent check",
+        schedule_expr="20 16 * * *",
+        timezone="America/Toronto",
+        target_idea_id=idea_id,
+    )
+    idea = Idea(
+        id=idea_id,
+        title="Quota episode thread",
+        description="Verify quota notice episode semantics",
+        status="needs_input",
+        origin="cycle",
+        user_id=user_id,
+        org_id=org_id,
+    )
+    db_session.add_all([cycle, idea])
+    await db_session.flush()
+
+    quota_snapshots = [
+        {"status": "quota_blocked", "decision": "blocked"},
+        {"status": "quota_deferred", "decision": "deferred"},
+        {"status": "unknown", "decision": "admitted"},
+        {"status": "quota_blocked", "decision": "blocked"},
+    ]
+    runs = []
+    scheduled_for = datetime(2026, 8, 4, 13, 0, tzinfo=timezone.utc)
+    for offset, quota_snapshot in enumerate(quota_snapshots):
+        decision = quota_snapshot["decision"]
+        run = CycleRun(
+            cycle_id=cycle.id,
+            scheduled_for=scheduled_for + timedelta(minutes=offset),
+            status=(
+                "quota_blocked"
+                if decision == "blocked"
+                else "skipped" if decision == "deferred" else "running"
+            ),
+            skip_reason="quota_soft_limit" if decision == "deferred" else None,
+            idea_id=idea_id,
+            prompt_snapshot=cycle.prompt,
+            context_snapshot={"quota_preflight": quota_snapshot},
+        )
+        db_session.add(run)
+        runs.append(run)
+    await db_session.flush()
+
+    quota = ProviderQuotaPreflightResult(
+        status="quota_blocked",
+        decision="blocked",
+        provider="openai",
+        model="openai/gpt-5.6-sol",
+        usage_status="ok",
+        used_percent=92.0,
+        thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+        visible_message="Scheduled Cycle quota blocked.",
+    )
+
+    first, _ = await service._async_append_cycle_quota_notice(
+        db_session, idea, cycle, runs[0], quota
+    )
+    suppressed, _ = await service._async_append_cycle_quota_notice(
+        db_session, idea, cycle, runs[1], quota
+    )
+    repeated, _ = await service._async_append_cycle_quota_notice(
+        db_session, idea, cycle, runs[3], quota
+    )
+
+    notices = (
+        await db_session.scalars(
+            select(IdeaThread)
+            .where(
+                IdeaThread.idea_id == idea_id,
+                IdeaThread.metadata_.contains({"quota_notice": True}),
+            )
+            .order_by(IdeaThread.id)
+        )
+    ).all()
+
+    assert first is not None
+    assert suppressed is None
+    assert repeated is not None
+    assert [notice.metadata_["cycle_run_id"] for notice in notices] == [
+        runs[0].id,
+        runs[3].id,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -34,6 +34,10 @@ from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEven
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea
 from brain.platform.integrations.provider_auth_preflight import ProviderAuthPreflightResult
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+    ProviderQuotaThresholds,
+)
 from brain.platform.providers.model_policy import infer_provider_from_model
 
 
@@ -71,6 +75,20 @@ async def _passed_cycle_auth(_session, *, cycle):
         status="passed",
         provider=infer_provider_from_model(model),
         model=model,
+    )
+
+
+async def _passed_cycle_quota(_session, *, cycle, run):
+    model = str(cycle.model_override or "openai/gpt-5.6-sol")
+    return ProviderQuotaPreflightResult(
+        status="passed",
+        decision="admitted",
+        provider=infer_provider_from_model(model),
+        model=model,
+        usage_status="ok",
+        used_percent=10.0,
+        thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+        explicit_request=False,
     )
 
 
@@ -2203,6 +2221,7 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     monkeypatch.setattr("brain.platform.integrations.llm._async_resolve_key_from_db", fake_resolve_key)
     monkeypatch.setattr("brain.platform.integrations.llm.refresh_codex_access_token", fail_refresh)
     monkeypatch.setattr("brain.platform.integrations.llm.OpenAICodexClient", fake_codex_client)
+    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", _passed_cycle_quota)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2214,8 +2233,137 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     assert run.started_at is not None
     assert cycle.last_status == "running"
     assert run.context_snapshot["auth_preflight"]["status"] == "passed"
+    assert run.context_snapshot["quota_preflight"]["decision"] == "admitted"
     assert codex_client_calls[0][0][0] == "fresh-access"
     assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
+
+
+@pytest.mark.asyncio
+async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkeypatch):
+    run, cycle, idea = _cycle_execution_objects(model_override="openai/gpt-5.6-sol")
+    session = _AsyncExecuteCycleSession(
+        run=run,
+        cycle=cycle,
+        idea=idea,
+        expected_run_id=run.id,
+    )
+    quota = ProviderQuotaPreflightResult(
+        status="quota_blocked",
+        decision="blocked",
+        provider="openai",
+        model="openai/gpt-5.6-sol",
+        usage_status="ok",
+        used_percent=92.0,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/session.jsonl",
+        limit_id="codex",
+        plan_type="pro",
+        thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+        visible_message=(
+            "Cycle quota blocked: Codex usage is 92%, at or above the 90% hard limit."
+        ),
+    )
+
+    async def quota_preflight(*_args, **_kwargs):
+        return quota
+
+    async def fail_admit(*_args, **_kwargs):
+        raise AssertionError("hard-limit run must not be admitted")
+
+    original_scalar = session.scalar
+
+    async def scalar(statement):
+        if "FROM idea_threads" in str(statement):
+            return next(
+                (
+                    item.id
+                    for item in session.added
+                    if item.__class__.__name__ == "IdeaThread"
+                ),
+                None,
+            )
+        return await original_scalar(statement)
+
+    session.scalar = scalar
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
+    monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
+
+    await service.async_execute_cycle_run(run.id)
+
+    assert run.status == "quota_blocked"
+    assert run.run_id is None
+    assert run.started_at is None
+    assert run.context_snapshot["quota_preflight"]["decision"] == "blocked"
+    assert run.context_snapshot["quota_preflight"]["used_percent"] == 92.0
+    assert run.context_snapshot["quota_preflight"]["thresholds"] == {
+        "soft_percent": 75.0,
+        "hard_percent": 90.0,
+    }
+    notices = [
+        item for item in session.added if item.__class__.__name__ == "IdeaThread"
+    ]
+    assert len(notices) == 1
+    assert notices[0].metadata_["quota_notice"] is True
+
+    await service._async_append_cycle_quota_notice(
+        session,
+        idea,
+        cycle,
+        run,
+        quota,
+    )
+    assert len(
+        [item for item in session.added if item.__class__.__name__ == "IdeaThread"]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
+    run, cycle, idea = _cycle_execution_objects(model_override="openai/gpt-5.6-sol")
+    session = _AsyncExecuteCycleSession(
+        run=run,
+        cycle=cycle,
+        idea=idea,
+        expected_run_id=run.id,
+    )
+    quota = ProviderQuotaPreflightResult(
+        status="quota_deferred",
+        decision="deferred",
+        provider="openai",
+        model="openai/gpt-5.6-sol",
+        usage_status="ok",
+        used_percent=80.0,
+        thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+        visible_message="Scheduled Cycle quota deferred.",
+    )
+
+    async def quota_preflight(*_args, **_kwargs):
+        return quota
+
+    async def fail_admit(*_args, **_kwargs):
+        raise AssertionError("soft-limit scheduled run must not be admitted")
+
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
+    monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
+
+    await service.async_execute_cycle_run(run.id)
+
+    assert run.status == "skipped"
+    assert run.skip_reason == "quota_soft_limit"
+    assert run.context_snapshot["quota_preflight"]["decision"] == "deferred"
+    evaluation = next(
+        item
+        for item in session.added
+        if item.__class__.__name__ == "CycleRunEvaluation"
+    )
+    assert evaluation.details["status"] == "skipped"
+    assert evaluation.details["skip_reason"] == "quota_soft_limit"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -2347,6 +2347,8 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
     user_id = str(uuid4())
     idea_id = str(uuid4())
     db_session.add(Org(id=org_id, name="Quota Episode Org", slug=f"quota-{unique}"))
+    await db_session.flush()
+
     db_session.add(
         User(
             id=user_id,
@@ -2355,15 +2357,8 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
             email=f"quota-{unique}@example.com",
         )
     )
-    cycle = Cycle(
-        user_id=user_id,
-        org_id=org_id,
-        name="Quota episode Cycle",
-        prompt="Run a scheduled coding-agent check",
-        schedule_expr="20 16 * * *",
-        timezone="America/Toronto",
-        target_idea_id=idea_id,
-    )
+    await db_session.flush()
+
     idea = Idea(
         id=idea_id,
         title="Quota episode thread",
@@ -2373,12 +2368,24 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
         user_id=user_id,
         org_id=org_id,
     )
-    db_session.add_all([cycle, idea])
+    db_session.add(idea)
+    await db_session.flush()
+
+    cycle = Cycle(
+        user_id=user_id,
+        org_id=org_id,
+        name="Quota episode Cycle",
+        prompt="Run a scheduled coding-agent check",
+        schedule_expr="20 16 * * *",
+        timezone="America/Toronto",
+        target_idea_id=idea_id,
+    )
+    db_session.add(cycle)
     await db_session.flush()
 
     quota_snapshots = [
         {"status": "quota_blocked", "decision": "blocked"},
-        {"status": "quota_deferred", "decision": "deferred"},
+        {"status": "quota_blocked", "decision": "blocked"},
         {"status": "unknown", "decision": "admitted"},
         {"status": "quota_blocked", "decision": "blocked"},
     ]
@@ -2420,7 +2427,7 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
     suppressed, _ = await service._async_append_cycle_quota_notice(
         db_session, idea, cycle, runs[1], quota
     )
-    repeated, _ = await service._async_append_cycle_quota_notice(
+    after_admission, _ = await service._async_append_cycle_quota_notice(
         db_session, idea, cycle, runs[3], quota
     )
 
@@ -2437,7 +2444,8 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
 
     assert first is not None
     assert suppressed is None
-    assert repeated is not None
+    assert runs[2].context_snapshot["quota_preflight"]["decision"] == "admitted"
+    assert after_admission is not None
     assert [notice.metadata_["cycle_run_id"] for notice in notices] == [
         runs[0].id,
         runs[3].id,

--- a/tests/test_provider_quota_preflight.py
+++ b/tests/test_provider_quota_preflight.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+
+from brain.platform.integrations.codex_usage import CodexKnownUsage, CodexUsageReading
+from brain.platform.integrations import provider_quota_preflight
+
+
+def _usage(used_percent: float) -> CodexUsageReading:
+    return CodexUsageReading(
+        status="exhausted" if used_percent >= 100 else "ok",
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
+        limit_id="codex",
+        plan_type="pro",
+    )
+
+
+def _probe(*, explicit_request=False):
+    return provider_quota_preflight.probe_provider_quota(
+        provider="openai",
+        model="openai/gpt-5.6-sol",
+        explicit_request=explicit_request,
+    )
+
+
+def test_below_soft_limit_is_admitted(monkeypatch):
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: _usage(74.9))
+
+    result = _probe()
+
+    assert result.status == "passed"
+    assert result.decision == "admitted"
+    assert result.used_percent == 74.9
+    assert result.thresholds.to_dict() == {
+        "soft_percent": 75.0,
+        "hard_percent": 90.0,
+    }
+
+
+def test_soft_limit_defers_scheduled_run_but_admits_explicit_run(monkeypatch):
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: _usage(80))
+
+    scheduled = _probe(explicit_request=False)
+    explicit = _probe(explicit_request=True)
+
+    assert scheduled.status == "quota_deferred"
+    assert scheduled.decision == "deferred"
+    assert scheduled.deferred is True
+    assert explicit.status == "passed"
+    assert explicit.decision == "admitted"
+
+
+def test_hard_limit_blocks_even_explicit_run(monkeypatch):
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: _usage(90))
+
+    result = _probe(explicit_request=True)
+
+    assert result.status == "quota_blocked"
+    assert result.decision == "blocked"
+    assert result.blocked is True
+    assert result.used_percent == 90.0
+
+
+def test_real_exhausted_reading_blocks(monkeypatch):
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: _usage(100))
+
+    result = _probe()
+
+    assert result.usage_status == "exhausted"
+    assert result.decision == "blocked"
+    assert result.used_percent == 100.0
+
+
+def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
+    reading = CodexUsageReading(
+        status="unknown",
+        reason="primary_missing",
+        observed_at="2026-08-04T13:28:13Z",
+        source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
+        limit_id="codex",
+        last_known_good=CodexKnownUsage(
+            used_percent=31,
+            observed_at="2026-08-04T13:24:45Z",
+            source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
+            plan_type="pro",
+        ),
+    )
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: reading)
+
+    result = _probe()
+
+    assert result.status == "unknown"
+    assert result.decision == "admitted"
+    assert result.used_percent is None
+    assert result.unknown_reason == "primary_missing"
+    assert result.last_known_good == {
+        "used_percent": 31,
+        "observed_at": "2026-08-04T13:24:45Z",
+        "source_path": "/tmp/codex/sessions/2026/08/04/rollout.jsonl",
+        "limit_id": "codex",
+        "plan_type": "pro",
+    }
+
+
+def test_thresholds_are_configurable(monkeypatch):
+    monkeypatch.setenv("ILLO_CODEX_QUOTA_SOFT_PERCENT", "60")
+    monkeypatch.setenv("ILLO_CODEX_QUOTA_HARD_PERCENT", "70")
+    monkeypatch.setattr(provider_quota_preflight, "read_codex_usage", lambda: _usage(65))
+
+    result = _probe()
+
+    assert result.decision == "deferred"
+    assert result.thresholds.to_dict() == {
+        "soft_percent": 60.0,
+        "hard_percent": 70.0,
+    }
+
+
+def test_live_reader_recovers_automatically_after_window_reset(tmp_path, monkeypatch):
+    session_file = tmp_path / "sessions" / "2026" / "08" / "04" / "rollout.jsonl"
+    session_file.parent.mkdir(parents=True)
+
+    def write_usage(used_percent):
+        session_file.write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-08-04T13:24:45Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "rate_limits": {
+                            "limit_id": "codex",
+                            "primary": {"used_percent": used_percent},
+                            "plan_type": "pro",
+                        },
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    write_usage(95)
+
+    blocked = _probe()
+    write_usage(3)
+    recovered = _probe()
+
+    assert blocked.decision == "blocked"
+    assert recovered.decision == "admitted"
+    assert recovered.used_percent == 3.0
+
+
+def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
+    monkeypatch.setattr(
+        provider_quota_preflight,
+        "read_codex_usage",
+        lambda: (_ for _ in ()).throw(AssertionError("reader should not run")),
+    )
+
+    result = provider_quota_preflight.probe_provider_quota(
+        provider="anthropic",
+        model="anthropic/claude-sonnet-4-6",
+        explicit_request=False,
+    )
+
+    assert result.status == "skipped"
+    assert result.decision == "admitted"
+    assert result.usage_status is None


### PR DESCRIPTION
Closes #662.

## The ticket's mechanism was wrong. This implements the corrected version.

The issue says "Illo keeps dispatching `codex exec` runs into worktrees." It does not. Illo's only
Codex hand-off is a deep link — `brain/systems/launch_handoffs.py:318` returns
`codex://threads/new?...`, which a human or the desktop app opens. There is no
`subprocess`/`Popen`/`create_subprocess` anywhere in `external_agents/` or `launch_handoffs.py`.
The 28 sessions the ticket counted in `.codex-worktrees/illospace-*` are the `uwear-routines`
R1/R2/R3 harness — a different repository. So Illo's own quota draw is still unmeasured.

**The ask is still valid here for a different, verified reason.** Illo runs OpenAI models under
`auth_mode="chatgpt"` (`openai_codex_auth.py` parses Codex-CLI `auth.json`;
`required_openai_auth_mode()` forces the mode), so it draws down the *same* weekly subscription
window that hard-refused on 2026-08-04. The gate therefore belongs on Illo's run-admission
boundary — the one #274 already built for auth.

## What it does

A quota preflight mirroring the auth preflight, at the same Cycle admission point:

| usage reading | decision |
|---|---|
| `ok`, below 75% | admit |
| `ok`, ≥ 75% soft, scheduled run | defer (`skipped`, `skip_reason=quota_soft_limit`) |
| `ok`, ≥ 75% soft, explicit run | admit |
| `ok`, ≥ 90% hard | block (`quota_blocked`) |
| `exhausted` (`codex` limit ≥ 100%) | block |
| **`unknown`** | **admit — fail open** |

`unknown` covers a null `primary`, a non-`codex` `limit_id`, an unreadable/missing source, and auth
errors. It never becomes 0% or 100%, and it carries the last known good reading with its timestamp.
That is the #661 insight enforced in code: on 2026-08-04 a null-`primary` payload was read as "quota
fully burned" when 69% of the window remained. Blocking on `unknown` would have halted every Illo
run during an upstream glitch.

Thresholds: `ILLO_CODEX_QUOTA_SOFT_PERCENT` / `ILLO_CODEX_QUOTA_HARD_PERCENT` (documented in
`.env.example`). The per-run decision, the `used_percent` actually read, and the thresholds in force
persist in `context_snapshot["quota_preflight"]`. Recovery needs no operator action — the gate is a
live read at each admission.

## Verification

- **Repo's own CI command, on the host** (no path argument, so `pytest.ini`'s
  `testpaths = tests meetbot/tests` applies): **4739 passed, 11 skipped, 83 deselected** in 69s.
- **The DB lane, against the same Postgres image CI uses** (`pgvector/pgvector:pg16`):
  **79 passed** — up from 78 passed + 1 failed. The episode test genuinely executes the JSONB `@>`
  predicates now; it does not skip and it does not stub them.
- **The reader measured against the real corpus** — 3,436 session files / 2.3 GB: 15 ms for the
  happy path, 0.5 ms for the last-known-good lookup. It is synchronous, so this is event-loop time.
- No migration (`status` stays `String(20)`; `quota_blocked` is 13 chars). No frontend. No
  subprocess. Base `origin/main@06d3741`, re-verified unmoved at every push.

## Two defects I found and fixed before handing this over

1. **The notice deduplicated forever, not per episode** (`7a6c048b`). The first version suppressed a
   notice whenever *any* prior thread message carried `quota_notice: true`. A Cycle reuses one
   thread, so after the first notice that thread was muted permanently — a new, unrelated quota
   incident weeks later would settle runs as `quota_blocked` with nothing visible. The ticket asked
   for one notice per episode, not one ever. An episode is now anchored by the latest notice's
   `cycle_run_id` and closed by any intervening run whose `quota_preflight.decision == "admitted"`.
   Malformed notice metadata falls through and posts, so the failure direction is an extra notice
   rather than a silent one.
2. **The test meant to prove the JSONB queries never reached them** (`e1ae0f03`). It inserted a
   Cycle without seeding `orgs`/`users` and died on `cycles_user_id_fkey`. Fixed by seeding
   `Org → User → Idea → Cycle → CycleRun` in FK order, then verified against real Postgres.

## Maintainability review — findings filed, not folded in

A thermo-nuclear review (Codex, `xhigh`) returned three findings it called blocking. I disagree that
they block *this* ticket, and I did not expand a quota-gate PR into a refactor of the shipped auth
admission path. All three share one root: this PR **mirrored** the auth preflight #274 built, and
that mirroring is what makes the existing duplication visible. Filed instead:

- **#664** — Cycle admission resolves the route three times (`auth_preflight.py:53`,
  `quota_preflight.py:55`, `service.py:205`) and `async_execute_cycle_run` has become a staircase
  (126 → 160 lines). Proposes one `CycleProviderRoute` plus an extracted admission outcome.
- **#665** — the preflight result contracts are stringly typed and permit illegal states
  (`status="ok"` with no percentage). Spans the auth preflight too, so both should move together.

Also folded into #664: the fast-suite test fakes the DB by matching SQL text
(`"FROM idea_threads"`), and `tests/test_cycles_service.py` is now 4,246 lines.

## Known, deliberately not fixed

- **The usage read is blocking I/O on the async admission path.** 15 ms measured, so tolerable, but
  `read_codex_usage()` is called directly from an `async def` rather than through
  `asyncio.to_thread`. Worth changing if admission ever gets hot.
- **A non-`chatgpt` run closes an episode.** Quota is `skipped` for those, which records
  `decision="admitted"`, so an interleaved Anthropic run can end an episode early and produce a
  second notice. It errs toward visibility rather than silence, which is the right direction.

Gating stayed at the Cycle boundary. The other two auth-preflight call sites
(`runs/tool_catalog/handlers/workers.py`, `runs/work_intake.py`) lack the Cycle snapshot, thread, and
reliable run-origin signal the defer policy needs.
