### PR TITLE
refactor(cycles): one route resolution and a closed admission decision (#664)

### DIFF
--- a/brain/platform/integrations/codex_usage.py
+++ b/brain/platform/integrations/codex_usage.py
@@ -7,14 +7,28 @@ import math
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, Mapping
+from typing import Any, Mapping, TypeAlias
 
 
-CodexUsageStatus = Literal["ok", "unknown", "exhausted"]
+class CodexUsageUnknownReason(StrEnum):
+    AUTH_ERROR = "auth_error"
+    MALFORMED_LINE = "malformed_line"
+    PRIMARY_MISSING = "primary_missing"
+    RATE_LIMITS_MISSING = "rate_limits_missing"
+    SESSIONS_DIR_EMPTY = "sessions_dir_empty"
+    SESSIONS_DIR_MISSING = "sessions_dir_missing"
+    SESSIONS_DIR_UNREADABLE = "sessions_dir_unreadable"
+    SESSION_FILE_EMPTY = "session_file_empty"
+    SESSION_FILE_UNREADABLE = "session_file_unreadable"
+    TOKEN_COUNT_MISSING = "token_count_missing"
+    UNEXPECTED_LIMIT_ID = "unexpected_limit_id"
+    USED_PERCENT_INVALID = "used_percent_invalid"
+    USED_PERCENT_MISSING = "used_percent_missing"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class CodexKnownUsage:
     used_percent: float
     observed_at: str
@@ -23,39 +37,63 @@ class CodexKnownUsage:
     plan_type: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "used_percent": self.used_percent,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-        }
+        return _codex_usage_to_dict(self)
 
 
-@dataclass(frozen=True, slots=True)
-class CodexUsageReading:
-    status: CodexUsageStatus
-    used_percent: float | None = None
-    reason: str | None = None
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CodexUnknownUsageReading:
+    reason: CodexUsageUnknownReason
     observed_at: str | None = None
     source_path: str | None = None
     limit_id: str | None = None
     plan_type: str | None = None
     last_known_good: CodexKnownUsage | None = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, CodexUsageUnknownReason):
+            raise TypeError("reason must be a CodexUsageUnknownReason")
+
     def to_dict(self) -> dict[str, Any]:
+        return _codex_usage_to_dict(self)
+
+
+CodexUsageReading: TypeAlias = CodexKnownUsage | CodexUnknownUsageReading
+
+
+def _codex_usage_to_dict(reading: CodexUsageReading) -> dict[str, Any]:
+    """Serialize the legacy flat reading shape at its persistence boundary."""
+
+    if isinstance(reading, CodexKnownUsage):
         return {
-            "status": self.status,
-            "used_percent": self.used_percent,
-            "reason": self.reason,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-            "last_known_good": (
-                self.last_known_good.to_dict() if self.last_known_good else None
-            ),
+            "status": "exhausted" if reading.used_percent >= 100 else "ok",
+            "used_percent": reading.used_percent,
+            "reason": None,
+            "observed_at": reading.observed_at,
+            "source_path": reading.source_path,
+            "limit_id": reading.limit_id,
+            "plan_type": reading.plan_type,
+            "last_known_good": None,
         }
+    return {
+        "status": "unknown",
+        "used_percent": None,
+        "reason": reading.reason,
+        "observed_at": reading.observed_at,
+        "source_path": reading.source_path,
+        "limit_id": reading.limit_id,
+        "plan_type": reading.plan_type,
+        "last_known_good": (
+            {
+                "used_percent": reading.last_known_good.used_percent,
+                "observed_at": reading.last_known_good.observed_at,
+                "source_path": reading.last_known_good.source_path,
+                "limit_id": reading.last_known_good.limit_id,
+                "plan_type": reading.last_known_good.plan_type,
+            }
+            if reading.last_known_good is not None
+            else None
+        ),
+    }
 
 
 def codex_home_path(path: str | Path | None = None) -> Path:
@@ -68,15 +106,14 @@ def codex_home_path(path: str | Path | None = None) -> Path:
 
 
 def _unknown(
-    reason: str,
+    reason: CodexUsageUnknownReason,
     *,
     observed_at: str | None = None,
     source_path: Path | None = None,
     limit_id: str | None = None,
     plan_type: str | None = None,
 ) -> CodexUsageReading:
-    return CodexUsageReading(
-        status="unknown",
+    return CodexUnknownUsageReading(
         reason=reason,
         observed_at=observed_at,
         source_path=str(source_path) if source_path else None,
@@ -141,7 +178,7 @@ def _reading_from_event(
 ) -> CodexUsageReading | None:
     if _is_auth_error(data):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=_event_timestamp(data, source_path),
             source_path=source_path,
         )
@@ -153,20 +190,20 @@ def _reading_from_event(
     observed_at = _event_timestamp(data, source_path)
     if token_payload.get("error"):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=observed_at,
             source_path=source_path,
         )
     rate_limits = _rate_limits(data, token_payload)
     if not rate_limits:
         return _unknown(
-            "rate_limits_missing",
+            CodexUsageUnknownReason.RATE_LIMITS_MISSING,
             observed_at=observed_at,
             source_path=source_path,
         )
     if rate_limits.get("error"):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=observed_at,
             source_path=source_path,
         )
@@ -177,7 +214,7 @@ def _reading_from_event(
     plan_type = str(plan_value).strip() if plan_value is not None else None
     if limit_id != "codex":
         return _unknown(
-            "unexpected_limit_id",
+            CodexUsageUnknownReason.UNEXPECTED_LIMIT_ID,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -187,7 +224,7 @@ def _reading_from_event(
     primary = rate_limits.get("primary")
     if not isinstance(primary, Mapping):
         return _unknown(
-            "primary_missing",
+            CodexUsageUnknownReason.PRIMARY_MISSING,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -197,7 +234,7 @@ def _reading_from_event(
     used_percent = primary.get("used_percent")
     if isinstance(used_percent, bool) or not isinstance(used_percent, (int, float)):
         return _unknown(
-            "used_percent_missing",
+            CodexUsageUnknownReason.USED_PERCENT_MISSING,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -206,14 +243,13 @@ def _reading_from_event(
     normalized_percent = float(used_percent)
     if not math.isfinite(normalized_percent) or normalized_percent < 0:
         return _unknown(
-            "used_percent_invalid",
+            CodexUsageUnknownReason.USED_PERCENT_INVALID,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
             plan_type=plan_type,
         )
-    return CodexUsageReading(
-        status="exhausted" if normalized_percent >= 100 else "ok",
+    return CodexKnownUsage(
         used_percent=normalized_percent,
         observed_at=observed_at,
         source_path=str(source_path),
@@ -249,11 +285,17 @@ def _scan_lines(
             data = json.loads(raw_line)
         except (json.JSONDecodeError, UnicodeDecodeError):
             if malformed_is_verdict:
-                return _unknown("malformed_line", source_path=source_path)
+                return _unknown(
+                    CodexUsageUnknownReason.MALFORMED_LINE,
+                    source_path=source_path,
+                )
             continue
         if not isinstance(data, Mapping):
             if malformed_is_verdict:
-                return _unknown("malformed_line", source_path=source_path)
+                return _unknown(
+                    CodexUsageUnknownReason.MALFORMED_LINE,
+                    source_path=source_path,
+                )
             continue
         reading = _reading_from_event(data, source_path=source_path)
         if reading is not None:
@@ -275,14 +317,9 @@ def _find_last_known(files: list[Path]) -> CodexKnownUsage | None:
             if not isinstance(data, Mapping):
                 continue
             reading = _reading_from_event(data, source_path=source_path)
-            if reading is None or reading.status == "unknown":
+            if not isinstance(reading, CodexKnownUsage):
                 continue
-            return CodexKnownUsage(
-                used_percent=float(reading.used_percent),
-                observed_at=str(reading.observed_at),
-                source_path=str(source_path),
-                plan_type=reading.plan_type,
-            )
+            return reading
     return None
 
 
@@ -296,34 +333,42 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
     sessions_path = codex_home_path(path) / "sessions"
     try:
         if not sessions_path.exists():
-            return _unknown("sessions_dir_missing")
+            return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_MISSING)
         if not sessions_path.is_dir():
-            return _unknown("sessions_dir_unreadable")
+            return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_UNREADABLE)
         files = _session_files(sessions_path)
     except OSError:
-        return _unknown("sessions_dir_unreadable")
+        return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_UNREADABLE)
     if not files:
-        return _unknown("sessions_dir_empty")
+        return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_EMPTY)
 
     newest = files[0]
     try:
         newest_lines = _read_lines(newest)
     except (OSError, UnicodeError):
-        verdict = _unknown("session_file_unreadable", source_path=newest)
+        verdict = _unknown(
+            CodexUsageUnknownReason.SESSION_FILE_UNREADABLE,
+            source_path=newest,
+        )
     else:
         if not any(line.strip() for line in newest_lines):
-            verdict = _unknown("session_file_empty", source_path=newest)
+            verdict = _unknown(
+                CodexUsageUnknownReason.SESSION_FILE_EMPTY,
+                source_path=newest,
+            )
         else:
             verdict = _scan_lines(
                 newest_lines,
                 source_path=newest,
                 malformed_is_verdict=True,
-            ) or _unknown("token_count_missing", source_path=newest)
+            ) or _unknown(
+                CodexUsageUnknownReason.TOKEN_COUNT_MISSING,
+                source_path=newest,
+            )
 
-    if verdict.status != "unknown":
+    if isinstance(verdict, CodexKnownUsage):
         return verdict
-    return CodexUsageReading(
-        status=verdict.status,
+    return CodexUnknownUsageReading(
         reason=verdict.reason,
         observed_at=verdict.observed_at,
         source_path=verdict.source_path,
@@ -336,7 +381,8 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
 __all__ = [
     "CodexKnownUsage",
     "CodexUsageReading",
-    "CodexUsageStatus",
+    "CodexUsageUnknownReason",
+    "CodexUnknownUsageReading",
     "codex_home_path",
     "read_codex_usage",
 ]

--- a/brain/platform/integrations/provider_auth_preflight.py
+++ b/brain/platform/integrations/provider_auth_preflight.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Self, TypeAlias
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,26 +11,58 @@ from brain.platform.integrations.llm import async_resolve_llm_client
 from brain.platform.providers.model_policy import required_openai_auth_mode
 
 
-@dataclass(frozen=True, slots=True)
-class ProviderAuthPreflightResult:
-    status: str
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ProviderAuthPreflightResult:
     provider: str
     model: str
-    credential: str | None = None
-    error_code: str | None = None
+
+    def _to_dict(
+        self,
+        *,
+        status: str,
+        credential: str | None = None,
+        error_code: str | None = None,
+        repair_action: str | None = None,
+        visible_message: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "status": status,
+            "provider": self.provider,
+            "model": self.model,
+            "credential": credential,
+            "error_code": error_code,
+            "repair_action": repair_action,
+            "visible_message": visible_message,
+        }
+
+
+class ProviderAuthPassedPreflightResult(_ProviderAuthPreflightResult):
+    __slots__ = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(status="passed")
+
+
+class ProviderAuthSkippedPreflightResult(_ProviderAuthPreflightResult):
+    __slots__ = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(status="skipped")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderAuthBlockedPreflightResult(_ProviderAuthPreflightResult):
+    credential: str
+    error_code: str
     repair_action: str | None = None
     visible_message: str | None = None
-
-    @property
-    def blocked(self) -> bool:
-        return self.status == "auth_blocked"
 
     def with_presentation(
         self,
         *,
         repair_action: str,
         visible_message: str,
-    ) -> ProviderAuthPreflightResult:
+    ) -> Self:
         return replace(
             self,
             repair_action=repair_action,
@@ -38,24 +70,28 @@ class ProviderAuthPreflightResult:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "status": self.status,
-            "provider": self.provider,
-            "model": self.model,
-            "credential": self.credential,
-            "error_code": self.error_code,
-            "repair_action": self.repair_action,
-            "visible_message": self.visible_message,
-        }
+        return self._to_dict(
+            status="auth_blocked",
+            credential=self.credential,
+            error_code=self.error_code,
+            repair_action=self.repair_action,
+            visible_message=self.visible_message,
+        )
+
+
+ProviderAuthPreflightResult: TypeAlias = (
+    ProviderAuthPassedPreflightResult
+    | ProviderAuthSkippedPreflightResult
+    | ProviderAuthBlockedPreflightResult
+)
 
 
 def skipped_provider_auth_preflight(
     *,
     provider: str,
     model: str,
-) -> ProviderAuthPreflightResult:
-    return ProviderAuthPreflightResult(
-        status="skipped",
+) -> ProviderAuthSkippedPreflightResult:
+    return ProviderAuthSkippedPreflightResult(
         provider=provider,
         model=model,
     )
@@ -112,8 +148,7 @@ async def async_probe_provider_auth(
             session=session,
         )
     except Exception as exc:
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider=provider,
             model=model,
             credential=_credential_label(
@@ -125,15 +160,17 @@ async def async_probe_provider_auth(
             error_code="provider_credential_unavailable",
         )
 
-    return ProviderAuthPreflightResult(
-        status="passed",
+    return ProviderAuthPassedPreflightResult(
         provider=provider,
         model=model,
     )
 
 
 __all__ = [
+    "ProviderAuthBlockedPreflightResult",
+    "ProviderAuthPassedPreflightResult",
     "ProviderAuthPreflightResult",
+    "ProviderAuthSkippedPreflightResult",
     "async_probe_provider_auth",
     "skipped_provider_auth_preflight",
 ]

--- a/brain/platform/integrations/provider_quota_preflight.py
+++ b/brain/platform/integrations/provider_quota_preflight.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Self, TypeAlias
 
-from brain.platform.integrations.codex_usage import CodexUsageReading, read_codex_usage
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexUnknownUsageReading,
+    CodexUsageReading,
+    read_codex_usage,
+)
 from brain.platform.providers.model_policy import required_openai_auth_mode
 
 
@@ -27,53 +32,123 @@ class ProviderQuotaThresholds:
         }
 
 
-@dataclass(frozen=True, slots=True)
-class ProviderQuotaPreflightResult:
-    status: str
-    decision: str
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ProviderQuotaPreflightResult:
     provider: str
     model: str
-    usage_status: str | None
     thresholds: ProviderQuotaThresholds
-    used_percent: float | None = None
-    unknown_reason: str | None = None
-    observed_at: str | None = None
-    source_path: str | None = None
-    limit_id: str | None = None
-    plan_type: str | None = None
-    last_known_good: dict[str, Any] | None = None
     explicit_request: bool = False
     visible_message: str | None = None
 
-    @property
-    def blocked(self) -> bool:
-        return self.decision == "blocked"
-
-    @property
-    def deferred(self) -> bool:
-        return self.decision == "deferred"
-
-    def with_presentation(self, *, visible_message: str) -> ProviderQuotaPreflightResult:
+    def with_presentation(self, *, visible_message: str) -> Self:
         return replace(self, visible_message=visible_message)
 
-    def to_dict(self) -> dict[str, Any]:
+    def _to_dict(
+        self,
+        *,
+        status: str,
+        decision: str,
+        usage_fields: dict[str, Any],
+    ) -> dict[str, Any]:
         return {
-            "status": self.status,
-            "decision": self.decision,
+            "status": status,
+            "decision": decision,
             "provider": self.provider,
             "model": self.model,
-            "usage_status": self.usage_status,
-            "used_percent": self.used_percent,
-            "unknown_reason": self.unknown_reason,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-            "last_known_good": self.last_known_good,
+            **usage_fields,
             "explicit_request": self.explicit_request,
             "thresholds": self.thresholds.to_dict(),
             "visible_message": self.visible_message,
         }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderQuotaSkippedPreflightResult(_ProviderQuotaPreflightResult):
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(
+            status="skipped",
+            decision="admitted",
+            usage_fields={
+                "usage_status": None,
+                "used_percent": None,
+                "unknown_reason": None,
+                "observed_at": None,
+                "source_path": None,
+                "limit_id": None,
+                "plan_type": None,
+                "last_known_good": None,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ProviderQuotaKnownPreflightResult(_ProviderQuotaPreflightResult):
+    usage: CodexKnownUsage
+
+    def _known_to_dict(self, *, status: str, decision: str) -> dict[str, Any]:
+        return self._to_dict(
+            status=status,
+            decision=decision,
+            usage_fields=_provider_quota_usage_fields(self.usage),
+        )
+
+
+class ProviderQuotaPassedPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="passed", decision="admitted")
+
+
+class ProviderQuotaBlockedPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="quota_blocked", decision="blocked")
+
+
+class ProviderQuotaDeferredPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="quota_deferred", decision="deferred")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderQuotaUnknownPreflightResult(_ProviderQuotaPreflightResult):
+    usage: CodexUnknownUsageReading
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(
+            status="unknown",
+            decision="admitted",
+            usage_fields=_provider_quota_usage_fields(self.usage),
+        )
+
+
+ProviderQuotaPreflightResult: TypeAlias = (
+    ProviderQuotaSkippedPreflightResult
+    | ProviderQuotaPassedPreflightResult
+    | ProviderQuotaBlockedPreflightResult
+    | ProviderQuotaDeferredPreflightResult
+    | ProviderQuotaUnknownPreflightResult
+)
+
+
+def _provider_quota_usage_fields(
+    usage: CodexUsageReading,
+) -> dict[str, Any]:
+    reading = usage.to_dict()
+    return {
+        "usage_status": reading["status"],
+        "used_percent": reading["used_percent"],
+        "unknown_reason": reading["reason"],
+        "observed_at": reading["observed_at"],
+        "source_path": reading["source_path"],
+        "limit_id": reading["limit_id"],
+        "plan_type": reading["plan_type"],
+        "last_known_good": reading["last_known_good"],
+    }
 
 
 def _percent_setting(name: str, default: float) -> float:
@@ -107,44 +182,11 @@ def skipped_provider_quota_preflight(
     model: str,
     explicit_request: bool,
     thresholds: ProviderQuotaThresholds | None = None,
-) -> ProviderQuotaPreflightResult:
-    return ProviderQuotaPreflightResult(
-        status="skipped",
-        decision="admitted",
+) -> ProviderQuotaSkippedPreflightResult:
+    return ProviderQuotaSkippedPreflightResult(
         provider=provider,
         model=model,
-        usage_status=None,
         thresholds=thresholds or provider_quota_thresholds(),
-        explicit_request=explicit_request,
-    )
-
-
-def _result_from_usage(
-    usage: CodexUsageReading,
-    *,
-    status: str,
-    decision: str,
-    provider: str,
-    model: str,
-    explicit_request: bool,
-    thresholds: ProviderQuotaThresholds,
-) -> ProviderQuotaPreflightResult:
-    return ProviderQuotaPreflightResult(
-        status=status,
-        decision=decision,
-        provider=provider,
-        model=model,
-        usage_status=usage.status,
-        thresholds=thresholds,
-        used_percent=usage.used_percent,
-        unknown_reason=usage.reason,
-        observed_at=usage.observed_at,
-        source_path=usage.source_path,
-        limit_id=usage.limit_id,
-        plan_type=usage.plan_type,
-        last_known_good=(
-            usage.last_known_good.to_dict() if usage.last_known_good else None
-        ),
         explicit_request=explicit_request,
     )
 
@@ -166,55 +208,51 @@ def probe_provider_quota(
             thresholds=thresholds,
         )
 
-    usage = read_codex_usage()
-    if usage.status == "unknown":
-        return _result_from_usage(
-            usage,
-            status="unknown",
-            decision="admitted",
+    usage: CodexUsageReading = read_codex_usage()
+    if isinstance(usage, CodexUnknownUsageReading):
+        return ProviderQuotaUnknownPreflightResult(
             provider=provider,
             model=model,
-            explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
+            explicit_request=explicit_request,
         )
 
-    used_percent = float(usage.used_percent)
-    if used_percent >= thresholds.hard_percent:
-        return _result_from_usage(
-            usage,
-            status="quota_blocked",
-            decision="blocked",
+    if usage.used_percent >= thresholds.hard_percent:
+        return ProviderQuotaBlockedPreflightResult(
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
         )
-    if used_percent >= thresholds.soft_percent and not explicit_request:
-        return _result_from_usage(
-            usage,
-            status="quota_deferred",
-            decision="deferred",
+    if usage.used_percent >= thresholds.soft_percent and not explicit_request:
+        return ProviderQuotaDeferredPreflightResult(
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
         )
-    return _result_from_usage(
-        usage,
-        status="passed",
-        decision="admitted",
+    return ProviderQuotaPassedPreflightResult(
         provider=provider,
         model=model,
         explicit_request=explicit_request,
         thresholds=thresholds,
+        usage=usage,
     )
 
 
 __all__ = [
     "DEFAULT_CODEX_QUOTA_HARD_PERCENT",
     "DEFAULT_CODEX_QUOTA_SOFT_PERCENT",
+    "ProviderQuotaBlockedPreflightResult",
+    "ProviderQuotaDeferredPreflightResult",
+    "ProviderQuotaPassedPreflightResult",
     "ProviderQuotaPreflightResult",
+    "ProviderQuotaSkippedPreflightResult",
     "ProviderQuotaThresholds",
+    "ProviderQuotaUnknownPreflightResult",
     "probe_provider_quota",
     "provider_quota_thresholds",
     "skipped_provider_quota_preflight",

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -79,25 +79,63 @@ class CycleAdmissionAdmitted:
     route: CycleProviderRoute
 
 
-CycleAdmissionStatus: TypeAlias = Literal["auth_blocked", "quota_blocked", "skipped"]
-CycleAdmissionNoticeKind: TypeAlias = Literal["auth", "quota"]
-CycleAdmissionSkipReason: TypeAlias = Literal["quota_soft_limit"]
-CycleAdmissionNotice: TypeAlias = (
-    ProviderAuthPreflightResult | ProviderQuotaPreflightResult
-)
+def _require_rejection_notice_case(
+    *,
+    actual: str,
+    expected: str,
+    rejection: str,
+) -> None:
+    if actual != expected:
+        raise ValueError(f"{rejection} requires preflight case {expected!r}")
 
 
 @dataclass(frozen=True, slots=True)
-class CycleAdmissionRejected:
-    """A complete decision to settle a run without admitting work."""
+class CycleAdmissionAuthBlocked:
+    """An auth rejection with its matching provider notice."""
 
-    status: CycleAdmissionStatus
-    error: str | None
-    skip_reason: CycleAdmissionSkipReason | None
-    notice_kind: CycleAdmissionNoticeKind
-    notice: CycleAdmissionNotice
+    notice: ProviderAuthPreflightResult
+
+    def __post_init__(self) -> None:
+        _require_rejection_notice_case(
+            actual=self.notice.status,
+            expected="auth_blocked",
+            rejection=type(self).__name__,
+        )
 
 
+@dataclass(frozen=True, slots=True)
+class CycleAdmissionQuotaBlocked:
+    """A hard-quota rejection with its matching provider notice."""
+
+    notice: ProviderQuotaPreflightResult
+
+    def __post_init__(self) -> None:
+        _require_rejection_notice_case(
+            actual=self.notice.decision,
+            expected="blocked",
+            rejection=type(self).__name__,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CycleAdmissionQuotaDeferred:
+    """A soft-quota deferral with its matching provider notice."""
+
+    notice: ProviderQuotaPreflightResult
+
+    def __post_init__(self) -> None:
+        _require_rejection_notice_case(
+            actual=self.notice.decision,
+            expected="deferred",
+            rejection=type(self).__name__,
+        )
+
+
+CycleAdmissionRejected: TypeAlias = (
+    CycleAdmissionAuthBlocked
+    | CycleAdmissionQuotaBlocked
+    | CycleAdmissionQuotaDeferred
+)
 CycleAdmissionOutcome: TypeAlias = CycleAdmissionAdmitted | CycleAdmissionRejected
 
 
@@ -181,41 +219,30 @@ async def async_prepare_cycle_run_admission(
     if auth.status != "skipped":
         _record_preflight_snapshot(run, key="auth_preflight", preflight=auth)
     if auth.blocked:
-        return CycleAdmissionRejected(
-            status="auth_blocked",
-            error=auth.visible_message,
-            skip_reason=None,
-            notice_kind="auth",
-            notice=auth,
-        )
+        return CycleAdmissionAuthBlocked(notice=auth)
 
     quota = preflight_cycle_external_quota(
         route=route,
         run=run,
     )
     _record_preflight_snapshot(run, key="quota_preflight", preflight=quota)
-    if quota.decision == "admitted":
-        return CycleAdmissionAdmitted(route=route)
     try:
-        status, error, skip_reason = {
-            "blocked": ("quota_blocked", quota.visible_message, None),
-            "deferred": ("skipped", None, "quota_soft_limit"),
+        outcome_type, outcome_value = {
+            "admitted": (CycleAdmissionAdmitted, route),
+            "blocked": (CycleAdmissionQuotaBlocked, quota),
+            "deferred": (CycleAdmissionQuotaDeferred, quota),
         }[quota.decision]
     except KeyError as exc:
         raise ValueError(f"Unsupported Cycle quota decision: {quota.decision!r}") from exc
-    return CycleAdmissionRejected(
-        status=cast(CycleAdmissionStatus, status),
-        error=error,
-        skip_reason=cast(CycleAdmissionSkipReason | None, skip_reason),
-        notice_kind="quota",
-        notice=quota,
-    )
+    return outcome_type(outcome_value)
 
 
 __all__ = [
     "CycleAdmissionAdmitted",
-    "CycleAdmissionNoticeKind",
+    "CycleAdmissionAuthBlocked",
     "CycleAdmissionOutcome",
+    "CycleAdmissionQuotaBlocked",
+    "CycleAdmissionQuotaDeferred",
     "CycleAdmissionRejected",
     "CycleProviderRoute",
     "async_prepare_cycle_run_admission",

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -10,9 +10,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
+    ProviderAuthSkippedPreflightResult,
 )
 from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
     ProviderQuotaPreflightResult,
 )
 from brain.platform.providers.model_policy import (
@@ -79,56 +83,25 @@ class CycleAdmissionAdmitted:
     route: CycleProviderRoute
 
 
-def _require_rejection_notice_case(
-    *,
-    actual: str,
-    expected: str,
-    rejection: str,
-) -> None:
-    if actual != expected:
-        raise ValueError(f"{rejection} requires preflight case {expected!r}")
-
-
 @dataclass(frozen=True, slots=True)
 class CycleAdmissionAuthBlocked:
     """An auth rejection with its matching provider notice."""
 
-    notice: ProviderAuthPreflightResult
-
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.status,
-            expected="auth_blocked",
-            rejection=type(self).__name__,
-        )
+    notice: ProviderAuthBlockedPreflightResult
 
 
 @dataclass(frozen=True, slots=True)
 class CycleAdmissionQuotaBlocked:
     """A hard-quota rejection with its matching provider notice."""
 
-    notice: ProviderQuotaPreflightResult
-
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.decision,
-            expected="blocked",
-            rejection=type(self).__name__,
-        )
+    notice: ProviderQuotaBlockedPreflightResult
 
 
 @dataclass(frozen=True, slots=True)
 class CycleAdmissionQuotaDeferred:
     """A soft-quota deferral with its matching provider notice."""
 
-    notice: ProviderQuotaPreflightResult
-
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.decision,
-            expected="deferred",
-            rejection=type(self).__name__,
-        )
+    notice: ProviderQuotaDeferredPreflightResult
 
 
 CycleAdmissionRejected: TypeAlias = (
@@ -216,9 +189,9 @@ async def async_prepare_cycle_run_admission(
         run=run,
     )
     auth = await async_preflight_cycle_external_auth(session, route=route)
-    if auth.status != "skipped":
+    if not isinstance(auth, ProviderAuthSkippedPreflightResult):
         _record_preflight_snapshot(run, key="auth_preflight", preflight=auth)
-    if auth.blocked:
+    if isinstance(auth, ProviderAuthBlockedPreflightResult):
         return CycleAdmissionAuthBlocked(notice=auth)
 
     quota = preflight_cycle_external_quota(
@@ -226,15 +199,11 @@ async def async_prepare_cycle_run_admission(
         run=run,
     )
     _record_preflight_snapshot(run, key="quota_preflight", preflight=quota)
-    try:
-        outcome_type, outcome_value = {
-            "admitted": (CycleAdmissionAdmitted, route),
-            "blocked": (CycleAdmissionQuotaBlocked, quota),
-            "deferred": (CycleAdmissionQuotaDeferred, quota),
-        }[quota.decision]
-    except KeyError as exc:
-        raise ValueError(f"Unsupported Cycle quota decision: {quota.decision!r}") from exc
-    return outcome_type(outcome_value)
+    if isinstance(quota, ProviderQuotaBlockedPreflightResult):
+        return CycleAdmissionQuotaBlocked(notice=quota)
+    if isinstance(quota, ProviderQuotaDeferredPreflightResult):
+        return CycleAdmissionQuotaDeferred(notice=quota)
+    return CycleAdmissionAdmitted(route=route)
 
 
 __all__ = [

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -1,0 +1,181 @@
+"""Ordered admission for one resolved Cycle provider route."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPreflightResult,
+)
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+)
+from brain.platform.providers.model_policy import (
+    EFFORT_TIER_SET,
+    async_get_default_model,
+    infer_provider_from_model,
+    normalize_model_name,
+)
+from brain.systems.cycles.auth_preflight import (
+    async_preflight_cycle_external_auth,
+)
+from brain.systems.cycles.common import json_dict
+from brain.systems.cycles.quota_preflight import (
+    async_preflight_cycle_external_quota,
+)
+
+logger = logging.getLogger("cycles")
+
+
+@dataclass(frozen=True)
+class CycleProviderRoute:
+    """The one provider route used by every Cycle admission check."""
+
+    user_id: str | None
+    org_id: str | None
+    model: str
+    provider: str
+    model_policy: dict[str, str]
+
+
+@dataclass(frozen=True)
+class CycleAdmissionOutcome:
+    """Ordered auth and quota decisions for a resolved provider route."""
+
+    route: CycleProviderRoute
+    auth: ProviderAuthPreflightResult
+    quota: ProviderQuotaPreflightResult | None = None
+
+    @property
+    def rejection_status(self) -> str | None:
+        if self.auth.blocked:
+            return "auth_blocked"
+        if self.quota is not None and self.quota.blocked:
+            return "quota_blocked"
+        if self.quota is not None and self.quota.deferred:
+            return "skipped"
+        return None
+
+    @property
+    def rejected(self) -> bool:
+        return self.rejection_status is not None
+
+    @property
+    def error(self) -> str | None:
+        if self.auth.blocked:
+            return self.auth.visible_message
+        if self.quota is not None and self.quota.blocked:
+            return self.quota.visible_message
+        return None
+
+    @property
+    def skip_reason(self) -> str | None:
+        if self.quota is not None and self.quota.deferred:
+            return "quota_soft_limit"
+        return None
+
+
+def _cycle_run_overrides(cycle: Cycle, run: CycleRun) -> dict[str, Any]:
+    context_snapshot = json_dict(getattr(run, "context_snapshot", None))
+    revision_snapshot = context_snapshot.get("revision")
+    if isinstance(revision_snapshot, dict):
+        return revision_snapshot
+    return {
+        "model_override": getattr(cycle, "model_override", None),
+        "thinking_override": getattr(cycle, "thinking_override", None),
+    }
+
+
+async def async_resolve_cycle_provider_route(
+    session: AsyncSession,
+    *,
+    cycle: Cycle,
+    run: CycleRun,
+) -> CycleProviderRoute:
+    """Resolve the provider route once from the run-bound Cycle revision."""
+
+    user_id = str(getattr(cycle, "user_id", "") or "") or None
+    org_id = str(getattr(cycle, "org_id", "") or "") or None
+    overrides = _cycle_run_overrides(cycle, run)
+
+    raw_model = str(overrides.get("model_override") or "").strip()
+    if raw_model and raw_model.lower() != "default":
+        model = normalize_model_name(raw_model)
+    else:
+        model = await async_get_default_model(
+            session,
+            include_provider_prefix=True,
+            user_id=user_id,
+            org_id=org_id,
+        )
+
+    model_policy = {"model": model}
+    thinking = str(overrides.get("thinking_override") or "").strip().lower()
+    if thinking in EFFORT_TIER_SET:
+        model_policy["thinking"] = thinking
+    elif thinking:
+        logger.warning(
+            "Ignoring invalid thinking_override in CycleRun revision snapshot",
+        )
+
+    return CycleProviderRoute(
+        user_id=user_id,
+        org_id=org_id,
+        model=model,
+        provider=infer_provider_from_model(model),
+        model_policy=model_policy,
+    )
+
+
+def _record_admission_snapshot(
+    run: CycleRun,
+    outcome: CycleAdmissionOutcome,
+) -> None:
+    context_snapshot = dict(getattr(run, "context_snapshot", None) or {})
+    if outcome.auth.status != "skipped":
+        context_snapshot["auth_preflight"] = outcome.auth.to_dict()
+    if outcome.quota is not None:
+        context_snapshot["quota_preflight"] = outcome.quota.to_dict()
+    run.context_snapshot = context_snapshot
+
+
+async def async_prepare_cycle_run_admission(
+    session: AsyncSession,
+    *,
+    cycle: Cycle,
+    run: CycleRun,
+) -> CycleAdmissionOutcome:
+    """Resolve one route, then run auth and quota checks in order."""
+
+    route = await async_resolve_cycle_provider_route(
+        session,
+        cycle=cycle,
+        run=run,
+    )
+    auth = await async_preflight_cycle_external_auth(session, route=route)
+    if auth.blocked:
+        outcome = CycleAdmissionOutcome(route=route, auth=auth)
+        _record_admission_snapshot(run, outcome)
+        return outcome
+
+    quota = await async_preflight_cycle_external_quota(
+        session,
+        route=route,
+        run=run,
+    )
+    outcome = CycleAdmissionOutcome(route=route, auth=auth, quota=quota)
+    _record_admission_snapshot(run, outcome)
+    return outcome
+
+
+__all__ = [
+    "CycleAdmissionOutcome",
+    "CycleProviderRoute",
+    "async_prepare_cycle_run_admission",
+    "async_resolve_cycle_provider_route",
+]

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, TypeAlias, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,58 +26,79 @@ from brain.systems.cycles.auth_preflight import (
 )
 from brain.systems.cycles.common import json_dict
 from brain.systems.cycles.quota_preflight import (
-    async_preflight_cycle_external_quota,
+    preflight_cycle_external_quota,
 )
 
 logger = logging.getLogger("cycles")
 
 
-@dataclass(frozen=True)
+CycleThinking: TypeAlias = Literal["none", "low", "medium", "high", "xhigh"]
+
+
+@dataclass(frozen=True, slots=True)
 class CycleProviderRoute:
     """The one provider route used by every Cycle admission check."""
 
     user_id: str | None
     org_id: str | None
     model: str
-    provider: str
-    model_policy: dict[str, str]
+    thinking: CycleThinking | None = None
+
+    def __post_init__(self) -> None:
+        canonical_model = normalize_model_name(self.model)
+        checks = (
+            (
+                bool(self.model) and canonical_model == self.model,
+                f"Cycle route model must be canonical: {canonical_model!r}",
+            ),
+            (
+                self.thinking is None or self.thinking in EFFORT_TIER_SET,
+                "Cycle route thinking must be a canonical effort tier",
+            ),
+        )
+        for valid, message in checks:
+            if not valid:
+                raise ValueError(message)
+
+    @property
+    def provider(self) -> str:
+        return infer_provider_from_model(self.model)
+
+    @property
+    def work_intake_model_policy(self) -> dict[str, str]:
+        policy = {"model": self.model}
+        if self.thinking is not None:
+            policy["thinking"] = self.thinking
+        return policy
 
 
-@dataclass(frozen=True)
-class CycleAdmissionOutcome:
-    """Ordered auth and quota decisions for a resolved provider route."""
+@dataclass(frozen=True, slots=True)
+class CycleAdmissionAdmitted:
+    """A complete decision to admit work through one resolved route."""
 
     route: CycleProviderRoute
-    auth: ProviderAuthPreflightResult
-    quota: ProviderQuotaPreflightResult | None = None
 
-    @property
-    def rejection_status(self) -> str | None:
-        if self.auth.blocked:
-            return "auth_blocked"
-        if self.quota is not None and self.quota.blocked:
-            return "quota_blocked"
-        if self.quota is not None and self.quota.deferred:
-            return "skipped"
-        return None
 
-    @property
-    def rejected(self) -> bool:
-        return self.rejection_status is not None
+CycleAdmissionStatus: TypeAlias = Literal["auth_blocked", "quota_blocked", "skipped"]
+CycleAdmissionNoticeKind: TypeAlias = Literal["auth", "quota"]
+CycleAdmissionSkipReason: TypeAlias = Literal["quota_soft_limit"]
+CycleAdmissionNotice: TypeAlias = (
+    ProviderAuthPreflightResult | ProviderQuotaPreflightResult
+)
 
-    @property
-    def error(self) -> str | None:
-        if self.auth.blocked:
-            return self.auth.visible_message
-        if self.quota is not None and self.quota.blocked:
-            return self.quota.visible_message
-        return None
 
-    @property
-    def skip_reason(self) -> str | None:
-        if self.quota is not None and self.quota.deferred:
-            return "quota_soft_limit"
-        return None
+@dataclass(frozen=True, slots=True)
+class CycleAdmissionRejected:
+    """A complete decision to settle a run without admitting work."""
+
+    status: CycleAdmissionStatus
+    error: str | None
+    skip_reason: CycleAdmissionSkipReason | None
+    notice_kind: CycleAdmissionNoticeKind
+    notice: CycleAdmissionNotice
+
+
+CycleAdmissionOutcome: TypeAlias = CycleAdmissionAdmitted | CycleAdmissionRejected
 
 
 def _cycle_run_overrides(cycle: Cycle, run: CycleRun) -> dict[str, Any]:
@@ -89,6 +110,16 @@ def _cycle_run_overrides(cycle: Cycle, run: CycleRun) -> dict[str, Any]:
         "model_override": getattr(cycle, "model_override", None),
         "thinking_override": getattr(cycle, "thinking_override", None),
     }
+
+
+def _cycle_thinking(overrides: dict[str, Any]) -> CycleThinking | None:
+    thinking = str(overrides.get("thinking_override") or "").strip().lower()
+    if thinking and thinking not in EFFORT_TIER_SET:
+        logger.warning(
+            "Ignoring invalid thinking_override in CycleRun revision snapshot",
+        )
+        return None
+    return cast(CycleThinking | None, thinking or None)
 
 
 async def async_resolve_cycle_provider_route(
@@ -105,7 +136,7 @@ async def async_resolve_cycle_provider_route(
 
     raw_model = str(overrides.get("model_override") or "").strip()
     if raw_model and raw_model.lower() != "default":
-        model = normalize_model_name(raw_model)
+        model = raw_model
     else:
         model = await async_get_default_model(
             session,
@@ -114,33 +145,22 @@ async def async_resolve_cycle_provider_route(
             org_id=org_id,
         )
 
-    model_policy = {"model": model}
-    thinking = str(overrides.get("thinking_override") or "").strip().lower()
-    if thinking in EFFORT_TIER_SET:
-        model_policy["thinking"] = thinking
-    elif thinking:
-        logger.warning(
-            "Ignoring invalid thinking_override in CycleRun revision snapshot",
-        )
-
     return CycleProviderRoute(
         user_id=user_id,
         org_id=org_id,
-        model=model,
-        provider=infer_provider_from_model(model),
-        model_policy=model_policy,
+        model=normalize_model_name(model),
+        thinking=_cycle_thinking(overrides),
     )
 
 
-def _record_admission_snapshot(
+def _record_preflight_snapshot(
     run: CycleRun,
-    outcome: CycleAdmissionOutcome,
+    *,
+    key: str,
+    preflight: ProviderAuthPreflightResult | ProviderQuotaPreflightResult,
 ) -> None:
     context_snapshot = dict(getattr(run, "context_snapshot", None) or {})
-    if outcome.auth.status != "skipped":
-        context_snapshot["auth_preflight"] = outcome.auth.to_dict()
-    if outcome.quota is not None:
-        context_snapshot["quota_preflight"] = outcome.quota.to_dict()
+    context_snapshot[key] = preflight.to_dict()
     run.context_snapshot = context_snapshot
 
 
@@ -158,23 +178,45 @@ async def async_prepare_cycle_run_admission(
         run=run,
     )
     auth = await async_preflight_cycle_external_auth(session, route=route)
+    if auth.status != "skipped":
+        _record_preflight_snapshot(run, key="auth_preflight", preflight=auth)
     if auth.blocked:
-        outcome = CycleAdmissionOutcome(route=route, auth=auth)
-        _record_admission_snapshot(run, outcome)
-        return outcome
+        return CycleAdmissionRejected(
+            status="auth_blocked",
+            error=auth.visible_message,
+            skip_reason=None,
+            notice_kind="auth",
+            notice=auth,
+        )
 
-    quota = await async_preflight_cycle_external_quota(
-        session,
+    quota = preflight_cycle_external_quota(
         route=route,
         run=run,
     )
-    outcome = CycleAdmissionOutcome(route=route, auth=auth, quota=quota)
-    _record_admission_snapshot(run, outcome)
-    return outcome
+    _record_preflight_snapshot(run, key="quota_preflight", preflight=quota)
+    if quota.decision == "admitted":
+        return CycleAdmissionAdmitted(route=route)
+    try:
+        status, error, skip_reason = {
+            "blocked": ("quota_blocked", quota.visible_message, None),
+            "deferred": ("skipped", None, "quota_soft_limit"),
+        }[quota.decision]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported Cycle quota decision: {quota.decision!r}") from exc
+    return CycleAdmissionRejected(
+        status=cast(CycleAdmissionStatus, status),
+        error=error,
+        skip_reason=cast(CycleAdmissionSkipReason | None, skip_reason),
+        notice_kind="quota",
+        notice=quota,
+    )
 
 
 __all__ = [
+    "CycleAdmissionAdmitted",
+    "CycleAdmissionNoticeKind",
     "CycleAdmissionOutcome",
+    "CycleAdmissionRejected",
     "CycleProviderRoute",
     "async_prepare_cycle_run_admission",
     "async_resolve_cycle_provider_route",

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,10 +10,9 @@ from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
 )
-from brain.platform.providers.model_policy import (
-    async_get_default_model,
-    infer_provider_from_model,
-)
+
+if TYPE_CHECKING:
+    from brain.systems.cycles.admission import CycleProviderRoute
 
 
 def _with_cycle_presentation(
@@ -46,28 +45,16 @@ def _with_cycle_presentation(
 async def async_preflight_cycle_external_auth(
     session: AsyncSession,
     *,
-    cycle: Any,
+    route: CycleProviderRoute,
 ) -> ProviderAuthPreflightResult:
     """Probe the Cycle's selected provider before admitting an agent run."""
 
-    user_id = str(getattr(cycle, "user_id", "") or "") or None
-    org_id = str(getattr(cycle, "org_id", "") or "") or None
-    model = str(getattr(cycle, "model_override", None) or "").strip()
-    if not model:
-        model = await async_get_default_model(
-            session,
-            include_provider_prefix=True,
-            user_id=user_id,
-            org_id=org_id,
-        )
-
-    provider = infer_provider_from_model(model)
     result = await async_probe_provider_auth(
         session,
-        user_id=user_id,
-        org_id=org_id,
-        provider=provider,
-        model=model,
+        user_id=route.user_id,
+        org_id=route.org_id,
+        provider=route.provider,
+        model=route.model,
     )
     return _with_cycle_presentation(result)
 

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
 )
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 def _with_cycle_presentation(
     result: ProviderAuthPreflightResult,
 ) -> ProviderAuthPreflightResult:
-    if not result.blocked:
+    if not isinstance(result, ProviderAuthBlockedPreflightResult):
         return result
     if result.provider == "anthropic":
         repair_action = (

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -47,15 +47,13 @@ def _with_cycle_presentation(
     return result
 
 
-async def async_preflight_cycle_external_quota(
-    session: AsyncSession,
+def preflight_cycle_external_quota(
     *,
     route: CycleProviderRoute,
     run: CycleRun,
 ) -> ProviderQuotaPreflightResult:
     """Probe subscription quota before admitting a Cycle agent run."""
 
-    del session
     origin = str(cycle_run_launch_context(run).get("origin") or "")
     result = probe_provider_quota(
         provider=route.provider,
@@ -137,5 +135,5 @@ async def async_append_cycle_quota_notice(
 
 __all__ = [
     "async_append_cycle_quota_notice",
-    "async_preflight_cycle_external_quota",
+    "preflight_cycle_external_quota",
 ]

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
     ProviderQuotaPreflightResult,
     probe_provider_quota,
 )
@@ -26,20 +28,20 @@ if TYPE_CHECKING:
 def _with_cycle_presentation(
     result: ProviderQuotaPreflightResult,
 ) -> ProviderQuotaPreflightResult:
-    if result.blocked:
+    if isinstance(result, ProviderQuotaBlockedPreflightResult):
         return result.with_presentation(
             visible_message=(
                 "Cycle quota blocked: Codex usage is "
-                f"{result.used_percent:g}%, at or above the "
+                f"{result.usage.used_percent:g}%, at or above the "
                 f"{result.thresholds.hard_percent:g}% hard limit. "
                 "Illo will admit new runs automatically after usage falls below the limit."
             )
         )
-    if result.deferred:
+    if isinstance(result, ProviderQuotaDeferredPreflightResult):
         return result.with_presentation(
             visible_message=(
                 "Scheduled Cycle quota deferred: Codex usage is "
-                f"{result.used_percent:g}%, at or above the "
+                f"{result.usage.used_percent:g}%, at or above the "
                 f"{result.thresholds.soft_percent:g}% soft limit. "
                 "Illo will try again on a later scheduled run."
             )

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -2,22 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.integrations.provider_quota_preflight import (
     ProviderQuotaPreflightResult,
     probe_provider_quota,
 )
-from brain.platform.providers.model_policy import (
-    async_get_default_model,
-    infer_provider_from_model,
-)
+from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.common import (
     SCHEDULED_CYCLE_ORIGIN,
     cycle_run_launch_context,
 )
+
+if TYPE_CHECKING:
+    from brain.systems.cycles.admission import CycleProviderRoute
 
 
 def _with_cycle_presentation(
@@ -47,30 +50,92 @@ def _with_cycle_presentation(
 async def async_preflight_cycle_external_quota(
     session: AsyncSession,
     *,
-    cycle: Any,
-    run: Any,
+    route: CycleProviderRoute,
+    run: CycleRun,
 ) -> ProviderQuotaPreflightResult:
     """Probe subscription quota before admitting a Cycle agent run."""
 
-    user_id = str(getattr(cycle, "user_id", "") or "") or None
-    org_id = str(getattr(cycle, "org_id", "") or "") or None
-    model = str(getattr(cycle, "model_override", None) or "").strip()
-    if not model:
-        model = await async_get_default_model(
-            session,
-            include_provider_prefix=True,
-            user_id=user_id,
-            org_id=org_id,
-        )
-
-    provider = infer_provider_from_model(model)
+    del session
     origin = str(cycle_run_launch_context(run).get("origin") or "")
     result = probe_provider_quota(
-        provider=provider,
-        model=model,
+        provider=route.provider,
+        model=route.model,
         explicit_request=origin != SCHEDULED_CYCLE_ORIGIN,
     )
     return _with_cycle_presentation(result)
 
 
-__all__ = ["async_preflight_cycle_external_quota"]
+async def async_append_cycle_quota_notice(
+    session: AsyncSession,
+    idea: Idea,
+    cycle: Cycle,
+    cycle_run: CycleRun,
+    preflight: ProviderQuotaPreflightResult,
+) -> tuple[dict | None, dict | None]:
+    """Persist one visible notice for each quota-restricted episode."""
+
+    await session.scalar(
+        select(Idea.id).where(Idea.id == idea.id).with_for_update()
+    )
+    latest_notice_metadata = await session.scalar(
+        select(IdeaThread.metadata_)
+        .where(
+            IdeaThread.idea_id == idea.id,
+            IdeaThread.metadata_.contains({"quota_notice": True}),
+        )
+        .order_by(IdeaThread.id.desc())
+        .limit(1)
+    )
+    if isinstance(latest_notice_metadata, dict):
+        try:
+            notice_cycle_run_id = int(latest_notice_metadata["cycle_run_id"])
+        except (KeyError, TypeError, ValueError):
+            notice_cycle_run_id = None
+
+        if notice_cycle_run_id is not None:
+            admitted_since_notice = await session.scalar(
+                select(CycleRun.id)
+                .where(
+                    CycleRun.idea_id == idea.id,
+                    CycleRun.id > notice_cycle_run_id,
+                    CycleRun.id < cycle_run.id,
+                    CycleRun.context_snapshot.contains(
+                        {"quota_preflight": {"decision": "admitted"}}
+                    ),
+                )
+                .limit(1)
+            )
+            if admitted_since_notice is None:
+                return None, None
+
+    metadata = {
+        "source": "cycle",
+        "cycle_id": cycle.id,
+        "cycle_run_id": cycle_run.id,
+        "quota_notice": True,
+        "quota_preflight": preflight.to_dict(),
+    }
+    result = await post_thread_message(
+        session,
+        idea=idea,
+        command=ThreadMessageCommand(
+            idea_id=str(idea.id),
+            role="illo",
+            content=preflight.visible_message or "Cycle quota admission paused.",
+            actor={
+                "org_id": str(cycle.org_id) if cycle.org_id else None,
+                "name": "Illo",
+            },
+            attachments=[],
+            metadata=metadata,
+        ),
+        parse_message_type=lambda _content, _role: "agent_response",
+        lifecycle_trigger="cycle_quota_preflight_paused",
+    )
+    return result.message_payload, result.status_change
+
+
+__all__ = [
+    "async_append_cycle_quota_notice",
+    "async_preflight_cycle_external_quota",
+]

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, select
 
 from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.platform.integrations.provider_auth_preflight import (
-    ProviderAuthPreflightResult,
+    ProviderAuthBlockedPreflightResult,
 )
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
@@ -277,7 +277,7 @@ async def _async_append_cycle_auth_blocked_thread_message(
     idea: Idea,
     cycle: Cycle,
     cycle_run: CycleRun,
-    preflight: ProviderAuthPreflightResult,
+    preflight: ProviderAuthBlockedPreflightResult,
 ) -> tuple[dict, dict | None]:
     metadata = {
         "source": "cycle",

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -16,7 +16,10 @@ from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
 from brain.systems.cycles.admission import (
-    CycleAdmissionOutcome,
+    CycleAdmissionAdmitted,
+    CycleAdmissionNoticeKind,
+    CycleAdmissionRejected,
+    CycleProviderRoute,
     async_prepare_cycle_run_admission,
 )
 from brain.systems.cycles.quota_preflight import (
@@ -141,10 +144,9 @@ async def _async_admit_cycle_run(
     idea_id: str,
     message: str,
     priority: int,
-    user_id: str | None,
+    route: CycleProviderRoute,
     metadata: dict | None,
     cycle_run_id: int,
-    model_policy: dict | None = None,
     deadline_at: datetime | None = None,
 ) -> int | None:
     result = await admit_work(
@@ -153,12 +155,12 @@ async def _async_admit_cycle_run(
             source="cycle",
             event_type="cycle.due_run",
             org_id=str((metadata or {}).get("org_id") or ""),
-            actor={"id": user_id, "org_id": (metadata or {}).get("org_id")},
+            actor={"id": route.user_id, "org_id": (metadata or {}).get("org_id")},
             target={"kind": "cortex_idea", "idea_id": idea_id},
             payload={
                 "message": message,
                 "metadata": dict(metadata or {}),
-                "model_policy": dict(model_policy or {}),
+                "model_policy": route.work_intake_model_policy,
                 **({"deadline_at": deadline_at} if deadline_at is not None else {}),
             },
             policy={
@@ -299,6 +301,13 @@ async def _async_append_cycle_auth_blocked_thread_message(
         lifecycle_trigger="cycle_auth_preflight_blocked",
     )
     return result.message_payload, result.status_change
+
+
+def _cycle_admission_notice_appender(notice_kind: CycleAdmissionNoticeKind):
+    return {
+        "auth": _async_append_cycle_auth_blocked_thread_message,
+        "quota": async_append_cycle_quota_notice,
+    }[notice_kind]
 
 
 async def async_run_cycle_now(
@@ -798,48 +807,34 @@ async def async_schedule_due_cycles_once(*, limit: int = 10) -> list[int]:
 async def _async_settle_rejected_cycle_run(
     session,
     *,
-    admission: CycleAdmissionOutcome,
+    admission: CycleAdmissionRejected,
     idea: Idea,
     cycle: Cycle,
     run: CycleRun,
 ) -> tuple[dict | None, dict | None, dict]:
-    rejection_status = admission.rejection_status
-    if rejection_status is None:
-        raise ValueError("Cannot settle an admitted Cycle run")
-
     await _finalize_cycle_run(
         run,
         cycle,
-        status=rejection_status,
+        status=admission.status,
         error=admission.error,
         skip_reason=admission.skip_reason,
         session=session,
     )
-    if admission.auth.blocked:
-        message_payload, status_payload = await _async_append_cycle_auth_blocked_thread_message(
-            session,
-            idea,
-            cycle,
-            run,
-            admission.auth,
-        )
-    else:
-        if admission.quota is None:
-            raise ValueError("Rejected Cycle quota admission requires a quota result")
-        message_payload, status_payload = await async_append_cycle_quota_notice(
-            session,
-            idea,
-            cycle,
-            run,
-            admission.quota,
-        )
+    append_notice = _cycle_admission_notice_appender(admission.notice_kind)
+    message_payload, status_payload = await append_notice(
+        session,
+        idea,
+        cycle,
+        run,
+        admission.notice,
+    )
     return message_payload, status_payload, serialize_execution_idea(idea)
 
 
 async def _async_start_admitted_cycle_run(
     session,
     *,
-    admission: CycleAdmissionOutcome,
+    admission: CycleAdmissionAdmitted,
     idea: Idea,
     cycle: Cycle,
     run: CycleRun,
@@ -853,10 +848,9 @@ async def _async_start_admitted_cycle_run(
         idea_id=idea.id,
         message=run_message,
         priority=1,
-        user_id=admission.route.user_id,
+        route=admission.route,
         metadata=run_metadata,
         cycle_run_id=run.id,
-        model_policy=admission.route.model_policy,
         deadline_at=_cycle_run_deadline_at(cycle),
     )
     if agent_run_id is None:
@@ -939,7 +933,7 @@ async def async_execute_cycle_run(run_id: int) -> None:
             cycle=cycle,
             run=run,
         )
-        if admission.rejected:
+        if isinstance(admission, CycleAdmissionRejected):
             message_payload, status_payload, idea_snapshot = (
                 await _async_settle_rejected_cycle_run(
                     uow.session,
@@ -961,12 +955,21 @@ async def async_execute_cycle_run(run_id: int) -> None:
             if started is None:
                 return
             agent_run_id, message_payload, status_payload, idea_snapshot = started
-    if should_publish_idea and idea_snapshot:
-        publish("idea_upserted", {"idea": idea_snapshot})
-    if message_payload:
-        publish("thread_message", {"idea_id": idea_id, "message": message_payload})
-    if status_payload:
-        publish("status_change", status_payload)
+    for should_publish, event, payload in (
+        (
+            should_publish_idea and idea_snapshot,
+            "idea_upserted",
+            {"idea": idea_snapshot},
+        ),
+        (
+            message_payload,
+            "thread_message",
+            {"idea_id": idea_id, "message": message_payload},
+        ),
+        (status_payload, "status_change", status_payload),
+    ):
+        if should_publish:
+            publish(event, payload)
     if agent_run_id is not None:
         logger.info(
             "Enqueued cycle run #%s for idea %s... (cycle=%s)",

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -17,7 +17,9 @@ from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_th
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
 from brain.systems.cycles.admission import (
     CycleAdmissionAdmitted,
-    CycleAdmissionNoticeKind,
+    CycleAdmissionAuthBlocked,
+    CycleAdmissionQuotaBlocked,
+    CycleAdmissionQuotaDeferred,
     CycleAdmissionRejected,
     CycleProviderRoute,
     async_prepare_cycle_run_admission,
@@ -303,11 +305,41 @@ async def _async_append_cycle_auth_blocked_thread_message(
     return result.message_payload, result.status_change
 
 
-def _cycle_admission_notice_appender(notice_kind: CycleAdmissionNoticeKind):
+def _cycle_admission_notice_error(notice):
+    return notice.visible_message
+
+
+def _cycle_admission_without_error(_notice):
+    return None
+
+
+def _cycle_admission_notice_appender(notice_kind):
     return {
         "auth": _async_append_cycle_auth_blocked_thread_message,
         "quota": async_append_cycle_quota_notice,
     }[notice_kind]
+
+
+_CYCLE_ADMISSION_REJECTION_SETTLEMENTS = {
+    CycleAdmissionAuthBlocked: (
+        "auth_blocked",
+        None,
+        _cycle_admission_notice_error,
+        "auth",
+    ),
+    CycleAdmissionQuotaBlocked: (
+        "quota_blocked",
+        None,
+        _cycle_admission_notice_error,
+        "quota",
+    ),
+    CycleAdmissionQuotaDeferred: (
+        "skipped",
+        "quota_soft_limit",
+        _cycle_admission_without_error,
+        "quota",
+    ),
+}
 
 
 async def async_run_cycle_now(
@@ -812,15 +844,18 @@ async def _async_settle_rejected_cycle_run(
     cycle: Cycle,
     run: CycleRun,
 ) -> tuple[dict | None, dict | None, dict]:
+    status, skip_reason, notice_error, notice_kind = (
+        _CYCLE_ADMISSION_REJECTION_SETTLEMENTS[type(admission)]
+    )
     await _finalize_cycle_run(
         run,
         cycle,
-        status=admission.status,
-        error=admission.error,
-        skip_reason=admission.skip_reason,
+        status=status,
+        error=notice_error(admission.notice),
+        skip_reason=skip_reason,
         session=session,
     )
-    append_notice = _cycle_admission_notice_appender(admission.notice_kind)
+    append_notice = _cycle_admission_notice_appender(notice_kind)
     message_payload, status_payload = await append_notice(
         session,
         idea,

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -12,18 +12,15 @@ from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
 )
-from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
-)
-from brain.platform.providers.model_policy import EFFORT_TIER_SET, normalize_model_name
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
-from brain.systems.cycles.auth_preflight import (
-    async_preflight_cycle_external_auth,
+from brain.systems.cycles.admission import (
+    CycleAdmissionOutcome,
+    async_prepare_cycle_run_admission,
 )
 from brain.systems.cycles.quota_preflight import (
-    async_preflight_cycle_external_quota,
+    async_append_cycle_quota_notice,
 )
 from brain.systems.cycles.common import (
     MANUAL_CYCLE_ORIGIN,
@@ -83,7 +80,7 @@ from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.agent_run import AgentRunEventRow
-from brain.platform.db.models.idea import Idea, IdeaThread
+from brain.platform.db.models.idea import Idea
 from brain.platform.db.models.org import User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
@@ -202,32 +199,6 @@ def _cycle_run_deadline_at(
     return admitted_at + timedelta(seconds=timeout_seconds)
 
 
-def _cycle_run_model_policy(cycle: Cycle, run: CycleRun) -> dict[str, str]:
-    context_snapshot = json_dict(getattr(run, "context_snapshot", None))
-    revision_snapshot = context_snapshot.get("revision")
-    if isinstance(revision_snapshot, dict):
-        overrides = revision_snapshot
-    else:
-        overrides = {
-            "model_override": cycle.model_override,
-            "thinking_override": cycle.thinking_override,
-        }
-
-    policy: dict[str, str] = {}
-    raw_model = str(overrides.get("model_override") or "").strip()
-    if raw_model and raw_model.lower() != "default":
-        policy["model"] = normalize_model_name(raw_model)
-
-    thinking = str(overrides.get("thinking_override") or "").strip().lower()
-    if thinking in EFFORT_TIER_SET:
-        policy["thinking"] = thinking
-    elif thinking:
-        logger.warning(
-            "Ignoring invalid thinking_override in CycleRun revision snapshot",
-        )
-    return policy
-
-
 async def _async_attach_open_ask_stragglers(
     session,
     cycle: Cycle,
@@ -326,77 +297,6 @@ async def _async_append_cycle_auth_blocked_thread_message(
         ),
         parse_message_type=lambda _content, _role: "agent_response",
         lifecycle_trigger="cycle_auth_preflight_blocked",
-    )
-    return result.message_payload, result.status_change
-
-
-async def _async_append_cycle_quota_notice(
-    session,
-    idea: Idea,
-    cycle: Cycle,
-    cycle_run: CycleRun,
-    preflight: ProviderQuotaPreflightResult,
-) -> tuple[dict | None, dict | None]:
-    # Serialize the check and insert on the reusable thread. The quota gate can
-    # settle many scheduled runs, but the user should see one durable notice
-    # for each contiguous quota-restricted episode.
-    await session.scalar(
-        select(Idea.id).where(Idea.id == idea.id).with_for_update()
-    )
-    latest_notice_metadata = await session.scalar(
-        select(IdeaThread.metadata_)
-        .where(
-            IdeaThread.idea_id == idea.id,
-            IdeaThread.metadata_.contains({"quota_notice": True}),
-        )
-        .order_by(IdeaThread.id.desc())
-        .limit(1)
-    )
-    if isinstance(latest_notice_metadata, dict):
-        try:
-            notice_cycle_run_id = int(latest_notice_metadata["cycle_run_id"])
-        except (KeyError, TypeError, ValueError):
-            notice_cycle_run_id = None
-
-        if notice_cycle_run_id is not None:
-            admitted_since_notice = await session.scalar(
-                select(CycleRun.id)
-                .where(
-                    CycleRun.idea_id == idea.id,
-                    CycleRun.id > notice_cycle_run_id,
-                    CycleRun.id < cycle_run.id,
-                    CycleRun.context_snapshot.contains(
-                        {"quota_preflight": {"decision": "admitted"}}
-                    ),
-                )
-                .limit(1)
-            )
-            if admitted_since_notice is None:
-                return None, None
-
-    metadata = {
-        "source": "cycle",
-        "cycle_id": cycle.id,
-        "cycle_run_id": cycle_run.id,
-        "quota_notice": True,
-        "quota_preflight": preflight.to_dict(),
-    }
-    result = await post_thread_message(
-        session,
-        idea=idea,
-        command=ThreadMessageCommand(
-            idea_id=str(idea.id),
-            role="illo",
-            content=preflight.visible_message or "Cycle quota admission paused.",
-            actor={
-                "org_id": str(cycle.org_id) if cycle.org_id else None,
-                "name": "Illo",
-            },
-            attachments=[],
-            metadata=metadata,
-        ),
-        parse_message_type=lambda _content, _role: "agent_response",
-        lifecycle_trigger="cycle_quota_preflight_paused",
     )
     return result.message_payload, result.status_change
 
@@ -895,16 +795,101 @@ async def async_schedule_due_cycles_once(*, limit: int = 10) -> list[int]:
     return executable_run_ids
 
 
+async def _async_settle_rejected_cycle_run(
+    session,
+    *,
+    admission: CycleAdmissionOutcome,
+    idea: Idea,
+    cycle: Cycle,
+    run: CycleRun,
+) -> tuple[dict | None, dict | None, dict]:
+    rejection_status = admission.rejection_status
+    if rejection_status is None:
+        raise ValueError("Cannot settle an admitted Cycle run")
+
+    await _finalize_cycle_run(
+        run,
+        cycle,
+        status=rejection_status,
+        error=admission.error,
+        skip_reason=admission.skip_reason,
+        session=session,
+    )
+    if admission.auth.blocked:
+        message_payload, status_payload = await _async_append_cycle_auth_blocked_thread_message(
+            session,
+            idea,
+            cycle,
+            run,
+            admission.auth,
+        )
+    else:
+        if admission.quota is None:
+            raise ValueError("Rejected Cycle quota admission requires a quota result")
+        message_payload, status_payload = await async_append_cycle_quota_notice(
+            session,
+            idea,
+            cycle,
+            run,
+            admission.quota,
+        )
+    return message_payload, status_payload, serialize_execution_idea(idea)
+
+
+async def _async_start_admitted_cycle_run(
+    session,
+    *,
+    admission: CycleAdmissionOutcome,
+    idea: Idea,
+    cycle: Cycle,
+    run: CycleRun,
+    owner: User | None,
+) -> tuple[int, dict, dict | None, dict] | None:
+    run.started_at = datetime.now(timezone.utc)
+    run_metadata = _cycle_run_metadata(cycle, run)
+    run_message = _cycle_run_message(idea, cycle, run)
+    agent_run_id = await _async_admit_cycle_run(
+        session,
+        idea_id=idea.id,
+        message=run_message,
+        priority=1,
+        user_id=admission.route.user_id,
+        metadata=run_metadata,
+        cycle_run_id=run.id,
+        model_policy=admission.route.model_policy,
+        deadline_at=_cycle_run_deadline_at(cycle),
+    )
+    if agent_run_id is None:
+        await _finalize_cycle_run(
+            run,
+            cycle,
+            status="failed",
+            error="Cycle work admission failed before an agent run was created",
+            session=session,
+        )
+        return None
+
+    message_payload, status_payload = await _async_append_cycle_thread_message(
+        session,
+        idea,
+        cycle,
+        run,
+        owner,
+    )
+    idea_snapshot = serialize_execution_idea(idea)
+    run.run_id = agent_run_id
+    cycle.last_status = "running"
+    cycle.last_error = None
+    return agent_run_id, message_payload, status_payload, idea_snapshot
+
+
 async def async_execute_cycle_run(run_id: int) -> None:
     message_payload = None
     status_payload = None
     should_publish_idea = False
     idea_snapshot = None
     idea_id = None
-    run_message = None
-    run_metadata = None
     cycle_name = ""
-    cycle_user_id = None
     agent_run_id = None
 
     async with UnitOfWork() as uow:
@@ -914,8 +899,6 @@ async def async_execute_cycle_run(run_id: int) -> None:
         run, cycle = claim
 
         cycle_name = cycle.name
-        cycle_user_id = cycle.user_id
-        run_model_policy = _cycle_run_model_policy(cycle, run)
         owner = await uow.session.get(User, cycle.user_id)
         cycle.execution_mode = REUSABLE_THREAD_EXECUTION_MODE
         cycle.reopen_archived = True
@@ -951,97 +934,33 @@ async def async_execute_cycle_run(run_id: int) -> None:
         )
         idea_id = idea.id
 
-        auth_preflight = await async_preflight_cycle_external_auth(uow.session, cycle=cycle)
-        if auth_preflight.status != "skipped":
-            context_snapshot = dict(run.context_snapshot or {})
-            context_snapshot["auth_preflight"] = auth_preflight.to_dict()
-            run.context_snapshot = context_snapshot
-
-        if auth_preflight.blocked:
-            await _finalize_cycle_run(
-                run,
-                cycle,
-                status="auth_blocked",
-                error=auth_preflight.visible_message,
-                session=uow.session,
+        admission = await async_prepare_cycle_run_admission(
+            uow.session,
+            cycle=cycle,
+            run=run,
+        )
+        if admission.rejected:
+            message_payload, status_payload, idea_snapshot = (
+                await _async_settle_rejected_cycle_run(
+                    uow.session,
+                    admission=admission,
+                    idea=idea,
+                    cycle=cycle,
+                    run=run,
+                )
             )
-            message_payload, status_payload = await _async_append_cycle_auth_blocked_thread_message(
-                uow.session,
-                idea,
-                cycle,
-                run,
-                auth_preflight,
-            )
-            idea_snapshot = serialize_execution_idea(idea)
         else:
-            quota_preflight = await async_preflight_cycle_external_quota(
+            started = await _async_start_admitted_cycle_run(
                 uow.session,
+                admission=admission,
+                idea=idea,
                 cycle=cycle,
                 run=run,
+                owner=owner,
             )
-            context_snapshot = dict(run.context_snapshot or {})
-            context_snapshot["quota_preflight"] = quota_preflight.to_dict()
-            run.context_snapshot = context_snapshot
-
-            if quota_preflight.blocked or quota_preflight.deferred:
-                terminal_status = "quota_blocked" if quota_preflight.blocked else "skipped"
-                await _finalize_cycle_run(
-                    run,
-                    cycle,
-                    status=terminal_status,
-                    error=(
-                        quota_preflight.visible_message
-                        if quota_preflight.blocked
-                        else None
-                    ),
-                    skip_reason=(
-                        "quota_soft_limit" if quota_preflight.deferred else None
-                    ),
-                    session=uow.session,
-                )
-                message_payload, status_payload = await _async_append_cycle_quota_notice(
-                    uow.session,
-                    idea,
-                    cycle,
-                    run,
-                    quota_preflight,
-                )
-                idea_snapshot = serialize_execution_idea(idea)
-            else:
-                run.started_at = datetime.now(timezone.utc)
-                run_metadata = _cycle_run_metadata(cycle, run)
-                run_message = _cycle_run_message(idea, cycle, run)
-                agent_run_id = await _async_admit_cycle_run(
-                    uow.session,
-                    idea_id=idea.id,
-                    message=run_message,
-                    priority=1,
-                    user_id=cycle_user_id,
-                    metadata=run_metadata,
-                    cycle_run_id=run.id,
-                    model_policy=run_model_policy,
-                    deadline_at=_cycle_run_deadline_at(cycle),
-                )
-                if agent_run_id is None:
-                    await _finalize_cycle_run(
-                        run,
-                        cycle,
-                        status="failed",
-                        error="Cycle work admission failed before an agent run was created",
-                        session=uow.session,
-                    )
-                    return
-                message_payload, status_payload = await _async_append_cycle_thread_message(
-                    uow.session,
-                    idea,
-                    cycle,
-                    run,
-                    owner,
-                )
-                idea_snapshot = serialize_execution_idea(idea)
-                run.run_id = agent_run_id
-                cycle.last_status = "running"
-                cycle.last_error = None
+            if started is None:
+                return
+            agent_run_id, message_payload, status_payload, idea_snapshot = started
     if should_publish_idea and idea_snapshot:
         publish("idea_upserted", {"idea": idea_snapshot})
     if message_payload:

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -13,6 +13,7 @@ from typing import Any
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.effort import EFFORT_TIERS, EFFORT_TIER_SET
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
     skipped_provider_auth_preflight,
@@ -67,7 +68,7 @@ _SPAWN_WORKER_AUTH_PROVIDERS = frozenset({"anthropic", "openai"})
 def _with_spawn_worker_auth_presentation(
     result: ProviderAuthPreflightResult,
 ) -> ProviderAuthPreflightResult:
-    if not result.blocked:
+    if not isinstance(result, ProviderAuthBlockedPreflightResult):
         return result
 
     credential = result.credential or "provider"
@@ -575,7 +576,7 @@ async def _handle_spawn_worker(
                 org_id=parent.org_id,
                 model=str(child_policy["model"]),
             )
-            if preflight.blocked:
+            if isinstance(preflight, ProviderAuthBlockedPreflightResult):
                 shard = str(worker_metadata["worker_shard"])
                 failure = WorkerEvidenceFailure.for_admission(
                     worker_role=assignment.role,

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -12,7 +12,10 @@ from typing import Any
 from sqlalchemy import text
 
 from brain.platform.db.models.idea import Idea
-from brain.platform.integrations.provider_auth_preflight import async_probe_provider_auth
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
+    async_probe_provider_auth,
+)
 from brain.platform.providers.model_policy import (
     EFFORT_TIER_SET,
     async_get_default_model,
@@ -1141,7 +1144,7 @@ async def admit_work(
                 provider=provider,
                 model=model,
             )
-            if auth_preflight.blocked:
+            if isinstance(auth_preflight, ProviderAuthBlockedPreflightResult):
                 reason = (
                     f"{auth_preflight.error_code}: provider={provider} model={model} "
                     f"credential={auth_preflight.credential or 'unavailable'}"

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2222,8 +2222,6 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
             user_id="user-1",
             org_id="org-1",
             model="anthropic/claude-sonnet-4-6",
-            provider="anthropic",
-            model_policy={"model": "anthropic/claude-sonnet-4-6"},
         ),
     )
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -50,12 +50,11 @@ def _stub_spawn_worker_auth_preflight(monkeypatch, worker_handlers):
     developer laptop and the auth_blocked path on credential-free CI.
     """
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthPassedPreflightResult,
     )
 
     async def passed_preflight(_session, *, model, **_kwargs):
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider="openai",
             model=model,
         )
@@ -336,7 +335,7 @@ async def test_run_admission_marks_idea_working_without_worker_details(monkeypat
 
 async def test_run_admission_rejects_uncredentialed_anthropic_before_creation(monkeypatch):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
     from brain.systems.runs.domain import AgentRunRequest
     from brain.systems.runs import work_intake
@@ -354,8 +353,7 @@ async def test_run_admission_rejects_uncredentialed_anthropic_before_creation(mo
         return request
 
     async def blocked_probe(_session, **kwargs):
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",
@@ -1761,7 +1759,7 @@ async def _captured_spawn_worker(
     **spawn_kwargs,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthPassedPreflightResult,
     )
     from brain.systems.runs.domain import RunProfile, RunRecipe
     from brain.systems.runs.evidence_health import WorkerEvidenceReceipt
@@ -1826,8 +1824,7 @@ async def _captured_spawn_worker(
 
     async def fake_preflight(*_args, **_kwargs):
         captured["preflight"] = dict(_kwargs)
-        return preflight_result or ProviderAuthPreflightResult(
-            status="passed",
+        return preflight_result or ProviderAuthPassedPreflightResult(
             provider="openai",
             model="openai/gpt-5.6-sol",
         )
@@ -2057,11 +2054,10 @@ async def test_spawn_worker_auth_preflight_rejects_missing_provider_credential_b
     monkeypatch,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
 
-    blocked = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    blocked = ProviderAuthBlockedPreflightResult(
         provider="anthropic",
         model="anthropic/claude-sonnet-4-6",
         credential="Anthropic API key",
@@ -2136,7 +2132,7 @@ async def test_neutral_auth_probe_names_missing_anthropic_configuration(
         model="anthropic/claude-sonnet-4-6",
     )
 
-    assert result.status == "auth_blocked"
+    assert result.to_dict()["status"] == "auth_blocked"
     assert result.error_code == "provider_credential_unavailable"
     assert result.credential == "Anthropic API key"
     assert result.visible_message is None
@@ -2147,7 +2143,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
     monkeypatch,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
@@ -2155,8 +2151,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
 
     async def blocked_probe(_session, **kwargs):
         captured.update(kwargs)
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",
@@ -2182,7 +2177,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
         "provider": "anthropic",
         "model": "anthropic/claude-sonnet-4-6",
     }
-    assert result.blocked is True
+    assert isinstance(result, ProviderAuthBlockedPreflightResult)
     assert result.repair_action == (
         "Add an Anthropic API key in Settings > Access, then retry the run."
     )
@@ -2195,15 +2190,14 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
     from brain.systems.cycles import auth_preflight
     from brain.systems.cycles.admission import CycleProviderRoute
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
 
     probes = []
 
     async def blocked_probe(*_args, **kwargs):
         probes.append(kwargs)
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",
@@ -2225,7 +2219,7 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
         ),
     )
 
-    assert result.status == "auth_blocked"
+    assert isinstance(result, ProviderAuthBlockedPreflightResult)
     assert result.provider == "anthropic"
     assert probes[0]["provider"] == "anthropic"
     assert "Add an Anthropic API key" in result.visible_message

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2193,6 +2193,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
 
 async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatch):
     from brain.systems.cycles import auth_preflight
+    from brain.systems.cycles.admission import CycleProviderRoute
     from brain.platform.integrations.provider_auth_preflight import (
         ProviderAuthPreflightResult,
     )
@@ -2217,10 +2218,12 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
 
     result = await auth_preflight.async_preflight_cycle_external_auth(
         object(),
-        cycle=SimpleNamespace(
+        route=CycleProviderRoute(
             user_id="user-1",
             org_id="org-1",
-            model_override="anthropic/claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
+            provider="anthropic",
+            model_policy={"model": "anthropic/claude-sonnet-4-6"},
         ),
     )
 

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import json
 import os
 
-from brain.platform.integrations.codex_usage import read_codex_usage
+import pytest
+
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+    read_codex_usage,
+)
 
 
 def _event(
@@ -50,9 +57,9 @@ def test_reads_newest_real_codex_usage(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "ok"
+    assert isinstance(reading, CodexKnownUsage)
+    assert reading.to_dict()["status"] == "ok"
     assert reading.used_percent == 31.0
-    assert reading.reason is None
     assert reading.observed_at == "2026-08-04T13:24:46Z"
     assert reading.limit_id == "codex"
     assert reading.plan_type == "pro"
@@ -64,9 +71,9 @@ def test_real_codex_usage_at_one_hundred_is_exhausted(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "exhausted"
+    assert isinstance(reading, CodexKnownUsage)
+    assert reading.to_dict()["status"] == "exhausted"
     assert reading.used_percent == 100.0
-    assert reading.reason is None
 
 
 def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
@@ -85,9 +92,8 @@ def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "unexpected_limit_id"
-    assert reading.used_percent is None
     assert reading.limit_id == "premium"
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 31.0
@@ -100,9 +106,8 @@ def test_null_primary_on_codex_limit_is_unknown_not_zero_or_exhausted(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "primary_missing"
-    assert reading.used_percent is None
     assert reading.last_known_good is None
 
 
@@ -114,9 +119,8 @@ def test_malformed_newest_line_is_unknown_with_older_known_reading(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "malformed_line"
-    assert reading.used_percent is None
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 42.0
 
@@ -138,9 +142,8 @@ def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "auth_error"
-    assert reading.used_percent is None
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 52.0
 
@@ -148,9 +151,8 @@ def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
 def test_missing_sessions_directory_is_unknown(tmp_path):
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "sessions_dir_missing"
-    assert reading.used_percent is None
 
 
 def test_only_newest_session_file_controls_current_verdict(tmp_path):
@@ -163,7 +165,7 @@ def test_only_newest_session_file_controls_current_verdict(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert reading.status == "unknown"
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.reason == "token_count_missing"
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 12.0
@@ -174,4 +176,54 @@ def test_codex_home_environment_selects_usage_root(tmp_path, monkeypatch):
     _write_events(path, _event(17))
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
-    assert read_codex_usage().used_percent == 17.0
+    reading = read_codex_usage()
+    assert isinstance(reading, CodexKnownUsage)
+    assert reading.used_percent == 17.0
+
+
+def test_usage_reading_serialization_is_byte_compatible():
+    known = CodexKnownUsage(
+        used_percent=31.0,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+        plan_type="pro",
+    )
+    unknown = CodexUnknownUsageReading(
+        reason=CodexUsageUnknownReason.PRIMARY_MISSING,
+        observed_at="2026-08-04T13:28:13Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+        limit_id="codex",
+    )
+
+    assert json.dumps(known.to_dict(), separators=(",", ":")).encode() == (
+        b'{"status":"ok","used_percent":31.0,"reason":null,'
+        b'"observed_at":"2026-08-04T13:24:45Z",'
+        b'"source_path":"/tmp/codex/sessions/rollout.jsonl",'
+        b'"limit_id":"codex","plan_type":"pro","last_known_good":null}'
+    )
+    assert json.dumps(unknown.to_dict(), separators=(",", ":")).encode() == (
+        b'{"status":"unknown","used_percent":null,"reason":"primary_missing",'
+        b'"observed_at":"2026-08-04T13:28:13Z",'
+        b'"source_path":"/tmp/codex/sessions/rollout.jsonl",'
+        b'"limit_id":"codex","plan_type":null,"last_known_good":null}'
+    )
+
+
+def test_unknown_reasons_are_enumerable_and_reject_free_form_strings():
+    assert {reason.value for reason in CodexUsageUnknownReason} == {
+        "auth_error",
+        "malformed_line",
+        "primary_missing",
+        "rate_limits_missing",
+        "sessions_dir_empty",
+        "sessions_dir_missing",
+        "sessions_dir_unreadable",
+        "session_file_empty",
+        "session_file_unreadable",
+        "token_count_missing",
+        "unexpected_limit_id",
+        "used_percent_invalid",
+        "used_percent_missing",
+    }
+    with pytest.raises(TypeError):
+        CodexUnknownUsageReading(reason="new_reason")

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 
 import pytest
@@ -63,7 +64,7 @@ async def test_cycle_route_resolves_default_model_once(monkeypatch, raw_model):
     ]
     assert route.model == "openai/gpt-5.6-sol"
     assert route.provider == "openai"
-    assert route.model_policy == {"model": "openai/gpt-5.6-sol"}
+    assert route.work_intake_model_policy == {"model": "openai/gpt-5.6-sol"}
 
 
 @pytest.mark.asyncio
@@ -86,7 +87,7 @@ async def test_cycle_route_uses_bound_revision_instead_of_live_cycle():
 
     assert route.model == "openai/gpt-5.6-luna"
     assert route.provider == "openai"
-    assert route.model_policy == {
+    assert route.work_intake_model_policy == {
         "model": "openai/gpt-5.6-luna",
         "thinking": "xhigh",
     }
@@ -100,7 +101,7 @@ async def test_cycle_route_falls_back_to_live_cycle_without_snapshot():
         run=SimpleNamespace(context_snapshot=None),
     )
 
-    assert route.model_policy == {
+    assert route.work_intake_model_policy == {
         "model": "openai/gpt-5.6-luna",
         "thinking": "low",
     }
@@ -124,7 +125,7 @@ async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monke
             model=route.model,
         )
 
-    async def quota_preflight(_session, *, route, run):
+    def quota_preflight(*, route, run):
         quota_routes.append((route, run))
         return ProviderQuotaPreflightResult(
             status="passed",
@@ -139,7 +140,7 @@ async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monke
 
     monkeypatch.setattr(admission, "async_get_default_model", default_model)
     monkeypatch.setattr(admission, "async_preflight_cycle_external_auth", auth_preflight)
-    monkeypatch.setattr(admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(admission, "preflight_cycle_external_quota", quota_preflight)
     run = SimpleNamespace(
         context_snapshot={
             "revision": {"model_override": None, "thinking_override": "low"},
@@ -153,13 +154,158 @@ async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monke
         run=run,
     )
 
+    assert isinstance(outcome, admission.CycleAdmissionAdmitted)
     assert len(default_calls) == 1
     assert auth_routes == [outcome.route]
     assert quota_routes == [(outcome.route, run)]
     assert auth_routes[0] is quota_routes[0][0] is outcome.route
-    assert outcome.route.model_policy == {
+    assert outcome.route.work_intake_model_policy == {
         "model": "openai/gpt-5.6-sol",
         "thinking": "low",
     }
     assert run.context_snapshot["auth_preflight"]["status"] == "passed"
     assert run.context_snapshot["quota_preflight"]["decision"] == "admitted"
+
+
+def test_cycle_route_enforces_and_derives_its_invariants():
+    route = admission.CycleProviderRoute(
+        user_id="user-1",
+        org_id="org-1",
+        model="openai/gpt-5.6-sol",
+        thinking="high",
+    )
+
+    policy = route.work_intake_model_policy
+    policy["model"] = "anthropic/claude-opus-5"
+
+    assert route.provider == "openai"
+    assert route.work_intake_model_policy == {
+        "model": "openai/gpt-5.6-sol",
+        "thinking": "high",
+    }
+    assert not hasattr(route, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        route.model = "anthropic/claude-opus-5"
+
+
+@pytest.mark.parametrize(
+    ("model", "thinking"),
+    [
+        ("gpt-5.6-sol", None),
+        ("openai/gpt-5.6-sol", "ultra"),
+    ],
+)
+def test_cycle_route_rejects_noncanonical_construction(model, thinking):
+    with pytest.raises(ValueError):
+        admission.CycleProviderRoute(
+            user_id="user-1",
+            org_id="org-1",
+            model=model,
+            thinking=thinking,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
+    auth = ProviderAuthPreflightResult(
+        status="auth_blocked",
+        provider="openai",
+        model="openai/gpt-5.5",
+        visible_message="Reconnect OpenAI.",
+    )
+
+    async def auth_preflight(_session, *, route):
+        return auth
+
+    def unexpected_quota(**_kwargs):
+        raise AssertionError("quota must not run after an auth rejection")
+
+    monkeypatch.setattr(admission, "async_preflight_cycle_external_auth", auth_preflight)
+    monkeypatch.setattr(admission, "preflight_cycle_external_quota", unexpected_quota)
+    run = SimpleNamespace(context_snapshot={})
+
+    outcome = await admission.async_prepare_cycle_run_admission(
+        object(),
+        cycle=_cycle(),
+        run=run,
+    )
+
+    assert isinstance(outcome, admission.CycleAdmissionRejected)
+    assert outcome.status == "auth_blocked"
+    assert outcome.error == "Reconnect OpenAI."
+    assert outcome.skip_reason is None
+    assert outcome.notice_kind == "auth"
+    assert outcome.notice is auth
+    assert run.context_snapshot["auth_preflight"]["status"] == "auth_blocked"
+    assert "quota_preflight" not in run.context_snapshot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "decision", "message", "expected_status", "expected_error", "skip_reason"),
+    [
+        (
+            "quota_blocked",
+            "blocked",
+            "Quota is blocked.",
+            "quota_blocked",
+            "Quota is blocked.",
+            None,
+        ),
+        (
+            "quota_deferred",
+            "deferred",
+            "Quota is deferred.",
+            "skipped",
+            None,
+            "quota_soft_limit",
+        ),
+    ],
+)
+async def test_cycle_admission_returns_complete_quota_rejection(
+    monkeypatch,
+    status,
+    decision,
+    message,
+    expected_status,
+    expected_error,
+    skip_reason,
+):
+    quota = ProviderQuotaPreflightResult(
+        status=status,
+        decision=decision,
+        provider="openai",
+        model="openai/gpt-5.5",
+        usage_status="ok",
+        used_percent=90.0,
+        thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+        visible_message=message,
+    )
+
+    async def auth_preflight(_session, *, route):
+        return ProviderAuthPreflightResult(
+            status="passed",
+            provider=route.provider,
+            model=route.model,
+        )
+
+    def quota_preflight(*, route, run):
+        return quota
+
+    monkeypatch.setattr(admission, "async_preflight_cycle_external_auth", auth_preflight)
+    monkeypatch.setattr(admission, "preflight_cycle_external_quota", quota_preflight)
+    run = SimpleNamespace(context_snapshot={})
+
+    outcome = await admission.async_prepare_cycle_run_admission(
+        object(),
+        cycle=_cycle(),
+        run=run,
+    )
+
+    assert isinstance(outcome, admission.CycleAdmissionRejected)
+    assert outcome.status == expected_status
+    assert outcome.error == expected_error
+    assert outcome.skip_reason == skip_reason
+    assert outcome.notice_kind == "quota"
+    assert outcome.notice is quota
+    assert run.context_snapshot["quota_preflight"]["decision"] == decision

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPreflightResult,
+)
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaPreflightResult,
+    ProviderQuotaThresholds,
+)
+from brain.systems.cycles import admission
+
+
+def _cycle(**overrides):
+    values = {
+        "user_id": "user-1",
+        "org_id": "org-1",
+        "model_override": "openai/gpt-5.5",
+        "thinking_override": "high",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_model", [None, "", "default", "DEFAULT"])
+async def test_cycle_route_resolves_default_model_once(monkeypatch, raw_model):
+    calls = []
+
+    async def default_model(session, **kwargs):
+        calls.append((session, kwargs))
+        return "openai/gpt-5.6-sol"
+
+    monkeypatch.setattr(admission, "async_get_default_model", default_model)
+    session = object()
+    run = SimpleNamespace(
+        context_snapshot={
+            "revision": {
+                "model_override": raw_model,
+                "thinking_override": None,
+            }
+        }
+    )
+
+    route = await admission.async_resolve_cycle_provider_route(
+        session,
+        cycle=_cycle(),
+        run=run,
+    )
+
+    assert calls == [
+        (
+            session,
+            {
+                "include_provider_prefix": True,
+                "user_id": "user-1",
+                "org_id": "org-1",
+            },
+        )
+    ]
+    assert route.model == "openai/gpt-5.6-sol"
+    assert route.provider == "openai"
+    assert route.model_policy == {"model": "openai/gpt-5.6-sol"}
+
+
+@pytest.mark.asyncio
+async def test_cycle_route_uses_bound_revision_instead_of_live_cycle():
+    route = await admission.async_resolve_cycle_provider_route(
+        object(),
+        cycle=_cycle(
+            model_override="anthropic/claude-opus-5",
+            thinking_override="low",
+        ),
+        run=SimpleNamespace(
+            context_snapshot={
+                "revision": {
+                    "model_override": "gpt-5.6-luna",
+                    "thinking_override": "xhigh",
+                }
+            }
+        ),
+    )
+
+    assert route.model == "openai/gpt-5.6-luna"
+    assert route.provider == "openai"
+    assert route.model_policy == {
+        "model": "openai/gpt-5.6-luna",
+        "thinking": "xhigh",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cycle_route_falls_back_to_live_cycle_without_snapshot():
+    route = await admission.async_resolve_cycle_provider_route(
+        object(),
+        cycle=_cycle(model_override="openai/gpt-5.6-luna", thinking_override="low"),
+        run=SimpleNamespace(context_snapshot=None),
+    )
+
+    assert route.model_policy == {
+        "model": "openai/gpt-5.6-luna",
+        "thinking": "low",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monkeypatch):
+    default_calls = []
+    auth_routes = []
+    quota_routes = []
+
+    async def default_model(_session, **kwargs):
+        default_calls.append(kwargs)
+        return "openai/gpt-5.6-sol"
+
+    async def auth_preflight(_session, *, route):
+        auth_routes.append(route)
+        return ProviderAuthPreflightResult(
+            status="passed",
+            provider=route.provider,
+            model=route.model,
+        )
+
+    async def quota_preflight(_session, *, route, run):
+        quota_routes.append((route, run))
+        return ProviderQuotaPreflightResult(
+            status="passed",
+            decision="admitted",
+            provider=route.provider,
+            model=route.model,
+            usage_status="ok",
+            used_percent=10.0,
+            thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
+            explicit_request=False,
+        )
+
+    monkeypatch.setattr(admission, "async_get_default_model", default_model)
+    monkeypatch.setattr(admission, "async_preflight_cycle_external_auth", auth_preflight)
+    monkeypatch.setattr(admission, "async_preflight_cycle_external_quota", quota_preflight)
+    run = SimpleNamespace(
+        context_snapshot={
+            "revision": {"model_override": None, "thinking_override": "low"},
+            "launch_context": {"origin": "scheduled_cycle"},
+        }
+    )
+
+    outcome = await admission.async_prepare_cycle_run_admission(
+        object(),
+        cycle=_cycle(),
+        run=run,
+    )
+
+    assert len(default_calls) == 1
+    assert auth_routes == [outcome.route]
+    assert quota_routes == [(outcome.route, run)]
+    assert auth_routes[0] is quota_routes[0][0] is outcome.route
+    assert outcome.route.model_policy == {
+        "model": "openai/gpt-5.6-sol",
+        "thinking": "low",
+    }
+    assert run.context_snapshot["auth_preflight"]["status"] == "passed"
+    assert run.context_snapshot["quota_preflight"]["decision"] == "admitted"

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -205,6 +205,86 @@ def test_cycle_route_rejects_noncanonical_construction(model, thinking):
         )
 
 
+def test_cycle_rejection_union_rejects_contradictory_construction():
+    auth = ProviderAuthPreflightResult(
+        status="auth_blocked",
+        provider="openai",
+        model="openai/gpt-5.5",
+        visible_message="Reconnect OpenAI.",
+    )
+
+    with pytest.raises(TypeError):
+        admission.CycleAdmissionRejected(
+            status="auth_blocked",
+            error="Reconnect OpenAI.",
+            skip_reason="quota_soft_limit",
+            notice_kind="quota",
+            notice=auth,
+        )
+
+
+@pytest.mark.parametrize(
+    "rejection_type",
+    [
+        admission.CycleAdmissionAuthBlocked,
+        admission.CycleAdmissionQuotaBlocked,
+        admission.CycleAdmissionQuotaDeferred,
+    ],
+)
+def test_cycle_rejection_variants_reject_independent_settlement_fields(rejection_type):
+    with pytest.raises(TypeError):
+        rejection_type(notice=object(), status="auth_blocked")
+
+
+@pytest.mark.parametrize(
+    ("rejection_type", "notice"),
+    [
+        (
+            admission.CycleAdmissionAuthBlocked,
+            ProviderAuthPreflightResult(
+                status="passed",
+                provider="openai",
+                model="openai/gpt-5.5",
+            ),
+        ),
+        (
+            admission.CycleAdmissionQuotaBlocked,
+            ProviderQuotaPreflightResult(
+                status="quota_deferred",
+                decision="deferred",
+                provider="openai",
+                model="openai/gpt-5.5",
+                usage_status="ok",
+                thresholds=ProviderQuotaThresholds(
+                    soft_percent=75.0,
+                    hard_percent=90.0,
+                ),
+            ),
+        ),
+        (
+            admission.CycleAdmissionQuotaDeferred,
+            ProviderQuotaPreflightResult(
+                status="quota_blocked",
+                decision="blocked",
+                provider="openai",
+                model="openai/gpt-5.5",
+                usage_status="ok",
+                thresholds=ProviderQuotaThresholds(
+                    soft_percent=75.0,
+                    hard_percent=90.0,
+                ),
+            ),
+        ),
+    ],
+)
+def test_cycle_rejection_variants_reject_mismatched_notices(
+    rejection_type,
+    notice,
+):
+    with pytest.raises(ValueError):
+        rejection_type(notice=notice)
+
+
 @pytest.mark.asyncio
 async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
     auth = ProviderAuthPreflightResult(
@@ -230,11 +310,7 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
         run=run,
     )
 
-    assert isinstance(outcome, admission.CycleAdmissionRejected)
-    assert outcome.status == "auth_blocked"
-    assert outcome.error == "Reconnect OpenAI."
-    assert outcome.skip_reason is None
-    assert outcome.notice_kind == "auth"
+    assert isinstance(outcome, admission.CycleAdmissionAuthBlocked)
     assert outcome.notice is auth
     assert run.context_snapshot["auth_preflight"]["status"] == "auth_blocked"
     assert "quota_preflight" not in run.context_snapshot
@@ -242,23 +318,19 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("status", "decision", "message", "expected_status", "expected_error", "skip_reason"),
+    ("status", "decision", "message", "expected_type"),
     [
         (
             "quota_blocked",
             "blocked",
             "Quota is blocked.",
-            "quota_blocked",
-            "Quota is blocked.",
-            None,
+            admission.CycleAdmissionQuotaBlocked,
         ),
         (
             "quota_deferred",
             "deferred",
             "Quota is deferred.",
-            "skipped",
-            None,
-            "quota_soft_limit",
+            admission.CycleAdmissionQuotaDeferred,
         ),
     ],
 )
@@ -267,9 +339,7 @@ async def test_cycle_admission_returns_complete_quota_rejection(
     status,
     decision,
     message,
-    expected_status,
-    expected_error,
-    skip_reason,
+    expected_type,
 ):
     quota = ProviderQuotaPreflightResult(
         status=status,
@@ -302,10 +372,6 @@ async def test_cycle_admission_returns_complete_quota_rejection(
         run=run,
     )
 
-    assert isinstance(outcome, admission.CycleAdmissionRejected)
-    assert outcome.status == expected_status
-    assert outcome.error == expected_error
-    assert outcome.skip_reason == skip_reason
-    assert outcome.notice_kind == "quota"
+    assert isinstance(outcome, expected_type)
     assert outcome.notice is quota
     assert run.context_snapshot["quota_preflight"]["decision"] == decision

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -5,11 +5,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from brain.platform.integrations.codex_usage import CodexKnownUsage
 from brain.platform.integrations.provider_auth_preflight import (
-    ProviderAuthPreflightResult,
+    ProviderAuthBlockedPreflightResult,
+    ProviderAuthPassedPreflightResult,
 )
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
 )
 from brain.systems.cycles import admission
@@ -24,6 +28,14 @@ def _cycle(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+    )
 
 
 @pytest.mark.asyncio
@@ -119,21 +131,17 @@ async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monke
 
     async def auth_preflight(_session, *, route):
         auth_routes.append(route)
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider=route.provider,
             model=route.model,
         )
 
     def quota_preflight(*, route, run):
         quota_routes.append((route, run))
-        return ProviderQuotaPreflightResult(
-            status="passed",
-            decision="admitted",
+        return ProviderQuotaPassedPreflightResult(
             provider=route.provider,
             model=route.model,
-            usage_status="ok",
-            used_percent=10.0,
+            usage=_usage(10.0),
             thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
             explicit_request=False,
         )
@@ -206,10 +214,11 @@ def test_cycle_route_rejects_noncanonical_construction(model, thinking):
 
 
 def test_cycle_rejection_union_rejects_contradictory_construction():
-    auth = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    auth = ProviderAuthBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.5",
+        credential="OpenAI Codex / ChatGPT",
+        error_code="provider_credential_unavailable",
         visible_message="Reconnect OpenAI.",
     )
 
@@ -236,61 +245,13 @@ def test_cycle_rejection_variants_reject_independent_settlement_fields(rejection
         rejection_type(notice=object(), status="auth_blocked")
 
 
-@pytest.mark.parametrize(
-    ("rejection_type", "notice"),
-    [
-        (
-            admission.CycleAdmissionAuthBlocked,
-            ProviderAuthPreflightResult(
-                status="passed",
-                provider="openai",
-                model="openai/gpt-5.5",
-            ),
-        ),
-        (
-            admission.CycleAdmissionQuotaBlocked,
-            ProviderQuotaPreflightResult(
-                status="quota_deferred",
-                decision="deferred",
-                provider="openai",
-                model="openai/gpt-5.5",
-                usage_status="ok",
-                thresholds=ProviderQuotaThresholds(
-                    soft_percent=75.0,
-                    hard_percent=90.0,
-                ),
-            ),
-        ),
-        (
-            admission.CycleAdmissionQuotaDeferred,
-            ProviderQuotaPreflightResult(
-                status="quota_blocked",
-                decision="blocked",
-                provider="openai",
-                model="openai/gpt-5.5",
-                usage_status="ok",
-                thresholds=ProviderQuotaThresholds(
-                    soft_percent=75.0,
-                    hard_percent=90.0,
-                ),
-            ),
-        ),
-    ],
-)
-def test_cycle_rejection_variants_reject_mismatched_notices(
-    rejection_type,
-    notice,
-):
-    with pytest.raises(ValueError):
-        rejection_type(notice=notice)
-
-
 @pytest.mark.asyncio
 async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
-    auth = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    auth = ProviderAuthBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.5",
+        credential="OpenAI Codex / ChatGPT",
+        error_code="provider_credential_unavailable",
         visible_message="Reconnect OpenAI.",
     )
 
@@ -318,16 +279,16 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("status", "decision", "message", "expected_type"),
+    ("quota_type", "decision", "message", "expected_type"),
     [
         (
-            "quota_blocked",
+            ProviderQuotaBlockedPreflightResult,
             "blocked",
             "Quota is blocked.",
             admission.CycleAdmissionQuotaBlocked,
         ),
         (
-            "quota_deferred",
+            ProviderQuotaDeferredPreflightResult,
             "deferred",
             "Quota is deferred.",
             admission.CycleAdmissionQuotaDeferred,
@@ -336,25 +297,21 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
 )
 async def test_cycle_admission_returns_complete_quota_rejection(
     monkeypatch,
-    status,
+    quota_type,
     decision,
     message,
     expected_type,
 ):
-    quota = ProviderQuotaPreflightResult(
-        status=status,
-        decision=decision,
+    quota = quota_type(
         provider="openai",
         model="openai/gpt-5.5",
-        usage_status="ok",
-        used_percent=90.0,
+        usage=_usage(90.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message=message,
     )
 
     async def auth_preflight(_session, *, route):
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider=route.provider,
             model=route.model,
         )

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -15,12 +15,10 @@ def _route(model: str = "openai/gpt-5.6-sol") -> CycleProviderRoute:
         user_id="user-1",
         org_id="org-1",
         model=model,
-        provider="openai",
-        model_policy={"model": model},
     )
 
 
-async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
+def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     captured = {}
 
     def probe(**kwargs):
@@ -36,8 +34,7 @@ async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
         )
 
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
-    result = await quota_preflight.async_preflight_cycle_external_quota(
-        object(),
+    result = quota_preflight.preflight_cycle_external_quota(
         route=_route(),
         run=SimpleNamespace(
             context_snapshot={"launch_context": {"origin": "scheduled_cycle"}}
@@ -50,7 +47,7 @@ async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     assert "75% soft limit" in result.visible_message
 
 
-async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
+def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     captured = {}
 
     def probe(**kwargs):
@@ -67,8 +64,7 @@ async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
         )
 
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
-    result = await quota_preflight.async_preflight_cycle_external_quota(
-        object(),
+    result = quota_preflight.preflight_cycle_external_quota(
         route=_route(),
         run=SimpleNamespace(
             context_snapshot={"launch_context": {"origin": "manual_cycle"}}
@@ -80,7 +76,7 @@ async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     assert result.visible_message is None
 
 
-async def test_cycle_quota_consumes_resolved_route(monkeypatch):
+def test_cycle_quota_consumes_resolved_route(monkeypatch):
     captured = {}
 
     def probe(**kwargs):
@@ -96,8 +92,7 @@ async def test_cycle_quota_consumes_resolved_route(monkeypatch):
         )
 
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
-    result = await quota_preflight.async_preflight_cycle_external_quota(
-        object(),
+    result = quota_preflight.preflight_cycle_external_quota(
         route=_route(),
         run=SimpleNamespace(context_snapshot={}),
     )

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -6,7 +6,18 @@ from brain.platform.integrations.provider_quota_preflight import (
     ProviderQuotaPreflightResult,
     ProviderQuotaThresholds,
 )
+from brain.systems.cycles.admission import CycleProviderRoute
 from brain.systems.cycles import quota_preflight
+
+
+def _route(model: str = "openai/gpt-5.6-sol") -> CycleProviderRoute:
+    return CycleProviderRoute(
+        user_id="user-1",
+        org_id="org-1",
+        model=model,
+        provider="openai",
+        model_policy={"model": model},
+    )
 
 
 async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
@@ -27,11 +38,7 @@ async def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
     result = await quota_preflight.async_preflight_cycle_external_quota(
         object(),
-        cycle=SimpleNamespace(
-            user_id="user-1",
-            org_id="org-1",
-            model_override="openai/gpt-5.6-sol",
-        ),
+        route=_route(),
         run=SimpleNamespace(
             context_snapshot={"launch_context": {"origin": "scheduled_cycle"}}
         ),
@@ -62,11 +69,7 @@ async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
     result = await quota_preflight.async_preflight_cycle_external_quota(
         object(),
-        cycle=SimpleNamespace(
-            user_id="user-1",
-            org_id="org-1",
-            model_override="openai/gpt-5.6-sol",
-        ),
+        route=_route(),
         run=SimpleNamespace(
             context_snapshot={"launch_context": {"origin": "manual_cycle"}}
         ),
@@ -77,12 +80,8 @@ async def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     assert result.visible_message is None
 
 
-async def test_cycle_quota_resolves_default_model(monkeypatch):
+async def test_cycle_quota_consumes_resolved_route(monkeypatch):
     captured = {}
-
-    async def default_model(_session, **kwargs):
-        captured["default"] = kwargs
-        return "openai/gpt-5.6-sol"
 
     def probe(**kwargs):
         captured["probe"] = kwargs
@@ -96,23 +95,13 @@ async def test_cycle_quota_resolves_default_model(monkeypatch):
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
         )
 
-    monkeypatch.setattr(quota_preflight, "async_get_default_model", default_model)
     monkeypatch.setattr(quota_preflight, "probe_provider_quota", probe)
     result = await quota_preflight.async_preflight_cycle_external_quota(
         object(),
-        cycle=SimpleNamespace(
-            user_id="user-1",
-            org_id="org-1",
-            model_override=None,
-        ),
+        route=_route(),
         run=SimpleNamespace(context_snapshot={}),
     )
 
-    assert captured["default"] == {
-        "include_provider_prefix": True,
-        "user_id": "user-1",
-        "org_id": "org-1",
-    }
     assert captured["probe"]["model"] == "openai/gpt-5.6-sol"
     assert result.status == "unknown"
     assert result.decision == "admitted"

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+)
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
+    ProviderQuotaUnknownPreflightResult,
 )
 from brain.systems.cycles.admission import CycleProviderRoute
 from brain.systems.cycles import quota_preflight
@@ -18,18 +25,23 @@ def _route(model: str = "openai/gpt-5.6-sol") -> CycleProviderRoute:
     )
 
 
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+    )
+
+
 def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     captured = {}
 
     def probe(**kwargs):
         captured.update(kwargs)
-        return ProviderQuotaPreflightResult(
-            status="quota_deferred",
-            decision="deferred",
+        return ProviderQuotaDeferredPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="ok",
-            used_percent=80,
+            usage=_usage(80),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
         )
 
@@ -42,7 +54,7 @@ def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     )
 
     assert captured["explicit_request"] is False
-    assert result.deferred is True
+    assert isinstance(result, ProviderQuotaDeferredPreflightResult)
     assert "80%" in result.visible_message
     assert "75% soft limit" in result.visible_message
 
@@ -52,13 +64,10 @@ def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
 
     def probe(**kwargs):
         captured.update(kwargs)
-        return ProviderQuotaPreflightResult(
-            status="passed",
-            decision="admitted",
+        return ProviderQuotaPassedPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="ok",
-            used_percent=80,
+            usage=_usage(80),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
             explicit_request=kwargs["explicit_request"],
         )
@@ -72,7 +81,7 @@ def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     )
 
     assert captured["explicit_request"] is True
-    assert result.decision == "admitted"
+    assert isinstance(result, ProviderQuotaPassedPreflightResult)
     assert result.visible_message is None
 
 
@@ -81,13 +90,12 @@ def test_cycle_quota_consumes_resolved_route(monkeypatch):
 
     def probe(**kwargs):
         captured["probe"] = kwargs
-        return ProviderQuotaPreflightResult(
-            status="unknown",
-            decision="admitted",
+        return ProviderQuotaUnknownPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="unknown",
-            unknown_reason="sessions_dir_missing",
+            usage=CodexUnknownUsageReading(
+                reason=CodexUsageUnknownReason.SESSIONS_DIR_MISSING,
+            ),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
         )
 
@@ -98,5 +106,4 @@ def test_cycle_quota_consumes_resolved_route(monkeypatch):
     )
 
     assert captured["probe"]["model"] == "openai/gpt-5.6-sol"
-    assert result.status == "unknown"
-    assert result.decision == "admitted"
+    assert isinstance(result, ProviderQuotaUnknownPreflightResult)

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -13,8 +13,10 @@ from sqlalchemy import select
 from brain.app.api.schemas.cycles import CycleCreate, CycleRead, CycleRunRead
 from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.systems.cycles import access as cycle_access
+from brain.systems.cycles import admission as cycle_admission
 from brain.systems.cycles import execution as cycle_execution
 from brain.systems.cycles import prompts as cycle_prompts
+from brain.systems.cycles import quota_preflight as cycle_quota_preflight
 from brain.systems.cycles import service
 from brain.systems.cycles.common import AGENT_TRIGGERED_CYCLE_ORIGIN, MANUAL_CYCLE_ORIGIN
 from brain.systems.cycles.contracts import (
@@ -39,7 +41,6 @@ from brain.platform.integrations.provider_quota_preflight import (
     ProviderQuotaPreflightResult,
     ProviderQuotaThresholds,
 )
-from brain.platform.providers.model_policy import infer_provider_from_model
 
 
 RAW_PROVIDER_ERROR = (
@@ -70,22 +71,21 @@ REFLEX_ANSWER = (
 )
 
 
-async def _passed_cycle_auth(_session, *, cycle):
-    model = str(cycle.model_override or "openai/gpt-5.6-sol")
+async def _passed_cycle_auth(_session, *, route):
     return ProviderAuthPreflightResult(
         status="passed",
-        provider=infer_provider_from_model(model),
-        model=model,
+        provider=route.provider,
+        model=route.model,
     )
 
 
-async def _passed_cycle_quota(_session, *, cycle, run):
-    model = str(cycle.model_override or "openai/gpt-5.6-sol")
+async def _passed_cycle_quota(_session, *, route, run):
+    del run
     return ProviderQuotaPreflightResult(
         status="passed",
         decision="admitted",
-        provider=infer_provider_from_model(model),
-        model=model,
+        provider=route.provider,
+        model=route.model,
         usage_status="ok",
         used_percent=10.0,
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
@@ -655,55 +655,6 @@ def test_cycle_router_bad_request_returns_400():
 
     assert caught.value.status_code == 400
     assert caught.value.detail == "Unknown timezone: Mars/Base"
-
-
-@pytest.mark.parametrize("raw_model", [None, "", "default", "DEFAULT"])
-def test_cycle_run_model_policy_treats_absent_and_default_models_as_org_fallback(
-    raw_model,
-):
-    cycle = Cycle()
-    cycle.model_override = "openai/gpt-5.5"
-    cycle.thinking_override = "high"
-    run = CycleRun()
-    run.context_snapshot = {
-        "revision": {
-            "model_override": raw_model,
-            "thinking_override": None,
-        }
-    }
-
-    assert service._cycle_run_model_policy(cycle, run) == {}
-
-
-def test_cycle_run_model_policy_uses_bound_revision_instead_of_live_cycle():
-    cycle = Cycle()
-    cycle.model_override = "anthropic/claude-opus-5"
-    cycle.thinking_override = "low"
-    run = CycleRun()
-    run.context_snapshot = {
-        "revision": {
-            "model_override": "gpt-5.6-luna",
-            "thinking_override": "xhigh",
-        }
-    }
-
-    assert service._cycle_run_model_policy(cycle, run) == {
-        "model": "openai/gpt-5.6-luna",
-        "thinking": "xhigh",
-    }
-
-
-def test_cycle_run_model_policy_falls_back_to_live_cycle_without_snapshot():
-    cycle = Cycle()
-    cycle.model_override = "openai/gpt-5.6-luna"
-    cycle.thinking_override = "low"
-    run = CycleRun()
-    run.context_snapshot = None
-
-    assert service._cycle_run_model_policy(cycle, run) == {
-        "model": "openai/gpt-5.6-luna",
-        "thinking": "low",
-    }
 
 
 @pytest.fixture
@@ -1829,7 +1780,11 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
             "thinking_override": "high",
         }
     }
-    model_policy = service._cycle_run_model_policy(cycle, cycle_run)
+    route = await cycle_admission.async_resolve_cycle_provider_route(
+        session,
+        cycle=cycle,
+        run=cycle_run,
+    )
     deadline_at = datetime(2026, 7, 30, 19, 0, tzinfo=timezone.utc)
 
     run_id = await service._async_admit_cycle_run(
@@ -1840,7 +1795,7 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
         user_id="user-1",
         metadata={"source": "cycle", "cycle_run_id": 12},
         cycle_run_id=12,
-        model_policy=model_policy,
+        model_policy=route.model_policy,
         deadline_at=deadline_at,
     )
 
@@ -1869,7 +1824,7 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
         user_id="user-1",
         metadata={"source": "cycle", "cycle_run_id": 13},
         cycle_run_id=13,
-        model_policy=model_policy,
+        model_policy=route.model_policy,
     )
 
     _, default_deadline_event = calls[1]
@@ -1954,7 +1909,7 @@ async def test_execute_cycle_run_passes_live_timeout_deadline_and_uuid_idea_id(m
         "UnitOfWork",
         _AsyncUnitOfWorkFactory([session]),
     )
-    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     admissions = []
 
     async def fake_admit(*args, **kwargs):
@@ -2069,7 +2024,7 @@ async def test_async_execute_cycle_run_uses_native_uow_without_sync_bridges(monk
         return 77
 
     monkeypatch.setattr(service, "UnitOfWork", factory)
-    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_async_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
     monkeypatch.setattr(service, "open_unit_of_work", _fail_sync_bridge, raising=False)
@@ -2222,7 +2177,7 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     monkeypatch.setattr("brain.platform.integrations.llm._async_resolve_key_from_db", fake_resolve_key)
     monkeypatch.setattr("brain.platform.integrations.llm.refresh_codex_access_token", fail_refresh)
     monkeypatch.setattr("brain.platform.integrations.llm.OpenAICodexClient", fake_codex_client)
-    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", _passed_cycle_quota)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", _passed_cycle_quota)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2236,7 +2191,54 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     assert run.context_snapshot["auth_preflight"]["status"] == "passed"
     assert run.context_snapshot["quota_preflight"]["decision"] == "admitted"
     assert codex_client_calls[0][0][0] == "fresh-access"
+    assert admissions[0]["model_policy"] == {"model": "openai/gpt-5.6-sol"}
     assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
+
+
+@pytest.mark.asyncio
+async def test_execute_cycle_run_resolves_one_route_shared_with_work_admission(monkeypatch):
+    run, cycle, idea = _cycle_execution_objects(model_override=None)
+    session = _AsyncExecuteCycleSession(
+        run=run,
+        cycle=cycle,
+        idea=idea,
+        expected_run_id=run.id,
+    )
+    default_model_calls = []
+    preflight_routes = []
+    admitted_model_policies = []
+
+    async def default_model(_session, **kwargs):
+        default_model_calls.append(kwargs)
+        return "openai/gpt-5.6-sol"
+
+    async def auth_preflight(_session, *, route):
+        preflight_routes.append(route)
+        return await _passed_cycle_auth(_session, route=route)
+
+    async def quota_preflight(_session, *, route, run):
+        preflight_routes.append(route)
+        return await _passed_cycle_quota(_session, route=route, run=run)
+
+    async def admit(*_args, **kwargs):
+        admitted_model_policies.append(kwargs["model_policy"])
+        return 77
+
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr(cycle_admission, "async_get_default_model", default_model)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", auth_preflight)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(service, "_async_admit_cycle_run", admit)
+    monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
+
+    await service.async_execute_cycle_run(run.id)
+
+    assert len(default_model_calls) == 1
+    assert len(preflight_routes) == 2
+    assert preflight_routes[0] is preflight_routes[1]
+    assert admitted_model_policies == [preflight_routes[0].model_policy]
+    assert admitted_model_policies[0] is preflight_routes[0].model_policy
+    assert run.status == "running"
 
 
 @pytest.mark.asyncio
@@ -2271,28 +2273,16 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
     async def fail_admit(*_args, **_kwargs):
         raise AssertionError("hard-limit run must not be admitted")
 
-    original_scalar = session.scalar
-    admission_since_notice = False
+    notice_calls = []
 
-    async def scalar(statement):
-        nonlocal admission_since_notice
-        if "FROM idea_threads" in str(statement):
-            return next(
-                (
-                    item.metadata_
-                    for item in session.added
-                    if item.__class__.__name__ == "IdeaThread"
-                ),
-                None,
-            )
-        if "FROM cycle_runs" in str(statement):
-            return 99 if admission_since_notice else None
-        return await original_scalar(statement)
+    async def append_quota_notice(active_session, active_idea, active_cycle, active_run, result):
+        notice_calls.append((active_session, active_idea, active_cycle, active_run, result))
+        return {"id": 1}, None
 
-    session.scalar = scalar
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
-    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
-    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(service, "async_append_cycle_quota_notice", append_quota_notice)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2307,36 +2297,7 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
         "soft_percent": 75.0,
         "hard_percent": 90.0,
     }
-    notices = [
-        item for item in session.added if item.__class__.__name__ == "IdeaThread"
-    ]
-    assert len(notices) == 1
-    assert notices[0].metadata_["quota_notice"] is True
-
-    await service._async_append_cycle_quota_notice(
-        session,
-        idea,
-        cycle,
-        run,
-        quota,
-    )
-    assert len(
-        [item for item in session.added if item.__class__.__name__ == "IdeaThread"]
-    ) == 1
-
-    admission_since_notice = True
-    later_run = CycleRun()
-    later_run.id = run.id + 1
-    await service._async_append_cycle_quota_notice(
-        session,
-        idea,
-        cycle,
-        later_run,
-        quota,
-    )
-    assert len(
-        [item for item in session.added if item.__class__.__name__ == "IdeaThread"]
-    ) == 2
+    assert notice_calls == [(session, idea, cycle, run, quota)]
 
 
 @pytest.mark.requires_db
@@ -2421,13 +2382,13 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
         visible_message="Scheduled Cycle quota blocked.",
     )
 
-    first, _ = await service._async_append_cycle_quota_notice(
+    first, _ = await cycle_quota_preflight.async_append_cycle_quota_notice(
         db_session, idea, cycle, runs[0], quota
     )
-    suppressed, _ = await service._async_append_cycle_quota_notice(
+    suppressed, _ = await cycle_quota_preflight.async_append_cycle_quota_notice(
         db_session, idea, cycle, runs[1], quota
     )
-    after_admission, _ = await service._async_append_cycle_quota_notice(
+    after_admission, _ = await cycle_quota_preflight.async_append_cycle_quota_notice(
         db_session, idea, cycle, runs[3], quota
     )
 
@@ -2479,8 +2440,8 @@ async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
         raise AssertionError("soft-limit scheduled run must not be admitted")
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
-    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
-    monkeypatch.setattr(service, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2557,7 +2518,7 @@ async def test_execute_cycle_run_creates_execution_thread_when_target_thread_is_
         return True
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
-    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
+    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     monkeypatch.setattr(cycle_execution, "_async_idea_has_active_run", fake_idea_has_active_run)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_async_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
@@ -4046,33 +4007,6 @@ def test_finalize_cycle_run_from_run_skips_terminal_runs(monkeypatch):
 
     assert cycle_run.status == "completed"
     assert cycle.last_status is None
-
-
-def test_cycle_run_model_policy_ignores_live_cycle_when_snapshot_pins_a_model():
-    """A cleared cycle whose bound revision still pins a model keeps the pin.
-
-    This is why migration 0039 records a pin-free revision: clearing
-    `cycles.model_override` alone does not change what a run resolves, because
-    routing reads the revision snapshot bound to the run.
-    """
-    cycle = Cycle()
-    cycle.model_override = None
-    cycle.thinking_override = "low"
-    run = CycleRun()
-    run.context_snapshot = {
-        "revision": {"model_override": "gpt-5.6-luna", "thinking_override": "low"}
-    }
-
-    assert service._cycle_run_model_policy(cycle, run) == {
-        "model": "openai/gpt-5.6-luna",
-        "thinking": "low",
-    }
-
-    run.context_snapshot = {
-        "revision": {"model_override": None, "thinking_override": "low"}
-    }
-
-    assert service._cycle_run_model_policy(cycle, run) == {"thinking": "low"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -79,7 +79,7 @@ async def _passed_cycle_auth(_session, *, route):
     )
 
 
-async def _passed_cycle_quota(_session, *, route, run):
+def _passed_cycle_quota(*, route, run):
     del run
     return ProviderQuotaPreflightResult(
         status="passed",
@@ -1771,6 +1771,7 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
     session = object()
 
     cycle = Cycle()
+    cycle.user_id = "user-1"
     cycle.model_override = "anthropic/claude-opus-5"
     cycle.thinking_override = "low"
     cycle_run = CycleRun()
@@ -1792,10 +1793,9 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
         idea_id="idea-1",
         message="cycle prompt",
         priority=1,
-        user_id="user-1",
+        route=route,
         metadata={"source": "cycle", "cycle_run_id": 12},
         cycle_run_id=12,
-        model_policy=route.model_policy,
         deadline_at=deadline_at,
     )
 
@@ -1821,10 +1821,9 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
         idea_id="idea-1",
         message="cycle prompt",
         priority=1,
-        user_id="user-1",
+        route=route,
         metadata={"source": "cycle", "cycle_run_id": 13},
         cycle_run_id=13,
-        model_policy=route.model_policy,
     )
 
     _, default_deadline_event = calls[1]
@@ -2177,7 +2176,7 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     monkeypatch.setattr("brain.platform.integrations.llm._async_resolve_key_from_db", fake_resolve_key)
     monkeypatch.setattr("brain.platform.integrations.llm.refresh_codex_access_token", fail_refresh)
     monkeypatch.setattr("brain.platform.integrations.llm.OpenAICodexClient", fake_codex_client)
-    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", _passed_cycle_quota)
+    monkeypatch.setattr(cycle_admission, "preflight_cycle_external_quota", _passed_cycle_quota)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2191,7 +2190,9 @@ async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admissi
     assert run.context_snapshot["auth_preflight"]["status"] == "passed"
     assert run.context_snapshot["quota_preflight"]["decision"] == "admitted"
     assert codex_client_calls[0][0][0] == "fresh-access"
-    assert admissions[0]["model_policy"] == {"model": "openai/gpt-5.6-sol"}
+    assert admissions[0]["route"].work_intake_model_policy == {
+        "model": "openai/gpt-5.6-sol"
+    }
     assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
 
 
@@ -2206,7 +2207,7 @@ async def test_execute_cycle_run_resolves_one_route_shared_with_work_admission(m
     )
     default_model_calls = []
     preflight_routes = []
-    admitted_model_policies = []
+    admitted_routes = []
 
     async def default_model(_session, **kwargs):
         default_model_calls.append(kwargs)
@@ -2216,18 +2217,18 @@ async def test_execute_cycle_run_resolves_one_route_shared_with_work_admission(m
         preflight_routes.append(route)
         return await _passed_cycle_auth(_session, route=route)
 
-    async def quota_preflight(_session, *, route, run):
+    def quota_preflight(*, route, run):
         preflight_routes.append(route)
-        return await _passed_cycle_quota(_session, route=route, run=run)
+        return _passed_cycle_quota(route=route, run=run)
 
     async def admit(*_args, **kwargs):
-        admitted_model_policies.append(kwargs["model_policy"])
+        admitted_routes.append(kwargs["route"])
         return 77
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
     monkeypatch.setattr(cycle_admission, "async_get_default_model", default_model)
     monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", auth_preflight)
-    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(cycle_admission, "preflight_cycle_external_quota", quota_preflight)
     monkeypatch.setattr(service, "_async_admit_cycle_run", admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
@@ -2236,8 +2237,8 @@ async def test_execute_cycle_run_resolves_one_route_shared_with_work_admission(m
     assert len(default_model_calls) == 1
     assert len(preflight_routes) == 2
     assert preflight_routes[0] is preflight_routes[1]
-    assert admitted_model_policies == [preflight_routes[0].model_policy]
-    assert admitted_model_policies[0] is preflight_routes[0].model_policy
+    assert admitted_routes == [preflight_routes[0]]
+    assert admitted_routes[0] is preflight_routes[0]
     assert run.status == "running"
 
 
@@ -2267,7 +2268,7 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
         ),
     )
 
-    async def quota_preflight(*_args, **_kwargs):
+    def quota_preflight(*_args, **_kwargs):
         return quota
 
     async def fail_admit(*_args, **_kwargs):
@@ -2281,7 +2282,7 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
     monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
-    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(cycle_admission, "preflight_cycle_external_quota", quota_preflight)
     monkeypatch.setattr(service, "async_append_cycle_quota_notice", append_quota_notice)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
@@ -2433,7 +2434,7 @@ async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
         visible_message="Scheduled Cycle quota deferred.",
     )
 
-    async def quota_preflight(*_args, **_kwargs):
+    def quota_preflight(*_args, **_kwargs):
         return quota
 
     async def fail_admit(*_args, **_kwargs):
@@ -2441,7 +2442,7 @@ async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
     monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_auth", _passed_cycle_auth)
-    monkeypatch.setattr(cycle_admission, "async_preflight_cycle_external_quota", quota_preflight)
+    monkeypatch.setattr(cycle_admission, "preflight_cycle_external_quota", quota_preflight)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -36,9 +36,14 @@ from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEven
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.db.models.org import Org, User
-from brain.platform.integrations.provider_auth_preflight import ProviderAuthPreflightResult
+from brain.platform.integrations.codex_usage import CodexKnownUsage
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPassedPreflightResult,
+)
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
 )
 
@@ -72,22 +77,27 @@ REFLEX_ANSWER = (
 
 
 async def _passed_cycle_auth(_session, *, route):
-    return ProviderAuthPreflightResult(
-        status="passed",
+    return ProviderAuthPassedPreflightResult(
         provider=route.provider,
         model=route.model,
     )
 
 
+def _quota_usage(used_percent, *, source_path="/tmp/codex/session.jsonl"):
+    return CodexKnownUsage(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path=source_path,
+        plan_type="pro",
+    )
+
+
 def _passed_cycle_quota(*, route, run):
     del run
-    return ProviderQuotaPreflightResult(
-        status="passed",
-        decision="admitted",
+    return ProviderQuotaPassedPreflightResult(
         provider=route.provider,
         model=route.model,
-        usage_status="ok",
-        used_percent=10.0,
+        usage=_quota_usage(10.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         explicit_request=False,
     )
@@ -2251,17 +2261,10 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
         idea=idea,
         expected_run_id=run.id,
     )
-    quota = ProviderQuotaPreflightResult(
-        status="quota_blocked",
-        decision="blocked",
+    quota = ProviderQuotaBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=92.0,
-        observed_at="2026-08-04T13:24:45Z",
-        source_path="/tmp/codex/session.jsonl",
-        limit_id="codex",
-        plan_type="pro",
+        usage=_quota_usage(92.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message=(
             "Cycle quota blocked: Codex usage is 92%, at or above the 90% hard limit."
@@ -2372,13 +2375,10 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
         runs.append(run)
     await db_session.flush()
 
-    quota = ProviderQuotaPreflightResult(
-        status="quota_blocked",
-        decision="blocked",
+    quota = ProviderQuotaBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=92.0,
+        usage=_quota_usage(92.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message="Scheduled Cycle quota blocked.",
     )
@@ -2423,13 +2423,10 @@ async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
         idea=idea,
         expected_run_id=run.id,
     )
-    quota = ProviderQuotaPreflightResult(
-        status="quota_deferred",
-        decision="deferred",
+    quota = ProviderQuotaDeferredPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=80.0,
+        usage=_quota_usage(80.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message="Scheduled Cycle quota deferred.",
     )

--- a/tests/test_provider_auth_preflight.py
+++ b/tests/test_provider_auth_preflight.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
+    ProviderAuthPassedPreflightResult,
+)
+
+
+def test_auth_variants_fix_their_status_and_preserve_serialization():
+    blocked = ProviderAuthBlockedPreflightResult(
+        provider="anthropic",
+        model="anthropic/claude-sonnet-4-6",
+        credential="Anthropic API key",
+        error_code="provider_credential_unavailable",
+    )
+
+    assert blocked.to_dict() == {
+        "status": "auth_blocked",
+        "provider": "anthropic",
+        "model": "anthropic/claude-sonnet-4-6",
+        "credential": "Anthropic API key",
+        "error_code": "provider_credential_unavailable",
+        "repair_action": None,
+        "visible_message": None,
+    }
+    with pytest.raises(TypeError):
+        ProviderAuthPassedPreflightResult(
+            status="auth_blocked",
+            provider="anthropic",
+            model="anthropic/claude-sonnet-4-6",
+        )

--- a/tests/test_provider_quota_preflight.py
+++ b/tests/test_provider_quota_preflight.py
@@ -2,13 +2,25 @@ from __future__ import annotations
 
 import json
 
-from brain.platform.integrations.codex_usage import CodexKnownUsage, CodexUsageReading
+import pytest
+
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+)
 from brain.platform.integrations import provider_quota_preflight
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
+    ProviderQuotaSkippedPreflightResult,
+    ProviderQuotaUnknownPreflightResult,
+)
 
 
-def _usage(used_percent: float) -> CodexUsageReading:
-    return CodexUsageReading(
-        status="exhausted" if used_percent >= 100 else "ok",
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
@@ -30,9 +42,10 @@ def test_below_soft_limit_is_admitted(monkeypatch):
 
     result = _probe()
 
-    assert result.status == "passed"
-    assert result.decision == "admitted"
-    assert result.used_percent == 74.9
+    assert isinstance(result, ProviderQuotaPassedPreflightResult)
+    assert result.to_dict()["status"] == "passed"
+    assert result.to_dict()["decision"] == "admitted"
+    assert result.usage.used_percent == 74.9
     assert result.thresholds.to_dict() == {
         "soft_percent": 75.0,
         "hard_percent": 90.0,
@@ -45,11 +58,12 @@ def test_soft_limit_defers_scheduled_run_but_admits_explicit_run(monkeypatch):
     scheduled = _probe(explicit_request=False)
     explicit = _probe(explicit_request=True)
 
-    assert scheduled.status == "quota_deferred"
-    assert scheduled.decision == "deferred"
-    assert scheduled.deferred is True
-    assert explicit.status == "passed"
-    assert explicit.decision == "admitted"
+    assert isinstance(scheduled, ProviderQuotaDeferredPreflightResult)
+    assert isinstance(explicit, ProviderQuotaPassedPreflightResult)
+    assert scheduled.to_dict()["status"] == "quota_deferred"
+    assert scheduled.to_dict()["decision"] == "deferred"
+    assert explicit.to_dict()["status"] == "passed"
+    assert explicit.to_dict()["decision"] == "admitted"
 
 
 def test_hard_limit_blocks_even_explicit_run(monkeypatch):
@@ -57,10 +71,10 @@ def test_hard_limit_blocks_even_explicit_run(monkeypatch):
 
     result = _probe(explicit_request=True)
 
-    assert result.status == "quota_blocked"
-    assert result.decision == "blocked"
-    assert result.blocked is True
-    assert result.used_percent == 90.0
+    assert isinstance(result, ProviderQuotaBlockedPreflightResult)
+    assert result.to_dict()["status"] == "quota_blocked"
+    assert result.to_dict()["decision"] == "blocked"
+    assert result.usage.used_percent == 90.0
 
 
 def test_real_exhausted_reading_blocks(monkeypatch):
@@ -68,15 +82,15 @@ def test_real_exhausted_reading_blocks(monkeypatch):
 
     result = _probe()
 
-    assert result.usage_status == "exhausted"
-    assert result.decision == "blocked"
-    assert result.used_percent == 100.0
+    assert isinstance(result, ProviderQuotaBlockedPreflightResult)
+    assert result.usage.to_dict()["status"] == "exhausted"
+    assert result.to_dict()["decision"] == "blocked"
+    assert result.usage.used_percent == 100.0
 
 
 def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
-    reading = CodexUsageReading(
-        status="unknown",
-        reason="primary_missing",
+    reading = CodexUnknownUsageReading(
+        reason=CodexUsageUnknownReason.PRIMARY_MISSING,
         observed_at="2026-08-04T13:28:13Z",
         source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
         limit_id="codex",
@@ -91,11 +105,12 @@ def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
 
     result = _probe()
 
-    assert result.status == "unknown"
-    assert result.decision == "admitted"
-    assert result.used_percent is None
-    assert result.unknown_reason == "primary_missing"
-    assert result.last_known_good == {
+    assert isinstance(result, ProviderQuotaUnknownPreflightResult)
+    assert result.to_dict()["status"] == "unknown"
+    assert result.to_dict()["decision"] == "admitted"
+    assert result.usage.reason == "primary_missing"
+    assert result.usage.last_known_good is reading.last_known_good
+    assert result.to_dict()["last_known_good"] == {
         "used_percent": 31,
         "observed_at": "2026-08-04T13:24:45Z",
         "source_path": "/tmp/codex/sessions/2026/08/04/rollout.jsonl",
@@ -111,7 +126,7 @@ def test_thresholds_are_configurable(monkeypatch):
 
     result = _probe()
 
-    assert result.decision == "deferred"
+    assert result.to_dict()["decision"] == "deferred"
     assert result.thresholds.to_dict() == {
         "soft_percent": 60.0,
         "hard_percent": 70.0,
@@ -149,9 +164,11 @@ def test_live_reader_recovers_automatically_after_window_reset(tmp_path, monkeyp
     write_usage(3)
     recovered = _probe()
 
-    assert blocked.decision == "blocked"
-    assert recovered.decision == "admitted"
-    assert recovered.used_percent == 3.0
+    assert isinstance(blocked, ProviderQuotaBlockedPreflightResult)
+    assert isinstance(recovered, ProviderQuotaPassedPreflightResult)
+    assert blocked.to_dict()["decision"] == "blocked"
+    assert recovered.to_dict()["decision"] == "admitted"
+    assert recovered.usage.used_percent == 3.0
 
 
 def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
@@ -167,6 +184,19 @@ def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
         explicit_request=False,
     )
 
-    assert result.status == "skipped"
-    assert result.decision == "admitted"
-    assert result.usage_status is None
+    assert isinstance(result, ProviderQuotaSkippedPreflightResult)
+    assert result.to_dict()["status"] == "skipped"
+    assert result.to_dict()["decision"] == "admitted"
+    assert result.to_dict()["usage_status"] is None
+
+
+def test_quota_variants_do_not_accept_independent_status_or_decision_fields():
+    with pytest.raises(TypeError):
+        ProviderQuotaPassedPreflightResult(
+            status="quota_blocked",
+            decision="blocked",
+            provider="openai",
+            model="openai/gpt-5.6-sol",
+            thresholds=provider_quota_preflight.ProviderQuotaThresholds(75, 90),
+            usage=_usage(10),
+        )


### PR DESCRIPTION
Closes #664

## What was wrong

Cycle admission resolved the same route three times and then nested its own
executors. `auth_preflight.py:53` resolved user, org, model and provider;
`quota_preflight.py:55` resolved all four again; `service.py:205` derived the
model policy a third time from the run revision. The auth `else` branch owned
quota probing, and the quota branch reached back into auth concerns.

## What this changes

- **One resolution, one owner.** New `brain/systems/cycles/admission.py` resolves
  a single `CycleProviderRoute` — identity, canonical model, typed thinking — and
  both preflights plus work admission consume that same object. It reaches
  `_async_admit_cycle_run` intact instead of being torn back into `user_id` and
  `model_policy`.
- **The decision is closed.** Admission returns either an admitted outcome or one
  of three rejection variants — auth-blocked, quota-blocked, quota-deferred —
  each carrying only the fields its own case can have. Contradictory fields raise
  `TypeError`; a variant holding the wrong preflight notice raises `ValueError`.
  `service.py` applies the decision without re-inspecting `auth.blocked` or
  `quota`.
- **The executor is flat.** The nested auth/quota executors become prepare →
  settle → start.
- **The quota adapter is honest.** `preflight_cycle_external_quota` is no longer
  `async` and no longer takes a session it immediately discarded.

**Behavior is unchanged by design.** `auth_blocked`, quota block, quota
defer/skip and the normal `passed → running` path keep their exact persisted
statuses and their Slack/ledger side effects.

## The number that matters

A consolidation that *moves* complexity looks identical to one that deletes it
unless you count. Measured across the four touched production modules
(`if` / conditional-expression / boolean-operator nodes, `origin/main` vs this
branch):

| | before | after |
|---|---|---|
| conditionals across the four modules | 139 | **132** |
| `service.py` lines | 1145 | **1102** |

The reviewer's own narrower metric tells the same story with different absolute
numbers: 77 at baseline, **85 after the first attempt** — complexity moved, not
deleted — and **75** after the fixes. That first 85 is why this PR has three
commits instead of one.

## How to judge it without reading the diff

```
python3 -m brain.jobs.check_cycle_context_admission
python3 -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
python3 -m pytest tests/ -m requires_db -q
```

On the host: admission `ok: true` (cycles 2, 8, 9), **4760 passed, 11 skipped, 83
deselected in 73.5s**, and **79 passed** on the DB lane. No migration.

After deploy, watch one scheduled cycle of each shape:

1. A cycle with an expired OpenAI credential still settles `auth_blocked`, posts
   the same reconnect message, and never admits the agent.
2. A cycle over its hard quota still blocks and records exactly one notice.
3. A scheduled cycle at soft quota still defers, with the same skip reason.
4. A healthy cycle still goes `passed → running`, and the model it runs is the
   one its bound revision pins — not the live cycle's current override.

## Review trail

Two Codex maintainability passes, both folded:

- **Pass 1 — 2 blocking.** `CycleProviderRoute` did not enforce its invariant
  (`model`, `provider` and `model_policy["model"]` could disagree; `frozen=True`
  did not freeze the nested dict), and the outcome was not a closed decision —
  "auth passed + quota None" read as admitted while the service re-derived the
  same state. Both fixed.
- **Pass 2 — 1 blocking.** The rejection type still allowed
  `status="auth_blocked"` to carry a quota skip reason and a quota notice. Fixed
  by splitting it into the three variants above, with tests that assert the
  illegal construction now raises.

Pass 2 also independently checked the test churn: `tests/test_cycles_service.py`
lost ~90 net lines and one test was deleted, but every invariant it held —
default resolution, bound-revision precedence, model normalization, live-cycle
fallback, retained thinking — is re-covered in `tests/test_cycle_admission.py`.
I verified that one myself before accepting the diff.
