### PR TITLE
fix(runs): make sibling runs on one thread visible to each other (#671)

### DIFF
--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -10,6 +10,7 @@ from brain.systems.runs.skill_commands import parse_slash_skill_names
 from brain.systems.runs.status_questions import (
     format_active_sibling_context,
     format_status_question_context,
+    is_status_question,
 )
 
 PROMPT_REFERENCE_CHAR_LIMIT = 12_000
@@ -196,8 +197,7 @@ class RunContext:
     skills: list[str] = field(default_factory=list)
     handoff: dict[str, Any] = field(default_factory=dict)
     request_source: dict[str, Any] = field(default_factory=dict)
-    active_sibling_context: dict[str, Any] = field(default_factory=dict)
-    status_question_context: dict[str, Any] = field(default_factory=dict)
+    same_thread_run_context: dict[str, Any] = field(default_factory=dict)
     scheduled_result_contract: bool = False
 
     def prompt_context(self) -> str:
@@ -246,12 +246,14 @@ class RunContext:
             )
         if self.memory:
             parts.append("Memory:\n" + "\n".join(f"- {item}" for item in self.memory))
-        sibling_context = format_active_sibling_context(self.active_sibling_context)
-        if sibling_context:
-            parts.append(sibling_context)
-        status_context = format_status_question_context(self.status_question_context)
-        if status_context:
-            parts.append(status_context)
+        if is_status_question(self.message):
+            status_context = format_status_question_context(self.same_thread_run_context)
+            if status_context:
+                parts.append(status_context)
+        else:
+            sibling_context = format_active_sibling_context(self.same_thread_run_context)
+            if sibling_context:
+                parts.append(sibling_context)
         return "\n\n".join(parts)
 
 
@@ -274,14 +276,9 @@ class RunContextLoader:
             workspace_ref=dict(workspace_ref or {}),
             thread_context=dict(thread_context) if isinstance(thread_context, dict) else {},
             request_source=_request_source_from_metadata(metadata),
-            active_sibling_context=(
-                dict(metadata.get("active_sibling_context") or {})
-                if isinstance(metadata.get("active_sibling_context"), dict)
-                else {}
-            ),
-            status_question_context=(
-                dict(metadata.get("status_question_context") or {})
-                if isinstance(metadata.get("status_question_context"), dict)
+            same_thread_run_context=(
+                dict(metadata.get("same_thread_run_context") or {})
+                if isinstance(metadata.get("same_thread_run_context"), dict)
                 else {}
             ),
             skills=_skill_names_from_metadata(metadata, message),

--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -7,7 +7,10 @@ import json
 from typing import Any
 
 from brain.systems.runs.skill_commands import parse_slash_skill_names
-from brain.systems.runs.status_questions import format_status_question_context
+from brain.systems.runs.status_questions import (
+    format_active_sibling_context,
+    format_status_question_context,
+)
 
 PROMPT_REFERENCE_CHAR_LIMIT = 12_000
 PROMPT_SCALAR_CHAR_LIMIT = 1_200
@@ -193,6 +196,7 @@ class RunContext:
     skills: list[str] = field(default_factory=list)
     handoff: dict[str, Any] = field(default_factory=dict)
     request_source: dict[str, Any] = field(default_factory=dict)
+    active_sibling_context: dict[str, Any] = field(default_factory=dict)
     status_question_context: dict[str, Any] = field(default_factory=dict)
     scheduled_result_contract: bool = False
 
@@ -242,6 +246,9 @@ class RunContext:
             )
         if self.memory:
             parts.append("Memory:\n" + "\n".join(f"- {item}" for item in self.memory))
+        sibling_context = format_active_sibling_context(self.active_sibling_context)
+        if sibling_context:
+            parts.append(sibling_context)
         status_context = format_status_question_context(self.status_question_context)
         if status_context:
             parts.append(status_context)
@@ -267,6 +274,11 @@ class RunContextLoader:
             workspace_ref=dict(workspace_ref or {}),
             thread_context=dict(thread_context) if isinstance(thread_context, dict) else {},
             request_source=_request_source_from_metadata(metadata),
+            active_sibling_context=(
+                dict(metadata.get("active_sibling_context") or {})
+                if isinstance(metadata.get("active_sibling_context"), dict)
+                else {}
+            ),
             status_question_context=(
                 dict(metadata.get("status_question_context") or {})
                 if isinstance(metadata.get("status_question_context"), dict)

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -108,6 +108,9 @@ from brain.systems.runs.execution_context import (
     bind_agent_context,
     current_agent_context,
 )
+from brain.systems.runs.outbound_reply_admission import (
+    REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY,
+)
 from brain.systems.runs.direct_loop.telemetry import (
     async_record_api_call as _async_record_api_call,
 )
@@ -1385,7 +1388,15 @@ async def run_agent_async(
         "loop_control": state.loop_control,
         "final_reply_review": None,
         "resolved_llm_context": None,
-        "reply_admission_block_count": 0,
+        "reply_admission_block_count": _metadata_int(
+            execution_provenance,
+            REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY,
+            _metadata_int(
+                metadata,
+                REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY,
+                0,
+            ),
+        ),
     }
     if workspace_root:
         context_attrs["workspace_root"] = workspace_root

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -155,7 +155,6 @@ from brain.systems.runs.tool_definitions import (  # noqa: F401
 )
 
 from brain.systems.runs.tool_handlers import (  # noqa: F401
-    _build_final_reply_check_context,
     _get_tool_handlers,
     get_tools_with_extended,
     WORKSPACE_ROOT,
@@ -349,6 +348,7 @@ def review_candidate_final_reply(
     candidate_output: str,
     execution_context: str | None = None,
     evidence: FinalReplyEvidence | None = None,
+    coordination: Any = None,
     intent_profile: dict | None = None,
     user_id: str | None = None,
     provider=None,
@@ -362,6 +362,7 @@ def review_candidate_final_reply(
         candidate_output=candidate_output,
         execution_context=execution_context,
         evidence=evidence,
+        coordination=coordination,
         intent_profile=intent_profile,
         user_id=user_id,
         provider=provider,
@@ -381,6 +382,7 @@ def review_final_reply_once(
     candidate_output: str,
     execution_context: str | None = None,
     evidence: FinalReplyEvidence | None = None,
+    coordination: Any = None,
     intent_profile: dict | None = None,
     user_id: str | None = None,
     provider=None,
@@ -394,6 +396,7 @@ def review_final_reply_once(
         candidate_output=candidate_output,
         execution_context=execution_context,
         evidence=evidence,
+        coordination=coordination,
         intent_profile=intent_profile,
         user_id=user_id,
         provider=provider,
@@ -1382,7 +1385,7 @@ async def run_agent_async(
         "loop_control": state.loop_control,
         "final_reply_review": None,
         "resolved_llm_context": None,
-        "artifact_contract_block_count": 0,
+        "reply_admission_block_count": 0,
     }
     if workspace_root:
         context_attrs["workspace_root"] = workspace_root

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -118,6 +118,27 @@ _STATUS_IN_PROGRESS_RE = re.compile(
     r"not (?:done|complete|completed|finished)|not done yet)\b",
     re.IGNORECASE,
 )
+_ACTIVE_SIBLING_REFERENCE_RE = re.compile(
+    r"\b(?:active|another|other|sibling|earlier|existing|prior)\s+"
+    r"(?:agent\s+)?run\b|\b(?:the|that)\s+(?:active\s+)?run\b",
+    re.IGNORECASE,
+)
+_ACTIVE_SIBLING_WAIT_RE = re.compile(
+    r"(?:\b(?:i|we)(?:['’]ll|\s+will|\s+should|\s+can)?\s+"
+    r"(?:wait|hold)(?:\s+off)?\b|"
+    r"\b(?:wait|waiting|holding)\s+(?:for|on|until)\b|"
+    r"\blet(?:['’]s|\s+us)\s+wait\b|"
+    r"\b(?:one|a)\s+(?:sec(?:ond)?|moment)\b)",
+    re.IGNORECASE,
+)
+_ACTIVE_SIBLING_HANDOFF_RE = re.compile(
+    r"\b(?:hand(?:ing)?|pass(?:ing)?)\s+(?:this|it|the\s+"
+    r"(?:question|request|answer))\s+(?:off|over)\b|"
+    r"\bdefer(?:ring)?\s+(?:this|it|the\s+(?:question|request|answer))\s+to\b|"
+    r"\bleav(?:e|ing)\s+(?:this|it|the\s+(?:question|request|answer))\s+"
+    r"(?:to|with)\b",
+    re.IGNORECASE,
+)
 _UNRESOLVED_RE = re.compile(
     r"\b(?:unresolved|outstanding|pending|missing|not (?:created|opened|filed|done)|"
     r"has not been (?:created|opened|filed|done)|hasn't been (?:created|opened|filed|done)|"
@@ -553,6 +574,51 @@ def _successful_assignees(evidence: FinalReplyEvidence) -> tuple[str, ...]:
     return tuple(found)
 
 
+def _coordinates_with_active_sibling(
+    candidate_output: str,
+    evidence: FinalReplyEvidence,
+) -> bool:
+    active = evidence.active_siblings
+    if active is None or not active.has_active_sibling:
+        return True
+    candidate = str(candidate_output or "")
+    if _ACTIVE_SIBLING_WAIT_RE.search(candidate):
+        return True
+    if _ACTIVE_SIBLING_HANDOFF_RE.search(candidate):
+        return True
+    if _ACTIVE_SIBLING_REFERENCE_RE.search(candidate):
+        return True
+    return any(
+        run.run_id is not None
+        and re.search(
+            rf"\brun\s*#?\s*{re.escape(str(run.run_id))}\b",
+            candidate,
+            re.IGNORECASE,
+        )
+        for run in active.runs
+    )
+
+
+def active_sibling_contract_issue(
+    candidate_output: str,
+    evidence: FinalReplyEvidence,
+) -> str | None:
+    active = evidence.active_siblings
+    if active is None or not active.has_active_sibling:
+        return None
+    if _coordinates_with_active_sibling(candidate_output, evidence):
+        return None
+    runs = ", ".join(
+        f"{run.run_id} ({run.status})"
+        for run in active.runs
+    )
+    return (
+        f"Admission evidence names active sibling run(s) {runs}, but the candidate "
+        "ignores that work. The reply must wait, reference a sibling run, or "
+        "explicitly hand the question off."
+    )
+
+
 def _status_question_contract_issue(
     candidate_output: str,
     evidence: FinalReplyEvidence,
@@ -848,6 +914,23 @@ def review_candidate_final_reply(
                 "tool-dependent work before ending the run.",
             ),
             raw_output="deterministic_tool_failure_honesty_contract",
+            enforcement=FinalReplyEnforcement.BLOCK,
+        ).to_dict()
+
+    active_sibling_issue = active_sibling_contract_issue(
+        candidate_output,
+        structured_evidence,
+    )
+    if active_sibling_issue:
+        return FinalReplyReview(
+            status="continue",
+            approved=False,
+            rationale=active_sibling_issue,
+            missing_requirements=(
+                "Wait for the active sibling, reference an active sibling run, or "
+                "explicitly hand the question off.",
+            ),
+            raw_output="deterministic_active_sibling_contract",
             enforcement=FinalReplyEnforcement.BLOCK,
         ).to_dict()
 

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -30,6 +30,10 @@ from brain.systems.runs.direct_loop.final_reply_evidence import (
     FinalReplyEvidence,
     ToolResultEvidence,
 )
+from brain.systems.runs.direct_loop.reply_coordination import (
+    ReplyCoordination,
+    ReplyCoordinationAction,
+)
 from brain.systems.runs.direct_loop.request import build_api_request, strip_provider_prefix
 from brain.systems.runs.status import RunStatus
 from brain.systems.sessions import _content_to_dicts
@@ -116,27 +120,6 @@ _TRACKER_ARTIFACT_RE = re.compile(
 _STATUS_IN_PROGRESS_RE = re.compile(
     r"\b(?:in progress|still (?:running|working|underway|ongoing)|"
     r"not (?:done|complete|completed|finished)|not done yet)\b",
-    re.IGNORECASE,
-)
-_ACTIVE_SIBLING_REFERENCE_RE = re.compile(
-    r"\b(?:active|another|other|sibling|earlier|existing|prior)\s+"
-    r"(?:agent\s+)?run\b|\b(?:the|that)\s+(?:active\s+)?run\b",
-    re.IGNORECASE,
-)
-_ACTIVE_SIBLING_WAIT_RE = re.compile(
-    r"(?:\b(?:i|we)(?:['’]ll|\s+will|\s+should|\s+can)?\s+"
-    r"(?:wait|hold)(?:\s+off)?\b|"
-    r"\b(?:wait|waiting|holding)\s+(?:for|on|until)\b|"
-    r"\blet(?:['’]s|\s+us)\s+wait\b|"
-    r"\b(?:one|a)\s+(?:sec(?:ond)?|moment)\b)",
-    re.IGNORECASE,
-)
-_ACTIVE_SIBLING_HANDOFF_RE = re.compile(
-    r"\b(?:hand(?:ing)?|pass(?:ing)?)\s+(?:this|it|the\s+"
-    r"(?:question|request|answer))\s+(?:off|over)\b|"
-    r"\bdefer(?:ring)?\s+(?:this|it|the\s+(?:question|request|answer))\s+to\b|"
-    r"\bleav(?:e|ing)\s+(?:this|it|the\s+(?:question|request|answer))\s+"
-    r"(?:to|with)\b",
     re.IGNORECASE,
 )
 _UNRESOLVED_RE = re.compile(
@@ -286,12 +269,14 @@ def _review_scope(
     execution_context: str | None,
     evidence: FinalReplyEvidence | None,
     intent_profile: dict | None,
+    coordination: ReplyCoordination | None,
 ) -> dict[str, Any]:
     return {
         "user_request": " ".join((user_request or "").split())[:1200],
         "execution_context": " ".join((execution_context or "").split())[:2500],
         "evidence": evidence.cache_fingerprint() if evidence is not None else "",
         "intent_profile": intent_profile or {},
+        "coordination": coordination.cache_payload() if coordination is not None else None,
     }
 
 
@@ -574,48 +559,41 @@ def _successful_assignees(evidence: FinalReplyEvidence) -> tuple[str, ...]:
     return tuple(found)
 
 
-def _coordinates_with_active_sibling(
-    candidate_output: str,
-    evidence: FinalReplyEvidence,
-) -> bool:
-    active = evidence.active_siblings
-    if active is None or not active.has_active_sibling:
-        return True
-    candidate = str(candidate_output or "")
-    if _ACTIVE_SIBLING_WAIT_RE.search(candidate):
-        return True
-    if _ACTIVE_SIBLING_HANDOFF_RE.search(candidate):
-        return True
-    if _ACTIVE_SIBLING_REFERENCE_RE.search(candidate):
-        return True
-    return any(
-        run.run_id is not None
-        and re.search(
-            rf"\brun\s*#?\s*{re.escape(str(run.run_id))}\b",
-            candidate,
-            re.IGNORECASE,
-        )
-        for run in active.runs
-    )
-
-
 def active_sibling_contract_issue(
-    candidate_output: str,
+    coordination: ReplyCoordination | dict[str, Any] | None,
     evidence: FinalReplyEvidence,
 ) -> str | None:
-    active = evidence.active_siblings
-    if active is None or not active.has_active_sibling:
+    same_thread = evidence.same_thread_run_context
+    if (
+        same_thread is None
+        or same_thread.status_question
+        or same_thread.lookup_status != "verified"
+        or not same_thread.live_sibling_runs
+    ):
         return None
-    if _coordinates_with_active_sibling(candidate_output, evidence):
-        return None
+    declaration = ReplyCoordination.from_value(coordination)
     runs = ", ".join(
         f"{run.run_id} ({run.status})"
-        for run in active.runs
+        for run in same_thread.live_sibling_runs
     )
+    if declaration is None:
+        return (
+            f"Admission evidence names active sibling run(s) {runs}, but the reply "
+            "has no valid coordination declaration."
+        )
+    if declaration.action in {
+        ReplyCoordinationAction.WAIT,
+        ReplyCoordinationAction.HANDOFF,
+    }:
+        return None
+    active_run_ids = {
+        run.run_id for run in same_thread.live_sibling_runs if run.run_id is not None
+    }
+    if declaration.run_id in active_run_ids:
+        return None
     return (
-        f"Admission evidence names active sibling run(s) {runs}, but the candidate "
-        "ignores that work. The reply must wait, reference a sibling run, or "
-        "explicitly hand the question off."
+        f"Admission evidence names active sibling run(s) {runs}, but the reply "
+        f"references run {declaration.run_id}, which is not in that snapshot."
     )
 
 
@@ -623,8 +601,8 @@ def _status_question_contract_issue(
     candidate_output: str,
     evidence: FinalReplyEvidence,
 ) -> str | None:
-    status = evidence.status_question
-    if status is None:
+    status = evidence.same_thread_run_context
+    if status is None or not status.status_question:
         return None
     candidate = str(candidate_output or "")
     claims_complete = _claims_request_complete(candidate)
@@ -885,6 +863,7 @@ def review_candidate_final_reply(
     candidate_output: str,
     execution_context: str | None = None,
     evidence: FinalReplyEvidence | None = None,
+    coordination: ReplyCoordination | dict[str, Any] | None = None,
     intent_profile: dict | None = None,
     user_id: str | None = None,
     provider=None,
@@ -900,6 +879,7 @@ def review_candidate_final_reply(
     """Run the final-reply checker and return a dict-compatible review payload."""
 
     structured_evidence = evidence or FinalReplyEvidence()
+    declared_coordination = ReplyCoordination.from_value(coordination)
     tool_failure_issue = _tool_failure_success_issue(
         candidate_output,
         structured_evidence,
@@ -918,7 +898,7 @@ def review_candidate_final_reply(
         ).to_dict()
 
     active_sibling_issue = active_sibling_contract_issue(
-        candidate_output,
+        declared_coordination,
         structured_evidence,
     )
     if active_sibling_issue:
@@ -1095,6 +1075,7 @@ def review_final_reply_once(
     candidate_output: str,
     execution_context: str | None = None,
     evidence: FinalReplyEvidence | None = None,
+    coordination: ReplyCoordination | dict[str, Any] | None = None,
     intent_profile: dict | None = None,
     user_id: str | None = None,
     provider=None,
@@ -1106,11 +1087,13 @@ def review_final_reply_once(
 ) -> dict:
     """Review a candidate final reply once per unique candidate text."""
 
+    declared_coordination = ReplyCoordination.from_value(coordination)
     scope = _review_scope(
         user_request=user_request,
         execution_context=execution_context,
         evidence=evidence,
         intent_profile=intent_profile,
+        coordination=declared_coordination,
     )
     if agent_context is not None:
         cached = cached_final_reply_review(agent_context, candidate_output, scope)
@@ -1123,6 +1106,7 @@ def review_final_reply_once(
         candidate_output=candidate_output,
         execution_context=execution_context,
         evidence=evidence,
+        coordination=declared_coordination,
         intent_profile=intent_profile,
         user_id=user_id,
         provider=provider,

--- a/brain/systems/runs/direct_loop/final_reply_evidence.py
+++ b/brain/systems/runs/direct_loop/final_reply_evidence.py
@@ -184,61 +184,8 @@ class ToolFailureStateEvidence:
 
 
 @dataclass(frozen=True)
-class ActiveSiblingRunEvidence:
-    """One run that was active on the Slack thread at admission."""
-
-    run_id: int | None = None
-    status: RunStatus = RunStatus.FAILED
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> "ActiveSiblingRunEvidence":
-        return cls(
-            run_id=_coerce_optional_int(value.get("run_id")),
-            status=coerce_run_status(
-                value.get("status"),
-                default=RunStatus.FAILED,
-            ),
-        )
-
-    def cache_payload(self) -> dict[str, Any]:
-        return {"run_id": self.run_id, "status": self.status}
-
-
-@dataclass(frozen=True)
-class ActiveSiblingEvidence:
-    """Typed admission snapshot of active same-thread Slack runs."""
-
-    thread_id: str = ""
-    lookup_status: str = ""
-    runs: tuple[ActiveSiblingRunEvidence, ...] = ()
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> "ActiveSiblingEvidence":
-        return cls(
-            thread_id=str(value.get("thread_id") or "").strip(),
-            lookup_status=str(value.get("lookup_status") or "").strip().lower(),
-            runs=tuple(
-                ActiveSiblingRunEvidence.from_mapping(item)
-                for item in list(value.get("active_sibling_runs") or [])
-                if isinstance(item, Mapping)
-            ),
-        )
-
-    @property
-    def has_active_sibling(self) -> bool:
-        return self.lookup_status == "verified" and bool(self.runs)
-
-    def cache_payload(self) -> dict[str, Any]:
-        return {
-            "thread_id": self.thread_id,
-            "lookup_status": self.lookup_status,
-            "active_sibling_runs": [item.cache_payload() for item in self.runs],
-        }
-
-
-@dataclass(frozen=True)
-class StatusRunEvidence:
-    """One prior same-thread run relevant to a status question."""
+class SameThreadRunSnapshot:
+    """One typed top-level run from the admission-time thread snapshot."""
 
     run_id: int | None = None
     status: RunStatus = RunStatus.FAILED
@@ -246,7 +193,7 @@ class StatusRunEvidence:
     final_output: str | None = None
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> "StatusRunEvidence":
+    def from_mapping(cls, value: Mapping[str, Any]) -> "SameThreadRunSnapshot":
         return cls(
             run_id=_coerce_optional_int(value.get("run_id")),
             status=coerce_run_status(
@@ -291,21 +238,22 @@ class StatusDeliverableEvidence:
 
 
 @dataclass(frozen=True)
-class StatusQuestionEvidence:
-    """Typed snapshot of the originating and live same-thread runs."""
+class SameThreadRunContextEvidence:
+    """The single typed contract for same-thread status and coordination rules."""
 
     thread_id: str = ""
     lookup_status: str = ""
     lookup_error: str | None = None
-    originating_run: StatusRunEvidence | None = None
-    live_sibling_runs: tuple[StatusRunEvidence, ...] = ()
+    status_question: bool = False
+    originating_run: SameThreadRunSnapshot | None = None
+    live_sibling_runs: tuple[SameThreadRunSnapshot, ...] = ()
     deliverables: tuple[StatusDeliverableEvidence, ...] = ()
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> "StatusQuestionEvidence":
+    def from_mapping(cls, value: Mapping[str, Any]) -> "SameThreadRunContextEvidence":
         origin = value.get("originating_run")
         live_runs = tuple(
-            StatusRunEvidence.from_mapping(item)
+            SameThreadRunSnapshot.from_mapping(item)
             for item in list(value.get("live_sibling_runs") or [])
             if isinstance(item, Mapping)
         )
@@ -324,8 +272,9 @@ class StatusQuestionEvidence:
                 if value.get("lookup_error")
                 else None
             ),
+            status_question=bool(value.get("status_question")),
             originating_run=(
-                StatusRunEvidence.from_mapping(origin)
+                SameThreadRunSnapshot.from_mapping(origin)
                 if isinstance(origin, Mapping)
                 else None
             ),
@@ -342,6 +291,7 @@ class StatusQuestionEvidence:
             "thread_id": self.thread_id,
             "lookup_status": self.lookup_status,
             "lookup_error": self.lookup_error,
+            "status_question": self.status_question,
             "originating_run": (
                 self.originating_run.cache_payload()
                 if self.originating_run is not None
@@ -363,8 +313,7 @@ class FinalReplyEvidence:
     tool_results: tuple[ToolResultEvidence, ...] = ()
     execution_artifacts: tuple[Mapping[str, Any], ...] = ()
     worker_results: tuple[Mapping[str, Any], ...] = ()
-    active_siblings: ActiveSiblingEvidence | None = None
-    status_question: StatusQuestionEvidence | None = None
+    same_thread_run_context: SameThreadRunContextEvidence | None = None
     tool_failure_state: ToolFailureStateEvidence | None = None
 
     @classmethod
@@ -392,15 +341,13 @@ class FinalReplyEvidence:
                     "evidence": getattr(item, "evidence", None),
                 }
             )
-        active_siblings = _active_sibling_evidence_from_context(agent_context)
-        status_question = _status_question_evidence_from_context(agent_context)
+        same_thread_run_context = _same_thread_run_context_evidence(agent_context)
         failure_state = _tool_failure_state_from_context(agent_context, tool_results)
         return cls(
             tool_results=tuple(tool_results),
             execution_artifacts=artifacts,
             worker_results=tuple(workers),
-            active_siblings=active_siblings,
-            status_question=status_question,
+            same_thread_run_context=same_thread_run_context,
             tool_failure_state=failure_state,
         )
 
@@ -473,14 +420,9 @@ class FinalReplyEvidence:
             "tool_results": [item.cache_payload() for item in self.tool_results],
             "execution_artifacts": self.execution_artifacts,
             "worker_results": self.worker_results,
-            "active_siblings": (
-                self.active_siblings.cache_payload()
-                if self.active_siblings is not None
-                else None
-            ),
-            "status_question": (
-                self.status_question.cache_payload()
-                if self.status_question is not None
+            "same_thread_run_context": (
+                self.same_thread_run_context.cache_payload()
+                if self.same_thread_run_context is not None
                 else None
             ),
             "tool_failure_state": (
@@ -558,28 +500,21 @@ def _find_context_mapping(
     return None
 
 
-def _active_sibling_evidence_from_context(
+def _same_thread_run_context_evidence(
     agent_context: Any,
-) -> ActiveSiblingEvidence | None:
+) -> SameThreadRunContextEvidence | None:
     execution_metadata = getattr(agent_context, "execution_metadata", None)
-    mapping = _find_context_mapping(execution_metadata, "active_sibling_context")
+    mapping = _find_context_mapping(execution_metadata, "same_thread_run_context")
     if mapping is None:
         mapping = _find_context_mapping(
             getattr(agent_context, "metadata", None),
-            "active_sibling_context",
+            "same_thread_run_context",
         )
-    return ActiveSiblingEvidence.from_mapping(mapping) if mapping is not None else None
-
-
-def _status_question_evidence_from_context(agent_context: Any) -> StatusQuestionEvidence | None:
-    execution_metadata = getattr(agent_context, "execution_metadata", None)
-    mapping = _find_context_mapping(execution_metadata, "status_question_context")
-    if mapping is None:
-        mapping = _find_context_mapping(
-            getattr(agent_context, "metadata", None),
-            "status_question_context",
-        )
-    return StatusQuestionEvidence.from_mapping(mapping) if mapping is not None else None
+    return (
+        SameThreadRunContextEvidence.from_mapping(mapping)
+        if mapping is not None
+        else None
+    )
 
 
 def _tool_failure_state_from_context(
@@ -618,13 +553,11 @@ def _tool_failure_state_from_context(
 
 
 __all__ = [
-    "ActiveSiblingEvidence",
-    "ActiveSiblingRunEvidence",
     "DEFAULT_TOOL_FAILURE_THRESHOLD",
     "FinalReplyEvidence",
+    "SameThreadRunContextEvidence",
+    "SameThreadRunSnapshot",
     "StatusDeliverableEvidence",
-    "StatusQuestionEvidence",
-    "StatusRunEvidence",
     "ToolFailureStateEvidence",
     "ToolResultEvidence",
 ]

--- a/brain/systems/runs/direct_loop/final_reply_evidence.py
+++ b/brain/systems/runs/direct_loop/final_reply_evidence.py
@@ -184,6 +184,59 @@ class ToolFailureStateEvidence:
 
 
 @dataclass(frozen=True)
+class ActiveSiblingRunEvidence:
+    """One run that was active on the Slack thread at admission."""
+
+    run_id: int | None = None
+    status: RunStatus = RunStatus.FAILED
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ActiveSiblingRunEvidence":
+        return cls(
+            run_id=_coerce_optional_int(value.get("run_id")),
+            status=coerce_run_status(
+                value.get("status"),
+                default=RunStatus.FAILED,
+            ),
+        )
+
+    def cache_payload(self) -> dict[str, Any]:
+        return {"run_id": self.run_id, "status": self.status}
+
+
+@dataclass(frozen=True)
+class ActiveSiblingEvidence:
+    """Typed admission snapshot of active same-thread Slack runs."""
+
+    thread_id: str = ""
+    lookup_status: str = ""
+    runs: tuple[ActiveSiblingRunEvidence, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ActiveSiblingEvidence":
+        return cls(
+            thread_id=str(value.get("thread_id") or "").strip(),
+            lookup_status=str(value.get("lookup_status") or "").strip().lower(),
+            runs=tuple(
+                ActiveSiblingRunEvidence.from_mapping(item)
+                for item in list(value.get("active_sibling_runs") or [])
+                if isinstance(item, Mapping)
+            ),
+        )
+
+    @property
+    def has_active_sibling(self) -> bool:
+        return self.lookup_status == "verified" and bool(self.runs)
+
+    def cache_payload(self) -> dict[str, Any]:
+        return {
+            "thread_id": self.thread_id,
+            "lookup_status": self.lookup_status,
+            "active_sibling_runs": [item.cache_payload() for item in self.runs],
+        }
+
+
+@dataclass(frozen=True)
 class StatusRunEvidence:
     """One prior same-thread run relevant to a status question."""
 
@@ -310,6 +363,7 @@ class FinalReplyEvidence:
     tool_results: tuple[ToolResultEvidence, ...] = ()
     execution_artifacts: tuple[Mapping[str, Any], ...] = ()
     worker_results: tuple[Mapping[str, Any], ...] = ()
+    active_siblings: ActiveSiblingEvidence | None = None
     status_question: StatusQuestionEvidence | None = None
     tool_failure_state: ToolFailureStateEvidence | None = None
 
@@ -338,12 +392,14 @@ class FinalReplyEvidence:
                     "evidence": getattr(item, "evidence", None),
                 }
             )
+        active_siblings = _active_sibling_evidence_from_context(agent_context)
         status_question = _status_question_evidence_from_context(agent_context)
         failure_state = _tool_failure_state_from_context(agent_context, tool_results)
         return cls(
             tool_results=tuple(tool_results),
             execution_artifacts=artifacts,
             worker_results=tuple(workers),
+            active_siblings=active_siblings,
             status_question=status_question,
             tool_failure_state=failure_state,
         )
@@ -417,6 +473,11 @@ class FinalReplyEvidence:
             "tool_results": [item.cache_payload() for item in self.tool_results],
             "execution_artifacts": self.execution_artifacts,
             "worker_results": self.worker_results,
+            "active_siblings": (
+                self.active_siblings.cache_payload()
+                if self.active_siblings is not None
+                else None
+            ),
             "status_question": (
                 self.status_question.cache_payload()
                 if self.status_question is not None
@@ -474,25 +535,50 @@ def _coerce_tool_names(value: Any) -> tuple[str, ...]:
     return tuple(names)
 
 
-def _find_status_question_mapping(value: Any, *, depth: int = 0) -> Mapping[str, Any] | None:
+def _find_context_mapping(
+    value: Any,
+    context_key: str,
+    *,
+    depth: int = 0,
+) -> Mapping[str, Any] | None:
     if not isinstance(value, Mapping) or depth > 3:
         return None
-    direct = value.get("status_question_context")
+    direct = value.get(context_key)
     if isinstance(direct, Mapping):
         return direct
     for key in ("execution_provenance", "metadata", "request_metadata"):
         nested = value.get(key)
-        found = _find_status_question_mapping(nested, depth=depth + 1)
+        found = _find_context_mapping(
+            nested,
+            context_key,
+            depth=depth + 1,
+        )
         if found is not None:
             return found
     return None
 
 
+def _active_sibling_evidence_from_context(
+    agent_context: Any,
+) -> ActiveSiblingEvidence | None:
+    execution_metadata = getattr(agent_context, "execution_metadata", None)
+    mapping = _find_context_mapping(execution_metadata, "active_sibling_context")
+    if mapping is None:
+        mapping = _find_context_mapping(
+            getattr(agent_context, "metadata", None),
+            "active_sibling_context",
+        )
+    return ActiveSiblingEvidence.from_mapping(mapping) if mapping is not None else None
+
+
 def _status_question_evidence_from_context(agent_context: Any) -> StatusQuestionEvidence | None:
     execution_metadata = getattr(agent_context, "execution_metadata", None)
-    mapping = _find_status_question_mapping(execution_metadata)
+    mapping = _find_context_mapping(execution_metadata, "status_question_context")
     if mapping is None:
-        mapping = _find_status_question_mapping(getattr(agent_context, "metadata", None))
+        mapping = _find_context_mapping(
+            getattr(agent_context, "metadata", None),
+            "status_question_context",
+        )
     return StatusQuestionEvidence.from_mapping(mapping) if mapping is not None else None
 
 
@@ -532,6 +618,8 @@ def _tool_failure_state_from_context(
 
 
 __all__ = [
+    "ActiveSiblingEvidence",
+    "ActiveSiblingRunEvidence",
     "DEFAULT_TOOL_FAILURE_THRESHOLD",
     "FinalReplyEvidence",
     "StatusDeliverableEvidence",

--- a/brain/systems/runs/direct_loop/reply_coordination.py
+++ b/brain/systems/runs/direct_loop/reply_coordination.py
@@ -1,0 +1,77 @@
+"""Typed coordination declarations for outbound replies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ReplyCoordinationAction(str, Enum):
+    WAIT = "wait"
+    REFERENCE = "reference"
+    HANDOFF = "handoff"
+
+
+REPLY_COORDINATION_INPUT_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Required when admission context lists an active same-thread run. Declare "
+        "whether this reply will wait, reference one listed run, or hand the question off."
+    ),
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [action.value for action in ReplyCoordinationAction],
+        },
+        "run_id": {
+            "type": "integer",
+            "description": "Active run id; required when action is reference.",
+        },
+    },
+    "required": ["action"],
+}
+
+
+@dataclass(frozen=True)
+class ReplyCoordination:
+    """A reply's declared handling of active same-thread work."""
+
+    action: ReplyCoordinationAction
+    run_id: int | None = None
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ReplyCoordination | None":
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            return None
+        try:
+            action = ReplyCoordinationAction(
+                str(value.get("action") or "").strip().lower()
+            )
+        except ValueError:
+            return None
+        raw_run_id = value.get("run_id")
+        try:
+            run_id = int(raw_run_id) if raw_run_id not in (None, "") else None
+        except (TypeError, ValueError):
+            return None
+        if action is ReplyCoordinationAction.REFERENCE and run_id is None:
+            return None
+        return cls(action=action, run_id=run_id)
+
+    def cache_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"action": self.action.value}
+        if self.run_id is not None:
+            payload["run_id"] = self.run_id
+        return payload
+
+
+__all__ = [
+    "REPLY_COORDINATION_INPUT_SCHEMA",
+    "ReplyCoordination",
+    "ReplyCoordinationAction",
+]

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -24,7 +24,6 @@ from brain.systems.runs.direct_loop.loop_control import (
 from brain.systems.runs.direct_loop.tool_failure_policy import ToolDisablement
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
 from brain.systems.runs.direct_loop.final_reply_evidence import (
-    FinalReplyEvidence,
     ToolResultEvidence,
 )
 from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
@@ -234,11 +233,7 @@ def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedTool
             "\n\n[System: brain_encode failed. Do not retry brain_encode in this run. "
             "Move on and end your turn unless another required tool remains.]"
         )
-    elif (
-        request.tool_name in {"cortex_reply", "post_slack_reply"}
-        and isinstance(result, dict)
-        and (result.get("blocked") or result.get("error"))
-    ):
+    elif isinstance(result, dict) and (result.get("blocked") or result.get("error")):
         if result.get("instruction"):
             result_text += f"\n\n[System: {result['instruction']}]"
     elif request.result_nudge:
@@ -252,44 +247,6 @@ def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedTool
         outcome=outcome,
         result_content=model_content,
         result_value=result,
-    )
-
-
-def _blocked_active_sibling_reply(
-    request: PendingToolCall,
-    agent_context: Any,
-) -> ResolvedToolCall | None:
-    if request.tool_name != "post_slack_reply" or agent_context is None:
-        return None
-    evidence = FinalReplyEvidence.from_agent_context(agent_context)
-    if (
-        evidence.active_siblings is None
-        or not evidence.active_siblings.has_active_sibling
-    ):
-        return None
-    from brain.systems.runs.direct_loop.final_reply_checker import (
-        active_sibling_contract_issue,
-    )
-
-    issue = active_sibling_contract_issue(
-        str(request.tool_input.get("body") or ""),
-        evidence,
-    )
-    if issue is None:
-        return None
-    return _resolved_tool_result(
-        request,
-        {
-            "ok": False,
-            "posted": False,
-            "blocked": True,
-            "error": "active_sibling_reply_requires_coordination",
-            "detail": issue,
-            "instruction": (
-                "Rewrite the reply to wait for the active sibling, reference an active "
-                "sibling run, or explicitly hand the question off."
-            ),
-        },
     )
 
 
@@ -414,9 +371,6 @@ async def _async_resolve_tool_call_once(
 ) -> ResolvedToolCall:
     """Execute one tool request and normalize success/error handling."""
     try:
-        policy_block = _blocked_active_sibling_reply(request, agent_context)
-        if policy_block is not None:
-            return policy_block
         if not getattr(request.handler, "_illo_marks_side_effect_start", False):
             mark_side_effect_started()
         result = await async_invoke_tool_handler(
@@ -521,9 +475,6 @@ def _resolve_tool_call_sync(
 ) -> ResolvedToolCall:
     """Execute one tool request and normalize success/error handling."""
     try:
-        policy_block = _blocked_active_sibling_reply(request, agent_context)
-        if policy_block is not None:
-            return policy_block
         result = invoke_tool_handler(
             request.handler,
             request.tool_input,

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -23,7 +23,10 @@ from brain.systems.runs.direct_loop.loop_control import (
 )
 from brain.systems.runs.direct_loop.tool_failure_policy import ToolDisablement
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
-from brain.systems.runs.direct_loop.final_reply_evidence import ToolResultEvidence
+from brain.systems.runs.direct_loop.final_reply_evidence import (
+    FinalReplyEvidence,
+    ToolResultEvidence,
+)
 from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
 from brain.systems.runs.tool_catalog.registry import (
     action_policy_for_tool,
@@ -231,8 +234,10 @@ def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedTool
             "\n\n[System: brain_encode failed. Do not retry brain_encode in this run. "
             "Move on and end your turn unless another required tool remains.]"
         )
-    elif request.tool_name == "cortex_reply" and isinstance(result, dict) and (
-        result.get("blocked") or result.get("error")
+    elif (
+        request.tool_name in {"cortex_reply", "post_slack_reply"}
+        and isinstance(result, dict)
+        and (result.get("blocked") or result.get("error"))
     ):
         if result.get("instruction"):
             result_text += f"\n\n[System: {result['instruction']}]"
@@ -247,6 +252,44 @@ def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedTool
         outcome=outcome,
         result_content=model_content,
         result_value=result,
+    )
+
+
+def _blocked_active_sibling_reply(
+    request: PendingToolCall,
+    agent_context: Any,
+) -> ResolvedToolCall | None:
+    if request.tool_name != "post_slack_reply" or agent_context is None:
+        return None
+    evidence = FinalReplyEvidence.from_agent_context(agent_context)
+    if (
+        evidence.active_siblings is None
+        or not evidence.active_siblings.has_active_sibling
+    ):
+        return None
+    from brain.systems.runs.direct_loop.final_reply_checker import (
+        active_sibling_contract_issue,
+    )
+
+    issue = active_sibling_contract_issue(
+        str(request.tool_input.get("body") or ""),
+        evidence,
+    )
+    if issue is None:
+        return None
+    return _resolved_tool_result(
+        request,
+        {
+            "ok": False,
+            "posted": False,
+            "blocked": True,
+            "error": "active_sibling_reply_requires_coordination",
+            "detail": issue,
+            "instruction": (
+                "Rewrite the reply to wait for the active sibling, reference an active "
+                "sibling run, or explicitly hand the question off."
+            ),
+        },
     )
 
 
@@ -371,6 +414,9 @@ async def _async_resolve_tool_call_once(
 ) -> ResolvedToolCall:
     """Execute one tool request and normalize success/error handling."""
     try:
+        policy_block = _blocked_active_sibling_reply(request, agent_context)
+        if policy_block is not None:
+            return policy_block
         if not getattr(request.handler, "_illo_marks_side_effect_start", False):
             mark_side_effect_started()
         result = await async_invoke_tool_handler(
@@ -475,6 +521,9 @@ def _resolve_tool_call_sync(
 ) -> ResolvedToolCall:
     """Execute one tool request and normalize success/error handling."""
     try:
+        policy_block = _blocked_active_sibling_reply(request, agent_context)
+        if policy_block is not None:
+            return policy_block
         result = invoke_tool_handler(
             request.handler,
             request.tool_input,

--- a/brain/systems/runs/execution_context.py
+++ b/brain/systems/runs/execution_context.py
@@ -115,7 +115,7 @@ class AgentExecutionContext:
     resolved_llm_context: ResolvedLLMContext | None = None
     intent_satisfaction: dict | None = None
     final_reply_review: dict | None = None
-    artifact_contract_block_count: int = 0
+    reply_admission_block_count: int = 0
     resource_summary: dict | None = None
     slash_skill_refs: list[str] = field(default_factory=list)
 

--- a/brain/systems/runs/interactive_reply.py
+++ b/brain/systems/runs/interactive_reply.py
@@ -15,10 +15,13 @@ INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE = (
 
 
 def is_interactive_slack_reply_context(*contexts: Mapping | None) -> bool:
-    """Recognize the two conversational Slack origins through nested provenance."""
+    """Recognize a Slack reply surface through nested provenance and surface policy."""
 
     pending = [context for context in contexts if isinstance(context, Mapping)]
     seen: set[int] = set()
+    has_interactive_origin = False
+    targets_slack = False
+    is_headless = False
     while pending:
         context = pending.pop()
         identity = id(context)
@@ -26,12 +29,20 @@ def is_interactive_slack_reply_context(*contexts: Mapping | None) -> bool:
             continue
         seen.add(identity)
         if str(context.get("origin") or "").strip().lower() in INTERACTIVE_SLACK_ORIGINS:
-            return True
+            has_interactive_origin = True
+        if str(context.get("final_answer_target_surface") or "").strip().lower() == "slack":
+            targets_slack = True
+        if (
+            bool(context.get("headless"))
+            or str(context.get("final_answer_target_surface") or "").strip().lower()
+            == "headless"
+        ):
+            is_headless = True
         for key in ("execution_provenance", "target_ref"):
             nested = context.get(key)
             if isinstance(nested, Mapping):
                 pending.append(nested)
-    return False
+    return not is_headless and (has_interactive_origin or targets_slack)
 
 
 def interactive_transport_fallback(

--- a/brain/systems/runs/outbound_reply_admission.py
+++ b/brain/systems/runs/outbound_reply_admission.py
@@ -1,0 +1,336 @@
+"""Shared admission policy for user-visible outbound replies."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from brain.systems.runs.direct_loop.final_reply_checker import (
+    FinalReplyEnforcement,
+    active_sibling_contract_issue,
+    review_final_reply_once,
+)
+from brain.systems.runs.direct_loop.final_reply_evidence import (
+    FinalReplyEvidence,
+    ToolResultEvidence,
+)
+from brain.systems.runs.direct_loop.reply_coordination import ReplyCoordination
+from brain.systems.runs.execution_context import get_or_create_agent_run_state
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
+
+
+MAX_OUTBOUND_REPLY_BLOCKS = 2
+
+
+@dataclass(frozen=True)
+class OutboundReplyAdmission:
+    admitted: bool
+    review: dict[str, Any]
+    blocked_result: dict[str, Any] | None = None
+
+
+def _safe_failure_message(diagnostic: object) -> str:
+    category = failure_category_for_error(diagnostic)
+    failure = public_run_failure("failed", category)
+    return str((failure or {}).get("message") or "")
+
+
+def _current_effective_model(agent_context: Any) -> str | None:
+    """Read the model from the run's canonical live routing metadata."""
+
+    execution_metadata = getattr(agent_context, "execution_metadata", None)
+    if not isinstance(execution_metadata, Mapping):
+        return None
+    routing = execution_metadata.get("routing")
+    if not isinstance(routing, Mapping):
+        return None
+    effective = routing.get("effective")
+    if not isinstance(effective, Mapping):
+        return None
+    model = effective.get("model")
+    return str(model) if model else None
+
+
+def build_final_reply_check_context(
+    agent_context: Any,
+    evidence: FinalReplyEvidence | None = None,
+) -> str:
+    """Summarize recent execution evidence for the final-reply checker."""
+
+    run = getattr(agent_context, "run", None)
+    execution_artifacts = list(getattr(agent_context, "execution_artifacts", []) or [])
+    lines: list[str] = [
+        "Evidence guardrail: approve direct source/runtime/commit claims only when raw "
+        "command output or file artifacts support them. Worker-summary-level evidence "
+        "must be attributed as worker-reported, with uncertainty preserved."
+    ]
+
+    if run:
+        worker_results = list(getattr(run, "worker_results", []) or [])
+        lines.append(
+            "Run summary: "
+            f"workers={len(worker_results)}, "
+            f"tokens={int(getattr(run, 'total_tokens', 0) or 0)}"
+        )
+        for idx, worker_result in enumerate(worker_results[-4:], 1):
+            status = "success" if worker_result.success else "failed"
+            worker_evidence = (
+                worker_result.evidence
+                if isinstance(worker_result.evidence, dict)
+                else {}
+            )
+            unresolved = worker_evidence.get("unresolved_uncertainty") or []
+            evidence_counts = {
+                "files": len(worker_evidence.get("files") or []),
+                "commands": len(worker_evidence.get("commands") or []),
+                "artifacts": len(worker_evidence.get("artifacts") or []),
+                "uncertainty": len(unresolved),
+            }
+            if worker_result.success:
+                summary = str(worker_result.output or "").strip().replace("\n", " ")
+            else:
+                diagnostic = getattr(worker_result, "error", None) or getattr(
+                    worker_result,
+                    "output",
+                    None,
+                )
+                summary = _safe_failure_message(diagnostic)
+            lines.append(
+                f"Worker {idx} [{worker_result.skill_name or 'unknown'} / {status}]: "
+                f"trust={worker_result.trust_status or 'unknown'}; "
+                f"evidence_counts={evidence_counts}; "
+                f"summary={summary[:350] or '(no output)'}"
+            )
+            if unresolved and worker_result.success:
+                lines.append(f"Worker {idx} unresolved: {str(unresolved[:3])[:350]}")
+
+    intent_profile = getattr(agent_context, "intent_satisfaction", None)
+    if isinstance(intent_profile, dict) and intent_profile:
+        try:
+            lines.append(
+                "Intent satisfaction profile: "
+                + json.dumps(
+                    {
+                        "intent_type": intent_profile.get("intent_type"),
+                        "completion_mode": intent_profile.get("completion_mode"),
+                        "completion_contract": intent_profile.get("completion_contract") or [],
+                        "continuation_policy": intent_profile.get("continuation_policy"),
+                    },
+                    sort_keys=True,
+                    default=str,
+                )[:900]
+            )
+        except Exception:
+            lines.append(f"Intent satisfaction profile: {str(intent_profile)[:900]}")
+
+    for idx, artifact in enumerate(execution_artifacts[-3:], 1):
+        if not isinstance(artifact, dict):
+            lines.append(f"Artifact {idx}: {str(artifact)[:350]}")
+            continue
+        artifact_status = str(artifact.get("status") or "").strip().lower()
+        artifact_summary = artifact.get("summary")
+        if artifact_status in {"error", "failed", "failure"}:
+            artifact_summary = _safe_failure_message(artifact_summary)
+        try:
+            compact = json.dumps(
+                {
+                    "kind": artifact.get("kind"),
+                    "summary": artifact_summary,
+                    "path": artifact.get("path"),
+                    "status": artifact.get("status"),
+                },
+                default=str,
+            )
+        except Exception:
+            compact = str(artifact)
+        lines.append(f"Artifact {idx}: {compact[:350]}")
+
+    recent_tool_results = list(
+        evidence.tool_results
+        if evidence is not None
+        else (getattr(agent_context, "recent_tool_results", []) or [])
+    )
+    for idx, tool_result in enumerate(recent_tool_results[-5:], 1):
+        if isinstance(tool_result, ToolResultEvidence):
+            try:
+                args_preview = json.dumps(
+                    tool_result.arguments,
+                    sort_keys=True,
+                    default=str,
+                )
+            except Exception:
+                args_preview = str(tool_result.arguments)
+            try:
+                result_preview = json.dumps(
+                    tool_result.result,
+                    sort_keys=True,
+                    default=str,
+                )
+            except Exception:
+                result_preview = str(tool_result.result)
+            is_error = tool_result.failed
+        elif isinstance(tool_result, dict):
+            args_preview = tool_result.get("args_preview")
+            result_preview = tool_result.get("result_preview")
+            is_error = bool(tool_result.get("is_error"))
+        else:
+            continue
+        if is_error:
+            result_preview = _safe_failure_message(result_preview)
+        try:
+            compact = json.dumps(
+                {
+                    "tool_name": (
+                        tool_result.tool_name
+                        if isinstance(tool_result, ToolResultEvidence)
+                        else tool_result.get("tool_name")
+                    ),
+                    "args_preview": str(args_preview or "")[:400],
+                    "is_error": is_error,
+                    "result_preview": result_preview,
+                },
+                default=str,
+                sort_keys=True,
+            )
+        except Exception:
+            compact = str(tool_result)
+        lines.append(f"Recent tool result {idx}: {compact[:650]}")
+
+    return "\n".join(lines)[:2500]
+
+
+def _coordination_review(
+    coordination: ReplyCoordination | dict[str, Any] | None,
+    evidence: FinalReplyEvidence,
+) -> dict[str, Any]:
+    issue = active_sibling_contract_issue(coordination, evidence)
+    if issue is None:
+        return {
+            "status": "resolved",
+            "approved": True,
+            "rationale": "Outbound reply coordination is admitted.",
+            "missing_requirements": [],
+            "raw_output": "deterministic_active_sibling_contract",
+            "enforcement": FinalReplyEnforcement.ADVISORY,
+        }
+    return {
+        "status": "continue",
+        "approved": False,
+        "rationale": issue,
+        "missing_requirements": [
+            "Declare coordination as wait, reference an active run id, or handoff."
+        ],
+        "raw_output": "deterministic_active_sibling_contract",
+        "enforcement": FinalReplyEnforcement.BLOCK,
+    }
+
+
+def _enforcement(review: Mapping[str, Any]) -> FinalReplyEnforcement:
+    try:
+        return FinalReplyEnforcement(
+            review.get("enforcement", FinalReplyEnforcement.ADVISORY)
+        )
+    except (TypeError, ValueError):
+        return FinalReplyEnforcement.ADVISORY
+
+
+def _block_state(agent_context: Any) -> dict[str, int]:
+    return get_or_create_agent_run_state(
+        "outbound_reply_admission",
+        lambda: {
+            "blocked_attempts": int(
+                getattr(agent_context, "reply_admission_block_count", 0) or 0
+            )
+        },
+    )
+
+
+def _bounded_admission(
+    review: dict[str, Any],
+    *,
+    agent_context: Any,
+) -> OutboundReplyAdmission:
+    if _enforcement(review) is not FinalReplyEnforcement.BLOCK:
+        return OutboundReplyAdmission(admitted=True, review=review)
+
+    state = _block_state(agent_context)
+    blocked_attempts = int(state.get("blocked_attempts", 0) or 0)
+    if blocked_attempts < MAX_OUTBOUND_REPLY_BLOCKS:
+        blocked_attempts += 1
+        state["blocked_attempts"] = blocked_attempts
+        agent_context.reply_admission_block_count = blocked_attempts
+        return OutboundReplyAdmission(
+            admitted=False,
+            review=review,
+            blocked_result={
+                "ok": False,
+                "posted": False,
+                "blocked": True,
+                "error": "outbound_reply_admission_blocked",
+                "checker_status": review.get("status", "continue"),
+                "checker_reason": review.get("rationale"),
+                "missing_requirements": review.get("missing_requirements") or [],
+                "reply_admission_block_count": blocked_attempts,
+                "instruction": (
+                    "Revise the reply and its typed coordination declaration. "
+                    "The gate degrades after two blocked attempts."
+                ),
+            },
+        )
+
+    downgraded = dict(review)
+    downgraded["enforcement"] = FinalReplyEnforcement.ADVISORY
+    downgraded["rationale"] = (
+        f"{str(review.get('rationale') or '').strip()} "
+        "Outbound reply admission already blocked two replies in this run, so this "
+        "verdict is now advisory and cannot prevent a human-visible reply."
+    ).strip()
+    return OutboundReplyAdmission(admitted=True, review=downgraded)
+
+
+def admit_outbound_reply(
+    *,
+    agent_context: Any,
+    content: str,
+    coordination: ReplyCoordination | dict[str, Any] | None,
+    review_completion: bool,
+) -> OutboundReplyAdmission:
+    """Admit one outbound reply before its handler crosses the post boundary."""
+
+    evidence = FinalReplyEvidence.from_agent_context(agent_context)
+    declared_coordination = ReplyCoordination.from_value(coordination)
+    if review_completion:
+        resolved_llm_context = getattr(agent_context, "resolved_llm_context", None)
+        review = review_final_reply_once(
+            user_request=(
+                getattr(agent_context, "user_request", None)
+                or getattr(getattr(agent_context, "run", None), "user_task", None)
+                or ""
+            ),
+            candidate_output=str(content or ""),
+            execution_context=build_final_reply_check_context(agent_context, evidence),
+            evidence=evidence,
+            coordination=declared_coordination,
+            intent_profile=getattr(agent_context, "intent_satisfaction", None),
+            user_id=getattr(agent_context, "user_id", None),
+            provider=(
+                resolved_llm_context.provider if resolved_llm_context else None
+            ),
+            llm=(resolved_llm_context.llm if resolved_llm_context else None),
+            model=_current_effective_model(agent_context),
+            session_id=getattr(agent_context, "session_id", None),
+            agent_context=agent_context,
+        )
+    else:
+        review = _coordination_review(declared_coordination, evidence)
+    return _bounded_admission(review, agent_context=agent_context)
+
+
+__all__ = [
+    "MAX_OUTBOUND_REPLY_BLOCKS",
+    "OutboundReplyAdmission",
+    "admit_outbound_reply",
+    "build_final_reply_check_context",
+]

--- a/brain/systems/runs/outbound_reply_admission.py
+++ b/brain/systems/runs/outbound_reply_admission.py
@@ -22,6 +22,7 @@ from brain.systems.runs.failures import failure_category_for_error, public_run_f
 
 
 MAX_OUTBOUND_REPLY_BLOCKS = 2
+REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY = "reply_admission_block_count"
 
 
 @dataclass(frozen=True)
@@ -261,6 +262,10 @@ def _bounded_admission(
         blocked_attempts += 1
         state["blocked_attempts"] = blocked_attempts
         agent_context.reply_admission_block_count = blocked_attempts
+        execution_metadata = getattr(agent_context, "execution_metadata", None)
+        if isinstance(execution_metadata, dict):
+            execution_metadata[REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY] = blocked_attempts
+            agent_context.execution_metadata = execution_metadata
         return OutboundReplyAdmission(
             admitted=False,
             review=review,
@@ -331,6 +336,7 @@ def admit_outbound_reply(
 __all__ = [
     "MAX_OUTBOUND_REPLY_BLOCKS",
     "OutboundReplyAdmission",
+    "REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY",
     "admit_outbound_reply",
     "build_final_reply_check_context",
 ]

--- a/brain/systems/runs/status_questions.py
+++ b/brain/systems/runs/status_questions.py
@@ -62,18 +62,16 @@ def enumerate_status_deliverables(request: str | None) -> list[dict[str, str]]:
     return deliverables
 
 
-async def build_status_question_context(
+async def build_same_thread_run_context(
     session: Any,
     *,
     thread_id: str,
-    message: str,
     org_id: str | None = None,
     limit: int = 32,
+    include_status_details: bool = False,
 ) -> dict[str, Any] | None:
-    """Snapshot the prior same-thread run that a status question refers to."""
+    """Snapshot prior top-level runs on a thread for admission-time policies."""
 
-    if not is_status_question(message):
-        return None
     clean_thread_id = str(thread_id or "").strip()
     if not clean_thread_id:
         return {
@@ -95,19 +93,20 @@ async def build_status_question_context(
         }
 
     try:
-        statement = select(AgentRunRow).where(AgentRunRow.thread_id == clean_thread_id)
+        statement = select(AgentRunRow).where(
+            AgentRunRow.thread_id == clean_thread_id,
+            AgentRunRow.parent_run_id.is_(None),
+        )
         clean_org_id = str(org_id or "").strip()
         if clean_org_id:
             statement = statement.where(AgentRunRow.org_id == clean_org_id)
         result = await session.scalars(
-            statement
-            .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
-            .limit(max(1, int(limit)))
+            statement.order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
         )
         rows = list(result.all())
     except Exception as exc:
         logger.warning(
-            "status_question_run_lookup_failed thread_id=%s error=%s",
+            "same_thread_run_lookup_failed thread_id=%s error=%s",
             clean_thread_id,
             exc,
         )
@@ -141,13 +140,13 @@ async def build_status_question_context(
     origin_with_status = next(
         (
             (row, status)
-            for row, status in rows_with_status
+            for row, status in rows_with_status[:max(1, int(limit))]
             if not is_status_question(getattr(row, "input_message", None))
         ),
         None,
     )
     origin_payload: dict[str, Any] | None = None
-    if origin_with_status is not None:
+    if include_status_details and origin_with_status is not None:
         origin, origin_status = origin_with_status
         final_output = await _latest_final_output(session, int(origin.id))
         origin_payload = {
@@ -162,9 +161,55 @@ async def build_status_question_context(
         "lookup_status": "verified",
         "originating_run": origin_payload,
         "live_sibling_runs": live_runs,
-        "deliverables": enumerate_status_deliverables(
-            origin_payload.get("request") if origin_payload else None
+        "deliverables": (
+            enumerate_status_deliverables(
+                origin_payload.get("request") if origin_payload else None
+            )
+            if include_status_details
+            else []
         ),
+    }
+
+
+async def build_status_question_context(
+    session: Any,
+    *,
+    thread_id: str,
+    message: str,
+    org_id: str | None = None,
+    limit: int = 32,
+) -> dict[str, Any] | None:
+    """Snapshot the prior same-thread run that a status question refers to."""
+
+    if not is_status_question(message):
+        return None
+    return await build_same_thread_run_context(
+        session,
+        thread_id=thread_id,
+        org_id=org_id,
+        limit=limit,
+        include_status_details=True,
+    )
+
+
+def active_sibling_context(
+    value: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project a shared same-thread snapshot into active-sibling evidence."""
+
+    if not isinstance(value, Mapping) or value.get("lookup_status") != "verified":
+        return None
+    active_runs = [
+        dict(item)
+        for item in list(value.get("live_sibling_runs") or [])
+        if isinstance(item, Mapping)
+    ]
+    if not active_runs:
+        return None
+    return {
+        "thread_id": str(value.get("thread_id") or "").strip(),
+        "lookup_status": "verified",
+        "active_sibling_runs": active_runs,
     }
 
 
@@ -253,9 +298,43 @@ def format_status_question_context(value: Mapping[str, Any] | None) -> str:
     return "\n".join(lines)
 
 
+def format_active_sibling_context(value: Mapping[str, Any] | None) -> str:
+    """Render active siblings as authoritative admission-time context."""
+
+    if not isinstance(value, Mapping) or not value:
+        return ""
+    active_runs = [
+        item
+        for item in list(value.get("active_sibling_runs") or [])
+        if isinstance(item, Mapping)
+    ]
+    if not active_runs:
+        return ""
+
+    lines = ["Authoritative active-sibling evidence captured at admission:"]
+    for run in active_runs:
+        lines.append(
+            f"Sibling run {run.get('run_id')} status: "
+            f"{run.get('status') or 'unknown'}."
+        )
+    lines.append(
+        "Do not answer as if this is the only active work on the Slack thread. "
+        "Your final reply must wait for the active work, reference an active sibling "
+        "run, or explicitly hand the question off."
+    )
+    lines.append(
+        "This admission snapshot is authoritative even if the sibling work seems "
+        "unrelated or may have finished since admission."
+    )
+    return "\n".join(lines)
+
+
 __all__ = [
+    "active_sibling_context",
+    "build_same_thread_run_context",
     "build_status_question_context",
     "enumerate_status_deliverables",
+    "format_active_sibling_context",
     "format_status_question_context",
     "is_status_question",
 ]

--- a/brain/systems/runs/status_questions.py
+++ b/brain/systems/runs/status_questions.py
@@ -38,6 +38,13 @@ _ASSIGNMENT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# A top-level same-thread run needs coordination while it is open. This is
+# intentionally conservative: the run model has no typed "investigating this
+# question" state, so queued, starting, running, paused, and verifying runs all
+# count. Child runs never count because they are work owned by their root run,
+# not independent siblings of the newly admitted run.
+SAME_THREAD_COORDINATION_POLICY = OPEN_RUN_STATUSES
+
 
 def is_status_question(message: str | None) -> bool:
     """Return whether the current message is asking about prior work's status."""
@@ -67,7 +74,7 @@ async def build_same_thread_run_context(
     *,
     thread_id: str,
     org_id: str | None = None,
-    limit: int = 32,
+    origin_search_limit: int = 32,
     include_status_details: bool = False,
 ) -> dict[str, Any] | None:
     """Snapshot prior top-level runs on a thread for admission-time policies."""
@@ -78,6 +85,7 @@ async def build_same_thread_run_context(
             "thread_id": "",
             "lookup_status": "failed",
             "lookup_error": "missing thread id",
+            "status_question": bool(include_status_details),
             "originating_run": None,
             "live_sibling_runs": [],
             "deliverables": [],
@@ -87,23 +95,46 @@ async def build_same_thread_run_context(
             "thread_id": clean_thread_id,
             "lookup_status": "failed",
             "lookup_error": "run lookup unavailable",
+            "status_question": bool(include_status_details),
             "originating_run": None,
             "live_sibling_runs": [],
             "deliverables": [],
         }
 
     try:
-        statement = select(AgentRunRow).where(
+        filters = (
             AgentRunRow.thread_id == clean_thread_id,
             AgentRunRow.parent_run_id.is_(None),
         )
         clean_org_id = str(org_id or "").strip()
         if clean_org_id:
-            statement = statement.where(AgentRunRow.org_id == clean_org_id)
-        result = await session.scalars(
-            statement.order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
+            filters = (*filters, AgentRunRow.org_id == clean_org_id)
+
+        live_result = await session.scalars(
+            select(AgentRunRow)
+            .where(
+                *filters,
+                AgentRunRow.status.in_(
+                    tuple(
+                        status.value
+                        for status in RunStatus
+                        if status in SAME_THREAD_COORDINATION_POLICY
+                    )
+                ),
+            )
+            .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
         )
-        rows = list(result.all())
+        live_rows = list(live_result.all())
+
+        origin_rows: list[Any] = []
+        if include_status_details:
+            origin_result = await session.scalars(
+                select(AgentRunRow)
+                .where(*filters)
+                .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
+                .limit(max(1, int(origin_search_limit)))
+            )
+            origin_rows = list(origin_result.all())
     except Exception as exc:
         logger.warning(
             "same_thread_run_lookup_failed thread_id=%s error=%s",
@@ -114,33 +145,32 @@ async def build_same_thread_run_context(
             "thread_id": clean_thread_id,
             "lookup_status": "failed",
             "lookup_error": "same-thread run lookup failed",
+            "status_question": bool(include_status_details),
             "originating_run": None,
             "live_sibling_runs": [],
             "deliverables": [],
         }
 
-    rows_with_status = [
-        (
-            row,
-            coerce_run_status(
-                getattr(row, "status", None),
-                default=RunStatus.FAILED,
-            ),
-        )
-        for row in rows
-    ]
     live_runs = [
         {
             "run_id": int(row.id),
-            "status": status,
+            "status": coerce_run_status(
+                getattr(row, "status", None),
+                default=RunStatus.FAILED,
+            ),
         }
-        for row, status in rows_with_status
-        if status in OPEN_RUN_STATUSES
+        for row in live_rows
     ]
     origin_with_status = next(
         (
-            (row, status)
-            for row, status in rows_with_status[:max(1, int(limit))]
+            (
+                row,
+                coerce_run_status(
+                    getattr(row, "status", None),
+                    default=RunStatus.FAILED,
+                ),
+            )
+            for row in origin_rows
             if not is_status_question(getattr(row, "input_message", None))
         ),
         None,
@@ -159,6 +189,7 @@ async def build_same_thread_run_context(
     return {
         "thread_id": clean_thread_id,
         "lookup_status": "verified",
+        "status_question": bool(include_status_details),
         "originating_run": origin_payload,
         "live_sibling_runs": live_runs,
         "deliverables": (
@@ -177,7 +208,7 @@ async def build_status_question_context(
     thread_id: str,
     message: str,
     org_id: str | None = None,
-    limit: int = 32,
+    origin_search_limit: int = 32,
 ) -> dict[str, Any] | None:
     """Snapshot the prior same-thread run that a status question refers to."""
 
@@ -187,30 +218,9 @@ async def build_status_question_context(
         session,
         thread_id=thread_id,
         org_id=org_id,
-        limit=limit,
+        origin_search_limit=origin_search_limit,
         include_status_details=True,
     )
-
-
-def active_sibling_context(
-    value: Mapping[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Project a shared same-thread snapshot into active-sibling evidence."""
-
-    if not isinstance(value, Mapping) or value.get("lookup_status") != "verified":
-        return None
-    active_runs = [
-        dict(item)
-        for item in list(value.get("live_sibling_runs") or [])
-        if isinstance(item, Mapping)
-    ]
-    if not active_runs:
-        return None
-    return {
-        "thread_id": str(value.get("thread_id") or "").strip(),
-        "lookup_status": "verified",
-        "active_sibling_runs": active_runs,
-    }
 
 
 async def _latest_final_output(session: Any, run_id: int) -> str:
@@ -305,7 +315,7 @@ def format_active_sibling_context(value: Mapping[str, Any] | None) -> str:
         return ""
     active_runs = [
         item
-        for item in list(value.get("active_sibling_runs") or [])
+        for item in list(value.get("live_sibling_runs") or [])
         if isinstance(item, Mapping)
     ]
     if not active_runs:
@@ -323,6 +333,11 @@ def format_active_sibling_context(value: Mapping[str, Any] | None) -> str:
         "run, or explicitly hand the question off."
     )
     lines.append(
+        "Declare that choice in the reply tool's coordination field as "
+        "{'action': 'wait'}, {'action': 'reference', 'run_id': N}, or "
+        "{'action': 'handoff'}."
+    )
+    lines.append(
         "This admission snapshot is authoritative even if the sibling work seems "
         "unrelated or may have finished since admission."
     )
@@ -330,7 +345,7 @@ def format_active_sibling_context(value: Mapping[str, Any] | None) -> str:
 
 
 __all__ = [
-    "active_sibling_context",
+    "SAME_THREAD_COORDINATION_POLICY",
     "build_same_thread_run_context",
     "build_status_question_context",
     "enumerate_status_deliverables",

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from brain.systems.runs.direct_loop.reply_coordination import (
+    REPLY_COORDINATION_INPUT_SCHEMA,
+)
+
 from brain.systems.cortex.status import IDEA_STATUS_VALUES
 
 
@@ -361,6 +365,7 @@ CHAT_TOOLS = [
                     ),
                     "default": False,
                 },
+                "coordination": REPLY_COORDINATION_INPUT_SCHEMA,
                 "exception_ping": {
                     "type": "object",
                     "description": (

--- a/brain/systems/runs/tool_catalog/definitions/run_support.py
+++ b/brain/systems/runs/tool_catalog/definitions/run_support.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from brain.systems.runs.direct_loop.reply_coordination import (
+    REPLY_COORDINATION_INPUT_SCHEMA,
+)
+
 
 # ── Soul Tools ────────────────────────────────────────────────
 # Controlled access to private operator/personality context.
@@ -61,6 +65,7 @@ CORTEX_REPLY_TOOL = {
                     "no raw evidence dumps, no one-metric-per-line formatting, and no punctuation on its own line."
                 ),
             },
+            "coordination": REPLY_COORDINATION_INPUT_SCHEMA,
         },
         "required": ["content"],
     },

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -27,7 +27,6 @@ from brain.systems.runs.tool_catalog.handlers.browser import (
 )
 from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
 from brain.systems.runs.tool_catalog.handlers.cortex_reply import (
-    _build_final_reply_check_context,
     _handle_cortex_reply,
     _handle_cortex_visual_reply,
 )

--- a/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
+++ b/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
@@ -4,43 +4,15 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
 
 from brain.systems.runs.tool_catalog.handlers.common import *
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 from brain.systems.runs.direct_loop.final_reply_checker import (
     FinalReplyEnforcement,
 )
-from brain.systems.runs.direct_loop.final_reply_evidence import (
-    FinalReplyEvidence,
-    ToolResultEvidence,
+from brain.systems.runs.outbound_reply_admission import (
+    admit_outbound_reply,
 )
-from brain.systems.runs.failures import failure_category_for_error, public_run_failure
-
-
-_MAX_ARTIFACT_CONTRACT_BLOCKS = 2
-
-
-def _current_effective_model() -> str | None:
-    """Read the model from the run's canonical live routing metadata."""
-
-    execution_metadata = _agent_context.execution_metadata
-    if not isinstance(execution_metadata, Mapping):
-        return None
-    routing = execution_metadata.get("routing")
-    if not isinstance(routing, Mapping):
-        return None
-    effective = routing.get("effective")
-    if not isinstance(effective, Mapping):
-        return None
-    model = effective.get("model")
-    return str(model) if model else None
-
-
-def _safe_failure_message(diagnostic: object) -> str:
-    category = failure_category_for_error(diagnostic)
-    failure = public_run_failure("failed", category)
-    return str((failure or {}).get("message") or "")
 
 
 def _normalize_reply_whitespace(content: str) -> str:
@@ -58,136 +30,6 @@ def _normalize_reply_whitespace(content: str) -> str:
         text = re.sub(r"\n{3,}", "\n\n", text)
         normalized_parts.append(text)
     return "```".join(normalized_parts).strip()
-
-
-def _build_final_reply_check_context(
-    evidence: FinalReplyEvidence | None = None,
-) -> str:
-    """Summarize recent execution evidence for the final-reply checker."""
-    run = getattr(_agent_context, "run", None)
-    execution_artifacts = list(getattr(_agent_context, "execution_artifacts", []) or [])
-    lines: list[str] = [
-        "Evidence guardrail: approve direct source/runtime/commit claims only when raw "
-        "command output or file artifacts support them. Worker-summary-level evidence "
-        "must be attributed as worker-reported, with uncertainty preserved."
-    ]
-
-    if run:
-        worker_results = list(getattr(run, "worker_results", []) or [])
-        lines.append(
-            "Run summary: "
-            f"workers={len(worker_results)}, "
-            f"tokens={int(getattr(run, 'total_tokens', 0) or 0)}"
-        )
-        for idx, worker_result in enumerate(worker_results[-4:], 1):
-            status = "success" if worker_result.success else "failed"
-            worker_evidence = worker_result.evidence if isinstance(worker_result.evidence, dict) else {}
-            unresolved = worker_evidence.get("unresolved_uncertainty") or []
-            evidence_counts = {
-                "files": len(worker_evidence.get("files") or []),
-                "commands": len(worker_evidence.get("commands") or []),
-                "artifacts": len(worker_evidence.get("artifacts") or []),
-                "uncertainty": len(unresolved),
-            }
-            if worker_result.success:
-                summary = str(worker_result.output or "").strip().replace("\n", " ")
-            else:
-                diagnostic = getattr(worker_result, "error", None) or getattr(worker_result, "output", None)
-                summary = _safe_failure_message(diagnostic)
-            lines.append(
-                f"Worker {idx} [{worker_result.skill_name or 'unknown'} / {status}]: "
-                f"trust={worker_result.trust_status or 'unknown'}; "
-                f"evidence_counts={evidence_counts}; "
-                f"summary={summary[:350] or '(no output)'}"
-            )
-            if unresolved and worker_result.success:
-                lines.append(f"Worker {idx} unresolved: {str(unresolved[:3])[:350]}")
-
-    intent_profile = getattr(_agent_context, "intent_satisfaction", None)
-    if isinstance(intent_profile, dict) and intent_profile:
-        try:
-            lines.append(
-                "Intent satisfaction profile: "
-                + json.dumps(
-                    {
-                        "intent_type": intent_profile.get("intent_type"),
-                        "completion_mode": intent_profile.get("completion_mode"),
-                        "completion_contract": intent_profile.get("completion_contract") or [],
-                        "continuation_policy": intent_profile.get("continuation_policy"),
-                    },
-                    sort_keys=True,
-                    default=str,
-                )[:900]
-            )
-        except Exception:
-            lines.append(f"Intent satisfaction profile: {str(intent_profile)[:900]}")
-
-    for idx, artifact in enumerate(execution_artifacts[-3:], 1):
-        if not isinstance(artifact, dict):
-            lines.append(f"Artifact {idx}: {str(artifact)[:350]}")
-            continue
-        artifact_status = str(artifact.get("status") or "").strip().lower()
-        artifact_summary = artifact.get("summary")
-        if artifact_status in {"error", "failed", "failure"}:
-            artifact_summary = _safe_failure_message(artifact_summary)
-        try:
-            compact = json.dumps(
-                {
-                    "kind": artifact.get("kind"),
-                    "summary": artifact_summary,
-                    "path": artifact.get("path"),
-                    "status": artifact.get("status"),
-                },
-                default=str,
-            )
-        except Exception:
-            compact = str(artifact)
-        lines.append(f"Artifact {idx}: {compact[:350]}")
-
-    recent_tool_results = list(
-        evidence.tool_results
-        if evidence is not None
-        else (getattr(_agent_context, "recent_tool_results", []) or [])
-    )
-    for idx, tool_result in enumerate(recent_tool_results[-5:], 1):
-        if isinstance(tool_result, ToolResultEvidence):
-            try:
-                args_preview = json.dumps(tool_result.arguments, sort_keys=True, default=str)
-            except Exception:
-                args_preview = str(tool_result.arguments)
-            try:
-                result_preview = json.dumps(tool_result.result, sort_keys=True, default=str)
-            except Exception:
-                result_preview = str(tool_result.result)
-            is_error = tool_result.failed
-        elif isinstance(tool_result, dict):
-            args_preview = tool_result.get("args_preview")
-            result_preview = tool_result.get("result_preview")
-            is_error = bool(tool_result.get("is_error"))
-        else:
-            continue
-        if is_error:
-            result_preview = _safe_failure_message(result_preview)
-        try:
-            compact = json.dumps(
-                {
-                    "tool_name": (
-                        tool_result.tool_name
-                        if isinstance(tool_result, ToolResultEvidence)
-                        else tool_result.get("tool_name")
-                    ),
-                    "args_preview": str(args_preview or "")[:400],
-                    "is_error": is_error,
-                    "result_preview": result_preview,
-                },
-                default=str,
-                sort_keys=True,
-            )
-        except Exception:
-            compact = str(tool_result)
-        lines.append(f"Recent tool result {idx}: {compact[:650]}")
-
-    return "\n".join(lines)[:2500]
 
 
 def _stage_cortex_reply(content: str, *, run_id: int | None, review: dict) -> dict:
@@ -225,7 +67,10 @@ def _stage_cortex_reply(content: str, *, run_id: int | None, review: dict) -> di
     return result
 
 
-def _handle_cortex_reply(content: str) -> dict:
+def _handle_cortex_reply(
+    content: str,
+    coordination: dict | None = None,
+) -> dict:
     """Accept a final Cortex reply.
 
     Run-scoped replies are staged, not posted immediately. The run
@@ -249,62 +94,15 @@ def _handle_cortex_reply(content: str) -> dict:
             ),
         }
 
-    from brain.systems.runs.direct_agent import review_final_reply_once
-
-    user_request = (
-        getattr(_agent_context, "user_request", None)
-        or getattr(getattr(_agent_context, "run", None), "user_task", None)
-        or ""
+    admission = admit_outbound_reply(
+        agent_context=_agent_context,
+        content=proposed_reply,
+        coordination=coordination,
+        review_completion=True,
     )
-    evidence = FinalReplyEvidence.from_agent_context(_agent_context)
-    execution_context = _build_final_reply_check_context(evidence)
-    resolved_llm_context = _agent_context.resolved_llm_context
-    review = review_final_reply_once(
-        user_request=user_request,
-        candidate_output=proposed_reply,
-        execution_context=execution_context,
-        evidence=evidence,
-        intent_profile=getattr(_agent_context, "intent_satisfaction", None),
-        user_id=getattr(_agent_context, "user_id", None),
-        provider=(resolved_llm_context.provider if resolved_llm_context else None),
-        llm=(resolved_llm_context.llm if resolved_llm_context else None),
-        model=_current_effective_model(),
-        session_id=getattr(_agent_context, "session_id", None),
-    )
-    try:
-        enforcement = FinalReplyEnforcement(
-            review.get("enforcement", FinalReplyEnforcement.ADVISORY)
-        )
-    except (TypeError, ValueError):
-        enforcement = FinalReplyEnforcement.ADVISORY
-    if enforcement is FinalReplyEnforcement.BLOCK:
-        block_count = int(getattr(_agent_context, "artifact_contract_block_count", 0) or 0)
-        if block_count < _MAX_ARTIFACT_CONTRACT_BLOCKS:
-            block_count += 1
-            _agent_context.artifact_contract_block_count = block_count
-            return {
-                "blocked": True,
-                "error": "Final reply violates the requested-artifact contract.",
-                "checker_status": review["status"],
-                "checker_reason": review.get("rationale"),
-                "missing_requirements": review.get("missing_requirements") or [],
-                "artifact_contract_block_count": block_count,
-                "instruction": (
-                    "Continue the required artifact work, or replace the reply with the requested "
-                    "artifact name and its concrete blocker. Do not report a substitute artifact as success."
-                ),
-            }
-
-        review = dict(review)
-        review["enforcement"] = FinalReplyEnforcement.ADVISORY
-        review["rationale"] = (
-            f"{str(review.get('rationale') or '').strip()} "
-            "The artifact-contract check already blocked two replies in this run, so this verdict "
-            "is now advisory and cannot keep the run alive."
-        ).strip()
-
-    # Other checker verdicts are advisory: surface them as a non-blocking warning
-    # so the model can decide whether to continue or reply again.
+    if not admission.admitted:
+        return dict(admission.blocked_result or {})
+    review = admission.review
 
     run_id = getattr(getattr(_agent_context, "run", None), "run_id", None)
     if run_id:

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -23,6 +23,7 @@ from brain.systems.runs.obligation_specs import (
     ObligationSettlementPolicy,
     obligation_spec_from_metadata,
 )
+from brain.systems.runs.outbound_reply_admission import admit_outbound_reply
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
 from brain.systems.slack.exception_ping_posting import post_exception_ping
@@ -446,6 +447,7 @@ async def _handle_post_slack_reply(
     image_alt: str | None = None,
     answers_open_ask: bool = False,
     exception_ping: dict[str, Any] | None = None,
+    coordination: dict[str, Any] | None = None,
 ) -> str:
     """Post an Illo-authored reply to the originating Slack surface."""
 
@@ -473,6 +475,15 @@ async def _handle_post_slack_reply(
         return json.dumps({"error": str(exc)})
     if not text.strip() and image_upload is None:
         return json.dumps({"error": "post_slack_reply requires body or image_data"})
+
+    admission = admit_outbound_reply(
+        agent_context=_agent_context,
+        content=text,
+        coordination=coordination,
+        review_completion=False,
+    )
+    if not admission.admitted:
+        return json.dumps(admission.blocked_result, default=str)
 
     if _makes_persistence_claim(text):
         try:

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -27,6 +27,9 @@ from brain.systems.runs.actions import (
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType, EventVisibility
 from brain.systems.runs.events import activity_event, redact_tool_call_result, run_event
 from brain.systems.runs.execution_context import bind_agent_context, current_agent_context
+from brain.systems.runs.outbound_reply_admission import (
+    REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY,
+)
 from brain.systems.runs.secret_mounts import (
     handler_args_with_resolved_secret_env,
     resolve_secret_env_mounts,
@@ -219,6 +222,7 @@ class AsyncRunToolExecutor:
                     result = await invoke_maybe_async(handler, **handler_args)
             finally:
                 workspace_tool_runtime.cleanup()
+            await self._persist_reply_admission_block_count(run_id, result)
         except BlockingInvocationCancelled as exc:
             failure = str(exc.error) if exc.error else result_failure_summary(exc.result)
             if manifest_id:
@@ -417,6 +421,36 @@ class AsyncRunToolExecutor:
         await self._commit_event_boundary(run_id)
         return result
 
+    async def _persist_reply_admission_block_count(
+        self,
+        run_id: int,
+        result: Any,
+    ) -> None:
+        payload = result
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (TypeError, ValueError):
+                return
+        if not isinstance(payload, dict):
+            return
+        if (
+            payload.get("blocked") is not True
+            or payload.get("error") != "outbound_reply_admission_blocked"
+        ):
+            return
+        try:
+            block_count = max(
+                0,
+                int(payload[REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return
+        await self.store.update_metadata(
+            int(run_id),
+            {REPLY_ADMISSION_BLOCK_COUNT_METADATA_KEY: block_count},
+        )
+
     async def _commit_event_boundary(self, run_id: int) -> None:
         commit_event_boundary = getattr(self.store, "commit_event_boundary", None)
         if callable(commit_event_boundary):
@@ -562,6 +596,9 @@ def _handler_context_from_action_context(action_context: dict[str, Any]) -> dict
         metadata.pop(key, None)
         metadata[key] = context.get(key)
     context["execution_metadata"] = metadata
+    run_state = getattr(current_agent_context(), "_run_state", None)
+    if run_state is not None:
+        context["_run_state"] = run_state
     return context
 
 

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -27,9 +27,9 @@ from brain.systems.runs.direct_targets import (
     resolve_direct_target,
 )
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
+from brain.systems.runs.interactive_reply import is_interactive_slack_reply_context
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
 from brain.systems.runs.status_questions import (
-    active_sibling_context,
     build_same_thread_run_context,
     is_status_question,
 )
@@ -726,20 +726,18 @@ async def build_agent_run_request(
         org_id=request.org_id,
         include_status_details=status_question,
     )
-    context_metadata: dict[str, Any] = {}
-    if status_question:
-        context_metadata["status_question_context"] = same_thread_context
-    elif interactive_slack_thread:
-        sibling_context = active_sibling_context(same_thread_context)
-        if sibling_context is not None:
-            context_metadata["active_sibling_context"] = sibling_context
-    if not context_metadata:
+    live_siblings = (
+        list(same_thread_context.get("live_sibling_runs") or [])
+        if isinstance(same_thread_context, dict)
+        else []
+    )
+    if not status_question and not live_siblings:
         return request
     return replace(
         request,
         metadata={
             **request.metadata,
-            **context_metadata,
+            "same_thread_run_context": same_thread_context,
         },
     )
 
@@ -750,9 +748,7 @@ def _is_interactive_slack_thread(request: AgentRunRequest) -> bool:
     return bool(
         str(request.thread_id or "").startswith("slack:")
         and target.get("kind") == "slack_message"
-        and not metadata.get("headless")
-        and not metadata.get("slack_monitor")
-        and metadata.get("final_answer_target_surface") == "slack"
+        and is_interactive_slack_reply_context(metadata, target)
     )
 
 

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -28,7 +28,11 @@ from brain.systems.runs.direct_targets import (
 )
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
-from brain.systems.runs.status_questions import build_status_question_context
+from brain.systems.runs.status_questions import (
+    active_sibling_context,
+    build_same_thread_run_context,
+    is_status_question,
+)
 from brain.systems.runs.store import AsyncAgentRunStore
 
 _VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
@@ -711,20 +715,44 @@ async def build_agent_run_request(
             model_policy["model"] = target_model
             model_policy.pop("model_override", None)
             request = replace(request, model_policy=model_policy)
-    status_context = await build_status_question_context(
+    status_question = is_status_question(request.message)
+    interactive_slack_thread = _is_interactive_slack_thread(request)
+    if not status_question and not interactive_slack_thread:
+        return request
+
+    same_thread_context = await build_same_thread_run_context(
         session,
         thread_id=request.thread_id,
         org_id=request.org_id,
-        message=request.message,
+        include_status_details=status_question,
     )
-    if status_context is None:
+    context_metadata: dict[str, Any] = {}
+    if status_question:
+        context_metadata["status_question_context"] = same_thread_context
+    elif interactive_slack_thread:
+        sibling_context = active_sibling_context(same_thread_context)
+        if sibling_context is not None:
+            context_metadata["active_sibling_context"] = sibling_context
+    if not context_metadata:
         return request
     return replace(
         request,
         metadata={
             **request.metadata,
-            "status_question_context": status_context,
+            **context_metadata,
         },
+    )
+
+
+def _is_interactive_slack_thread(request: AgentRunRequest) -> bool:
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    target = request.target_ref if isinstance(request.target_ref, dict) else {}
+    return bool(
+        str(request.thread_id or "").startswith("slack:")
+        and target.get("kind") == "slack_message"
+        and not metadata.get("headless")
+        and not metadata.get("slack_monitor")
+        and metadata.get("final_answer_target_surface") == "slack"
     )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2224,6 +2224,185 @@ class TestFinalReplyReview:
             ),
         )
 
+    @staticmethod
+    def _active_sibling_evidence():
+        from brain.systems.runs.direct_loop.final_reply_evidence import (
+            ActiveSiblingEvidence,
+            FinalReplyEvidence,
+        )
+
+        return FinalReplyEvidence(
+            active_siblings=ActiveSiblingEvidence.from_mapping(
+                {
+                    "thread_id": "slack:T:C:1785870481.000100",
+                    "lookup_status": "verified",
+                    "active_sibling_runs": [
+                        {"run_id": 14644, "status": "running"},
+                    ],
+                }
+            )
+        )
+
+    def test_active_sibling_blocks_reply_that_ignores_known_work(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_checker import (
+            FinalReplyEnforcement,
+        )
+
+        provider = MagicMock()
+        result = review_candidate_final_reply(
+            user_request="Which image model is she trying to use?",
+            candidate_output="She doesn't specify the image model.",
+            evidence=self._active_sibling_evidence(),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["enforcement"] is FinalReplyEnforcement.BLOCK
+        assert "14644 (running)" in result["rationale"]
+        assert "wait" in " ".join(result["missing_requirements"]).lower()
+        provider.create.assert_not_called()
+
+    def test_active_sibling_evidence_is_loaded_from_admission_metadata(self):
+        from brain.systems.runs.direct_loop.final_reply_evidence import FinalReplyEvidence
+
+        agent_context = SimpleNamespace(
+            execution_metadata={
+                "active_sibling_context": {
+                    "thread_id": "slack:T:C:1785870481.000100",
+                    "lookup_status": "verified",
+                    "active_sibling_runs": [
+                        {"run_id": 14644, "status": "running"},
+                    ],
+                }
+            },
+            recent_tool_results=[],
+            execution_artifacts=[],
+            run=SimpleNamespace(worker_results=[]),
+        )
+
+        evidence = FinalReplyEvidence.from_agent_context(agent_context)
+
+        assert evidence.active_siblings is not None
+        assert evidence.active_siblings.has_active_sibling
+        assert evidence.active_siblings.runs[0].run_id == 14644
+        assert evidence.active_siblings.runs[0].status == "running"
+
+    def test_active_sibling_blocks_slack_reply_before_side_effect(self):
+        from brain.systems.runs.direct_loop.tool_execution import (
+            PendingToolCall,
+            resolve_tool_call,
+        )
+
+        agent_context = SimpleNamespace(
+            execution_metadata={
+                "active_sibling_context": {
+                    "thread_id": "slack:T:C:1785870481.000100",
+                    "lookup_status": "verified",
+                    "active_sibling_runs": [
+                        {"run_id": 14644, "status": "running"},
+                    ],
+                }
+            },
+            recent_tool_results=[],
+            execution_artifacts=[],
+            run=SimpleNamespace(worker_results=[]),
+        )
+        handler = MagicMock(return_value={"ok": True, "posted": True})
+
+        resolved = resolve_tool_call(
+            PendingToolCall(
+                block_id="reply-1",
+                tool_name="post_slack_reply",
+                tool_input={"body": "She doesn't specify the image model."},
+                handler=handler,
+            ),
+            agent_context=agent_context,
+        )
+
+        assert resolved.result_value["blocked"] is True
+        assert resolved.result_value["posted"] is False
+        assert "Rewrite the reply" in resolved.result_text
+        handler.assert_not_called()
+
+        accepted_body = (
+            "Run 14644 is checking the payloads; I'll wait for that result."
+        )
+        accepted = resolve_tool_call(
+            PendingToolCall(
+                block_id="reply-2",
+                tool_name="post_slack_reply",
+                tool_input={"body": accepted_body},
+                handler=handler,
+            ),
+            agent_context=agent_context,
+        )
+
+        assert accepted.result_value == {"ok": True, "posted": True}
+        handler.assert_called_once_with(body=accepted_body)
+
+    def test_active_sibling_accepts_reply_that_references_and_waits_for_run(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+
+        provider = self._resolved_checker_provider()
+        result = review_candidate_final_reply(
+            user_request="Which image model is she trying to use?",
+            candidate_output=(
+                "Run 14644 is checking the payloads; I'll wait for that result."
+            ),
+            evidence=self._active_sibling_evidence(),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "resolved"
+        assert result["approved"] is True
+        provider.create.assert_called_once()
+
+    def test_no_active_sibling_adds_no_deterministic_rejection(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_evidence import FinalReplyEvidence
+        from brain.systems.runs.direct_loop.tool_execution import (
+            PendingToolCall,
+            resolve_tool_call,
+        )
+
+        provider = self._resolved_checker_provider()
+        result = review_candidate_final_reply(
+            user_request="Which image model is she trying to use?",
+            candidate_output="She doesn't specify the image model.",
+            evidence=FinalReplyEvidence(),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "resolved"
+        assert result["approved"] is True
+        provider.create.assert_called_once()
+
+        handler = MagicMock(return_value={"ok": True, "posted": True})
+        posted = resolve_tool_call(
+            PendingToolCall(
+                block_id="reply-no-sibling",
+                tool_name="post_slack_reply",
+                tool_input={"body": "She doesn't specify the image model."},
+                handler=handler,
+            ),
+            agent_context=SimpleNamespace(
+                execution_metadata={},
+                recent_tool_results=[],
+                execution_artifacts=[],
+                run=SimpleNamespace(worker_results=[]),
+            ),
+        )
+
+        assert posted.result_value == {"ok": True, "posted": True}
+        handler.assert_called_once()
+
     @pytest.mark.parametrize(
         "status",
         ["queued", "starting", "running", "paused", "verifying"],

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -297,7 +297,10 @@ async def test_cortex_reply_checker_reuses_run_client_with_model_after_fallback(
         "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
         AsyncMock(),
     )
-    monkeypatch.setattr("brain.systems.runs.direct_agent.review_final_reply_once", review)
+    monkeypatch.setattr(
+        "brain.systems.runs.outbound_reply_admission.review_final_reply_once",
+        review,
+    )
 
     context = AgentExecutionContext(
         run=SimpleNamespace(run_id=42),
@@ -2163,7 +2166,7 @@ class TestFinalReplyReview:
     def _incident_status_evidence(*, status: str, final_output: str | None = None):
         from brain.systems.runs.direct_loop.final_reply_evidence import (
             FinalReplyEvidence,
-            StatusQuestionEvidence,
+            SameThreadRunContextEvidence,
             ToolResultEvidence,
         )
         from brain.systems.runs.status import (
@@ -2192,10 +2195,11 @@ class TestFinalReplyReview:
                     },
                 ),
             ),
-            status_question=StatusQuestionEvidence.from_mapping(
+            same_thread_run_context=SameThreadRunContextEvidence.from_mapping(
                 {
                     "thread_id": "slack:T_ALERTS:C_ALERTS:1784741844.000100",
                     "lookup_status": "verified",
+                    "status_question": True,
                     "originating_run": {
                         "run_id": 2327,
                         "status": run_status,
@@ -2227,16 +2231,17 @@ class TestFinalReplyReview:
     @staticmethod
     def _active_sibling_evidence():
         from brain.systems.runs.direct_loop.final_reply_evidence import (
-            ActiveSiblingEvidence,
             FinalReplyEvidence,
+            SameThreadRunContextEvidence,
         )
 
         return FinalReplyEvidence(
-            active_siblings=ActiveSiblingEvidence.from_mapping(
+            same_thread_run_context=SameThreadRunContextEvidence.from_mapping(
                 {
                     "thread_id": "slack:T:C:1785870481.000100",
                     "lookup_status": "verified",
-                    "active_sibling_runs": [
+                    "status_question": False,
+                    "live_sibling_runs": [
                         {"run_id": 14644, "status": "running"},
                     ],
                 }
@@ -2270,10 +2275,11 @@ class TestFinalReplyReview:
 
         agent_context = SimpleNamespace(
             execution_metadata={
-                "active_sibling_context": {
+                "same_thread_run_context": {
                     "thread_id": "slack:T:C:1785870481.000100",
                     "lookup_status": "verified",
-                    "active_sibling_runs": [
+                    "status_question": False,
+                    "live_sibling_runs": [
                         {"run_id": 14644, "status": "running"},
                     ],
                 }
@@ -2285,74 +2291,62 @@ class TestFinalReplyReview:
 
         evidence = FinalReplyEvidence.from_agent_context(agent_context)
 
-        assert evidence.active_siblings is not None
-        assert evidence.active_siblings.has_active_sibling
-        assert evidence.active_siblings.runs[0].run_id == 14644
-        assert evidence.active_siblings.runs[0].status == "running"
+        assert evidence.same_thread_run_context is not None
+        assert evidence.same_thread_run_context.has_live_sibling
+        assert evidence.same_thread_run_context.live_sibling_runs[0].run_id == 14644
+        assert evidence.same_thread_run_context.live_sibling_runs[0].status == "running"
 
-    def test_active_sibling_blocks_slack_reply_before_side_effect(self):
-        from brain.systems.runs.direct_loop.tool_execution import (
-            PendingToolCall,
-            resolve_tool_call,
+    async def test_active_sibling_blocks_slack_reply_before_side_effect(self):
+        from brain.systems.runs.execution_context import bind_agent_context
+        from brain.systems.runs.tool_catalog.handlers.slack import (
+            _handle_post_slack_reply,
         )
 
-        agent_context = SimpleNamespace(
-            execution_metadata={
-                "active_sibling_context": {
+        context = {
+            "execution_metadata": {
+                "same_thread_run_context": {
                     "thread_id": "slack:T:C:1785870481.000100",
                     "lookup_status": "verified",
-                    "active_sibling_runs": [
+                    "status_question": False,
+                    "live_sibling_runs": [
                         {"run_id": 14644, "status": "running"},
                     ],
                 }
             },
-            recent_tool_results=[],
-            execution_artifacts=[],
-            run=SimpleNamespace(worker_results=[]),
-        )
-        handler = MagicMock(return_value={"ok": True, "posted": True})
+            "recent_tool_results": [],
+            "execution_artifacts": [],
+            "run": SimpleNamespace(worker_results=[]),
+        }
 
-        resolved = resolve_tool_call(
-            PendingToolCall(
-                block_id="reply-1",
-                tool_name="post_slack_reply",
-                tool_input={"body": "She doesn't specify the image model."},
-                handler=handler,
-            ),
-            agent_context=agent_context,
-        )
+        with (
+            bind_agent_context(context),
+            patch(
+                "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+                new_callable=AsyncMock,
+            ) as slack_client,
+        ):
+            result = json.loads(
+                await _handle_post_slack_reply(
+                    body="She doesn't specify the image model."
+                )
+            )
 
-        assert resolved.result_value["blocked"] is True
-        assert resolved.result_value["posted"] is False
-        assert "Rewrite the reply" in resolved.result_text
-        handler.assert_not_called()
+        assert result["blocked"] is True
+        assert result["posted"] is False
+        assert result["reply_admission_block_count"] == 1
+        slack_client.assert_not_awaited()
 
-        accepted_body = (
-            "Run 14644 is checking the payloads; I'll wait for that result."
-        )
-        accepted = resolve_tool_call(
-            PendingToolCall(
-                block_id="reply-2",
-                tool_name="post_slack_reply",
-                tool_input={"body": accepted_body},
-                handler=handler,
-            ),
-            agent_context=agent_context,
-        )
-
-        assert accepted.result_value == {"ok": True, "posted": True}
-        handler.assert_called_once_with(body=accepted_body)
-
-    def test_active_sibling_accepts_reply_that_references_and_waits_for_run(self):
+    def test_active_sibling_accepts_declared_wait_with_natural_paraphrase(self):
         from brain.systems.runs.direct_agent import review_candidate_final_reply
 
         provider = self._resolved_checker_provider()
         result = review_candidate_final_reply(
             user_request="Which image model is she trying to use?",
             candidate_output=(
-                "Run 14644 is checking the payloads; I'll wait for that result."
+                "I'll let the investigation already under way finish, then I'll report back."
             ),
             evidence=self._active_sibling_evidence(),
+            coordination={"action": "wait"},
             provider=provider,
             llm=_mock_llm_client(MagicMock(), provider="openai"),
             model="openai/gpt-5.5",
@@ -2361,6 +2355,66 @@ class TestFinalReplyReview:
         assert result["status"] == "resolved"
         assert result["approved"] is True
         provider.create.assert_called_once()
+
+    def test_active_sibling_rejects_deceptive_phrase_without_declaration(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_checker import (
+            FinalReplyEnforcement,
+        )
+
+        provider = MagicMock()
+        result = review_candidate_final_reply(
+            user_request="Which image model is she trying to use?",
+            candidate_output=(
+                "One moment — the other run is irrelevant; she did not specify the model."
+            ),
+            evidence=self._active_sibling_evidence(),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["enforcement"] is FinalReplyEnforcement.BLOCK
+        assert "no valid coordination declaration" in result["rationale"]
+        provider.create.assert_not_called()
+
+    def test_active_sibling_gate_degrades_after_two_blocks(self):
+        from brain.systems.runs.outbound_reply_admission import admit_outbound_reply
+
+        context = SimpleNamespace(
+            execution_metadata={
+                "same_thread_run_context": {
+                    "thread_id": "slack:T:C:1785870481.000100",
+                    "lookup_status": "verified",
+                    "status_question": False,
+                    "live_sibling_runs": [
+                        {"run_id": 14644, "status": "running"},
+                    ],
+                }
+            },
+            recent_tool_results=[],
+            execution_artifacts=[],
+            run=SimpleNamespace(worker_results=[]),
+            reply_admission_block_count=0,
+        )
+
+        admissions = [
+            admit_outbound_reply(
+                agent_context=context,
+                content="She doesn't specify the image model.",
+                coordination=None,
+                review_completion=False,
+            )
+            for _ in range(3)
+        ]
+
+        assert [item.admitted for item in admissions] == [False, False, True]
+        assert [
+            item.blocked_result["reply_admission_block_count"]
+            for item in admissions[:2]
+        ] == [1, 2]
+        assert admissions[2].review["enforcement"] == "advisory"
+        assert "already blocked two replies" in admissions[2].review["rationale"]
 
     def test_no_active_sibling_adds_no_deterministic_rejection(self):
         from brain.systems.runs.direct_agent import review_candidate_final_reply
@@ -2447,14 +2501,15 @@ class TestFinalReplyReview:
         from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
         from brain.systems.runs.direct_loop.final_reply_evidence import (
             FinalReplyEvidence,
-            StatusQuestionEvidence,
+            SameThreadRunContextEvidence,
         )
 
         evidence = FinalReplyEvidence(
-            status_question=StatusQuestionEvidence.from_mapping(
+            same_thread_run_context=SameThreadRunContextEvidence.from_mapping(
                 {
                     "thread_id": "thread-1",
                     "lookup_status": "verified",
+                    "status_question": True,
                     "originating_run": {
                         "run_id": 2327,
                         "status": "completed",
@@ -3177,7 +3232,7 @@ class TestCortexReplyHandler:
         from types import SimpleNamespace
 
         from brain.systems.runs.direct_agent import _agent_context
-        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+        from brain.systems.runs.outbound_reply_admission import build_final_reply_check_context
 
         _agent_context.run = SimpleNamespace(
             run_id=42,
@@ -3214,7 +3269,7 @@ class TestCortexReplyHandler:
         }
 
         try:
-            context = _build_final_reply_check_context()
+            context = build_final_reply_check_context(_agent_context)
         finally:
             _agent_context.run = None
             _agent_context.execution_artifacts = []
@@ -3234,7 +3289,7 @@ class TestCortexReplyHandler:
 
     def test_final_reply_context_uses_stable_sorted_key_rendering(self):
         from brain.systems.runs.direct_agent import _agent_context
-        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+        from brain.systems.runs.outbound_reply_admission import build_final_reply_check_context
 
         _agent_context.run = None
         _agent_context.execution_artifacts = []
@@ -3249,7 +3304,7 @@ class TestCortexReplyHandler:
         _agent_context.intent_satisfaction = None
 
         try:
-            context = _build_final_reply_check_context()
+            context = build_final_reply_check_context(_agent_context)
         finally:
             _agent_context.run = None
             _agent_context.execution_artifacts = []
@@ -3266,7 +3321,7 @@ class TestCortexReplyHandler:
 
         from brain.systems.runs.direct_agent import _agent_context
         from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
-        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+        from brain.systems.runs.outbound_reply_admission import build_final_reply_check_context
 
         raw_error = "peer closed connection without sending complete message body"
         _agent_context.run = SimpleNamespace(
@@ -3288,7 +3343,7 @@ class TestCortexReplyHandler:
         _agent_context.intent_satisfaction = None
 
         try:
-            context = _build_final_reply_check_context()
+            context = build_final_reply_check_context(_agent_context)
         finally:
             _agent_context.run = None
             _agent_context.execution_artifacts = []
@@ -3302,7 +3357,7 @@ class TestCortexReplyHandler:
         from types import SimpleNamespace
 
         from brain.systems.runs.direct_agent import _agent_context
-        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+        from brain.systems.runs.outbound_reply_admission import build_final_reply_check_context
 
         raw_error = "provider request failed with private diagnostic"
         _agent_context.run = SimpleNamespace(
@@ -3333,7 +3388,7 @@ class TestCortexReplyHandler:
         _agent_context.intent_satisfaction = None
 
         try:
-            context = _build_final_reply_check_context()
+            context = build_final_reply_check_context(_agent_context)
         finally:
             _agent_context.run = None
             _agent_context.execution_artifacts = []
@@ -3361,7 +3416,7 @@ class TestCortexReplyHandler:
             "```text\nkeep\n\n,\nraw\n```"
         )
 
-    @patch("brain.systems.runs.direct_agent.review_final_reply_once")
+    @patch("brain.systems.runs.outbound_reply_admission.review_final_reply_once")
     def test_cortex_reply_stages_run_reply_for_settlement(self, mock_review):
         from brain.systems.runs.direct_agent import _handle_cortex_reply, _agent_context
 
@@ -3422,7 +3477,7 @@ class TestCortexReplyHandler:
             _agent_context.execution_metadata = None
             _agent_context.intent_satisfaction = None
 
-    @patch("brain.systems.runs.direct_agent.review_final_reply_once")
+    @patch("brain.systems.runs.outbound_reply_admission.review_final_reply_once")
     def test_cortex_reply_stages_reply_with_advisory_warning_when_checker_unresolved(self, mock_review):
         """An 'unresolved' checker verdict is advisory: the reply still stages, and the
         verdict is surfaced as a non-blocking warning instead of vetoing the reply."""
@@ -3467,7 +3522,7 @@ class TestCortexReplyHandler:
             _agent_context.reply_contents = []
             _agent_context.final_reply_review = None
 
-    @patch("brain.systems.runs.direct_agent.review_final_reply_once")
+    @patch("brain.systems.runs.outbound_reply_admission.review_final_reply_once")
     def test_cortex_reply_blocks_requested_artifact_contract_violation(self, mock_review):
         from brain.systems.runs.direct_agent import _handle_cortex_reply, _agent_context
         from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
@@ -3488,16 +3543,16 @@ class TestCortexReplyHandler:
         _agent_context.user_request = "File a GitHub issue"
         _agent_context.reply_contents = []
         _agent_context.final_reply_review = None
-        _agent_context.artifact_contract_block_count = 0
+        _agent_context.reply_admission_block_count = 0
 
         try:
             result = _handle_cortex_reply("Done — tracker record 2383 was created.")
 
             assert result["blocked"] is True
             assert result["checker_status"] == "continue"
-            assert result["artifact_contract_block_count"] == 1
+            assert result["reply_admission_block_count"] == 1
             assert result["missing_requirements"] == ["Name the GitHub issue and blocker."]
-            assert "substitute artifact" in result["instruction"]
+            assert "degrades after two blocked attempts" in result["instruction"]
             assert _agent_context.reply_contents == []
         finally:
             _agent_context.idea_id = None
@@ -3505,9 +3560,9 @@ class TestCortexReplyHandler:
             _agent_context.user_request = None
             _agent_context.reply_contents = []
             _agent_context.final_reply_review = None
-            _agent_context.artifact_contract_block_count = 0
+            _agent_context.reply_admission_block_count = 0
 
-    @patch("brain.systems.runs.direct_agent.review_final_reply_once")
+    @patch("brain.systems.runs.outbound_reply_admission.review_final_reply_once")
     def test_cortex_reply_degrades_repeated_artifact_contract_block_to_advisory(self, mock_review):
         from brain.systems.runs.direct_agent import _handle_cortex_reply, _agent_context
         from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
@@ -3528,7 +3583,7 @@ class TestCortexReplyHandler:
         _agent_context.user_request = "File a GitHub issue"
         _agent_context.reply_contents = []
         _agent_context.final_reply_review = None
-        _agent_context.artifact_contract_block_count = 0
+        _agent_context.reply_admission_block_count = 0
 
         try:
             first = _handle_cortex_reply("Done — tracker record 2383 was created.")
@@ -3537,8 +3592,8 @@ class TestCortexReplyHandler:
 
             assert first["blocked"] is True
             assert second["blocked"] is True
-            assert first["artifact_contract_block_count"] == 1
-            assert second["artifact_contract_block_count"] == 2
+            assert first["reply_admission_block_count"] == 1
+            assert second["reply_admission_block_count"] == 2
             assert "blocked" not in third
             assert third["staged"] is True
             assert third["checker_enforcement"] == "advisory"
@@ -3550,7 +3605,7 @@ class TestCortexReplyHandler:
             _agent_context.user_request = None
             _agent_context.reply_contents = []
             _agent_context.final_reply_review = None
-            _agent_context.artifact_contract_block_count = 0
+            _agent_context.reply_admission_block_count = 0
 
 
 class TestExecutionArtifacts:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2416,6 +2416,177 @@ class TestFinalReplyReview:
         assert admissions[2].review["enforcement"] == "advisory"
         assert "already blocked two replies" in admissions[2].review["rationale"]
 
+    async def test_active_sibling_gate_keeps_block_budget_when_run_is_reexecuted(
+        self,
+        monkeypatch,
+    ):
+        from brain.platform.integrations.providers import (
+            LLMResponse,
+            ToolUseContentBlock,
+            Usage,
+        )
+        from brain.systems.runs.direct_agent import run_agent_async
+        from brain.systems.runs.execution_context import current_agent_context
+        from brain.systems.runs.outbound_reply_admission import admit_outbound_reply
+        from brain.systems.runs.tools import AsyncRunToolExecutor, wrap_tool_handlers
+
+        class _PersistedRunStore:
+            def __init__(self):
+                self.metadata = {
+                    "same_thread_run_context": {
+                        "thread_id": "slack:T:C:1785870481.000100",
+                        "lookup_status": "verified",
+                        "status_question": False,
+                        "live_sibling_runs": [
+                            {"run_id": 14644, "status": "running"},
+                        ],
+                    }
+                }
+                self.row = SimpleNamespace(
+                    id=671,
+                    org_id="org-1",
+                    user_id="user-1",
+                    thread_id="slack:T:C:1785870481.000100",
+                    recipe="fast",
+                    trace_id="trace-671",
+                    root_run_id=671,
+                    target_ref={},
+                    metadata_=self.metadata,
+                )
+                self.events = []
+                self.artifacts = []
+
+            async def require_run(self, run_id):
+                assert run_id == 671
+                return self.row
+
+            async def update_metadata(self, run_id, patch):
+                assert run_id == 671
+                self.metadata.update(dict(patch))
+                self.row.metadata_ = self.metadata
+                return dict(self.metadata)
+
+            async def append_event(self, event):
+                self.events.append(event)
+                return SimpleNamespace(
+                    id=len(self.events),
+                    root_run_id=671,
+                    sequence_no=len(self.events),
+                )
+
+            async def append_artifact(self, artifact):
+                self.artifacts.append(artifact)
+                return artifact
+
+            async def commit_event_boundary(self, run_id):
+                assert run_id == 671
+
+        store = _PersistedRunStore()
+        admissions = []
+
+        async def reply(content):
+            admission = admit_outbound_reply(
+                agent_context=current_agent_context(),
+                content=content,
+                coordination=None,
+                review_completion=False,
+            )
+            admissions.append(admission)
+            if not admission.admitted:
+                return json.dumps(admission.blocked_result)
+            return json.dumps(
+                {
+                    "ok": True,
+                    "posted": True,
+                    "checker_enforcement": admission.review["enforcement"],
+                }
+            )
+
+        handlers = wrap_tool_handlers(
+            {"reply": reply},
+            executor=AsyncRunToolExecutor(store),
+            run_id=671,
+            root_run_id=671,
+        )
+        tool = {
+            "name": "reply",
+            "description": "Reply to the user.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"content": {"type": "string"}},
+                "required": ["content"],
+            },
+        }
+        responses = iter(
+            [
+                LLMResponse(
+                    content=[
+                        ToolUseContentBlock(
+                            id=f"reply-{attempt}",
+                            name="reply",
+                            input={"content": "She doesn't specify the image model."},
+                        )
+                    ],
+                    stop_reason="tool_use",
+                    usage=Usage(input_tokens=3, output_tokens=2),
+                    model="gpt-5.5",
+                )
+                for attempt in range(1, 4)
+            ]
+        )
+
+        async def fake_api_call(*_args, **_kwargs):
+            return next(responses)
+
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent.get_provider",
+            lambda *_args: MagicMock(),
+        )
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent._api_call_with_retry_async",
+            fake_api_call,
+        )
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent._async_record_api_call",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent.load_budget_notices_sent",
+            AsyncMock(return_value={"soft", "ceiling"}),
+        )
+        llm = _mock_llm_client(MagicMock(), provider="openai")
+
+        async def execute_attempt(max_turns):
+            await run_agent_async(
+                "Which image model is she trying to use?",
+                model="openai/gpt-5.5",
+                tools=[tool],
+                tool_handlers=handlers,
+                max_turns=max_turns,
+                persist_session=False,
+                skip_harvest=True,
+                brain_context_preloaded=True,
+                resolved_llm=llm,
+                org_id="org-1",
+                user_id="user-1",
+                run_id=671,
+                metadata={"execution_provenance": dict(store.metadata)},
+            )
+
+        await execute_attempt(max_turns=2)
+        assert [item.admitted for item in admissions] == [False, False]
+        assert store.metadata["reply_admission_block_count"] == 2
+
+        await execute_attempt(max_turns=1)
+
+        assert [item.admitted for item in admissions] == [False, False, True]
+        assert admissions[2].review["enforcement"] == "advisory"
+        assert "already blocked two replies" in admissions[2].review["rationale"]
+
     def test_no_active_sibling_adds_no_deterministic_rejection(self):
         from brain.systems.runs.direct_agent import review_candidate_final_reply
         from brain.systems.runs.direct_loop.final_reply_evidence import FinalReplyEvidence

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -578,9 +578,10 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
         loop_control=loop_control,
         execution_metadata={
             "execution_provenance": {
-                "status_question_context": {
+                "same_thread_run_context": {
                     "thread_id": "thread-1",
                     "lookup_status": "verified",
+                    "status_question": True,
                     "originating_run": {
                         "run_id": 2327,
                         "status": "running",
@@ -598,13 +599,13 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
 
     evidence = FinalReplyEvidence.from_agent_context(context)
 
-    assert evidence.status_question is not None
-    assert evidence.status_question.originating_run is not None
-    assert evidence.status_question.originating_run.run_id == 2327
-    assert evidence.status_question.originating_run.status is RunStatus.RUNNING
-    assert evidence.status_question.has_live_sibling is True
+    assert evidence.same_thread_run_context is not None
+    assert evidence.same_thread_run_context.originating_run is not None
+    assert evidence.same_thread_run_context.originating_run.run_id == 2327
+    assert evidence.same_thread_run_context.originating_run.status is RunStatus.RUNNING
+    assert evidence.same_thread_run_context.has_live_sibling is True
     assert (
-        evidence.status_question.live_sibling_runs[0].status
+        evidence.same_thread_run_context.live_sibling_runs[0].status
         is RunStatus.RUNNING
     )
     assert evidence.tool_failure_state is not None

--- a/tests/test_cortex_thread_context.py
+++ b/tests/test_cortex_thread_context.py
@@ -282,6 +282,128 @@ async def test_slack_work_intake_attaches_same_thread_status_context(session):
     ]
 
 
+async def test_slack_work_intake_attaches_active_sibling_to_non_status_question(session):
+    from brain.systems.runs.context import RunContextLoader
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    thread_ts = "1785870481.000100"
+    slack_thread_id = f"slack:T:C:{thread_ts}"
+    session.add(
+        AgentRunRow(
+            id=14644,
+            org_id=ORG_ID,
+            user_id=USER_ID,
+            thread_id=slack_thread_id,
+            profile="fast",
+            recipe="fast",
+            status="running",
+            input_message="Investigate the customer's generation payloads.",
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={},
+            created_at=datetime(2026, 8, 4, 18, 51, 53, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+    session.add(
+        AgentRunRow(
+            id=14646,
+            org_id=ORG_ID,
+            user_id=USER_ID,
+            thread_id=slack_thread_id,
+            parent_run_id=14644,
+            root_run_id=14644,
+            profile="fast",
+            recipe="fast",
+            status="running",
+            input_message="Inspect one payload batch.",
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={},
+            created_at=datetime(2026, 8, 4, 18, 52, 10, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+
+    request = await build_agent_run_request(
+        session,
+        WorkIntakeEvent(
+            source="slack",
+            event_type="slack.message",
+            org_id=ORG_ID,
+            actor={"id": USER_ID, "org_id": ORG_ID, "internal": False},
+            target={
+                "kind": "slack_message",
+                "team_id": "T",
+                "channel_id": "C",
+                "thread_ts": thread_ts,
+            },
+            payload={
+                "message": "Which image model is she trying to use?",
+                "metadata": {
+                    "slack_trigger": {
+                        "team_id": "T",
+                        "channel_id": "C",
+                        "thread_ts": thread_ts,
+                    }
+                },
+            },
+        ),
+    )
+
+    assert request.thread_id == slack_thread_id
+    assert "status_question_context" not in request.metadata
+    assert request.metadata["active_sibling_context"]["active_sibling_runs"] == [
+        {"run_id": 14644, "status": "running"}
+    ]
+
+    context = RunContextLoader().load(
+        thread_id=request.thread_id,
+        message=request.message,
+        target_ref=request.target_ref,
+        metadata=request.metadata,
+    ).prompt_context()
+    assert "Authoritative active-sibling evidence" in context
+    assert "Sibling run 14644 status: running" in context
+    assert "wait for the active work" in context
+
+
+async def test_slack_work_intake_without_active_sibling_has_no_deferral_context(session):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    thread_ts = "1785870481.000200"
+    request = await build_agent_run_request(
+        session,
+        WorkIntakeEvent(
+            source="slack",
+            event_type="slack.message",
+            org_id=ORG_ID,
+            actor={"id": USER_ID, "org_id": ORG_ID, "internal": False},
+            target={
+                "kind": "slack_message",
+                "team_id": "T",
+                "channel_id": "C",
+                "thread_ts": thread_ts,
+            },
+            payload={
+                "message": "Which image model is she trying to use?",
+                "metadata": {
+                    "slack_trigger": {
+                        "team_id": "T",
+                        "channel_id": "C",
+                        "thread_ts": thread_ts,
+                    }
+                },
+            },
+        ),
+    )
+
+    assert "active_sibling_context" not in request.metadata
+    assert "status_question_context" not in request.metadata
+
+
 def test_run_context_prompt_includes_thread_context():
     from brain.systems.runs.context import RunContextLoader
 

--- a/tests/test_cortex_thread_context.py
+++ b/tests/test_cortex_thread_context.py
@@ -273,7 +273,7 @@ async def test_slack_work_intake_attaches_same_thread_status_context(session):
         ),
     )
 
-    status_context = request.metadata["status_question_context"]
+    status_context = request.metadata["same_thread_run_context"]
     assert request.thread_id == slack_thread_id
     assert status_context["originating_run"]["run_id"] == 2328
     assert status_context["originating_run"]["status"] == "running"
@@ -294,6 +294,7 @@ async def test_slack_work_intake_attaches_active_sibling_to_non_status_question(
             org_id=ORG_ID,
             user_id=USER_ID,
             thread_id=slack_thread_id,
+            root_run_id=14644,
             profile="fast",
             recipe="fast",
             status="running",
@@ -314,6 +315,7 @@ async def test_slack_work_intake_attaches_active_sibling_to_non_status_question(
             thread_id=slack_thread_id,
             parent_run_id=14644,
             root_run_id=14644,
+            parent_step_key_hash="payload-batch-step",
             profile="fast",
             recipe="fast",
             status="running",
@@ -354,10 +356,13 @@ async def test_slack_work_intake_attaches_active_sibling_to_non_status_question(
     )
 
     assert request.thread_id == slack_thread_id
-    assert "status_question_context" not in request.metadata
-    assert request.metadata["active_sibling_context"]["active_sibling_runs"] == [
+    assert request.metadata["same_thread_run_context"]["live_sibling_runs"] == [
         {"run_id": 14644, "status": "running"}
     ]
+    assert all(
+        item["run_id"] != 14646
+        for item in request.metadata["same_thread_run_context"]["live_sibling_runs"]
+    )
 
     context = RunContextLoader().load(
         thread_id=request.thread_id,
@@ -368,6 +373,7 @@ async def test_slack_work_intake_attaches_active_sibling_to_non_status_question(
     assert "Authoritative active-sibling evidence" in context
     assert "Sibling run 14644 status: running" in context
     assert "wait for the active work" in context
+    assert "coordination field" in context
 
 
 async def test_slack_work_intake_without_active_sibling_has_no_deferral_context(session):
@@ -400,8 +406,26 @@ async def test_slack_work_intake_without_active_sibling_has_no_deferral_context(
         ),
     )
 
-    assert "active_sibling_context" not in request.metadata
-    assert "status_question_context" not in request.metadata
+    assert "same_thread_run_context" not in request.metadata
+
+
+def test_interactive_slack_classifier_uses_surface_policy_for_monitors():
+    from brain.systems.runs.interactive_reply import is_interactive_slack_reply_context
+
+    assert not is_interactive_slack_reply_context(
+        {
+            "origin": "slack_channel_monitor",
+            "headless": True,
+            "final_answer_target_surface": "headless",
+        }
+    )
+    assert is_interactive_slack_reply_context(
+        {
+            "origin": "slack_channel_monitor",
+            "headless": False,
+            "final_answer_target_surface": "slack",
+        }
+    )
 
 
 def test_run_context_prompt_includes_thread_context():
@@ -429,9 +453,10 @@ def test_run_context_prompt_marks_live_status_work_as_in_progress():
         thread_id="idea-1",
         message="was it done?",
         metadata={
-            "status_question_context": {
+            "same_thread_run_context": {
                 "thread_id": "idea-1",
                 "lookup_status": "verified",
+                "status_question": True,
                 "originating_run": {
                     "run_id": 2327,
                     "status": "running",

--- a/tests/test_worker_failure_surface_guards.py
+++ b/tests/test_worker_failure_surface_guards.py
@@ -69,8 +69,8 @@ def test_cli_and_checker_public_error_values_use_safe_failure_projectors():
     assert not any(ast.unparse(value) in {"str(e)", "str(exc)"} for value in returned_error_values)
 
     checker = _function(
-        "brain/systems/runs/tool_catalog/handlers/cortex_reply.py",
-        "_build_final_reply_check_context",
+        "brain/systems/runs/outbound_reply_admission.py",
+        "build_final_reply_check_context",
     )
     checker_source = ast.unparse(checker)
     assert "worker_result.output or worker_result.error" not in checker_source


### PR DESCRIPTION
Closes #671

> *This PR was built by an autonomous routine (R3): Codex implemented, Claude directed and reviewed. It is a draft — Reda merges.*

> **⚠️ Stacked on [PR #676](https://github.com/Illospace/illospace/pull/676) — merge that one first.** This PR targets `illo-qa/667-open-ask-terminal-states`, not `main`, because both change `tool_catalog/handlers/slack.py` and they genuinely conflict (`git merge-tree` reports a content conflict there). GitHub will retarget this to `main` automatically once #676 merges. The diff below shows only this ticket's changes.

## What this fixes

Two runs can serve the same Slack thread at the same time without knowing about each other. On 2026-08-04, run 14644 was 11 `search_knowledge` calls and 5 prod-Postgres queries deep into the customer's generation payloads when run 14645 answered the same thread from the report text alone: *"She doesn't specify the image model in the report."* Three minutes later 14644 had the exact answer. You had already been given the shallow one.

A human teammate in that state says "checking the payloads now — one sec."

## How

Two halves. Visibility alone would not have prevented this — a model that is merely *told* about a sibling can still answer from surface text.

1. **Visibility.** Active same-thread runs are now attached at admission and rendered in the run's context as authoritative state. This generalises the query that already existed for status questions (`status_questions.py`) rather than adding a second concurrency system — no locks, no queue, no serialisation.
2. **Enforcement.** A reply that ignores a live sibling is rejected. The run must **declare** how it is coordinating — `{"action": "wait"}`, `{"action": "reference", "run_id": N}`, or `{"action": "handoff"}`.

## What to check

1. A question arriving on a thread with an active investigating run gets a reply that waits, references the sibling, or hands off — never a surface-text answer as if nothing were running.
2. A thread with **no** active sibling behaves exactly as before. This is the regression that matters most: the rule runs on every interactive reply.
3. After deploy, the next real concurrent thread is the live test. Watch for a reply that says it is waiting when nothing is actually running — that is the conservative-deferral trade below.

## Three things worth knowing before you merge

- **Coordination is a declared value, not a guess at English.** The first implementation matched phrases in the reply body. The maintainability review broke it in both directions: *"I'll let the investigation already under way finish"* was blocked, while *"one moment — the other run is irrelevant; she did not specify the model"* passed. Deterministic code cannot judge a sentence, so it no longer tries; it verifies a typed declaration instead.
- **The block is bounded, per persisted run.** After two blocked replies the third is admitted as advisory and reaches you. A gate that could block every retry would be strictly worse than the bug this fixes — a shallow answer at least arrives. The first version of the bound reset on every execution attempt, so a requeued run got two fresh blocks; the count is now persisted in run metadata and rehydrated per attempt, with a test that blocks twice, re-executes the same run, and asserts the third reply comes through.
- **Any open same-thread run counts as active work — deliberately.** There is no typed "investigating" state in the schema, so a narrower test would be guesswork. The cost is conservative deferral for unrelated same-thread work. The rationale is written down at the policy, not left implicit.

## Verification

- **Host fast lane, the repo's own CI command, whole suite:** `4757 passed, 11 skipped, 83 deselected` on `main`, and `4762 passed, 11 skipped, 84 deselected` after the rebase onto #676's branch. Zero failures both times. Baseline on `main` is 4750; the extra 7 are this ticket's tests, and the remaining 5 are #676's own.
- Tests cover the acceptance case (context names the sibling; the shallow answer is blocked; a declared wait is accepted), the no-sibling regression, the legitimate paraphrase that must pass, the deceptive phrase that must fail, and the bound.
- No schema change, no alembic migration.
- Two Codex maintainability reviews. The first returned three blocking findings, the second confirmed two structurally resolved and caught the reset-on-restart bound. Both folded. One honest negative it volunteered and I am passing on unchanged: **conditional count is 658 before and 658 after** across the 16 touched files — reply policy moved into a better owner (a shared `outbound_reply_admission` service both the Cortex and Slack handlers call, with `tool_execution.py` back to its original 989 lines and no reply-tool names in it), but complexity relocated rather than left.

## Design note

The fix direction was left open on the ticket. A [read-only investigation](https://github.com/Illospace/illospace/issues/671#issuecomment-5185202034) costed three options against the real code first — sibling visibility, per-thread serialisation, and steering into the active run — and picked this one. Serialisation is survivable but buys a convoy, because "investigating" is not a typed state; steering races the active loop's final drain.
