### PR TITLE
fix(cycles): store the agent's self-review, not the token bill (#668)

### DIFF
--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -16,11 +16,13 @@ from brain.platform.integrations.provider_error_sentinel import (
 )
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.systems.cycles.contracts import SELF_REVIEW_SUMMARY_MARKERS
 from brain.systems.personality import soul_prompt_section
 
 logger = logging.getLogger(__name__)
 
 MISSION_RESULT_CONTRACT_VERDICT_KEY = "mission_result_contract_verdict"
+SELF_REVIEW_SUMMARY_VERDICT_KEY = "self_review_summary"
 _CONTRACT_KIND = "autonomous_cycle_run_result"
 _FINAL_ANSWER_TYPE = "final_answer"
 _MANDATORY_DEGRADATION_ESCALATION_PREFIX = "mandatory_degradation_escalation:"
@@ -52,6 +54,13 @@ _EVIDENCE_HEALTH_REPORT_RE = re.compile(
     r"(?P<value>ok|healthy|degraded|partial|sparse|failed|unavailable|unknown)"
     r"(?P<detail>[^\n.]{0,240})",
     re.IGNORECASE,
+)
+_SELF_REVIEW_SUMMARY_RES = tuple(
+    re.compile(
+        rf"(?:\*\*)?{re.escape(marker)}(?:\*\*)?[ \t]*(?P<summary>[^\r\n]+)",
+        re.IGNORECASE,
+    )
+    for marker in SELF_REVIEW_SUMMARY_MARKERS
 )
 
 _NON_PRESERVABLE_OUTPUTS = frozenset(
@@ -120,11 +129,27 @@ def _reported_evidence_health(candidate_answer: str | None) -> dict[str, Any] | 
     return report
 
 
+def extract_self_review_summary(candidate_answer: str | None) -> str | None:
+    """Return the final agent-authored self-review recognized by the gate."""
+
+    answer = str(candidate_answer or "")
+    matches = [
+        match
+        for pattern in _SELF_REVIEW_SUMMARY_RES
+        for match in pattern.finditer(answer)
+    ]
+    if not matches:
+        return None
+    summary = max(matches, key=lambda match: match.start()).group("summary").strip()
+    return summary or None
+
+
 def _satisfies_required_output(
     requirement: str,
     *,
     normalized_candidate: str,
     result_contract: dict[str, Any],
+    self_review_summary: str | None,
 ) -> bool:
     if requirement.startswith(_MANDATORY_DEGRADATION_ESCALATION_PREFIX):
         required_key = requirement.removeprefix(
@@ -167,10 +192,7 @@ def _satisfies_required_output(
     if requirement == "record_next_action_or_blocker":
         return _contains_any(normalized_candidate, ("next action", "next step", "blocker"))
     if requirement == "short_self_review_summary":
-        return _contains_any(
-            normalized_candidate,
-            ("self-review", "self review", "review summary", "self review summary"),
-        )
+        return self_review_summary is not None
     if requirement in {"domain_tracking", "domain_tracking_summary"}:
         return _contains_any(
             normalized_candidate,
@@ -190,6 +212,7 @@ def evaluate_cycle_result_contract(
     """Validate a visible answer against only its advertised required outputs."""
 
     normalized_candidate = _normalize_text(candidate_answer)
+    self_review_summary = extract_self_review_summary(candidate_answer)
     detected_provider_error = provider_error_kind(
         candidate_answer,
         provider_exception=provider_exception,
@@ -212,6 +235,7 @@ def evaluate_cycle_result_contract(
             requirement_name,
             normalized_candidate=normalized_candidate,
             result_contract=result_contract,
+            self_review_summary=self_review_summary,
         ):
             missing.append(requirement_name)
 
@@ -227,6 +251,7 @@ def evaluate_cycle_result_contract(
         ),
         "provider_error": detected_provider_error,
         "reported_evidence_health": _reported_evidence_health(candidate_answer),
+        SELF_REVIEW_SUMMARY_VERDICT_KEY: self_review_summary,
     }
 
 
@@ -680,6 +705,9 @@ def _base_verdict(
         "domain_side_effects_succeeded": bool(evidence_packet.get("domain_side_effects_succeeded")),
         "provider_error": initial_review.get("provider_error"),
         "reported_evidence_health": initial_review.get("reported_evidence_health"),
+        SELF_REVIEW_SUMMARY_VERDICT_KEY: initial_review.get(
+            SELF_REVIEW_SUMMARY_VERDICT_KEY
+        ),
     }
 
 
@@ -826,6 +854,9 @@ async def async_prepare_cycle_run_visible_finalization(
                     "reported_evidence_health": repair_review.get(
                         "reported_evidence_health"
                     ),
+                    SELF_REVIEW_SUMMARY_VERDICT_KEY: repair_review.get(
+                        SELF_REVIEW_SUMMARY_VERDICT_KEY
+                    ),
                 }
             )
             _persist_cycle_contract_verdict(cycle_run, verdict)
@@ -835,6 +866,9 @@ async def async_prepare_cycle_run_visible_finalization(
         if not append_only and _candidate_can_be_preserved(combined_answer, repair_review):
             preserved_answer = combined_answer
             preserved_answer_source = "repair"
+            verdict[SELF_REVIEW_SUMMARY_VERDICT_KEY] = repair_review.get(
+                SELF_REVIEW_SUMMARY_VERDICT_KEY
+            )
 
     missing_outputs = list(verdict.get("final_missing_outputs") or verdict["missing_outputs"])
     degraded_answer = _degraded_visible_answer(

--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -140,8 +140,15 @@ def extract_self_review_summary(candidate_answer: str | None) -> str | None:
     ]
     if not matches:
         return None
-    summary = max(matches, key=lambda match: match.start()).group("summary").strip()
-    return summary or None
+    return _normalize_self_review_summary(
+        max(matches, key=lambda match: match.start()).group("summary")
+    )
+
+
+def _normalize_self_review_summary(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
 
 
 def _satisfies_required_output(
@@ -320,10 +327,19 @@ def persisted_cycle_contract_verdict(cycle_run: CycleRun | None) -> dict[str, An
     return dict(verdict) if isinstance(verdict, dict) else None
 
 
-def _persist_cycle_contract_verdict(cycle_run: CycleRun, verdict: dict[str, Any]) -> None:
+def _persist_cycle_contract_verdict(
+    cycle_run: CycleRun,
+    verdict: dict[str, Any],
+    *,
+    self_review_summary: str | None,
+) -> None:
+    normalized_self_review_summary = _normalize_self_review_summary(self_review_summary)
+    stored_verdict = dict(verdict)
+    stored_verdict[SELF_REVIEW_SUMMARY_VERDICT_KEY] = normalized_self_review_summary
     context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
-    context_snapshot[MISSION_RESULT_CONTRACT_VERDICT_KEY] = dict(verdict)
+    context_snapshot[MISSION_RESULT_CONTRACT_VERDICT_KEY] = stored_verdict
     cycle_run.context_snapshot = context_snapshot
+    cycle_run.self_review_summary = normalized_self_review_summary
 
 
 async def _latest_final_answer_artifact(
@@ -684,6 +700,7 @@ def _base_verdict(
     candidate_artifact_id: Any,
     initial_review: dict[str, Any],
     evidence_packet: dict[str, Any],
+    self_review_summary: str | None,
 ) -> dict[str, Any]:
     return {
         "kind": "cycle_result_contract_verdict",
@@ -705,9 +722,7 @@ def _base_verdict(
         "domain_side_effects_succeeded": bool(evidence_packet.get("domain_side_effects_succeeded")),
         "provider_error": initial_review.get("provider_error"),
         "reported_evidence_health": initial_review.get("reported_evidence_health"),
-        SELF_REVIEW_SUMMARY_VERDICT_KEY: initial_review.get(
-            SELF_REVIEW_SUMMARY_VERDICT_KEY
-        ),
+        SELF_REVIEW_SUMMARY_VERDICT_KEY: self_review_summary,
     }
 
 
@@ -782,15 +797,23 @@ async def async_prepare_cycle_run_visible_finalization(
         evidence_packet=evidence_packet,
         provider_exception=captured_provider_exception,
     )
+    self_review_summary = _normalize_self_review_summary(
+        initial_review.get(SELF_REVIEW_SUMMARY_VERDICT_KEY)
+    )
     verdict = _base_verdict(
         candidate_answer=candidate_answer,
         candidate_artifact_id=getattr(artifact, "id", None),
         initial_review=initial_review,
         evidence_packet=evidence_packet,
+        self_review_summary=self_review_summary,
     )
 
     if initial_review["approved"]:
-        _persist_cycle_contract_verdict(cycle_run, verdict)
+        _persist_cycle_contract_verdict(
+            cycle_run,
+            verdict,
+            self_review_summary=self_review_summary,
+        )
         return verdict
 
     append_only = _candidate_can_be_preserved(candidate_answer, initial_review)
@@ -823,6 +846,9 @@ async def async_prepare_cycle_run_visible_finalization(
             mission=mission,
             evidence_packet=evidence_packet,
         )
+        repaired_self_review_summary = _normalize_self_review_summary(
+            repair_review.get(SELF_REVIEW_SUMMARY_VERDICT_KEY)
+        )
         if repair_review.get("provider_error"):
             logger.error(
                 "cycle_contract_repair_provider_error run_id=%s raw_error=%s",
@@ -854,21 +880,22 @@ async def async_prepare_cycle_run_visible_finalization(
                     "reported_evidence_health": repair_review.get(
                         "reported_evidence_health"
                     ),
-                    SELF_REVIEW_SUMMARY_VERDICT_KEY: repair_review.get(
-                        SELF_REVIEW_SUMMARY_VERDICT_KEY
-                    ),
+                    SELF_REVIEW_SUMMARY_VERDICT_KEY: repaired_self_review_summary,
                 }
             )
-            _persist_cycle_contract_verdict(cycle_run, verdict)
+            _persist_cycle_contract_verdict(
+                cycle_run,
+                verdict,
+                self_review_summary=repaired_self_review_summary,
+            )
             return verdict
         verdict["repair_missing_outputs"] = list(repair_review["missing_outputs"])
         verdict["final_missing_outputs"] = list(repair_review["missing_outputs"])
         if not append_only and _candidate_can_be_preserved(combined_answer, repair_review):
             preserved_answer = combined_answer
             preserved_answer_source = "repair"
-            verdict[SELF_REVIEW_SUMMARY_VERDICT_KEY] = repair_review.get(
-                SELF_REVIEW_SUMMARY_VERDICT_KEY
-            )
+            self_review_summary = repaired_self_review_summary
+            verdict[SELF_REVIEW_SUMMARY_VERDICT_KEY] = self_review_summary
 
     missing_outputs = list(verdict.get("final_missing_outputs") or verdict["missing_outputs"])
     degraded_answer = _degraded_visible_answer(
@@ -910,7 +937,11 @@ async def async_prepare_cycle_run_visible_finalization(
             "final_missing_outputs": missing_outputs,
         }
     )
-    _persist_cycle_contract_verdict(cycle_run, verdict)
+    _persist_cycle_contract_verdict(
+        cycle_run,
+        verdict,
+        self_review_summary=self_review_summary,
+    )
     return verdict
 
 

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -16,6 +16,12 @@ from brain.systems.cycles.common import (
 from brain.systems.cycles.degradation import mandatory_escalations
 
 SCHEDULED_REVIEW_WINDOW_HOURS = 24
+SELF_REVIEW_SUMMARY_MARKER = "Self-review summary:"
+SELF_REVIEW_SUMMARY_MARKERS = (
+    SELF_REVIEW_SUMMARY_MARKER,
+    # Existing Reflex answers use the shorter label; keep one gate-owned alias.
+    "Self-review:",
+)
 
 # One source of truth for the base result-contract keys and the visible sections
 # named in the launch prompt. The gate validates these same labels/aliases.
@@ -24,7 +30,7 @@ RESULT_CONTRACT_OUTPUT_SECTIONS = {
     "summarize_workspace_evidence_or_explicit_gaps": "`Evidence reviewed:`",
     "report_evidence_health": "`Evidence health:`",
     "record_next_action_or_blocker": "`Next action:` or `Blocker:`",
-    "short_self_review_summary": "`Self-review summary:`",
+    "short_self_review_summary": f"`{SELF_REVIEW_SUMMARY_MARKER}`",
 }
 
 # Keep each coordinator run kind's complete contract visible here. Do not derive

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -26,10 +26,7 @@ from brain.systems.cycles.common import (
     string_or_none,
     validate_nonempty_trimmed,
 )
-from brain.systems.cycles.contract_gate import (
-    MISSION_RESULT_CONTRACT_VERDICT_KEY,
-    SELF_REVIEW_SUMMARY_VERDICT_KEY,
-)
+from brain.systems.cycles.contract_gate import MISSION_RESULT_CONTRACT_VERDICT_KEY
 from brain.systems.cycles.contracts import (
     cycle_launch_receipt,
     cycle_result_contract,
@@ -465,13 +462,9 @@ async def record_cycle_run_evaluation(
         "observed_causes": observed_causes,
         "result_state": degradation_state,
     }
-    stored_usage = usage or json_dict(context_snapshot.get("usage"))
-    context_snapshot["usage"] = {**stored_usage, "summary": summary}
+    if usage is not None:
+        context_snapshot["usage"] = usage
     run.context_snapshot = jsonable(context_snapshot)
-    self_review_summary = verdict.get(SELF_REVIEW_SUMMARY_VERDICT_KEY)
-    run.self_review_summary = (
-        str(self_review_summary).strip() if self_review_summary else None
-    )
     session.add(
         CycleRunEvaluation(
             cycle_id=cycle.id,

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -26,7 +26,10 @@ from brain.systems.cycles.common import (
     string_or_none,
     validate_nonempty_trimmed,
 )
-from brain.systems.cycles.contract_gate import MISSION_RESULT_CONTRACT_VERDICT_KEY
+from brain.systems.cycles.contract_gate import (
+    MISSION_RESULT_CONTRACT_VERDICT_KEY,
+    SELF_REVIEW_SUMMARY_VERDICT_KEY,
+)
 from brain.systems.cycles.contracts import (
     cycle_launch_receipt,
     cycle_result_contract,
@@ -462,10 +465,13 @@ async def record_cycle_run_evaluation(
         "observed_causes": observed_causes,
         "result_state": degradation_state,
     }
-    if usage is not None:
-        context_snapshot["usage"] = usage
+    stored_usage = usage or json_dict(context_snapshot.get("usage"))
+    context_snapshot["usage"] = {**stored_usage, "summary": summary}
     run.context_snapshot = jsonable(context_snapshot)
-    run.self_review_summary = summary
+    self_review_summary = verdict.get(SELF_REVIEW_SUMMARY_VERDICT_KEY)
+    run.self_review_summary = (
+        str(self_review_summary).strip() if self_review_summary else None
+    )
     session.add(
         CycleRunEvaluation(
             cycle_id=cycle.id,

--- a/tests/test_cycle_self_review_persistence.py
+++ b/tests/test_cycle_self_review_persistence.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.systems.cycles import memory as cycle_memory
+from brain.systems.cycles.contract_gate import (
+    MISSION_RESULT_CONTRACT_VERDICT_KEY,
+    evaluate_cycle_result_contract,
+)
+
+
+SELF_REVIEW = "I should verify the evidence gap earlier in the next run."
+
+
+class _CaptureSession:
+    def __init__(self) -> None:
+        self.added = []
+
+    def add(self, value) -> None:
+        self.added.append(value)
+
+
+def _cycle_and_run(*, self_review_summary: str | None) -> tuple[Cycle, CycleRun]:
+    cycle = Cycle()
+    cycle.id = 7
+    cycle.user_id = "user-1"
+    cycle.org_id = "org-1"
+    cycle.target_idea_id = None
+    cycle.degradation_state = {}
+
+    run = CycleRun()
+    run.id = 12
+    run.run_id = 44
+    run.idea_id = None
+    run.scheduled_for = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    run.context_snapshot = {
+        MISSION_RESULT_CONTRACT_VERDICT_KEY: {
+            "settlement_status": "mission_success",
+            "self_review_summary": self_review_summary,
+        }
+    }
+    return cycle, run
+
+
+def test_contract_gate_extracts_the_agent_self_review_from_the_validated_marker():
+    review = evaluate_cycle_result_contract(
+        candidate_answer=(
+            "The cycle reviewed the workspace evidence and completed its mission.\n"
+            "Evidence health: ok.\n"
+            "Next action: inspect the next scheduled run.\n"
+            f"Self-review summary: {SELF_REVIEW}"
+        ),
+        result_contract={
+            "kind": "autonomous_cycle_run_result",
+            "required_outputs": ["short_self_review_summary"],
+        },
+        mission="Review the workspace.",
+    )
+
+    assert review["approved"] is True
+    assert review["self_review_summary"] == SELF_REVIEW
+
+
+@pytest.mark.asyncio
+async def test_cycle_evaluation_persists_self_review_and_keeps_cost_summary_in_usage(
+    monkeypatch,
+):
+    async def summarize_usage(_session, run_id):
+        assert run_id == 44
+        return {"tokens_total": 12_345, "estimated_cost": 0.06789}
+
+    monkeypatch.setattr(
+        cycle_memory,
+        "async_summarize_run_tree_usage_in_savepoint",
+        summarize_usage,
+    )
+    session = _CaptureSession()
+    cycle, run = _cycle_and_run(self_review_summary=SELF_REVIEW)
+
+    await cycle_memory.record_cycle_run_evaluation(
+        session,
+        run,
+        cycle,
+        status="completed",
+    )
+
+    assert run.self_review_summary == SELF_REVIEW
+    assert "tokens" not in run.self_review_summary
+    assert "$" not in run.self_review_summary
+    assert run.context_snapshot["usage"]["tokens_total"] == 12_345
+    assert run.context_snapshot["usage"]["estimated_cost"] == 0.06789
+    assert run.context_snapshot["usage"]["summary"].endswith(
+        "Burn: 12,345 tokens; estimated cost $0.067890."
+    )
+    assert session.added[-1].summary == run.context_snapshot["usage"]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_evaluation_persists_none_when_self_review_is_missing(monkeypatch):
+    async def summarize_usage(_session, _run_id):
+        return {"tokens_total": 900, "estimated_cost": 0.001}
+
+    monkeypatch.setattr(
+        cycle_memory,
+        "async_summarize_run_tree_usage_in_savepoint",
+        summarize_usage,
+    )
+    session = _CaptureSession()
+    cycle, run = _cycle_and_run(self_review_summary=None)
+    run.context_snapshot[MISSION_RESULT_CONTRACT_VERDICT_KEY].update(
+        {
+            "settlement_status": "mission_contract_failed",
+            "final_missing_outputs": ["short_self_review_summary"],
+        }
+    )
+
+    await cycle_memory.record_cycle_run_evaluation(
+        session,
+        run,
+        cycle,
+        status="degraded",
+        error="mission_contract_failed: missing short_self_review_summary",
+    )
+
+    assert run.self_review_summary is None
+    assert "900 tokens" in run.context_snapshot["usage"]["summary"]
+    assert "$0.001000" in run.context_snapshot["usage"]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_cycle_history_emits_the_agent_self_review_sentence():
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    now = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    run = SimpleNamespace(
+        id=12,
+        cycle_id=7,
+        revision_id=None,
+        created_at=now,
+        scheduled_for=now,
+        started_at=now,
+        completed_at=now,
+        status="completed",
+        error=None,
+        skip_reason=None,
+        idea_id=None,
+        run_id=44,
+        prompt_snapshot="Review the workspace.",
+        guidance_snapshot=[],
+        output_targets_snapshot=[],
+        context_snapshot={},
+        self_review_summary=SELF_REVIEW,
+    )
+    cycle = SimpleNamespace(
+        id=7,
+        name="Workspace review",
+        user_id="user-1",
+        org_id="org-1",
+        deleted_at=None,
+    )
+    user = SimpleNamespace(name="Illo")
+
+    class _RowsResult:
+        def all(self):
+            return [(run, cycle, user, None)]
+
+    class _Session:
+        def execute(self, _stmt):
+            return _RowsResult()
+
+    payload = {"sources": {}}
+    await workspace_data._query_cycle_runs(
+        _Session(),
+        payload,
+        start=None,
+        end=None,
+        org_id="org-1",
+        user_id=None,
+        person_ids=[],
+        idea_id=None,
+        cycle_id=7,
+        search=None,
+        include_archived=False,
+        limit=10,
+    )
+
+    assert payload["sources"]["cycle_runs"][0]["self_review_summary"] == SELF_REVIEW

--- a/tests/test_cycle_self_review_persistence.py
+++ b/tests/test_cycle_self_review_persistence.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from types import SimpleNamespace
 
 import pytest
 
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.systems.cycles import memory as cycle_memory
 from brain.systems.cycles.contract_gate import (
-    MISSION_RESULT_CONTRACT_VERDICT_KEY,
-    evaluate_cycle_result_contract,
+    extract_self_review_summary,
 )
 
 
@@ -24,7 +22,7 @@ class _CaptureSession:
         self.added.append(value)
 
 
-def _cycle_and_run(*, self_review_summary: str | None) -> tuple[Cycle, CycleRun]:
+def _cycle_and_run() -> tuple[Cycle, CycleRun]:
     cycle = Cycle()
     cycle.id = 7
     cycle.user_id = "user-1"
@@ -37,38 +35,26 @@ def _cycle_and_run(*, self_review_summary: str | None) -> tuple[Cycle, CycleRun]
     run.run_id = 44
     run.idea_id = None
     run.scheduled_for = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
-    run.context_snapshot = {
-        MISSION_RESULT_CONTRACT_VERDICT_KEY: {
-            "settlement_status": "mission_success",
-            "self_review_summary": self_review_summary,
-        }
-    }
+    run.context_snapshot = {}
     return cycle, run
 
 
-def test_contract_gate_extracts_the_agent_self_review_from_the_validated_marker():
-    review = evaluate_cycle_result_contract(
-        candidate_answer=(
-            "The cycle reviewed the workspace evidence and completed its mission.\n"
-            "Evidence health: ok.\n"
-            "Next action: inspect the next scheduled run.\n"
-            f"Self-review summary: {SELF_REVIEW}"
-        ),
-        result_contract={
-            "kind": "autonomous_cycle_run_result",
-            "required_outputs": ["short_self_review_summary"],
-        },
-        mission="Review the workspace.",
-    )
-
-    assert review["approved"] is True
-    assert review["self_review_summary"] == SELF_REVIEW
+@pytest.mark.parametrize(
+    ("answer", "expected"),
+    [
+        (f"Self-review summary: {SELF_REVIEW}", SELF_REVIEW),
+        (f"Self-review: {SELF_REVIEW}", SELF_REVIEW),
+        (f"My self review is that {SELF_REVIEW}", None),
+        ("Self-review summary:\nNext action: inspect the next run.", None),
+    ],
+    ids=["summary-marker", "short-marker", "loose-phrase", "empty-marker"],
+)
+def test_extract_self_review_summary_accepts_only_populated_markers(answer, expected):
+    assert extract_self_review_summary(answer) == expected
 
 
 @pytest.mark.asyncio
-async def test_cycle_evaluation_persists_self_review_and_keeps_cost_summary_in_usage(
-    monkeypatch,
-):
+async def test_cycle_evaluation_keeps_usage_numeric_and_summary_in_evaluation(monkeypatch):
     async def summarize_usage(_session, run_id):
         assert run_id == 44
         return {"tokens_total": 12_345, "estimated_cost": 0.06789}
@@ -79,7 +65,7 @@ async def test_cycle_evaluation_persists_self_review_and_keeps_cost_summary_in_u
         summarize_usage,
     )
     session = _CaptureSession()
-    cycle, run = _cycle_and_run(self_review_summary=SELF_REVIEW)
+    cycle, run = _cycle_and_run()
 
     await cycle_memory.record_cycle_run_evaluation(
         session,
@@ -88,21 +74,19 @@ async def test_cycle_evaluation_persists_self_review_and_keeps_cost_summary_in_u
         status="completed",
     )
 
-    assert run.self_review_summary == SELF_REVIEW
-    assert "tokens" not in run.self_review_summary
-    assert "$" not in run.self_review_summary
     assert run.context_snapshot["usage"]["tokens_total"] == 12_345
     assert run.context_snapshot["usage"]["estimated_cost"] == 0.06789
-    assert run.context_snapshot["usage"]["summary"].endswith(
+    assert "summary" not in run.context_snapshot["usage"]
+    assert session.added[-1].summary.endswith(
         "Burn: 12,345 tokens; estimated cost $0.067890."
     )
-    assert session.added[-1].summary == run.context_snapshot["usage"]["summary"]
+    assert session.added[-1].details["usage"] == run.context_snapshot["usage"]
 
 
 @pytest.mark.asyncio
-async def test_cycle_evaluation_persists_none_when_self_review_is_missing(monkeypatch):
+async def test_cycle_evaluation_omits_usage_when_no_usage_was_recorded(monkeypatch):
     async def summarize_usage(_session, _run_id):
-        return {"tokens_total": 900, "estimated_cost": 0.001}
+        return None
 
     monkeypatch.setattr(
         cycle_memory,
@@ -110,82 +94,15 @@ async def test_cycle_evaluation_persists_none_when_self_review_is_missing(monkey
         summarize_usage,
     )
     session = _CaptureSession()
-    cycle, run = _cycle_and_run(self_review_summary=None)
-    run.context_snapshot[MISSION_RESULT_CONTRACT_VERDICT_KEY].update(
-        {
-            "settlement_status": "mission_contract_failed",
-            "final_missing_outputs": ["short_self_review_summary"],
-        }
-    )
+    cycle, run = _cycle_and_run()
 
     await cycle_memory.record_cycle_run_evaluation(
         session,
         run,
         cycle,
-        status="degraded",
-        error="mission_contract_failed: missing short_self_review_summary",
+        status="completed",
     )
 
     assert run.self_review_summary is None
-    assert "900 tokens" in run.context_snapshot["usage"]["summary"]
-    assert "$0.001000" in run.context_snapshot["usage"]["summary"]
-
-
-@pytest.mark.asyncio
-async def test_workspace_cycle_history_emits_the_agent_self_review_sentence():
-    from brain.systems.runs.tool_catalog.handlers import workspace_data
-
-    now = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
-    run = SimpleNamespace(
-        id=12,
-        cycle_id=7,
-        revision_id=None,
-        created_at=now,
-        scheduled_for=now,
-        started_at=now,
-        completed_at=now,
-        status="completed",
-        error=None,
-        skip_reason=None,
-        idea_id=None,
-        run_id=44,
-        prompt_snapshot="Review the workspace.",
-        guidance_snapshot=[],
-        output_targets_snapshot=[],
-        context_snapshot={},
-        self_review_summary=SELF_REVIEW,
-    )
-    cycle = SimpleNamespace(
-        id=7,
-        name="Workspace review",
-        user_id="user-1",
-        org_id="org-1",
-        deleted_at=None,
-    )
-    user = SimpleNamespace(name="Illo")
-
-    class _RowsResult:
-        def all(self):
-            return [(run, cycle, user, None)]
-
-    class _Session:
-        def execute(self, _stmt):
-            return _RowsResult()
-
-    payload = {"sources": {}}
-    await workspace_data._query_cycle_runs(
-        _Session(),
-        payload,
-        start=None,
-        end=None,
-        org_id="org-1",
-        user_id=None,
-        person_ids=[],
-        idea_id=None,
-        cycle_id=7,
-        search=None,
-        include_archived=False,
-        limit=10,
-    )
-
-    assert payload["sources"]["cycle_runs"][0]["self_review_summary"] == SELF_REVIEW
+    assert "usage" not in run.context_snapshot
+    assert session.added[-1].details["usage"] is None

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -3250,6 +3250,44 @@ def test_coordinator_posted_digest_scores_one_without_repair_or_repost(monkeypat
     assert len(session._artifacts) == 1
 
 
+def test_cycle_finalization_persists_gate_extracted_self_review(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    self_review = "I should verify the evidence gap earlier in the next run."
+    answer = (
+        "The workspace review completed its mission using the current Cycle records.\n"
+        "Evidence reviewed: the Cycle ledger and current workspace records.\n"
+        "Evidence health: ok; all required readers returned complete results.\n"
+        "Next action: inspect the next scheduled run.\n"
+        f"Self-review summary: {self_review}"
+    )
+    session, cycle_run, _, _ = _contract_finalization_scenario(
+        cycle_id=8,
+        mission="Review the workspace.",
+        answer=answer,
+    )
+
+    async def fail_if_repair_runs(**_kwargs):
+        raise AssertionError("valid final answer should not need repair")
+
+    monkeypatch.setattr(
+        contract_gate,
+        "_async_repair_cycle_contract_answer",
+        fail_if_repair_runs,
+    )
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    verdict = cycle_run.context_snapshot["mission_result_contract_verdict"]
+    evaluation = next(
+        item for item in session.added if item.__class__.__name__ == "CycleRunEvaluation"
+    )
+    assert verdict["self_review_summary"] == self_review
+    assert cycle_run.self_review_summary == self_review
+    assert evaluation.summary == "Cycle run completed and was recorded in the Cycle ledger."
+
+
 @pytest.mark.parametrize(
     ("run_id", "answer"),
     [
@@ -3549,6 +3587,10 @@ async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
     assert verdict["settlement_status"] == "mission_success_after_repair"
     assert verdict["side_effects_succeeded"] is True
     assert verdict["domain_side_effects_succeeded"] is True
+    assert verdict["self_review_summary"] == (
+        "mission result contract satisfied after repair."
+    )
+    assert cycle_run.self_review_summary == verdict["self_review_summary"]
     latest_answer = session._artifacts[-1]
     assert latest_answer.artifact_type == "final_answer"
     assert latest_answer.text.startswith("24h readout")

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -759,6 +759,7 @@ async def test_read_cycles_pages_to_complete_history_and_watermark_is_one_bounde
     assert seen_ids == [5, 4, 3, 2, 1]
     assert pages[0]["truncated"] is True
     assert pages[0]["next_page"]
+    assert pages[0]["sources"]["cycle_runs"][0]["self_review_summary"] == "Healthy evidence"
     assert pages[-1]["truncated"] is False
     assert pages[-1]["evidence_health"] == {"status": "ok", "completeness": "complete"}
 


### PR DESCRIPTION
Closes #668

## What was wrong

`cycle_runs.self_review_summary` stored a machine-generated status-and-billing
string on **15 of 15 rows** between 2026-07-28 and 2026-08-04:

```
Cycle run completed and was recorded in the Cycle ledger. Burn 6,654,720 tokens; estimated cost $6.555452.
```

Every cycle mission ends with a mandated `Self-review summary:` line. The agent
writes it, the contract gate validates it — and then `memory.py` overwrote the
field with accounting. The one field designed to let Illo judge its own work was
the one field guaranteed to contain no judgement.

## What this changes

- The contract gate extracts the self-review line **once**
  (`extract_self_review_summary`) and passes it through the persisted verdict.
  There is no second parser: the gate already knew where the marker was, so the
  requirement check now uses that extraction instead of a substring scan.
- `record_cycle_run_evaluation` stores the agent's sentence, or `None` when the
  agent wrote none.
- The cost string moves to `context_snapshot["usage"]["summary"]`, beside the
  token and cost numbers it belongs with. **No accounting is lost.**
- `CycleRunEvaluation.summary` is untouched.
- **No column, no migration.** The ticket offered this path and it avoids an
  alembic head collision with the sibling PR in flight this cycle.

## How to judge it without reading the diff

Run the repo's own CI fast lane from the branch:

```
python3 -m brain.jobs.check_cycle_context_admission
python3 -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

I ran both on the host: `ok: true` (cycles 2, 8, 9 passed) and
**4750 passed, 11 skipped, 83 deselected in 84.76s**.

Then watch one real scheduled run of cycle 2, 8 or 9 and read its row:
`self_review_summary` should be a sentence the agent wrote about its own work,
with no token count and no dollar amount in it, and
`context_snapshot['usage']['summary']` should still hold the cost line.

### Acceptance checks
1. A run whose answer carries `Self-review summary:` stores that text — and only
   that text — in `self_review_summary`.
2. The token/cost string for the same run is still readable from
   `context_snapshot['usage']['summary']`.
3. A run with no self-review line stores `NULL`, never a cost line standing in for one.
4. `workspace_data`'s `self_review_summary` snippet returns the agent's sentence
   when an agent reads a prior run.

## Named, not fixed — two behavior changes worth your eye

1. **The gate requirement got stricter.** `short_self_review_summary` used to pass
   if the words *self-review*, *self review* or *review summary* appeared anywhere
   in the answer. It now requires the marker followed by text on the same line
   (`Self-review summary:` or the `Self-review:` alias). That matches the contract
   the launch prompt actually asks for, but a run that only gestured at a
   self-review will now be judged as missing one and degrade. Watch the next few
   scheduled runs for an uptick in degraded settlements.
2. **Runs with no contract verdict now store NULL** rather than the cost line.
   That is the intended outcome of check 3, but it means the column goes empty for
   any run path that does not go through the gate, instead of looking populated.

3. **The maintainability review flagged one thing I deliberately did not fold in.**
   `brain/systems/cycles/prompts.py:240` still hardcodes the `Self-review summary:`
   label instead of rendering it from the new `SELF_REVIEW_SUMMARY_MARKER` constant,
   so the prompt that asks for the line and the gate that reads it can still drift
   apart. It is a one-line change, but two sibling PRs are editing `prompts.py` in
   parallel this cycle and a third editor would have created a conflict for no
   urgency. Worth a follow-up.

## Review trail

A Codex maintainability pass called three things blocking; all three are fixed in
the second commit and re-verified:
- the cost string was being written into the numeric `usage` totals dict (removed —
  `CycleRunEvaluation.summary` and `details["usage"]` already held it),
- `memory.py` was reaching into the verdict JSON by key to fill the column (the gate
  now assigns it at every persist point, including the repair path),
- both new tests bypassed the gate-to-persistence bridge they were meant to protect,
  so either could have kept passing while the real path broke.
