### PR TITLE
fix(slack): require support recall before intake action (#669)

### DIFF
--- a/brain/systems/slack/channel_monitor_rendering.py
+++ b/brain/systems/slack/channel_monitor_rendering.py
@@ -5,6 +5,33 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 
+SUPPORT_INTAKE_RECALL_MANDATE = "\n".join(
+    [
+        "Mandatory customer-support recall gate (complete this before classification "
+        "or action):",
+        "- For every customer support intake or report, call `search_knowledge` once "
+        "for each requester email, company id, and error signature that the intake or "
+        "its Slack context actually provides. Do this before the first visible Slack "
+        "reply (including a clarifying question) and before creating or updating an "
+        "issue. Do not skip an available identifier.",
+        "- For a customer generation report, call `brain_skills` to resolve "
+        "`uwear-customer-generation-report-triage`, then call `skill_view` to load "
+        "skill 54's current procedure and follow its evidence-first payload "
+        "investigation. Do not depend on phrase-triggered skill discovery.",
+        "- The visible reply or filed issue must state what prior context those "
+        "searches found, or state that no prior context was found. Silence is not "
+        "allowed for a customer support intake.",
+        "- When a teammate asks a question about customer state, first use the "
+        "appropriate read-only payload reader and `search_knowledge`; only then "
+        "answer with `post_slack_reply`. Do not answer from the report text alone. "
+        "Search any additional requester, company, or error identifier revealed by "
+        "the payload before answering.",
+        "- This evidence gate runs before the existing triage branches. It does not "
+        "change their order or make casual chatter actionable.",
+    ]
+)
+
+
 def slack_channel_monitor_message(
     payload: Mapping[str, Any],
     slack_trigger_payload: Mapping[str, Any],
@@ -22,6 +49,8 @@ def slack_channel_monitor_message(
         "Do not use react_to_slack_message for another routine acknowledgement in this passive triage run.",
         "",
         durable_preference_guidance(),
+        "",
+        SUPPORT_INTAKE_RECALL_MANDATE,
         "",
         "Classify this message and act accordingly:",
         "- A human explicitly stating a durable presentation/behaviour preference requires a "
@@ -154,4 +183,8 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
-__all__ = ["durable_preference_guidance", "slack_channel_monitor_message"]
+__all__ = [
+    "SUPPORT_INTAKE_RECALL_MANDATE",
+    "durable_preference_guidance",
+    "slack_channel_monitor_message",
+]

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -318,6 +318,34 @@ def test_build_payload_for_channel_message_is_headless_and_not_forced_reply():
     assert "alternative_response_tools" not in metadata
 
 
+def test_channel_monitor_prompt_requires_customer_support_recall_before_action():
+    from brain.systems.slack.channel_monitor_rendering import (
+        SUPPORT_INTAKE_RECALL_MANDATE,
+    )
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    monitored = _channel_monitor_payload()
+    monitored["channel_id"] = "C082SUKQKJL"
+    monitored["channel_name"] = "support-intake"
+    monitored["response_target"]["channel_id"] = "C082SUKQKJL"
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=monitored,
+    )
+
+    run_message = payload["payload"]["run_message"]
+    assert "monitoring Slack #support-intake" in run_message
+    assert SUPPORT_INTAKE_RECALL_MANDATE in run_message
+    assert run_message.index(SUPPORT_INTAKE_RECALL_MANDATE) < run_message.index(
+        "Classify this message and act accordingly:"
+    )
+    assert "requester email, company id, and error signature" in run_message
+    assert "Silence is not allowed for a customer support intake." in run_message
+    assert "`uwear-customer-generation-report-triage`" in run_message
+    assert "appropriate read-only payload reader and `search_knowledge`" in run_message
+
+
 def test_channel_monitor_framing_routes_feature_requests_to_tickets():
     # Regression: a Retool-relayed customer feature request ("*New:* Idea") was
     # classified "low-signal" and dropped because the framing only made


### PR DESCRIPTION
Closes #669

## What was wrong

Support-intake runs classified, answered, and asked clarifying questions without
ever consulting the knowledge base. On 2026-08-04, run 14634 replied to
`mroyer@pentagone.com` with a tool trace of exactly
`read_slack_conversation → post_slack_reply` — zero `search_knowledge`, zero
`memory_reconstruct` — while the index already held that requester's three prior
requests, a memory node about their company, and six older reports from a
colleague at the same company.

Run 14644 the same day made 11 `search_knowledge` calls on its own initiative and
found exactly the right prior art. **The gap is mandate, not capability.**

## What this changes

One mandatory recall gate, rendered into the passive-monitor prompt ahead of the
existing triage branches:

- `search_knowledge` runs once per requester email, company id and error
  signature the intake actually provides — before the first visible reply
  (clarifying questions included) and before any issue is created.
- Generation reports resolve skill 54
  (`uwear-customer-generation-report-triage`) through `brain_skills` +
  `skill_view` explicitly, instead of depending on phrase-trigger luck.
- The reply or the filed issue must state what prior context was found, **or**
  state that none was. Silence is not an allowed outcome.
- A teammate question about customer state goes through the read-only payload
  reader and `search_knowledge` first — never answered from the report text
  alone.

The gate runs in front of the existing branches. It does not reorder them and it
does not make casual chatter actionable.

## Why code and not the runtime overlay

The ticket asked for that decision. The `#611` overlay mechanism exists but only
reaches the `contact_form_lead` intake; it does not reach the
`slack.channel_message` lane that `C082SUKQKJL` runs on. So the mandate lands in
the code-authored prompt, with a regression test that asserts on the mandate's own
text and its position ahead of the classify step — deleting the mandate breaks a
test.

## One limitation worth your eye

The mandate renders for **every** monitored channel, not only the support lane,
because `slack_channel_monitor_message` has no per-channel branch. Today that is
a distinction without a difference: the connection metadata lists exactly one
monitored channel, `C082SUKQKJL`. If a second channel is ever monitored, the gate
should be scoped rather than inherited — the mandate's own wording ("for every
customer support intake or report") is the only thing limiting it right now.

## How to judge it without reading the diff

```
python3 -m brain.jobs.check_cycle_context_admission
python3 -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

Both green on the host — admission `ok: true` (cycles 2, 8, 9), and the full fast
lane passing. (The worker's own run showed 6 tests unresolved from the sandbox's
`127.0.0.1` bind denial; the host run is the real one.)

Then watch the next support intake in `#alerts`:

1. Its event trace shows a `search_knowledge` call **before** the first visible
   reply.
2. On a repeat reporter, the reply or filed ticket references the prior history.
3. A teammate question about customer state pulls payloads before it answers.
4. Ordinary chatter in the channel still gets triaged the way it does today — the
   gate adds a step, it does not change the branches.

No migration, no schema change, no new dependency.
