### PR TITLE
ci: run checks on every pull request, not only PRs into main (#682)

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -3,8 +3,10 @@ name: Brain CI
 on:
   push:
     branches: [main]
+  # No base-branch filter. A stacked PR is based on another feature branch, and a
+  # `branches: [main]` filter gives it zero checks — silently, since an empty
+  # checks list reads as "none configured" rather than "never tested" (#682).
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  # No base-branch filter — see the note in brain-ci.yml and #682. PR builds never
+  # publish (`push:` is false for pull_request below), so this only widens what is
+  # built, never what is pushed to the registry.
   pull_request:
-    branches: [main]
     paths:
       - ".dockerignore"
       - "frontend/package.json"

--- a/.github/workflows/deployment-smoke.yml
+++ b/.github/workflows/deployment-smoke.yml
@@ -1,8 +1,9 @@
 name: Deployment Smoke
 
 on:
+  # No base-branch filter — see the note in brain-ci.yml and #682. The paths
+  # filter below still decides whether this workflow has anything to do.
   pull_request:
-    branches: [main]
     paths:
       - "deploy/**"
       - "requirements.txt"


### PR DESCRIPTION
Closes #682

## What this changes

Three lines. `.github/workflows/{brain-ci,deployment-smoke,container-images}.yml`
each declared `pull_request: branches: [main]`. That filter is removed. Every
`paths:` filter is left exactly as it was.

## Why it matters

A pull request based on a feature branch currently runs **no CI at all**, and says
nothing about it — the checks section is empty, which reads as "no checks
configured" rather than "this was never tested".

That is not hypothetical. PR #681 is based on `illo-qa/667-open-ask-terminal-states`:

```
$ gh run list --branch illo-qa/671-sibling-run-visibility
(no output — zero workflow runs have ever existed for that branch)
```

while its parent branch, based on `main`, got Brain CI and Deployment Smoke the same
day. Stacked PRs are now the standard way to ship dependent work here, so the count of
silently untested PRs goes up from here, not down.

## What this PR does and does not prove

**It does not prove itself.** This PR targets `main`, so it would have run CI with or
without the change. The proof arrives with the first stacked PR opened on a parent
branch that already contains this commit — until then, stacked children still need a
local run.

What you can check here instead:

1. **The diff is only the trigger lines.** `git diff` touches three `on:` blocks and
   adds three comments. No `paths:` filter, job, or step changes.
2. **Every check on this page is expected to run.** Each workflow lists its own file
   in its `paths:` filter (`.github/workflows/brain-ci.yml` appears under both the
   `backend` and `frontend` filters), so editing a workflow deliberately re-runs
   everything that workflow governs. A full board here is the filters working, not
   the filters being bypassed.
3. **No image is published.** `container-images.yml` passes
   `push: ${{ github.event_name != 'pull_request' }}` at lines 129, 177 and 225, so a
   PR build never reaches the registry. Widening the trigger widens what is built,
   never what is pushed.

## Assumptions

- Widening to every PR base is the intent, not an allowlist of `illo-qa/**`. An
  allowlist would work today and break the first time someone used a different
  prefix — and the failure mode is silence, which is the whole subject of this ticket.
- Extra Actions minutes on stacked PRs are worth paying to stop shipping untested
  code.