### PR TITLE
feat(knowledge): index skills so search_knowledge can find them (#674)

### DIFF
--- a/brain/jobs/pipelines/knowledge_index_sync.py
+++ b/brain/jobs/pipelines/knowledge_index_sync.py
@@ -13,6 +13,7 @@ from brain.systems.knowledge.connectors import (
     DomainRecordsConnector,
     GitHubConnector,
     MemoryConnector,
+    SkillsConnector,
     SlackKnowledgeConnector,
 )
 from brain.systems.knowledge.connectors.base import KnowledgeConnector
@@ -25,6 +26,7 @@ CONNECTOR_FACTORIES: tuple[Callable[[], KnowledgeConnector], ...] = (
     GitHubConnector,
     SlackKnowledgeConnector,
     MemoryConnector,
+    SkillsConnector,
 )
 
 

--- a/brain/systems/knowledge/connectors/__init__.py
+++ b/brain/systems/knowledge/connectors/__init__.py
@@ -3,11 +3,13 @@
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector
 from brain.systems.knowledge.connectors.memory import MemoryConnector
+from brain.systems.knowledge.connectors.skills import SkillsConnector
 from brain.systems.knowledge.connectors.slack import SlackKnowledgeConnector
 
 __all__ = [
     "DomainRecordsConnector",
     "GitHubConnector",
     "MemoryConnector",
+    "SkillsConnector",
     "SlackKnowledgeConnector",
 ]

--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import Any, Mapping, Protocol
 
+from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.systems.knowledge.scope import (
+    KNOWLEDGE_SCOPE_EXTRA_KEY,
+    KnowledgeScope,
+)
 
 
 @dataclass(frozen=True)
@@ -21,6 +27,7 @@ class KnowledgeDraft:
     source: str
     kind: str
     source_ref: str
+    scope: KnowledgeScope
     title: str
     summary: str
     resolution: str | None = None
@@ -31,6 +38,56 @@ class KnowledgeDraft:
     source_updated_at: datetime | None = None
     archived_at: datetime | None = None
     distill: bool = False
+
+
+def _cursor_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class UpdatedAtCursor:
+    """Stable ``(updated_at, id)`` cursor shared by structural connectors."""
+
+    updated_at: datetime | None
+    row_id: int
+
+    @classmethod
+    def from_mapping(cls, cursor: Mapping[str, Any]) -> UpdatedAtCursor:
+        return cls(
+            updated_at=_cursor_datetime(cursor.get("updated_at")),
+            row_id=max(0, int(cursor.get("id") or 0)),
+        )
+
+    def changed_after(self, updated_at_column: Any, id_column: Any) -> Any | None:
+        if self.updated_at is None:
+            return None
+        return or_(
+            updated_at_column > self.updated_at,
+            and_(
+                updated_at_column == self.updated_at,
+                id_column > self.row_id,
+            ),
+        )
+
+    def advanced_to(self, updated_at: datetime, row_id: int) -> dict[str, Any]:
+        return {
+            "updated_at": _utc_iso(updated_at),
+            "id": row_id,
+        }
 
 
 class EnumerationFailureKind(StrEnum):
@@ -75,7 +132,10 @@ class KnowledgeConnector(Protocol):
 __all__ = [
     "EnumerationFailure",
     "EnumerationFailureKind",
+    "KNOWLEDGE_SCOPE_EXTRA_KEY",
     "KnowledgeConnector",
     "KnowledgeDraft",
     "KnowledgeEnumeration",
+    "KnowledgeScope",
+    "UpdatedAtCursor",
 ]

--- a/brain/systems/knowledge/connectors/domain_records.py
+++ b/brain/systems/knowledge/connectors/domain_records.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
 from typing import Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
@@ -14,27 +13,10 @@ from brain.platform.db.models.domain import Domain, DomainObjectType, DomainReco
 from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
+    UpdatedAtCursor,
 )
 from brain.systems.user_domains.service import AsyncDomainService
-
-
-def _cursor_datetime(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except (TypeError, ValueError):
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc_iso(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat()
-
 
 class DomainRecordsConnector:
     source_key = "domain_records"
@@ -47,8 +29,7 @@ class DomainRecordsConnector:
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> KnowledgeEnumeration:
-        marker = _cursor_datetime(cursor.get("updated_at"))
-        marker_id = max(0, int(cursor.get("id") or 0))
+        watermark = UpdatedAtCursor.from_mapping(cursor)
         stmt = (
             select(DomainRecord, Domain, DomainObjectType)
             .join(Domain, Domain.id == DomainRecord.domain_id)
@@ -56,16 +37,12 @@ class DomainRecordsConnector:
             .order_by(DomainRecord.updated_at.asc(), DomainRecord.id.asc())
             .limit(self.max_items)
         )
-        if marker is not None:
-            stmt = stmt.where(
-                or_(
-                    DomainRecord.updated_at > marker,
-                    and_(
-                        DomainRecord.updated_at == marker,
-                        DomainRecord.id > marker_id,
-                    ),
-                )
-            )
+        changed_after = watermark.changed_after(
+            DomainRecord.updated_at,
+            DomainRecord.id,
+        )
+        if changed_after is not None:
+            stmt = stmt.where(changed_after)
 
         service = AsyncDomainService(session)
         drafts: list[KnowledgeDraft] = []
@@ -91,6 +68,7 @@ class DomainRecordsConnector:
                     source=self.source_key,
                     kind="doc_page" if object_type.key == "doc_page" else "record",
                     source_ref=f"domain_record:{record.id}",
+                    scope=KnowledgeScope.ORGANIZATION,
                     title=record.title,
                     summary=summary,
                     entities=[domain.slug, object_type.key],
@@ -114,10 +92,7 @@ class DomainRecordsConnector:
         last_record = rows[-1][0]
         return KnowledgeEnumeration(
             drafts=drafts,
-            cursor={
-                "updated_at": _utc_iso(last_record.updated_at),
-                "id": last_record.id,
-            },
+            cursor=watermark.advanced_to(last_record.updated_at, last_record.id),
         )
 
 

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -36,6 +36,7 @@ from brain.systems.knowledge.connectors.base import (
     EnumerationFailureKind,
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
 )
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS
 from brain.systems.vault import async_resolve_org_project_bound_env_tokens
@@ -344,6 +345,7 @@ def _draft_for_issue(
         source="github",
         kind=kind,
         source_ref=f"github:{repo}#{number}",
+        scope=KnowledgeScope.ORGANIZATION,
         title=str(issue.get("title") or f"{repo}#{number}"),
         summary=summary,
         resolution=resolution,

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -9,10 +9,9 @@ index has an ACL-aware read path.  The mirror is derived and additive: it reads
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
@@ -21,29 +20,12 @@ from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, Memor
 from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
+    UpdatedAtCursor,
 )
 
 _SHARED_VISIBILITIES = ("org", "team")
 _KNOWLEDGE_NODE_KINDS = ("content",)
-
-
-def _cursor_datetime(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except (TypeError, ValueError):
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc_iso(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat()
-
 
 def _draft_for_memory(
     node: MemoryNode,
@@ -59,6 +41,7 @@ def _draft_for_memory(
         source="memory",
         kind="memory",
         source_ref=f"memory_node:{node.id}",
+        scope=KnowledgeScope.ORGANIZATION,
         title=str(node.canonical_label).strip(),
         summary=content,
         entities=list(dict.fromkeys((memory_kind, scope))),
@@ -92,6 +75,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
         source="memory",
         kind="memory",
         source_ref=f"memory_node:{node.id}",
+        scope=KnowledgeScope.ORGANIZATION,
         title="Memory no longer shared",
         summary="This memory is no longer shared with the workspace.",
         raw_text="",
@@ -122,24 +106,16 @@ class MemoryConnector:
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> KnowledgeEnumeration:
-        marker = _cursor_datetime(cursor.get("updated_at"))
-        marker_id = max(0, int(cursor.get("id") or 0))
+        watermark = UpdatedAtCursor.from_mapping(cursor)
         statement = (
             select(MemoryNode)
             .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
             .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
             .limit(self.max_items)
         )
-        if marker is not None:
-            statement = statement.where(
-                or_(
-                    MemoryNode.updated_at > marker,
-                    and_(
-                        MemoryNode.updated_at == marker,
-                        MemoryNode.id > marker_id,
-                    ),
-                )
-            )
+        changed_after = watermark.changed_after(MemoryNode.updated_at, MemoryNode.id)
+        if changed_after is not None:
+            statement = statement.where(changed_after)
 
         rows = list((await session.scalars(statement)).all())
         if not rows:
@@ -183,10 +159,7 @@ class MemoryConnector:
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,
-            cursor={
-                "updated_at": _utc_iso(last.updated_at),
-                "id": last.id,
-            },
+            cursor=watermark.advanced_to(last.updated_at, last.id),
         )
 
 

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -9,6 +9,7 @@ index has an ACL-aware read path.  The mirror is derived and additive: it reads
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sqlalchemy import select
@@ -26,6 +27,20 @@ from brain.systems.knowledge.connectors.base import (
 
 _SHARED_VISIBILITIES = ("org", "team")
 _KNOWLEDGE_NODE_KINDS = ("content",)
+logger = logging.getLogger(__name__)
+
+
+def _candidate_node_query():
+    return select(MemoryNode).where(
+        MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS)
+    )
+
+
+def _required_org_id(node: MemoryNode) -> str:
+    if node.org_id is None:
+        raise ValueError(f"Memory node {node.id} has no organization")
+    return str(node.org_id)
+
 
 def _draft_for_memory(
     node: MemoryNode,
@@ -52,7 +67,7 @@ def _draft_for_memory(
             "freshness_status": node.freshness_status,
             "memory_type": memory_kind,
             "node_kind": node.node_kind,
-            "org_id": str(node.org_id) if node.org_id is not None else None,
+            "org_id": _required_org_id(node),
             "scope": scope,
             "sensitivity": node.sensitivity,
             "source_backed": True,
@@ -68,7 +83,7 @@ def _draft_for_memory(
     )
 
 
-def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
+def _withdrawn_draft(node: MemoryNode, *, org_id: str) -> KnowledgeDraft:
     """Scrub a formerly shared mirror after its source becomes private."""
 
     return KnowledgeDraft(
@@ -83,7 +98,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
             "archived": True,
             "mirror_status": "visibility_withdrawn",
             "node_kind": node.node_kind,
-            "org_id": str(node.org_id) if node.org_id is not None else None,
+            "org_id": org_id,
             "truth_status": node.truth_status,
             "visibility": node.visibility,
         },
@@ -101,6 +116,88 @@ class MemoryConnector:
     def __init__(self, *, max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE):
         self.max_items = max(1, int(max_items))
 
+    async def draft_for_node(
+        self,
+        session: AsyncSession,
+        *,
+        node_id: int,
+    ) -> KnowledgeDraft | None:
+        """Build one immediate-index draft with the sweep's eligibility rules."""
+
+        node = await session.scalar(
+            _candidate_node_query().where(MemoryNode.id == node_id)
+        )
+        if node is None:
+            return None
+        drafts = await self._drafts_for_rows(session, [node])
+        return drafts[0] if drafts else None
+
+    async def _drafts_for_rows(
+        self,
+        session: AsyncSession,
+        rows: list[MemoryNode],
+    ) -> list[KnowledgeDraft]:
+        if not rows:
+            return []
+        source_refs = [f"memory_node:{node.id}" for node in rows]
+        existing_org_ids = {
+            source_ref: extra["org_id"]
+            for source_ref, extra in (
+                await session.execute(
+                    select(KnowledgeItem.source_ref, KnowledgeItem.extra).where(
+                        KnowledgeItem.source == self.source_key,
+                        KnowledgeItem.source_ref.in_(source_refs),
+                    )
+                )
+            ).all()
+        }
+        candidate_rows = [
+            node
+            for node in rows
+            if node.visibility in _SHARED_VISIBILITIES
+            or f"memory_node:{node.id}" in existing_org_ids
+        ]
+        draft_rows: list[MemoryNode] = []
+        active_rows: list[MemoryNode] = []
+        for node in candidate_rows:
+            if node.visibility in _SHARED_VISIBILITIES:
+                if node.org_id is None:
+                    logger.warning(
+                        "Memory knowledge enumeration skipped node %s: org_id is missing",
+                        node.id,
+                    )
+                    continue
+                active_rows.append(node)
+            draft_rows.append(node)
+        supersession_rows = (
+            await session.execute(
+                select(
+                    MemoryEdgeNode.source_node_id,
+                    MemoryEdgeNode.target_node_id,
+                )
+                .where(
+                    MemoryEdgeNode.source_node_id.in_(
+                        [node.id for node in active_rows]
+                    )
+                )
+                .where(MemoryEdgeNode.edge_kind == "superseded_by")
+                .order_by(MemoryEdgeNode.id.asc())
+            )
+        ).all()
+        superseded_by = {
+            source_node_id: target_node_id
+            for source_node_id, target_node_id in supersession_rows
+        }
+        return [
+            _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
+            if node.visibility in _SHARED_VISIBILITIES
+            else _withdrawn_draft(
+                node,
+                org_id=existing_org_ids[f"memory_node:{node.id}"],
+            )
+            for node in draft_rows
+        ]
+
     async def enumerate_changed(
         self,
         session: AsyncSession,
@@ -108,8 +205,7 @@ class MemoryConnector:
     ) -> KnowledgeEnumeration:
         watermark = UpdatedAtCursor.from_mapping(cursor)
         statement = (
-            select(MemoryNode)
-            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
+            _candidate_node_query()
             .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
             .limit(self.max_items)
         )
@@ -120,42 +216,7 @@ class MemoryConnector:
         rows = list((await session.scalars(statement)).all())
         if not rows:
             return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
-        source_refs = [f"memory_node:{node.id}" for node in rows]
-        existing_refs = set(
-            (
-                await session.scalars(
-                    select(KnowledgeItem.source_ref).where(
-                        KnowledgeItem.source == self.source_key,
-                        KnowledgeItem.source_ref.in_(source_refs),
-                    )
-                )
-            ).all()
-        )
-        supersession_rows = (
-            await session.execute(
-                select(
-                    MemoryEdgeNode.source_node_id,
-                    MemoryEdgeNode.target_node_id,
-                )
-                .where(
-                    MemoryEdgeNode.source_node_id.in_([node.id for node in rows])
-                )
-                .where(MemoryEdgeNode.edge_kind == "superseded_by")
-                .order_by(MemoryEdgeNode.id.asc())
-            )
-        ).all()
-        superseded_by = {
-            source_node_id: target_node_id
-            for source_node_id, target_node_id in supersession_rows
-        }
-        drafts = [
-            _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
-            if node.visibility in _SHARED_VISIBILITIES
-            else _withdrawn_draft(node)
-            for node in rows
-            if node.visibility in _SHARED_VISIBILITIES
-            or f"memory_node:{node.id}" in existing_refs
-        ]
+        drafts = await self._drafts_for_rows(session, rows)
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,

--- a/brain/systems/knowledge/connectors/skills.py
+++ b/brain/systems/knowledge/connectors/skills.py
@@ -1,0 +1,145 @@
+"""Incremental mirror of procedural skills into Illo Knowledge."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
+from brain.platform.db.models.skill import Skill
+from brain.systems.knowledge.connectors.base import (
+    KnowledgeDraft,
+    KnowledgeEnumeration,
+)
+
+
+def _cursor_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _section(label: str, value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        content = value.strip()
+    elif isinstance(value, (list, dict)):
+        if not value:
+            return ""
+        content = json.dumps(
+            value,
+            default=str,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    else:
+        content = str(value).strip()
+    return f"{label}:\n{content}" if content else ""
+
+
+def _skill_raw_text(skill: Skill) -> str:
+    sections = (
+        _section("Description", skill.description),
+        _section("Procedure", skill.procedure),
+        _section("Trigger patterns", skill.triggers),
+        _section("Guardrails", skill.guardrails),
+        _section("Pitfalls", skill.pitfalls),
+    )
+    return "\n\n".join(section for section in sections if section)
+
+
+def _draft_for_skill(skill: Skill) -> KnowledgeDraft:
+    raw_text = _skill_raw_text(skill)
+    archived = bool(skill.archived)
+    return KnowledgeDraft(
+        source="skills",
+        kind="skill",
+        source_ref=f"skill:{skill.id}",
+        title=str(skill.name).strip(),
+        summary=raw_text,
+        entities=list(
+            dict.fromkeys(
+                (
+                    str(skill.skill_type or "skill").strip(),
+                    str(skill.maturity or "emerging").strip(),
+                )
+            )
+        ),
+        raw_text=raw_text,
+        extra={
+            "archived": archived,
+            "maturity": skill.maturity,
+            "skill_type": skill.skill_type,
+            "skill_view": {
+                "tool": "skill_view",
+                "arguments": {"name": skill.name},
+            },
+            "success_count": int(skill.success_count or 0),
+            "use_count": int(skill.use_count or 0),
+            "version": int(skill.version or 1),
+        },
+        source_created_at=skill.created_at,
+        source_updated_at=skill.updated_at,
+        archived_at=skill.updated_at if archived else None,
+    )
+
+
+class SkillsConnector:
+    """Enumerate skills by a stable update watermark."""
+
+    source_key = "skills"
+
+    def __init__(self, *, max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE):
+        self.max_items = max(1, int(max_items))
+
+    async def enumerate_changed(
+        self,
+        session: AsyncSession,
+        cursor: dict[str, Any],
+    ) -> KnowledgeEnumeration:
+        marker = _cursor_datetime(cursor.get("updated_at"))
+        marker_id = max(0, int(cursor.get("id") or 0))
+        statement = (
+            select(Skill)
+            .order_by(Skill.updated_at.asc(), Skill.id.asc())
+            .limit(self.max_items)
+        )
+        if marker is not None:
+            statement = statement.where(
+                or_(
+                    Skill.updated_at > marker,
+                    and_(Skill.updated_at == marker, Skill.id > marker_id),
+                )
+            )
+
+        rows = list((await session.scalars(statement)).all())
+        if not rows:
+            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
+        last = rows[-1]
+        return KnowledgeEnumeration(
+            drafts=[_draft_for_skill(skill) for skill in rows],
+            cursor={
+                "updated_at": _utc_iso(last.updated_at),
+                "id": last.id,
+            },
+        )
+
+
+__all__ = ["SkillsConnector"]

--- a/brain/systems/knowledge/connectors/skills.py
+++ b/brain/systems/knowledge/connectors/skills.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
 from typing import Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
@@ -14,25 +13,9 @@ from brain.platform.db.models.skill import Skill
 from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
+    UpdatedAtCursor,
 )
-
-
-def _cursor_datetime(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except (TypeError, ValueError):
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc_iso(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat()
 
 
 def _section(label: str, value: Any) -> str:
@@ -72,6 +55,7 @@ def _draft_for_skill(skill: Skill) -> KnowledgeDraft:
         source="skills",
         kind="skill",
         source_ref=f"skill:{skill.id}",
+        scope=KnowledgeScope.GLOBAL,
         title=str(skill.name).strip(),
         summary=raw_text,
         entities=list(
@@ -114,20 +98,15 @@ class SkillsConnector:
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> KnowledgeEnumeration:
-        marker = _cursor_datetime(cursor.get("updated_at"))
-        marker_id = max(0, int(cursor.get("id") or 0))
+        watermark = UpdatedAtCursor.from_mapping(cursor)
         statement = (
             select(Skill)
             .order_by(Skill.updated_at.asc(), Skill.id.asc())
             .limit(self.max_items)
         )
-        if marker is not None:
-            statement = statement.where(
-                or_(
-                    Skill.updated_at > marker,
-                    and_(Skill.updated_at == marker, Skill.id > marker_id),
-                )
-            )
+        changed_after = watermark.changed_after(Skill.updated_at, Skill.id)
+        if changed_after is not None:
+            statement = statement.where(changed_after)
 
         rows = list((await session.scalars(statement)).all())
         if not rows:
@@ -135,10 +114,7 @@ class SkillsConnector:
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=[_draft_for_skill(skill) for skill in rows],
-            cursor={
-                "updated_at": _utc_iso(last.updated_at),
-                "id": last.id,
-            },
+            cursor=watermark.advanced_to(last.updated_at, last.id),
         )
 
 

--- a/brain/systems/knowledge/connectors/slack.py
+++ b/brain/systems/knowledge/connectors/slack.py
@@ -18,6 +18,7 @@ from brain.platform.db.models.inbound import InboundEventRow
 from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
 )
 from brain.systems.slack.client import SlackApiError
 from brain.systems.slack.monitored_intakes import visible_slack_content
@@ -502,6 +503,7 @@ class SlackKnowledgeConnector:
             source=self.source_key,
             kind="slack_thread",
             source_ref=f"slack:{team_id}:{channel.id}:{thread_ts}",
+            scope=KnowledgeScope.ORGANIZATION,
             title=f"Slack {channel_label}: {title_lede}",
             summary=summary,
             entities=[channel.id, *([channel.name] if channel.name else []), *participants],
@@ -539,6 +541,7 @@ class SlackKnowledgeConnector:
             source=self.source_key,
             kind="slack_thread",
             source_ref=f"slack:{team_id}:{channel.id}:{thread_ts}",
+            scope=KnowledgeScope.ORGANIZATION,
             title=f"Slack {channel_label}: deleted thread {thread_ts}",
             summary=(
                 f"Slack thread {thread_ts} in {channel_label} was deleted at "

--- a/brain/systems/knowledge/distillation.py
+++ b/brain/systems/knowledge/distillation.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
 from brain.platform.db.models.org import User
 from brain.platform.providers.model_policy import async_get_bulk_route
-from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.connectors.base import KnowledgeDraft, KnowledgeScope
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 
 
@@ -139,6 +139,7 @@ def serialize_draft(draft: KnowledgeDraft) -> dict[str, Any]:
         "source": draft.source,
         "kind": draft.kind,
         "source_ref": draft.source_ref,
+        "scope": draft.scope.value,
         "title": draft.title,
         "summary": draft.summary,
         "resolution": draft.resolution,
@@ -163,6 +164,9 @@ def deserialize_draft(value: Mapping[str, Any]) -> KnowledgeDraft:
         source=str(value["source"]),
         kind=str(value["kind"]),
         source_ref=str(value["source_ref"]),
+        scope=KnowledgeScope(
+            str(value.get("scope") or KnowledgeScope.ORGANIZATION)
+        ),
         title=str(value["title"]),
         summary=str(value["summary"]),
         resolution=(str(value["resolution"]) if value.get("resolution") is not None else None),

--- a/brain/systems/knowledge/scope.py
+++ b/brain/systems/knowledge/scope.py
@@ -1,0 +1,16 @@
+"""Shared retrieval scope contract for indexed knowledge items."""
+
+from enum import StrEnum
+
+
+KNOWLEDGE_SCOPE_EXTRA_KEY = "knowledge_scope"
+
+
+class KnowledgeScope(StrEnum):
+    """Who may retrieve an indexed knowledge item."""
+
+    ORGANIZATION = "organization"
+    GLOBAL = "global"
+
+
+__all__ = ["KNOWLEDGE_SCOPE_EXTRA_KEY", "KnowledgeScope"]

--- a/brain/systems/knowledge/search.py
+++ b/brain/systems/knowledge/search.py
@@ -14,6 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
 from brain.platform.db.models.knowledge import KnowledgeItem, KnowledgeItemEmbedding
+from brain.systems.knowledge.scope import (
+    KNOWLEDGE_SCOPE_EXTRA_KEY,
+    KnowledgeScope,
+)
 from brain.systems.knowledge.search_contract import (
     KNOWLEDGE_SEARCH_DEFAULT_RESULTS,
     KnowledgeSearchResponse,
@@ -151,7 +155,8 @@ def knowledge_item_filters(
         KnowledgeItem.archived_at.is_(None),
         or_(
             KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
-            KnowledgeItem.source == "skills",
+            KnowledgeItem.extra[KNOWLEDGE_SCOPE_EXTRA_KEY].as_string()
+            == KnowledgeScope.GLOBAL.value,
         ),
     ]
     clean_sources = [str(value).strip() for value in sources or [] if str(value).strip()]

--- a/brain/systems/knowledge/search.py
+++ b/brain/systems/knowledge/search.py
@@ -9,7 +9,7 @@ import re
 from typing import Any
 
 import numpy as np
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
@@ -149,7 +149,10 @@ def knowledge_item_filters(
         raise ValueError("org_id is required for knowledge search")
     filters: list[Any] = [
         KnowledgeItem.archived_at.is_(None),
-        KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
+        or_(
+            KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
+            KnowledgeItem.source == "skills",
+        ),
     ]
     clean_sources = [str(value).strip() for value in sources or [] if str(value).strip()]
     clean_kinds = [str(value).strip() for value in kinds or [] if str(value).strip()]

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -23,6 +23,7 @@ from brain.platform.db.models.knowledge import (
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
     EnumerationFailureKind,
+    KNOWLEDGE_SCOPE_EXTRA_KEY,
     KnowledgeConnector,
     KnowledgeDraft,
 )
@@ -465,6 +466,7 @@ async def _upsert_item(
     if draft.source_ref.strip() == "":
         raise ValueError("Knowledge drafts require a stable source_ref")
     raw_text, extra, truncated = _bounded_raw_text(draft)
+    extra[KNOWLEDGE_SCOPE_EXTRA_KEY] = draft.scope.value
     digest = content_digest(draft, raw_text=raw_text, extra=extra)
     item = await session.scalar(
         select(KnowledgeItem).where(

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -27,6 +27,7 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeConnector,
     KnowledgeDraft,
 )
+from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.distillation import (
     DISTILLATION_CURSOR_KEY,
     DISTILLATION_MANIFEST_VERSION,
@@ -704,6 +705,34 @@ async def _ingest_drafts(
             )
 
 
+async def index_memory_node(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> KnowledgeSyncStats:
+    """Upsert one committed memory node without advancing the sweep cursor."""
+
+    stats = KnowledgeSyncStats()
+    connector = MemoryConnector(max_items=1)
+    draft = await connector.draft_for_node(
+        session,
+        node_id=node_id,
+    )
+    if draft is None:
+        stats.skipped = 1
+        return stats
+
+    bounded_draft, _ = _bounded_draft(draft)
+    await _ingest_drafts(
+        session,
+        source=connector.source_key,
+        drafts=[(bounded_draft, True)],
+        stats=stats,
+        run_at=datetime.now(timezone.utc),
+    )
+    return stats
+
+
 async def sync_connector(
     session: AsyncSession,
     connector: KnowledgeConnector,
@@ -887,5 +916,6 @@ __all__ = [
     "build_embedding_text",
     "build_search_text",
     "content_digest",
+    "index_memory_node",
     "sync_connector",
 ]

--- a/brain/systems/reconstructive_memory/ingestion.py
+++ b/brain/systems/reconstructive_memory/ingestion.py
@@ -7,6 +7,7 @@ nodes, and graph edges in one transaction.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.db.repositories.reconstructive_memory import (
     AssertionDraft,
     EdgeDraft,
@@ -26,6 +28,10 @@ from brain.platform.db.repositories.reconstructive_memory import (
 )
 
 logger = logging.getLogger(__name__)
+
+_INFO_QUEUE_KEY = "illo_memory_knowledge_index_queue"
+_INFO_ARMED_KEY = "illo_memory_knowledge_index_listeners_armed"
+_POST_COMMIT_TASKS: set[asyncio.Task] = set()
 
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
 _STOP_WORDS = {
@@ -90,6 +96,115 @@ class IngestedMemorySource:
             "tag_node_ids": list(self.tag_node_ids),
             "edge_ids": list(self.edge_ids),
         }
+
+
+async def _index_committed_memory_node(node_id: int) -> None:
+    """Best-effort mirror write after the memory transaction is durable."""
+
+    from brain.systems.knowledge.service import index_memory_node
+
+    try:
+        async with UnitOfWork() as uow:
+            stats = await index_memory_node(uow.session, node_id=node_id)
+            if stats.failed:
+                logger.warning(
+                    "Immediate knowledge indexing degraded for committed memory node %s",
+                    node_id,
+                )
+    except Exception:
+        # Knowledge is a disposable mirror. A failed index write must never
+        # change the successful outcome of the committed memory ingest.
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_id,
+        )
+
+
+async def _index_committed_memory_nodes(node_ids: list[int]) -> None:
+    for node_id in node_ids:
+        await _index_committed_memory_node(node_id)
+
+
+def _reap_knowledge_index_task(task: asyncio.Task) -> None:
+    _POST_COMMIT_TASKS.discard(task)
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+def _spawn_knowledge_index_task(node_ids: list[int]) -> None:
+    try:
+        task = asyncio.ensure_future(_index_committed_memory_nodes(node_ids))
+        _POST_COMMIT_TASKS.add(task)
+        task.add_done_callback(_reap_knowledge_index_task)
+    except Exception:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_ids,
+        )
+
+
+def _schedule_post_commit_knowledge_index(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> bool:
+    """Queue immediate indexing for the session's next outer commit."""
+
+    try:
+        sync_session = getattr(session, "sync_session", None)
+        if sync_session is None:
+            return False
+        loop = asyncio.get_running_loop()
+        queue: list[int] = sync_session.info.setdefault(_INFO_QUEUE_KEY, [])
+        queue.append(int(node_id))
+        if sync_session.info.get(_INFO_ARMED_KEY):
+            return True
+
+        def _drain_into_task(target_session: Any) -> None:
+            # SQLAlchemy fires after_commit for a savepoint release too. The
+            # nested transaction is still available during that callback, so
+            # keep the queue until the outer transaction commits.
+            previous = target_session.get_nested_transaction()
+            if getattr(previous, "nested", False):
+                return
+            drained = list(dict.fromkeys(target_session.info.get(_INFO_QUEUE_KEY) or []))
+            target_session.info[_INFO_QUEUE_KEY] = []
+            if not drained:
+                return
+            try:
+                loop.call_soon_threadsafe(_spawn_knowledge_index_task, drained)
+            except Exception:
+                logger.exception(
+                    "Immediate knowledge indexing failed for committed memory node %s",
+                    drained,
+                )
+
+        def _on_rollback(target_session: Any, previous: Any) -> None:
+            if getattr(previous, "nested", False):
+                return
+            target_session.info[_INFO_QUEUE_KEY] = []
+
+        from sqlalchemy import event
+
+        event.listen(sync_session, "after_commit", _drain_into_task)
+        event.listen(sync_session, "after_soft_rollback", _on_rollback)
+        sync_session.info[_INFO_ARMED_KEY] = True
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Immediate knowledge indexing not armed for memory node %s (%s); "
+            "the periodic sweep will deliver it",
+            node_id,
+            exc,
+        )
+        return False
 
 
 async def ingest_memory_source(
@@ -254,7 +369,7 @@ async def ingest_memory_source(
             exc,
         )
 
-    return IngestedMemorySource(
+    result = IngestedMemorySource(
         source_id=source.id,
         span_ids=span_ids,
         content_node_id=content_node.id,
@@ -263,6 +378,11 @@ async def ingest_memory_source(
         tag_node_ids=tuple(node.id for node in tag_nodes),
         edge_ids=tuple(edge.id for edge in edges),
     )
+    _schedule_post_commit_knowledge_index(
+        session,
+        node_id=result.content_node_id,
+    )
+    return result
 
 
 def _clean_content(content: str) -> str:

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -207,6 +207,7 @@ def test_default_knowledge_sync_includes_the_memory_mirror():
         "github",
         "slack",
         "memory",
+        "skills",
     ]
 
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
@@ -10,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import numpy as np
 import pytest
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
 from brain.app.api.auth import get_current_user
@@ -30,7 +31,13 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+)
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
     EnumerationFailureKind,
@@ -49,7 +56,10 @@ from brain.systems.knowledge.connectors.github import (
 )
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
-from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
+from brain.systems.knowledge.service import (
+    RAW_TEXT_MAX_CHARS,
+    sync_connector,
+)
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
@@ -317,7 +327,10 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
+            MemorySource.__table__,
+            MemorySpan.__table__,
             MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
         ]
     )
@@ -538,6 +551,343 @@ async def test_memory_connector_reports_an_empty_searchable_corpus(session):
     assert state.last_stats == result.stats
 
 
+async def test_memory_connector_skips_orgless_nodes_and_keeps_organization_scope(
+    session,
+    embedding_runtime,
+    caplog,
+):
+    del embedding_runtime
+    updated_at = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    session.add_all(
+        [
+            _memory_node(
+                14,
+                updated_at,
+                title="Unreachable org-less memory",
+                org_id=None,
+                visibility="org",
+            ),
+            _memory_node(
+                15,
+                updated_at,
+                title="Reachable organization memory",
+                org_id=_ORG_ID,
+                visibility="org",
+            ),
+        ]
+    )
+    await session.flush()
+
+    with caplog.at_level("WARNING"):
+        result = await sync_connector(session, MemoryConnector(max_items=10))
+
+    items = list((await session.scalars(select(KnowledgeItem))).all())
+    embeddings = list((await session.scalars(select(KnowledgeItemEmbedding))).all())
+
+    assert result.stats["ingested"] == 1
+    assert [item.source_ref for item in items] == ["memory_node:15"]
+    assert [embedding.item_id for embedding in embeddings] == [items[0].id]
+    assert items[0].extra[KNOWLEDGE_SCOPE_EXTRA_KEY] == (
+        KnowledgeScope.ORGANIZATION.value
+    )
+    assert items[0].extra["org_id"] == _ORG_ID
+    assert "skipped node 14: org_id is missing" in caplog.text
+
+
+def _committing_unit_of_work(session):
+    class _CommittingUnitOfWork:
+        async def __aenter__(self):
+            self.session = session
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            del exc, traceback
+            if exc_type is None:
+                await session.commit()
+            else:
+                await session.rollback()
+            return False
+
+    return _CommittingUnitOfWork
+
+
+async def _wait_for_memory_knowledge_index(memory_ingestion):
+    await asyncio.sleep(0)
+    if memory_ingestion._POST_COMMIT_TASKS:
+        await asyncio.gather(*list(memory_ingestion._POST_COMMIT_TASKS))
+
+
+async def _ingest_shared_memory_at_canonical_boundary(
+    session,
+    monkeypatch,
+    *,
+    content: str,
+    source_ref: str,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    monkeypatch.setattr(
+        memory_ingestion,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    result = await memory_ingestion.ingest_memory_source(
+        session,
+        content=content,
+        content_kind="decision",
+        source_kind="contract_test",
+        source_ref=source_ref,
+        org_id=_ORG_ID,
+        user_id="22222222-2222-4222-8222-222222222222",
+        visibility="team",
+        confidence=0.9,
+    )
+    await session.commit()
+    await _wait_for_memory_knowledge_index(memory_ingestion)
+    return result.to_dict()
+
+
+async def test_memory_ingest_indexes_committed_node_for_immediate_search(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    distinctive = "Zephyr quokka release ownership stays with the active worker."
+
+    payload = await _ingest_shared_memory_at_canonical_boundary(
+        session,
+        monkeypatch,
+        content=distinctive,
+        source_ref="immediate-knowledge-search",
+    )
+
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source == "memory",
+            KnowledgeItem.source_ref == source_ref,
+        )
+    )
+    search = await search_knowledge(session, "zephyr quokka", org_id=_ORG_ID)
+
+    assert item is not None
+    assert item.summary == distinctive
+    assert [result["source_ref"] for result in search["results"]] == [source_ref]
+
+
+async def test_memory_connector_immediate_and_sweep_eligibility_are_identical(
+    session,
+):
+    updated_at = datetime(2026, 8, 5, 14, 0, tzinfo=timezone.utc)
+    superseded = _memory_node(22, updated_at, visibility="team")
+    superseded.truth_status = "superseded"
+    rows = [
+        _memory_node(16, updated_at, visibility="org"),
+        _memory_node(17, updated_at, visibility="team"),
+        _memory_node(18, updated_at, node_kind="summary", visibility="org"),
+        _memory_node(19, updated_at, org_id=None, visibility="org"),
+        _memory_node(20, updated_at, visibility="private"),
+        _memory_node(21, updated_at, visibility="private"),
+        superseded,
+    ]
+    session.add_all(rows)
+    session.add(
+        KnowledgeItem(
+            source="memory",
+            kind="memory",
+            source_ref="memory_node:21",
+            title="Formerly shared memory",
+            summary="Formerly shared memory",
+            raw_text="Formerly shared memory",
+            search_text="Formerly shared memory",
+            extra={"org_id": _ORG_ID},
+            content_digest="former-shared-memory",
+        )
+    )
+    await session.flush()
+
+    connector = MemoryConnector(max_items=20)
+    immediate_drafts = {}
+    for row in rows:
+        draft = await connector.draft_for_node(session, node_id=row.id)
+        if draft is not None:
+            immediate_drafts[draft.source_ref] = draft
+    enumeration = await connector.enumerate_changed(session, {})
+    sweep_drafts = {draft.source_ref: draft for draft in enumeration.drafts}
+
+    assert immediate_drafts == sweep_drafts
+    assert set(immediate_drafts) == {
+        "memory_node:16",
+        "memory_node:17",
+        "memory_node:21",
+        "memory_node:22",
+    }
+    assert immediate_drafts["memory_node:21"].extra["mirror_status"] == (
+        "visibility_withdrawn"
+    )
+    assert immediate_drafts["memory_node:22"].archived_at == updated_at
+
+
+async def test_memory_index_waits_for_outer_commit_after_savepoint_release(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    async with session.begin_nested():
+        ingested = await memory_ingestion.ingest_memory_source(
+            session,
+            content="Savepoint release must not publish a memory projection early.",
+            content_kind="decision",
+            source_kind="contract_test",
+            org_id=_ORG_ID,
+            visibility="team",
+        )
+
+    await asyncio.sleep(0)
+    spawn_index.assert_not_called()
+
+    await session.commit()
+    await asyncio.sleep(0)
+    spawn_index.assert_called_once_with([ingested.content_node_id])
+
+
+async def test_memory_index_queue_is_cleared_on_outer_rollback(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    await memory_ingestion.ingest_memory_source(
+        session,
+        content="Rolled-back memory must never publish a knowledge projection.",
+        content_kind="decision",
+        source_kind="contract_test",
+        org_id=_ORG_ID,
+        visibility="team",
+    )
+    await session.rollback()
+    await asyncio.sleep(0)
+
+    spawn_index.assert_not_called()
+    assert session.sync_session.info[memory_ingestion._INFO_QUEUE_KEY] == []
+
+
+async def test_memory_sweep_and_cursor_rewalk_are_idempotent_after_immediate_ingest(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    payload = await _ingest_shared_memory_at_canonical_boundary(
+        session,
+        monkeypatch,
+        content="Cobalt narwhal decisions remain searchable after every reconciler pass.",
+        source_ref="immediate-then-sweep",
+    )
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    before = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+    )
+    assert before is not None
+    item_id = before.id
+    digest = before.content_digest
+
+    first_sweep = await sync_connector(session, MemoryConnector(max_items=20))
+    await session.execute(
+        delete(KnowledgeSyncState).where(KnowledgeSyncState.source == "memory")
+    )
+    await session.flush()
+    rewalk = await sync_connector(session, MemoryConnector(max_items=20))
+
+    items = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+            )
+        ).all()
+    )
+    embeddings = list(
+        (
+            await session.scalars(
+                select(KnowledgeItemEmbedding).where(
+                    KnowledgeItemEmbedding.item_id == item_id
+                )
+            )
+        ).all()
+    )
+    assert first_sweep.stats["ingested"] == 0
+    assert first_sweep.stats["skipped"] == 1
+    assert rewalk.stats["ingested"] == 0
+    assert rewalk.stats["skipped"] == 1
+    assert len(items) == 1
+    assert items[0].id == item_id
+    assert items[0].content_digest == digest
+    assert len(embeddings) == 1
+
+
+async def test_memory_index_failure_does_not_fail_committed_ingest(
+    session,
+    monkeypatch,
+    caplog,
+):
+    from brain.systems.knowledge import service as knowledge_service
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    monkeypatch.setattr(
+        memory_ingestion,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        knowledge_service,
+        "index_memory_node",
+        AsyncMock(side_effect=RuntimeError("knowledge mirror unavailable")),
+    )
+
+    with caplog.at_level("ERROR", logger=memory_ingestion.__name__):
+        result = await memory_ingestion.ingest_memory_source(
+            session,
+            content="Amber kestrel preservation remains durable during an index outage.",
+            content_kind="episode",
+            source_kind="contract_test",
+            source_ref="failed-immediate-index",
+            org_id=_ORG_ID,
+            user_id="22222222-2222-4222-8222-222222222222",
+            visibility="org",
+        )
+        await session.commit()
+        await _wait_for_memory_knowledge_index(memory_ingestion)
+
+    node = await session.get(MemoryNode, result.content_node_id)
+    assert node is not None
+    assert node.text == "Amber kestrel preservation remains durable during an index outage."
+    assert "Immediate knowledge indexing failed for committed memory node" in caplog.text
+
+
 async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(
     session,
     embedding_runtime,
@@ -714,6 +1064,45 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
         "truth_status": "active",
         "visibility": "private",
     }
+
+
+async def test_memory_connector_scrubs_a_mirror_after_its_organization_is_removed(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    created_at = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+    node = _memory_node(
+        42,
+        created_at,
+        title="Shared organization decision",
+        text="This organization detail must be scrubbed after withdrawal.",
+        visibility="org",
+    )
+    session.add(node)
+    await session.flush()
+    connector = MemoryConnector(max_items=10)
+    await sync_connector(session, connector)
+
+    withdrawn_at = datetime(2026, 7, 21, 13, 0, tzinfo=timezone.utc)
+    node.visibility = "private"
+    node.org_id = None
+    node.updated_at = withdrawn_at
+    await session.flush()
+
+    result = await sync_connector(session, connector)
+    mirrored = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "memory_node:42")
+    )
+
+    assert result.stats["ingested"] == 1
+    assert result.corpus_empty is True
+    assert mirrored is not None
+    assert mirrored.archived_at.replace(tzinfo=timezone.utc) == withdrawn_at
+    assert mirrored.raw_text == ""
+    assert "organization detail" not in mirrored.search_text
+    assert mirrored.extra["mirror_status"] == "visibility_withdrawn"
+    assert mirrored.extra["org_id"] == _ORG_ID
 
 
 def test_reciprocal_rank_fusion_uses_recency_as_weight_not_candidate_gate():

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -34,8 +34,10 @@ from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, Memor
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
     EnumerationFailureKind,
+    KNOWLEDGE_SCOPE_EXTRA_KEY,
     KnowledgeDraft,
     KnowledgeEnumeration,
+    KnowledgeScope,
 )
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import (
@@ -330,6 +332,7 @@ async def test_sync_connector_upsert_is_idempotent_by_digest(
         source="stub",
         kind="record",
         source_ref="stub:1",
+        scope=KnowledgeScope.ORGANIZATION,
         title="Stable knowledge",
         summary="The same source content should only be embedded once.",
         raw_text="stable source body",
@@ -503,6 +506,7 @@ async def test_memory_connector_mirrors_only_shared_source_backed_memories(
         "archived": False,
         "confidence": 0.92,
         "freshness_status": "fresh",
+        KNOWLEDGE_SCOPE_EXTRA_KEY: KnowledgeScope.ORGANIZATION.value,
         "memory_type": "decision",
         "node_kind": "content",
         "org_id": _ORG_ID,
@@ -703,6 +707,7 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
     assert "launch detail" not in mirrored.search_text
     assert mirrored.extra == {
         "archived": True,
+        KNOWLEDGE_SCOPE_EXTRA_KEY: KnowledgeScope.ORGANIZATION.value,
         "mirror_status": "visibility_withdrawn",
         "node_kind": "content",
         "org_id": _ORG_ID,
@@ -754,6 +759,7 @@ async def test_embedding_failures_degrade_to_lexical_ingest_and_search(
                 source="degraded",
                 kind="record",
                 source_ref="degraded:1",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Lexical lighthouse",
                 summary="This row survives an embedding outage.",
                 raw_text="lexical lighthouse fallback",
@@ -939,6 +945,7 @@ async def test_sync_connector_accounts_for_truncated_raw_text(
                 source="truncation",
                 kind="record",
                 source_ref="truncation:1",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Oversized source",
                 summary="A source body larger than the storage bound.",
                 raw_text=raw_text,
@@ -962,6 +969,7 @@ async def test_sync_connector_accounts_for_truncated_raw_text(
     assert item is not None
     assert len(item.raw_text) == RAW_TEXT_MAX_CHARS
     assert item.extra == {
+        KNOWLEDGE_SCOPE_EXTRA_KEY: KnowledgeScope.ORGANIZATION.value,
         "origin": "test",
         "raw_text_truncated": True,
         "raw_text_total_chars": len(raw_text),
@@ -1004,6 +1012,7 @@ async def test_distillation_admission_is_restart_safe_and_holds_cursor_until_har
                 source="slack",
                 kind="slack_thread",
                 source_ref="slack:T1:C1:1700000000.000001",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Release thread",
                 summary="Structural fallback summary",
                 raw_text="Why did release 42 fail? It was fixed in deploy.py.",
@@ -1119,6 +1128,7 @@ async def test_distillation_exhaustion_lands_lexical_fallback_without_embedding(
                 source="github",
                 kind="issue",
                 source_ref="github:Illospace/illospace#577",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Distill this issue",
                 summary="Structural fallback survives poison output.",
                 raw_text="Original issue body remains lexically searchable.",
@@ -1194,6 +1204,7 @@ async def test_mixed_distillation_batch_persists_completed_rows_while_others_wai
                 source="slack",
                 kind="slack_thread",
                 source_ref=f"slack:T1:C1:{index}",
+                scope=KnowledgeScope.ORGANIZATION,
                 title=f"Thread {index}",
                 summary=f"Fallback {index}",
                 raw_text=f"Raw thread {index}",
@@ -1276,6 +1287,7 @@ async def test_knowledge_search_scopes_lexical_and_semantic_candidates_to_org(
                 source="scoped",
                 kind="record",
                 source_ref=f"scoped:{suffix}",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Shared deployment keyword",
                 summary=f"Secret for org {suffix}",
                 raw_text="shared deployment keyword",
@@ -1295,6 +1307,55 @@ async def test_knowledge_search_scopes_lexical_and_semantic_candidates_to_org(
     assert result["org_id"] == "org-a"
     assert result["semantic_available"] is True
     assert [item["source_ref"] for item in result["results"]] == ["scoped:a"]
+
+
+async def test_knowledge_search_treats_missing_scope_as_organization_scoped(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    connector = _StubConnector(
+        source_key="legacy-scoped",
+        drafts=[
+            KnowledgeDraft(
+                source="legacy-scoped",
+                kind="record",
+                source_ref="legacy-scoped:a",
+                scope=KnowledgeScope.ORGANIZATION,
+                title="Legacy narwhal deployment",
+                summary="Legacy organization-only deployment detail.",
+                raw_text="legacy narwhal deployment",
+                extra={"org_id": "org-a"},
+            )
+        ],
+    )
+    await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source_ref == "legacy-scoped:a"
+        )
+    )
+    assert item is not None
+    legacy_extra = dict(item.extra)
+    legacy_extra.pop(KNOWLEDGE_SCOPE_EXTRA_KEY)
+    item.extra = legacy_extra
+    await session.flush()
+
+    own_org = await search_knowledge(
+        session,
+        "legacy narwhal deployment",
+        org_id="org-a",
+    )
+    other_org = await search_knowledge(
+        session,
+        "legacy narwhal deployment",
+        org_id="org-b",
+    )
+
+    assert [row["source_ref"] for row in own_org["results"]] == [
+        "legacy-scoped:a"
+    ]
+    assert other_org["results"] == []
 
 
 async def test_distillation_preserves_verified_github_resolution_when_model_omits_it(
@@ -1321,6 +1382,7 @@ async def test_distillation_preserves_verified_github_resolution_when_model_omit
                 source="github",
                 kind="issue",
                 source_ref="github:Illospace/illospace#577",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Quasarlexeme closure title",
                 summary="Closed issue awaiting distillation.",
                 resolution=structural_resolution,
@@ -1886,6 +1948,7 @@ async def test_enumeration_error_survives_pending_distillation_as_degraded(
                 source="github",
                 kind="issue",
                 source_ref="github:acme/healthy#33",
+                scope=KnowledgeScope.ORGANIZATION,
                 title="Healthy issue",
                 summary="A healthy repository continued indexing.",
                 raw_text="Healthy repository body.",

--- a/tests/test_knowledge_skills_connector.py
+++ b/tests/test_knowledge_skills_connector.py
@@ -16,10 +16,11 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.skill import Skill
-from brain.systems.knowledge.connectors.skills import (
-    SkillsConnector,
-    _draft_for_skill,
+from brain.systems.knowledge.connectors.base import (
+    KNOWLEDGE_SCOPE_EXTRA_KEY,
+    KnowledgeScope,
 )
+from brain.systems.knowledge.connectors.skills import SkillsConnector
 from brain.systems.knowledge.search import search_knowledge
 from brain.systems.knowledge.service import sync_connector
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
@@ -114,36 +115,38 @@ def _skill(
     )
 
 
-def test_skill_draft_contains_subject_matter_and_skill_view_provenance():
+async def test_synced_skill_contains_subject_matter_and_skill_view_provenance(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
     updated_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
-    draft = _draft_for_skill(
+    session.add(
         _skill(
             54,
             updated_at,
             name="uwear-customer-generation-report-triage",
         )
     )
+    await session.flush()
+    await sync_connector(session, SkillsConnector(max_items=10))
+    item = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "skill:54")
+    )
 
-    assert draft.source == "skills"
-    assert draft.kind == "skill"
-    assert draft.source_ref == "skill:54"
-    assert draft.title == "uwear-customer-generation-report-triage"
-    assert "Inspect the generation report" in draft.raw_text
-    assert "generation report triage" in draft.raw_text
-    assert "Preserve the original report" in draft.raw_text
-    assert "Do not infer a policy failure" in draft.raw_text
-    assert draft.summary == draft.raw_text
-    assert draft.extra == {
-        "archived": False,
-        "maturity": "proficient",
-        "skill_type": "procedure",
-        "skill_view": {
-            "tool": "skill_view",
-            "arguments": {"name": "uwear-customer-generation-report-triage"},
-        },
-        "success_count": 10,
-        "use_count": 12,
-        "version": 3,
+    assert item is not None
+    assert item.source == "skills"
+    assert item.kind == "skill"
+    assert item.title == "uwear-customer-generation-report-triage"
+    assert "Inspect the generation report" in item.raw_text
+    assert "generation report triage" in item.raw_text
+    assert "Preserve the original report" in item.raw_text
+    assert "Do not infer a policy failure" in item.raw_text
+    assert "Inspect the generation report" in item.summary
+    assert item.extra[KNOWLEDGE_SCOPE_EXTRA_KEY] == KnowledgeScope.GLOBAL.value
+    assert item.extra["skill_view"] == {
+        "tool": "skill_view",
+        "arguments": {"name": "uwear-customer-generation-report-triage"},
     }
 
 
@@ -232,14 +235,24 @@ async def test_customer_generation_report_triage_skill_is_searchable(
     await session.flush()
     await sync_connector(session, SkillsConnector(max_items=10))
 
-    result = await search_knowledge(
+    first_org_result = await search_knowledge(
         session,
         "customer generation report triage",
         org_id=_ORG_ID,
     )
+    second_org_result = await search_knowledge(
+        session,
+        "customer generation report triage",
+        org_id="22222222-2222-4222-8222-222222222222",
+    )
 
-    assert [hit["source_ref"] for hit in result["results"]] == ["skill:54"]
-    assert result["results"][0]["extra"]["skill_view"] == {
+    assert [hit["source_ref"] for hit in first_org_result["results"]] == [
+        "skill:54"
+    ]
+    assert [hit["source_ref"] for hit in second_org_result["results"]] == [
+        "skill:54"
+    ]
+    assert first_org_result["results"][0]["extra"]["skill_view"] == {
         "tool": "skill_view",
         "arguments": {"name": "uwear-customer-generation-report-triage"},
     }

--- a/tests/test_knowledge_skills_connector.py
+++ b/tests/test_knowledge_skills_connector.py
@@ -1,0 +1,245 @@
+"""Contract tests for the skills knowledge connector."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
+from brain.platform.db.models.knowledge import (
+    KnowledgeItem,
+    KnowledgeItemEmbedding,
+    KnowledgeSyncState,
+)
+from brain.platform.db.models.skill import Skill
+from brain.systems.knowledge.connectors.skills import (
+    SkillsConnector,
+    _draft_for_skill,
+)
+from brain.systems.knowledge.search import search_knowledge
+from brain.systems.knowledge.service import sync_connector
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+
+_ORG_ID = "11111111-1111-4111-8111-111111111111"
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    del sqlite_postgres_ddl_patch
+    SQLiteTypeCompiler.visit_VECTOR = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_Vector = lambda self, type_, **kw: "TEXT"
+    return await async_sqlite_session_factory(
+        [
+            Skill.__table__,
+            KnowledgeItem.__table__,
+            KnowledgeItemEmbedding.__table__,
+            KnowledgeSyncState.__table__,
+        ]
+    )
+
+
+@pytest.fixture
+def embedding_runtime(monkeypatch):
+    from brain.systems.memory import embeddings as embedding_client
+    from brain.systems.runtime_settings import memory as runtime_settings
+
+    runtime = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="test-knowledge-embedding",
+        cpu_model="unused",
+        dimensions=KNOWLEDGE_EMBEDDING_DIM,
+        api_key="test-key",
+    )
+    vector = np.zeros(KNOWLEDGE_EMBEDDING_DIM, dtype=np.float32)
+    vector[0] = 1.0
+
+    async def fake_runtime_config(session, *, include_secret=True):
+        del session, include_secret
+        return runtime
+
+    monkeypatch.setattr(
+        runtime_settings,
+        "async_get_embedding_runtime_config",
+        fake_runtime_config,
+    )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_document",
+        lambda text, runtime_config=None: vector,
+    )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_query",
+        lambda text, runtime_config=None: vector,
+    )
+    return runtime
+
+
+def _skill(
+    skill_id: int,
+    updated_at: datetime,
+    *,
+    name: str | None = None,
+    archived: bool = False,
+) -> Skill:
+    return Skill(
+        id=skill_id,
+        name=name or f"skill-{skill_id}",
+        description="Triage customer generation reports using source evidence.",
+        procedure=(
+            "Inspect the generation report, collect policy evidence, and route "
+            "the model before changing content policy."
+        ),
+        version=3,
+        level="cognitive",
+        skill_type="procedure",
+        maturity="proficient",
+        confidence=0.9,
+        use_count=12,
+        success_count=10,
+        failure_count=1,
+        partial_count=1,
+        pitfalls=[{"text": "Do not infer a policy failure without evidence."}],
+        triggers=[{"direction": "for", "pattern": "generation report triage"}],
+        guardrails=[{"text": "Preserve the original report before rerouting."}],
+        archived=archived,
+        created_at=updated_at,
+        updated_at=updated_at,
+    )
+
+
+def test_skill_draft_contains_subject_matter_and_skill_view_provenance():
+    updated_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    draft = _draft_for_skill(
+        _skill(
+            54,
+            updated_at,
+            name="uwear-customer-generation-report-triage",
+        )
+    )
+
+    assert draft.source == "skills"
+    assert draft.kind == "skill"
+    assert draft.source_ref == "skill:54"
+    assert draft.title == "uwear-customer-generation-report-triage"
+    assert "Inspect the generation report" in draft.raw_text
+    assert "generation report triage" in draft.raw_text
+    assert "Preserve the original report" in draft.raw_text
+    assert "Do not infer a policy failure" in draft.raw_text
+    assert draft.summary == draft.raw_text
+    assert draft.extra == {
+        "archived": False,
+        "maturity": "proficient",
+        "skill_type": "procedure",
+        "skill_view": {
+            "tool": "skill_view",
+            "arguments": {"name": "uwear-customer-generation-report-triage"},
+        },
+        "success_count": 10,
+        "use_count": 12,
+        "version": 3,
+    }
+
+
+async def test_skill_connector_cursor_is_incremental_and_upsert_is_idempotent(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    first_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    session.add_all([_skill(54, first_at), _skill(55, first_at)])
+    await session.flush()
+    connector = SkillsConnector(max_items=1)
+
+    first = await sync_connector(session, connector)
+    second = await sync_connector(session, connector)
+    exhausted = await sync_connector(session, connector)
+
+    assert first.cursor == {"updated_at": first_at.isoformat(), "id": 54}
+    assert first.stats["ingested"] == 1
+    assert second.cursor == {"updated_at": first_at.isoformat(), "id": 55}
+    assert second.stats["ingested"] == 1
+    assert exhausted.cursor == second.cursor
+    assert exhausted.stats["ingested"] == 0
+    assert await session.scalar(select(func.count(KnowledgeItem.id))) == 2
+
+    skill = await session.get(Skill, 54)
+    assert skill is not None
+    changed_at = datetime(2026, 8, 4, 13, 0, tzinfo=timezone.utc)
+    skill.procedure = "Updated evidence-first procedure."
+    skill.updated_at = changed_at
+    await session.flush()
+
+    updated = await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "skill:54")
+    )
+
+    assert updated.cursor == {"updated_at": changed_at.isoformat(), "id": 54}
+    assert updated.stats["ingested"] == 1
+    assert item is not None
+    assert item.raw_text.find("Updated evidence-first procedure") >= 0
+    assert await session.scalar(select(func.count(KnowledgeItem.id))) == 2
+
+
+async def test_archived_skill_updates_the_existing_item_as_archived(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    created_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    skill = _skill(54, created_at)
+    session.add(skill)
+    await session.flush()
+    connector = SkillsConnector(max_items=10)
+    await sync_connector(session, connector)
+
+    archived_at = datetime(2026, 8, 4, 14, 0, tzinfo=timezone.utc)
+    skill.archived = True
+    skill.updated_at = archived_at
+    await session.flush()
+
+    archived = await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "skill:54")
+    )
+
+    assert archived.stats["ingested"] == 1
+    assert item is not None
+    assert item.archived_at.replace(tzinfo=timezone.utc) == archived_at
+    assert item.extra["archived"] is True
+
+
+async def test_customer_generation_report_triage_skill_is_searchable(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    updated_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    session.add(
+        _skill(
+            54,
+            updated_at,
+            name="uwear-customer-generation-report-triage",
+        )
+    )
+    await session.flush()
+    await sync_connector(session, SkillsConnector(max_items=10))
+
+    result = await search_knowledge(
+        session,
+        "customer generation report triage",
+        org_id=_ORG_ID,
+    )
+
+    assert [hit["source_ref"] for hit in result["results"]] == ["skill:54"]
+    assert result["results"][0]["extra"]["skill_view"] == {
+        "tool": "skill_view",
+        "arguments": {"name": "uwear-customer-generation-report-triage"},
+    }


### PR DESCRIPTION
Closes #674

> *This PR was built by an autonomous routine (R3): Codex implemented, Claude directed and reviewed. It is a draft — Reda merges.*

## What this does

Skills were the only knowledge store `search_knowledge` could not see. Discovery depended on `brain_skills` phrase-trigger matching, which misses on paraphrase — on 2026-07-08 skill 46 never fired on a support alert because the alert did not contain its trigger phrases.

This adds a `skills` connector to the knowledge index, following the existing `connectors/memory.py` pattern. A skill's **subject matter** is what gets indexed — description, procedure, trigger patterns, guardrails and pitfalls all land in `raw_text`, so both the lexical and the semantic channel can match on what the skill is actually about rather than on its name.

## What to check (the acceptance criteria, and where they stand)

1. **`search_knowledge "customer generation report triage"` returns skill 54.** Covered by a test that runs a real sync and a real search — not a mock. Verify it in the world after deploy.
2. **A created / updated / archived skill lands in `knowledge_items` within one sync interval.** Covered: cursor paging, idempotent upsert on `(source, source_ref)`, and archived → archived item.
3. **`skill:<id>` resolves back to `skill_view`.** The provenance ref carries the `skill_view` tool call in `extra`.

## The one thing worth your attention: item scope

`Skill` has no `org_id` column — skills are global by schema. The first implementation expressed that by special-casing `source == "skills"` inside the shared org-scoping filter. The maintainability review called that blocking and I agree: a source-name literal inside a central access policy means every future global source has to edit that filter.

It now declares scope explicitly instead. `KnowledgeDraft` carries a **required** `scope` field (`organization` | `global`), persisted as `extra["knowledge_scope"]`, and search admits an item when its org matches **or** it declares global scope. Required, not defaulted — a new connector cannot silently inherit the wrong visibility.

Three consequences worth stating plainly:

- **Existing indexed items are unaffected.** They have no scope key, a missing key is organization-scoped, so they still match only their own `org_id`. No backfill, no migration — `extra` is JSON.
- **Skills are visible to every org.** That is not a change in exposure: skills were already global data with no org to belong to. It is now written down.
- **A latent bug is deliberately NOT fixed here.** `connectors/memory.py` writes `org_id: None` for org-less memory nodes, so those items match no org and are permanently unsearchable today. Making them visible is a behavior change outside this ticket's scope; it needs its own ticket and its own decision.

The review's second blocking finding is also folded: the `(updated_at, id)` cursor logic was on its third copy, so it moved into a shared `UpdatedAtCursor` in `connectors/base.py` and `memory.py` / `domain_records.py` now use it too. That is why the diff deletes 139 lines while adding the connector.

## Verification

- **Host fast lane, the repo's own CI command, whole suite:** `4751 passed, 11 skipped, 83 deselected` in 74.6s. Zero failures. The baseline before this branch is 4750; the extra one is the new cross-org isolation test.
- New tests prove the scope contract in all three directions: an org-scoped item is **not** returned to a different org, a global item **is** returned to any org, and an item with no scope key behaves as organization-scoped.
- No schema change, no alembic migration — nothing to collide with the `0051` revision on PR #676.
- Codex maintainability review returned CHANGES REQUIRED with two blocking findings; both are folded above, and the re-run is the 4751 number.

## Sequencing (per the ticket, Reda's direction 2026-08-04: max first, then assess)

This connector is step 1 — every knowledge store is now mirrored into the index. Step 2 is deploying and re-running the #650/#660 recall harness, knowledge engine vs memory engine. Step 3 is the #578 item 3 assessment: retire the memory-native recall tools if knowledge search wins, or write down why memory still earns its place.
