### PR TITLE
refactor(cycles): make illegal preflight results unconstructible (#665)

### DIFF
--- a/brain/platform/integrations/codex_usage.py
+++ b/brain/platform/integrations/codex_usage.py
@@ -7,11 +7,31 @@ import math
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, Mapping
+from typing import Any, Mapping, TypeAlias
 
 
-CodexUsageStatus = Literal["ok", "unknown", "exhausted"]
+class CodexUsageStatus(StrEnum):
+    OK = "ok"
+    UNKNOWN = "unknown"
+    EXHAUSTED = "exhausted"
+
+
+class CodexUsageUnknownReason(StrEnum):
+    AUTH_ERROR = "auth_error"
+    MALFORMED_LINE = "malformed_line"
+    PRIMARY_MISSING = "primary_missing"
+    RATE_LIMITS_MISSING = "rate_limits_missing"
+    SESSIONS_DIR_EMPTY = "sessions_dir_empty"
+    SESSIONS_DIR_MISSING = "sessions_dir_missing"
+    SESSIONS_DIR_UNREADABLE = "sessions_dir_unreadable"
+    SESSION_FILE_EMPTY = "session_file_empty"
+    SESSION_FILE_UNREADABLE = "session_file_unreadable"
+    TOKEN_COUNT_MISSING = "token_count_missing"
+    UNEXPECTED_LIMIT_ID = "unexpected_limit_id"
+    USED_PERCENT_INVALID = "used_percent_invalid"
+    USED_PERCENT_MISSING = "used_percent_missing"
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,21 +52,66 @@ class CodexKnownUsage:
         }
 
 
-@dataclass(frozen=True, slots=True)
-class CodexUsageReading:
-    status: CodexUsageStatus
-    used_percent: float | None = None
-    reason: str | None = None
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CodexKnownUsageReading:
+    used_percent: float
+    observed_at: str
+    source_path: str
+    limit_id: str = "codex"
+    plan_type: str | None = None
+
+    @property
+    def status(self) -> CodexUsageStatus:
+        if self.used_percent >= 100:
+            return CodexUsageStatus.EXHAUSTED
+        return CodexUsageStatus.OK
+
+    @property
+    def reason(self) -> None:
+        return None
+
+    @property
+    def last_known_good(self) -> None:
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "used_percent": self.used_percent,
+            "reason": None,
+            "observed_at": self.observed_at,
+            "source_path": self.source_path,
+            "limit_id": self.limit_id,
+            "plan_type": self.plan_type,
+            "last_known_good": None,
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CodexUnknownUsageReading:
+    reason: CodexUsageUnknownReason
     observed_at: str | None = None
     source_path: str | None = None
     limit_id: str | None = None
     plan_type: str | None = None
     last_known_good: CodexKnownUsage | None = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, CodexUsageUnknownReason):
+            raise TypeError("reason must be a CodexUsageUnknownReason")
+
+    @property
+    def status(self) -> CodexUsageStatus:
+        return CodexUsageStatus.UNKNOWN
+
+    @property
+    def used_percent(self) -> None:
+        return None
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "status": self.status,
-            "used_percent": self.used_percent,
+            "used_percent": None,
             "reason": self.reason,
             "observed_at": self.observed_at,
             "source_path": self.source_path,
@@ -56,6 +121,9 @@ class CodexUsageReading:
                 self.last_known_good.to_dict() if self.last_known_good else None
             ),
         }
+
+
+CodexUsageReading: TypeAlias = CodexKnownUsageReading | CodexUnknownUsageReading
 
 
 def codex_home_path(path: str | Path | None = None) -> Path:
@@ -68,15 +136,14 @@ def codex_home_path(path: str | Path | None = None) -> Path:
 
 
 def _unknown(
-    reason: str,
+    reason: CodexUsageUnknownReason,
     *,
     observed_at: str | None = None,
     source_path: Path | None = None,
     limit_id: str | None = None,
     plan_type: str | None = None,
 ) -> CodexUsageReading:
-    return CodexUsageReading(
-        status="unknown",
+    return CodexUnknownUsageReading(
         reason=reason,
         observed_at=observed_at,
         source_path=str(source_path) if source_path else None,
@@ -141,7 +208,7 @@ def _reading_from_event(
 ) -> CodexUsageReading | None:
     if _is_auth_error(data):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=_event_timestamp(data, source_path),
             source_path=source_path,
         )
@@ -153,20 +220,20 @@ def _reading_from_event(
     observed_at = _event_timestamp(data, source_path)
     if token_payload.get("error"):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=observed_at,
             source_path=source_path,
         )
     rate_limits = _rate_limits(data, token_payload)
     if not rate_limits:
         return _unknown(
-            "rate_limits_missing",
+            CodexUsageUnknownReason.RATE_LIMITS_MISSING,
             observed_at=observed_at,
             source_path=source_path,
         )
     if rate_limits.get("error"):
         return _unknown(
-            "auth_error",
+            CodexUsageUnknownReason.AUTH_ERROR,
             observed_at=observed_at,
             source_path=source_path,
         )
@@ -177,7 +244,7 @@ def _reading_from_event(
     plan_type = str(plan_value).strip() if plan_value is not None else None
     if limit_id != "codex":
         return _unknown(
-            "unexpected_limit_id",
+            CodexUsageUnknownReason.UNEXPECTED_LIMIT_ID,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -187,7 +254,7 @@ def _reading_from_event(
     primary = rate_limits.get("primary")
     if not isinstance(primary, Mapping):
         return _unknown(
-            "primary_missing",
+            CodexUsageUnknownReason.PRIMARY_MISSING,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -197,7 +264,7 @@ def _reading_from_event(
     used_percent = primary.get("used_percent")
     if isinstance(used_percent, bool) or not isinstance(used_percent, (int, float)):
         return _unknown(
-            "used_percent_missing",
+            CodexUsageUnknownReason.USED_PERCENT_MISSING,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
@@ -206,14 +273,13 @@ def _reading_from_event(
     normalized_percent = float(used_percent)
     if not math.isfinite(normalized_percent) or normalized_percent < 0:
         return _unknown(
-            "used_percent_invalid",
+            CodexUsageUnknownReason.USED_PERCENT_INVALID,
             observed_at=observed_at,
             source_path=source_path,
             limit_id=limit_id,
             plan_type=plan_type,
         )
-    return CodexUsageReading(
-        status="exhausted" if normalized_percent >= 100 else "ok",
+    return CodexKnownUsageReading(
         used_percent=normalized_percent,
         observed_at=observed_at,
         source_path=str(source_path),
@@ -249,11 +315,17 @@ def _scan_lines(
             data = json.loads(raw_line)
         except (json.JSONDecodeError, UnicodeDecodeError):
             if malformed_is_verdict:
-                return _unknown("malformed_line", source_path=source_path)
+                return _unknown(
+                    CodexUsageUnknownReason.MALFORMED_LINE,
+                    source_path=source_path,
+                )
             continue
         if not isinstance(data, Mapping):
             if malformed_is_verdict:
-                return _unknown("malformed_line", source_path=source_path)
+                return _unknown(
+                    CodexUsageUnknownReason.MALFORMED_LINE,
+                    source_path=source_path,
+                )
             continue
         reading = _reading_from_event(data, source_path=source_path)
         if reading is not None:
@@ -275,11 +347,11 @@ def _find_last_known(files: list[Path]) -> CodexKnownUsage | None:
             if not isinstance(data, Mapping):
                 continue
             reading = _reading_from_event(data, source_path=source_path)
-            if reading is None or reading.status == "unknown":
+            if not isinstance(reading, CodexKnownUsageReading):
                 continue
             return CodexKnownUsage(
-                used_percent=float(reading.used_percent),
-                observed_at=str(reading.observed_at),
+                used_percent=reading.used_percent,
+                observed_at=reading.observed_at,
                 source_path=str(source_path),
                 plan_type=reading.plan_type,
             )
@@ -296,34 +368,42 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
     sessions_path = codex_home_path(path) / "sessions"
     try:
         if not sessions_path.exists():
-            return _unknown("sessions_dir_missing")
+            return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_MISSING)
         if not sessions_path.is_dir():
-            return _unknown("sessions_dir_unreadable")
+            return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_UNREADABLE)
         files = _session_files(sessions_path)
     except OSError:
-        return _unknown("sessions_dir_unreadable")
+        return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_UNREADABLE)
     if not files:
-        return _unknown("sessions_dir_empty")
+        return _unknown(CodexUsageUnknownReason.SESSIONS_DIR_EMPTY)
 
     newest = files[0]
     try:
         newest_lines = _read_lines(newest)
     except (OSError, UnicodeError):
-        verdict = _unknown("session_file_unreadable", source_path=newest)
+        verdict = _unknown(
+            CodexUsageUnknownReason.SESSION_FILE_UNREADABLE,
+            source_path=newest,
+        )
     else:
         if not any(line.strip() for line in newest_lines):
-            verdict = _unknown("session_file_empty", source_path=newest)
+            verdict = _unknown(
+                CodexUsageUnknownReason.SESSION_FILE_EMPTY,
+                source_path=newest,
+            )
         else:
             verdict = _scan_lines(
                 newest_lines,
                 source_path=newest,
                 malformed_is_verdict=True,
-            ) or _unknown("token_count_missing", source_path=newest)
+            ) or _unknown(
+                CodexUsageUnknownReason.TOKEN_COUNT_MISSING,
+                source_path=newest,
+            )
 
-    if verdict.status != "unknown":
+    if isinstance(verdict, CodexKnownUsageReading):
         return verdict
-    return CodexUsageReading(
-        status=verdict.status,
+    return CodexUnknownUsageReading(
         reason=verdict.reason,
         observed_at=verdict.observed_at,
         source_path=verdict.source_path,
@@ -335,8 +415,11 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
 
 __all__ = [
     "CodexKnownUsage",
+    "CodexKnownUsageReading",
     "CodexUsageReading",
     "CodexUsageStatus",
+    "CodexUsageUnknownReason",
+    "CodexUnknownUsageReading",
     "codex_home_path",
     "read_codex_usage",
 ]

--- a/brain/platform/integrations/codex_usage.py
+++ b/brain/platform/integrations/codex_usage.py
@@ -12,12 +12,6 @@ from pathlib import Path
 from typing import Any, Mapping, TypeAlias
 
 
-class CodexUsageStatus(StrEnum):
-    OK = "ok"
-    UNKNOWN = "unknown"
-    EXHAUSTED = "exhausted"
-
-
 class CodexUsageUnknownReason(StrEnum):
     AUTH_ERROR = "auth_error"
     MALFORMED_LINE = "malformed_line"
@@ -34,7 +28,7 @@ class CodexUsageUnknownReason(StrEnum):
     USED_PERCENT_MISSING = "used_percent_missing"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class CodexKnownUsage:
     used_percent: float
     observed_at: str
@@ -43,48 +37,7 @@ class CodexKnownUsage:
     plan_type: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "used_percent": self.used_percent,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-        }
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class CodexKnownUsageReading:
-    used_percent: float
-    observed_at: str
-    source_path: str
-    limit_id: str = "codex"
-    plan_type: str | None = None
-
-    @property
-    def status(self) -> CodexUsageStatus:
-        if self.used_percent >= 100:
-            return CodexUsageStatus.EXHAUSTED
-        return CodexUsageStatus.OK
-
-    @property
-    def reason(self) -> None:
-        return None
-
-    @property
-    def last_known_good(self) -> None:
-        return None
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "status": self.status,
-            "used_percent": self.used_percent,
-            "reason": None,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-            "last_known_good": None,
-        }
+        return _codex_usage_to_dict(self)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -100,30 +53,47 @@ class CodexUnknownUsageReading:
         if not isinstance(self.reason, CodexUsageUnknownReason):
             raise TypeError("reason must be a CodexUsageUnknownReason")
 
-    @property
-    def status(self) -> CodexUsageStatus:
-        return CodexUsageStatus.UNKNOWN
-
-    @property
-    def used_percent(self) -> None:
-        return None
-
     def to_dict(self) -> dict[str, Any]:
+        return _codex_usage_to_dict(self)
+
+
+CodexUsageReading: TypeAlias = CodexKnownUsage | CodexUnknownUsageReading
+
+
+def _codex_usage_to_dict(reading: CodexUsageReading) -> dict[str, Any]:
+    """Serialize the legacy flat reading shape at its persistence boundary."""
+
+    if isinstance(reading, CodexKnownUsage):
         return {
-            "status": self.status,
-            "used_percent": None,
-            "reason": self.reason,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-            "last_known_good": (
-                self.last_known_good.to_dict() if self.last_known_good else None
-            ),
+            "status": "exhausted" if reading.used_percent >= 100 else "ok",
+            "used_percent": reading.used_percent,
+            "reason": None,
+            "observed_at": reading.observed_at,
+            "source_path": reading.source_path,
+            "limit_id": reading.limit_id,
+            "plan_type": reading.plan_type,
+            "last_known_good": None,
         }
-
-
-CodexUsageReading: TypeAlias = CodexKnownUsageReading | CodexUnknownUsageReading
+    return {
+        "status": "unknown",
+        "used_percent": None,
+        "reason": reading.reason,
+        "observed_at": reading.observed_at,
+        "source_path": reading.source_path,
+        "limit_id": reading.limit_id,
+        "plan_type": reading.plan_type,
+        "last_known_good": (
+            {
+                "used_percent": reading.last_known_good.used_percent,
+                "observed_at": reading.last_known_good.observed_at,
+                "source_path": reading.last_known_good.source_path,
+                "limit_id": reading.last_known_good.limit_id,
+                "plan_type": reading.last_known_good.plan_type,
+            }
+            if reading.last_known_good is not None
+            else None
+        ),
+    }
 
 
 def codex_home_path(path: str | Path | None = None) -> Path:
@@ -279,7 +249,7 @@ def _reading_from_event(
             limit_id=limit_id,
             plan_type=plan_type,
         )
-    return CodexKnownUsageReading(
+    return CodexKnownUsage(
         used_percent=normalized_percent,
         observed_at=observed_at,
         source_path=str(source_path),
@@ -347,14 +317,9 @@ def _find_last_known(files: list[Path]) -> CodexKnownUsage | None:
             if not isinstance(data, Mapping):
                 continue
             reading = _reading_from_event(data, source_path=source_path)
-            if not isinstance(reading, CodexKnownUsageReading):
+            if not isinstance(reading, CodexKnownUsage):
                 continue
-            return CodexKnownUsage(
-                used_percent=reading.used_percent,
-                observed_at=reading.observed_at,
-                source_path=str(source_path),
-                plan_type=reading.plan_type,
-            )
+            return reading
     return None
 
 
@@ -401,7 +366,7 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
                 source_path=newest,
             )
 
-    if isinstance(verdict, CodexKnownUsageReading):
+    if isinstance(verdict, CodexKnownUsage):
         return verdict
     return CodexUnknownUsageReading(
         reason=verdict.reason,
@@ -415,9 +380,7 @@ def read_codex_usage(path: str | Path | None = None) -> CodexUsageReading:
 
 __all__ = [
     "CodexKnownUsage",
-    "CodexKnownUsageReading",
     "CodexUsageReading",
-    "CodexUsageStatus",
     "CodexUsageUnknownReason",
     "CodexUnknownUsageReading",
     "codex_home_path",

--- a/brain/platform/integrations/provider_auth_preflight.py
+++ b/brain/platform/integrations/provider_auth_preflight.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
-from typing import Any
+from enum import StrEnum
+from typing import Any, Self
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,37 +13,91 @@ from brain.platform.integrations.llm import async_resolve_llm_client
 from brain.platform.providers.model_policy import required_openai_auth_mode
 
 
-@dataclass(frozen=True, slots=True)
-class ProviderAuthPreflightResult:
-    status: str
+class ProviderAuthPreflightStatus(StrEnum):
+    AUTH_BLOCKED = "auth_blocked"
+    PASSED = "passed"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderAuthPreflightResult(ABC):
     provider: str
     model: str
-    credential: str | None = None
-    error_code: str | None = None
-    repair_action: str | None = None
-    visible_message: str | None = None
+
+    @property
+    @abstractmethod
+    def status(self) -> ProviderAuthPreflightStatus:
+        raise NotImplementedError
 
     @property
     def blocked(self) -> bool:
-        return self.status == "auth_blocked"
+        return self.status is ProviderAuthPreflightStatus.AUTH_BLOCKED
 
-    def with_presentation(
-        self,
-        *,
-        repair_action: str,
-        visible_message: str,
-    ) -> ProviderAuthPreflightResult:
-        return replace(
-            self,
-            repair_action=repair_action,
-            visible_message=visible_message,
-        )
+    @abstractmethod
+    def _details_dict(self) -> dict[str, str | None]:
+        raise NotImplementedError
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "status": self.status,
             "provider": self.provider,
             "model": self.model,
+            **self._details_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ProviderAuthAvailablePreflightResult(ProviderAuthPreflightResult):
+    def _details_dict(self) -> dict[str, str | None]:
+        return {
+            "credential": None,
+            "error_code": None,
+            "repair_action": None,
+            "visible_message": None,
+        }
+
+
+class ProviderAuthPassedPreflightResult(_ProviderAuthAvailablePreflightResult):
+    __slots__ = ()
+
+    @property
+    def status(self) -> ProviderAuthPreflightStatus:
+        return ProviderAuthPreflightStatus.PASSED
+
+
+class ProviderAuthSkippedPreflightResult(_ProviderAuthAvailablePreflightResult):
+    __slots__ = ()
+
+    @property
+    def status(self) -> ProviderAuthPreflightStatus:
+        return ProviderAuthPreflightStatus.SKIPPED
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderAuthBlockedPreflightResult(ProviderAuthPreflightResult):
+    credential: str
+    error_code: str
+    repair_action: str | None = None
+    visible_message: str | None = None
+
+    @property
+    def status(self) -> ProviderAuthPreflightStatus:
+        return ProviderAuthPreflightStatus.AUTH_BLOCKED
+
+    def with_presentation(
+        self,
+        *,
+        repair_action: str,
+        visible_message: str,
+    ) -> Self:
+        return replace(
+            self,
+            repair_action=repair_action,
+            visible_message=visible_message,
+        )
+
+    def _details_dict(self) -> dict[str, str | None]:
+        return {
             "credential": self.credential,
             "error_code": self.error_code,
             "repair_action": self.repair_action,
@@ -53,9 +109,8 @@ def skipped_provider_auth_preflight(
     *,
     provider: str,
     model: str,
-) -> ProviderAuthPreflightResult:
-    return ProviderAuthPreflightResult(
-        status="skipped",
+) -> ProviderAuthSkippedPreflightResult:
+    return ProviderAuthSkippedPreflightResult(
         provider=provider,
         model=model,
     )
@@ -112,8 +167,7 @@ async def async_probe_provider_auth(
             session=session,
         )
     except Exception as exc:
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider=provider,
             model=model,
             credential=_credential_label(
@@ -125,15 +179,18 @@ async def async_probe_provider_auth(
             error_code="provider_credential_unavailable",
         )
 
-    return ProviderAuthPreflightResult(
-        status="passed",
+    return ProviderAuthPassedPreflightResult(
         provider=provider,
         model=model,
     )
 
 
 __all__ = [
+    "ProviderAuthBlockedPreflightResult",
+    "ProviderAuthPassedPreflightResult",
     "ProviderAuthPreflightResult",
+    "ProviderAuthPreflightStatus",
+    "ProviderAuthSkippedPreflightResult",
     "async_probe_provider_auth",
     "skipped_provider_auth_preflight",
 ]

--- a/brain/platform/integrations/provider_auth_preflight.py
+++ b/brain/platform/integrations/provider_auth_preflight.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
-from enum import StrEnum
-from typing import Any, Self
+from typing import Any, Self, TypeAlias
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,76 +11,51 @@ from brain.platform.integrations.llm import async_resolve_llm_client
 from brain.platform.providers.model_policy import required_openai_auth_mode
 
 
-class ProviderAuthPreflightStatus(StrEnum):
-    AUTH_BLOCKED = "auth_blocked"
-    PASSED = "passed"
-    SKIPPED = "skipped"
-
-
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ProviderAuthPreflightResult(ABC):
+class _ProviderAuthPreflightResult:
     provider: str
     model: str
 
-    @property
-    @abstractmethod
-    def status(self) -> ProviderAuthPreflightStatus:
-        raise NotImplementedError
-
-    @property
-    def blocked(self) -> bool:
-        return self.status is ProviderAuthPreflightStatus.AUTH_BLOCKED
-
-    @abstractmethod
-    def _details_dict(self) -> dict[str, str | None]:
-        raise NotImplementedError
-
-    def to_dict(self) -> dict[str, Any]:
+    def _to_dict(
+        self,
+        *,
+        status: str,
+        credential: str | None = None,
+        error_code: str | None = None,
+        repair_action: str | None = None,
+        visible_message: str | None = None,
+    ) -> dict[str, Any]:
         return {
-            "status": self.status,
+            "status": status,
             "provider": self.provider,
             "model": self.model,
-            **self._details_dict(),
+            "credential": credential,
+            "error_code": error_code,
+            "repair_action": repair_action,
+            "visible_message": visible_message,
         }
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class _ProviderAuthAvailablePreflightResult(ProviderAuthPreflightResult):
-    def _details_dict(self) -> dict[str, str | None]:
-        return {
-            "credential": None,
-            "error_code": None,
-            "repair_action": None,
-            "visible_message": None,
-        }
-
-
-class ProviderAuthPassedPreflightResult(_ProviderAuthAvailablePreflightResult):
+class ProviderAuthPassedPreflightResult(_ProviderAuthPreflightResult):
     __slots__ = ()
 
-    @property
-    def status(self) -> ProviderAuthPreflightStatus:
-        return ProviderAuthPreflightStatus.PASSED
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(status="passed")
 
 
-class ProviderAuthSkippedPreflightResult(_ProviderAuthAvailablePreflightResult):
+class ProviderAuthSkippedPreflightResult(_ProviderAuthPreflightResult):
     __slots__ = ()
 
-    @property
-    def status(self) -> ProviderAuthPreflightStatus:
-        return ProviderAuthPreflightStatus.SKIPPED
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(status="skipped")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ProviderAuthBlockedPreflightResult(ProviderAuthPreflightResult):
+class ProviderAuthBlockedPreflightResult(_ProviderAuthPreflightResult):
     credential: str
     error_code: str
     repair_action: str | None = None
     visible_message: str | None = None
-
-    @property
-    def status(self) -> ProviderAuthPreflightStatus:
-        return ProviderAuthPreflightStatus.AUTH_BLOCKED
 
     def with_presentation(
         self,
@@ -96,13 +69,21 @@ class ProviderAuthBlockedPreflightResult(ProviderAuthPreflightResult):
             visible_message=visible_message,
         )
 
-    def _details_dict(self) -> dict[str, str | None]:
-        return {
-            "credential": self.credential,
-            "error_code": self.error_code,
-            "repair_action": self.repair_action,
-            "visible_message": self.visible_message,
-        }
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(
+            status="auth_blocked",
+            credential=self.credential,
+            error_code=self.error_code,
+            repair_action=self.repair_action,
+            visible_message=self.visible_message,
+        )
+
+
+ProviderAuthPreflightResult: TypeAlias = (
+    ProviderAuthPassedPreflightResult
+    | ProviderAuthSkippedPreflightResult
+    | ProviderAuthBlockedPreflightResult
+)
 
 
 def skipped_provider_auth_preflight(
@@ -189,7 +170,6 @@ __all__ = [
     "ProviderAuthBlockedPreflightResult",
     "ProviderAuthPassedPreflightResult",
     "ProviderAuthPreflightResult",
-    "ProviderAuthPreflightStatus",
     "ProviderAuthSkippedPreflightResult",
     "async_probe_provider_auth",
     "skipped_provider_auth_preflight",

--- a/brain/platform/integrations/provider_quota_preflight.py
+++ b/brain/platform/integrations/provider_quota_preflight.py
@@ -4,17 +4,13 @@ from __future__ import annotations
 
 import math
 import os
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
-from enum import StrEnum
-from typing import Any, Self, TypeVar
+from typing import Any, Self, TypeAlias
 
 from brain.platform.integrations.codex_usage import (
     CodexKnownUsage,
-    CodexKnownUsageReading,
     CodexUnknownUsageReading,
     CodexUsageReading,
-    CodexUsageUnknownReason,
     read_codex_usage,
 )
 from brain.platform.providers.model_policy import required_openai_auth_mode
@@ -22,20 +18,6 @@ from brain.platform.providers.model_policy import required_openai_auth_mode
 
 DEFAULT_CODEX_QUOTA_SOFT_PERCENT = 75.0
 DEFAULT_CODEX_QUOTA_HARD_PERCENT = 90.0
-
-
-class ProviderQuotaPreflightStatus(StrEnum):
-    PASSED = "passed"
-    QUOTA_BLOCKED = "quota_blocked"
-    QUOTA_DEFERRED = "quota_deferred"
-    SKIPPED = "skipped"
-    UNKNOWN = "unknown"
-
-
-class ProviderQuotaDecision(StrEnum):
-    ADMITTED = "admitted"
-    BLOCKED = "blocked"
-    DEFERRED = "deferred"
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,45 +33,29 @@ class ProviderQuotaThresholds:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ProviderQuotaPreflightResult(ABC):
+class _ProviderQuotaPreflightResult:
     provider: str
     model: str
     thresholds: ProviderQuotaThresholds
     explicit_request: bool = False
     visible_message: str | None = None
 
-    @property
-    @abstractmethod
-    def status(self) -> ProviderQuotaPreflightStatus:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def decision(self) -> ProviderQuotaDecision:
-        raise NotImplementedError
-
-    @property
-    def blocked(self) -> bool:
-        return self.decision is ProviderQuotaDecision.BLOCKED
-
-    @property
-    def deferred(self) -> bool:
-        return self.decision is ProviderQuotaDecision.DEFERRED
-
     def with_presentation(self, *, visible_message: str) -> Self:
         return replace(self, visible_message=visible_message)
 
-    @abstractmethod
-    def _usage_dict(self) -> dict[str, Any]:
-        raise NotImplementedError
-
-    def to_dict(self) -> dict[str, Any]:
+    def _to_dict(
+        self,
+        *,
+        status: str,
+        decision: str,
+        usage_fields: dict[str, Any],
+    ) -> dict[str, Any]:
         return {
-            "status": self.status,
-            "decision": self.decision,
+            "status": status,
+            "decision": decision,
             "provider": self.provider,
             "model": self.model,
-            **self._usage_dict(),
+            **usage_fields,
             "explicit_request": self.explicit_request,
             "thresholds": self.thresholds.to_dict(),
             "visible_message": self.visible_message,
@@ -97,126 +63,92 @@ class ProviderQuotaPreflightResult(ABC):
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ProviderQuotaSkippedPreflightResult(ProviderQuotaPreflightResult):
-    @property
-    def status(self) -> ProviderQuotaPreflightStatus:
-        return ProviderQuotaPreflightStatus.SKIPPED
-
-    @property
-    def decision(self) -> ProviderQuotaDecision:
-        return ProviderQuotaDecision.ADMITTED
-
-    def _usage_dict(self) -> dict[str, Any]:
-        return {
-            "usage_status": None,
-            "used_percent": None,
-            "unknown_reason": None,
-            "observed_at": None,
-            "source_path": None,
-            "limit_id": None,
-            "plan_type": None,
-            "last_known_good": None,
-        }
+class ProviderQuotaSkippedPreflightResult(_ProviderQuotaPreflightResult):
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(
+            status="skipped",
+            decision="admitted",
+            usage_fields={
+                "usage_status": None,
+                "used_percent": None,
+                "unknown_reason": None,
+                "observed_at": None,
+                "source_path": None,
+                "limit_id": None,
+                "plan_type": None,
+                "last_known_good": None,
+            },
+        )
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class _ProviderQuotaKnownPreflightResult(ProviderQuotaPreflightResult):
-    usage: CodexKnownUsageReading
+class _ProviderQuotaKnownPreflightResult(_ProviderQuotaPreflightResult):
+    usage: CodexKnownUsage
 
-    @property
-    def used_percent(self) -> float:
-        return self.usage.used_percent
-
-    def _usage_dict(self) -> dict[str, Any]:
-        return {
-            "usage_status": self.usage.status,
-            "used_percent": self.usage.used_percent,
-            "unknown_reason": None,
-            "observed_at": self.usage.observed_at,
-            "source_path": self.usage.source_path,
-            "limit_id": self.usage.limit_id,
-            "plan_type": self.usage.plan_type,
-            "last_known_good": None,
-        }
+    def _known_to_dict(self, *, status: str, decision: str) -> dict[str, Any]:
+        return self._to_dict(
+            status=status,
+            decision=decision,
+            usage_fields=_provider_quota_usage_fields(self.usage),
+        )
 
 
 class ProviderQuotaPassedPreflightResult(_ProviderQuotaKnownPreflightResult):
     __slots__ = ()
 
-    @property
-    def status(self) -> ProviderQuotaPreflightStatus:
-        return ProviderQuotaPreflightStatus.PASSED
-
-    @property
-    def decision(self) -> ProviderQuotaDecision:
-        return ProviderQuotaDecision.ADMITTED
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="passed", decision="admitted")
 
 
 class ProviderQuotaBlockedPreflightResult(_ProviderQuotaKnownPreflightResult):
     __slots__ = ()
 
-    @property
-    def status(self) -> ProviderQuotaPreflightStatus:
-        return ProviderQuotaPreflightStatus.QUOTA_BLOCKED
-
-    @property
-    def decision(self) -> ProviderQuotaDecision:
-        return ProviderQuotaDecision.BLOCKED
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="quota_blocked", decision="blocked")
 
 
 class ProviderQuotaDeferredPreflightResult(_ProviderQuotaKnownPreflightResult):
     __slots__ = ()
 
-    @property
-    def status(self) -> ProviderQuotaPreflightStatus:
-        return ProviderQuotaPreflightStatus.QUOTA_DEFERRED
-
-    @property
-    def decision(self) -> ProviderQuotaDecision:
-        return ProviderQuotaDecision.DEFERRED
+    def to_dict(self) -> dict[str, Any]:
+        return self._known_to_dict(status="quota_deferred", decision="deferred")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ProviderQuotaUnknownPreflightResult(ProviderQuotaPreflightResult):
+class ProviderQuotaUnknownPreflightResult(_ProviderQuotaPreflightResult):
     usage: CodexUnknownUsageReading
 
-    @property
-    def status(self) -> ProviderQuotaPreflightStatus:
-        return ProviderQuotaPreflightStatus.UNKNOWN
-
-    @property
-    def decision(self) -> ProviderQuotaDecision:
-        return ProviderQuotaDecision.ADMITTED
-
-    @property
-    def unknown_reason(self) -> CodexUsageUnknownReason:
-        return self.usage.reason
-
-    @property
-    def last_known_good(self) -> CodexKnownUsage | None:
-        return self.usage.last_known_good
-
-    def _usage_dict(self) -> dict[str, Any]:
-        return {
-            "usage_status": self.usage.status,
-            "used_percent": None,
-            "unknown_reason": self.usage.reason,
-            "observed_at": self.usage.observed_at,
-            "source_path": self.usage.source_path,
-            "limit_id": self.usage.limit_id,
-            "plan_type": self.usage.plan_type,
-            "last_known_good": (
-                self.usage.last_known_good.to_dict()
-                if self.usage.last_known_good
-                else None
-            ),
-        }
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(
+            status="unknown",
+            decision="admitted",
+            usage_fields=_provider_quota_usage_fields(self.usage),
+        )
 
 
-KnownQuotaResultT = TypeVar(
-    "KnownQuotaResultT",
-    bound=_ProviderQuotaKnownPreflightResult,
+ProviderQuotaPreflightResult: TypeAlias = (
+    ProviderQuotaSkippedPreflightResult
+    | ProviderQuotaPassedPreflightResult
+    | ProviderQuotaBlockedPreflightResult
+    | ProviderQuotaDeferredPreflightResult
+    | ProviderQuotaUnknownPreflightResult
 )
+
+
+def _provider_quota_usage_fields(
+    usage: CodexUsageReading,
+) -> dict[str, Any]:
+    reading = usage.to_dict()
+    return {
+        "usage_status": reading["status"],
+        "used_percent": reading["used_percent"],
+        "unknown_reason": reading["reason"],
+        "observed_at": reading["observed_at"],
+        "source_path": reading["source_path"],
+        "limit_id": reading["limit_id"],
+        "plan_type": reading["plan_type"],
+        "last_known_good": reading["last_known_good"],
+    }
 
 
 def _percent_setting(name: str, default: float) -> float:
@@ -259,24 +191,6 @@ def skipped_provider_quota_preflight(
     )
 
 
-def _known_result(
-    result_type: type[KnownQuotaResultT],
-    usage: CodexKnownUsageReading,
-    *,
-    provider: str,
-    model: str,
-    explicit_request: bool,
-    thresholds: ProviderQuotaThresholds,
-) -> KnownQuotaResultT:
-    return result_type(
-        provider=provider,
-        model=model,
-        thresholds=thresholds,
-        usage=usage,
-        explicit_request=explicit_request,
-    )
-
-
 def probe_provider_quota(
     *,
     provider: str,
@@ -305,30 +219,27 @@ def probe_provider_quota(
         )
 
     if usage.used_percent >= thresholds.hard_percent:
-        return _known_result(
-            ProviderQuotaBlockedPreflightResult,
-            usage,
+        return ProviderQuotaBlockedPreflightResult(
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
         )
     if usage.used_percent >= thresholds.soft_percent and not explicit_request:
-        return _known_result(
-            ProviderQuotaDeferredPreflightResult,
-            usage,
+        return ProviderQuotaDeferredPreflightResult(
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
         )
-    return _known_result(
-        ProviderQuotaPassedPreflightResult,
-        usage,
+    return ProviderQuotaPassedPreflightResult(
         provider=provider,
         model=model,
         explicit_request=explicit_request,
         thresholds=thresholds,
+        usage=usage,
     )
 
 
@@ -336,11 +247,9 @@ __all__ = [
     "DEFAULT_CODEX_QUOTA_HARD_PERCENT",
     "DEFAULT_CODEX_QUOTA_SOFT_PERCENT",
     "ProviderQuotaBlockedPreflightResult",
-    "ProviderQuotaDecision",
     "ProviderQuotaDeferredPreflightResult",
     "ProviderQuotaPassedPreflightResult",
     "ProviderQuotaPreflightResult",
-    "ProviderQuotaPreflightStatus",
     "ProviderQuotaSkippedPreflightResult",
     "ProviderQuotaThresholds",
     "ProviderQuotaUnknownPreflightResult",

--- a/brain/platform/integrations/provider_quota_preflight.py
+++ b/brain/platform/integrations/provider_quota_preflight.py
@@ -4,15 +4,38 @@ from __future__ import annotations
 
 import math
 import os
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
-from typing import Any
+from enum import StrEnum
+from typing import Any, Self, TypeVar
 
-from brain.platform.integrations.codex_usage import CodexUsageReading, read_codex_usage
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexKnownUsageReading,
+    CodexUnknownUsageReading,
+    CodexUsageReading,
+    CodexUsageUnknownReason,
+    read_codex_usage,
+)
 from brain.platform.providers.model_policy import required_openai_auth_mode
 
 
 DEFAULT_CODEX_QUOTA_SOFT_PERCENT = 75.0
 DEFAULT_CODEX_QUOTA_HARD_PERCENT = 90.0
+
+
+class ProviderQuotaPreflightStatus(StrEnum):
+    PASSED = "passed"
+    QUOTA_BLOCKED = "quota_blocked"
+    QUOTA_DEFERRED = "quota_deferred"
+    SKIPPED = "skipped"
+    UNKNOWN = "unknown"
+
+
+class ProviderQuotaDecision(StrEnum):
+    ADMITTED = "admitted"
+    BLOCKED = "blocked"
+    DEFERRED = "deferred"
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,34 +50,38 @@ class ProviderQuotaThresholds:
         }
 
 
-@dataclass(frozen=True, slots=True)
-class ProviderQuotaPreflightResult:
-    status: str
-    decision: str
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderQuotaPreflightResult(ABC):
     provider: str
     model: str
-    usage_status: str | None
     thresholds: ProviderQuotaThresholds
-    used_percent: float | None = None
-    unknown_reason: str | None = None
-    observed_at: str | None = None
-    source_path: str | None = None
-    limit_id: str | None = None
-    plan_type: str | None = None
-    last_known_good: dict[str, Any] | None = None
     explicit_request: bool = False
     visible_message: str | None = None
 
     @property
+    @abstractmethod
+    def status(self) -> ProviderQuotaPreflightStatus:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def decision(self) -> ProviderQuotaDecision:
+        raise NotImplementedError
+
+    @property
     def blocked(self) -> bool:
-        return self.decision == "blocked"
+        return self.decision is ProviderQuotaDecision.BLOCKED
 
     @property
     def deferred(self) -> bool:
-        return self.decision == "deferred"
+        return self.decision is ProviderQuotaDecision.DEFERRED
 
-    def with_presentation(self, *, visible_message: str) -> ProviderQuotaPreflightResult:
+    def with_presentation(self, *, visible_message: str) -> Self:
         return replace(self, visible_message=visible_message)
+
+    @abstractmethod
+    def _usage_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -62,18 +89,134 @@ class ProviderQuotaPreflightResult:
             "decision": self.decision,
             "provider": self.provider,
             "model": self.model,
-            "usage_status": self.usage_status,
-            "used_percent": self.used_percent,
-            "unknown_reason": self.unknown_reason,
-            "observed_at": self.observed_at,
-            "source_path": self.source_path,
-            "limit_id": self.limit_id,
-            "plan_type": self.plan_type,
-            "last_known_good": self.last_known_good,
+            **self._usage_dict(),
             "explicit_request": self.explicit_request,
             "thresholds": self.thresholds.to_dict(),
             "visible_message": self.visible_message,
         }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderQuotaSkippedPreflightResult(ProviderQuotaPreflightResult):
+    @property
+    def status(self) -> ProviderQuotaPreflightStatus:
+        return ProviderQuotaPreflightStatus.SKIPPED
+
+    @property
+    def decision(self) -> ProviderQuotaDecision:
+        return ProviderQuotaDecision.ADMITTED
+
+    def _usage_dict(self) -> dict[str, Any]:
+        return {
+            "usage_status": None,
+            "used_percent": None,
+            "unknown_reason": None,
+            "observed_at": None,
+            "source_path": None,
+            "limit_id": None,
+            "plan_type": None,
+            "last_known_good": None,
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ProviderQuotaKnownPreflightResult(ProviderQuotaPreflightResult):
+    usage: CodexKnownUsageReading
+
+    @property
+    def used_percent(self) -> float:
+        return self.usage.used_percent
+
+    def _usage_dict(self) -> dict[str, Any]:
+        return {
+            "usage_status": self.usage.status,
+            "used_percent": self.usage.used_percent,
+            "unknown_reason": None,
+            "observed_at": self.usage.observed_at,
+            "source_path": self.usage.source_path,
+            "limit_id": self.usage.limit_id,
+            "plan_type": self.usage.plan_type,
+            "last_known_good": None,
+        }
+
+
+class ProviderQuotaPassedPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    @property
+    def status(self) -> ProviderQuotaPreflightStatus:
+        return ProviderQuotaPreflightStatus.PASSED
+
+    @property
+    def decision(self) -> ProviderQuotaDecision:
+        return ProviderQuotaDecision.ADMITTED
+
+
+class ProviderQuotaBlockedPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    @property
+    def status(self) -> ProviderQuotaPreflightStatus:
+        return ProviderQuotaPreflightStatus.QUOTA_BLOCKED
+
+    @property
+    def decision(self) -> ProviderQuotaDecision:
+        return ProviderQuotaDecision.BLOCKED
+
+
+class ProviderQuotaDeferredPreflightResult(_ProviderQuotaKnownPreflightResult):
+    __slots__ = ()
+
+    @property
+    def status(self) -> ProviderQuotaPreflightStatus:
+        return ProviderQuotaPreflightStatus.QUOTA_DEFERRED
+
+    @property
+    def decision(self) -> ProviderQuotaDecision:
+        return ProviderQuotaDecision.DEFERRED
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProviderQuotaUnknownPreflightResult(ProviderQuotaPreflightResult):
+    usage: CodexUnknownUsageReading
+
+    @property
+    def status(self) -> ProviderQuotaPreflightStatus:
+        return ProviderQuotaPreflightStatus.UNKNOWN
+
+    @property
+    def decision(self) -> ProviderQuotaDecision:
+        return ProviderQuotaDecision.ADMITTED
+
+    @property
+    def unknown_reason(self) -> CodexUsageUnknownReason:
+        return self.usage.reason
+
+    @property
+    def last_known_good(self) -> CodexKnownUsage | None:
+        return self.usage.last_known_good
+
+    def _usage_dict(self) -> dict[str, Any]:
+        return {
+            "usage_status": self.usage.status,
+            "used_percent": None,
+            "unknown_reason": self.usage.reason,
+            "observed_at": self.usage.observed_at,
+            "source_path": self.usage.source_path,
+            "limit_id": self.usage.limit_id,
+            "plan_type": self.usage.plan_type,
+            "last_known_good": (
+                self.usage.last_known_good.to_dict()
+                if self.usage.last_known_good
+                else None
+            ),
+        }
+
+
+KnownQuotaResultT = TypeVar(
+    "KnownQuotaResultT",
+    bound=_ProviderQuotaKnownPreflightResult,
+)
 
 
 def _percent_setting(name: str, default: float) -> float:
@@ -107,44 +250,29 @@ def skipped_provider_quota_preflight(
     model: str,
     explicit_request: bool,
     thresholds: ProviderQuotaThresholds | None = None,
-) -> ProviderQuotaPreflightResult:
-    return ProviderQuotaPreflightResult(
-        status="skipped",
-        decision="admitted",
+) -> ProviderQuotaSkippedPreflightResult:
+    return ProviderQuotaSkippedPreflightResult(
         provider=provider,
         model=model,
-        usage_status=None,
         thresholds=thresholds or provider_quota_thresholds(),
         explicit_request=explicit_request,
     )
 
 
-def _result_from_usage(
-    usage: CodexUsageReading,
+def _known_result(
+    result_type: type[KnownQuotaResultT],
+    usage: CodexKnownUsageReading,
     *,
-    status: str,
-    decision: str,
     provider: str,
     model: str,
     explicit_request: bool,
     thresholds: ProviderQuotaThresholds,
-) -> ProviderQuotaPreflightResult:
-    return ProviderQuotaPreflightResult(
-        status=status,
-        decision=decision,
+) -> KnownQuotaResultT:
+    return result_type(
         provider=provider,
         model=model,
-        usage_status=usage.status,
         thresholds=thresholds,
-        used_percent=usage.used_percent,
-        unknown_reason=usage.reason,
-        observed_at=usage.observed_at,
-        source_path=usage.source_path,
-        limit_id=usage.limit_id,
-        plan_type=usage.plan_type,
-        last_known_good=(
-            usage.last_known_good.to_dict() if usage.last_known_good else None
-        ),
+        usage=usage,
         explicit_request=explicit_request,
     )
 
@@ -166,43 +294,37 @@ def probe_provider_quota(
             thresholds=thresholds,
         )
 
-    usage = read_codex_usage()
-    if usage.status == "unknown":
-        return _result_from_usage(
-            usage,
-            status="unknown",
-            decision="admitted",
+    usage: CodexUsageReading = read_codex_usage()
+    if isinstance(usage, CodexUnknownUsageReading):
+        return ProviderQuotaUnknownPreflightResult(
             provider=provider,
             model=model,
-            explicit_request=explicit_request,
             thresholds=thresholds,
+            usage=usage,
+            explicit_request=explicit_request,
         )
 
-    used_percent = float(usage.used_percent)
-    if used_percent >= thresholds.hard_percent:
-        return _result_from_usage(
+    if usage.used_percent >= thresholds.hard_percent:
+        return _known_result(
+            ProviderQuotaBlockedPreflightResult,
             usage,
-            status="quota_blocked",
-            decision="blocked",
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
         )
-    if used_percent >= thresholds.soft_percent and not explicit_request:
-        return _result_from_usage(
+    if usage.used_percent >= thresholds.soft_percent and not explicit_request:
+        return _known_result(
+            ProviderQuotaDeferredPreflightResult,
             usage,
-            status="quota_deferred",
-            decision="deferred",
             provider=provider,
             model=model,
             explicit_request=explicit_request,
             thresholds=thresholds,
         )
-    return _result_from_usage(
+    return _known_result(
+        ProviderQuotaPassedPreflightResult,
         usage,
-        status="passed",
-        decision="admitted",
         provider=provider,
         model=model,
         explicit_request=explicit_request,
@@ -213,8 +335,15 @@ def probe_provider_quota(
 __all__ = [
     "DEFAULT_CODEX_QUOTA_HARD_PERCENT",
     "DEFAULT_CODEX_QUOTA_SOFT_PERCENT",
+    "ProviderQuotaBlockedPreflightResult",
+    "ProviderQuotaDecision",
+    "ProviderQuotaDeferredPreflightResult",
+    "ProviderQuotaPassedPreflightResult",
     "ProviderQuotaPreflightResult",
+    "ProviderQuotaPreflightStatus",
+    "ProviderQuotaSkippedPreflightResult",
     "ProviderQuotaThresholds",
+    "ProviderQuotaUnknownPreflightResult",
     "probe_provider_quota",
     "provider_quota_thresholds",
     "skipped_provider_quota_preflight",

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -10,9 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
 )
 from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
     ProviderQuotaPreflightResult,
 )
 from brain.platform.providers.model_policy import (
@@ -93,7 +96,7 @@ def _require_rejection_notice_case(
 class CycleAdmissionAuthBlocked:
     """An auth rejection with its matching provider notice."""
 
-    notice: ProviderAuthPreflightResult
+    notice: ProviderAuthBlockedPreflightResult
 
     def __post_init__(self) -> None:
         _require_rejection_notice_case(
@@ -107,7 +110,7 @@ class CycleAdmissionAuthBlocked:
 class CycleAdmissionQuotaBlocked:
     """A hard-quota rejection with its matching provider notice."""
 
-    notice: ProviderQuotaPreflightResult
+    notice: ProviderQuotaBlockedPreflightResult
 
     def __post_init__(self) -> None:
         _require_rejection_notice_case(
@@ -121,7 +124,7 @@ class CycleAdmissionQuotaBlocked:
 class CycleAdmissionQuotaDeferred:
     """A soft-quota deferral with its matching provider notice."""
 
-    notice: ProviderQuotaPreflightResult
+    notice: ProviderQuotaDeferredPreflightResult
 
     def __post_init__(self) -> None:
         _require_rejection_notice_case(
@@ -218,7 +221,7 @@ async def async_prepare_cycle_run_admission(
     auth = await async_preflight_cycle_external_auth(session, route=route)
     if auth.status != "skipped":
         _record_preflight_snapshot(run, key="auth_preflight", preflight=auth)
-    if auth.blocked:
+    if isinstance(auth, ProviderAuthBlockedPreflightResult):
         return CycleAdmissionAuthBlocked(notice=auth)
 
     quota = preflight_cycle_external_quota(

--- a/brain/systems/cycles/admission.py
+++ b/brain/systems/cycles/admission.py
@@ -12,6 +12,7 @@ from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
+    ProviderAuthSkippedPreflightResult,
 )
 from brain.platform.integrations.provider_quota_preflight import (
     ProviderQuotaBlockedPreflightResult,
@@ -82,28 +83,11 @@ class CycleAdmissionAdmitted:
     route: CycleProviderRoute
 
 
-def _require_rejection_notice_case(
-    *,
-    actual: str,
-    expected: str,
-    rejection: str,
-) -> None:
-    if actual != expected:
-        raise ValueError(f"{rejection} requires preflight case {expected!r}")
-
-
 @dataclass(frozen=True, slots=True)
 class CycleAdmissionAuthBlocked:
     """An auth rejection with its matching provider notice."""
 
     notice: ProviderAuthBlockedPreflightResult
-
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.status,
-            expected="auth_blocked",
-            rejection=type(self).__name__,
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,26 +96,12 @@ class CycleAdmissionQuotaBlocked:
 
     notice: ProviderQuotaBlockedPreflightResult
 
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.decision,
-            expected="blocked",
-            rejection=type(self).__name__,
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class CycleAdmissionQuotaDeferred:
     """A soft-quota deferral with its matching provider notice."""
 
     notice: ProviderQuotaDeferredPreflightResult
-
-    def __post_init__(self) -> None:
-        _require_rejection_notice_case(
-            actual=self.notice.decision,
-            expected="deferred",
-            rejection=type(self).__name__,
-        )
 
 
 CycleAdmissionRejected: TypeAlias = (
@@ -219,7 +189,7 @@ async def async_prepare_cycle_run_admission(
         run=run,
     )
     auth = await async_preflight_cycle_external_auth(session, route=route)
-    if auth.status != "skipped":
+    if not isinstance(auth, ProviderAuthSkippedPreflightResult):
         _record_preflight_snapshot(run, key="auth_preflight", preflight=auth)
     if isinstance(auth, ProviderAuthBlockedPreflightResult):
         return CycleAdmissionAuthBlocked(notice=auth)
@@ -229,15 +199,11 @@ async def async_prepare_cycle_run_admission(
         run=run,
     )
     _record_preflight_snapshot(run, key="quota_preflight", preflight=quota)
-    try:
-        outcome_type, outcome_value = {
-            "admitted": (CycleAdmissionAdmitted, route),
-            "blocked": (CycleAdmissionQuotaBlocked, quota),
-            "deferred": (CycleAdmissionQuotaDeferred, quota),
-        }[quota.decision]
-    except KeyError as exc:
-        raise ValueError(f"Unsupported Cycle quota decision: {quota.decision!r}") from exc
-    return outcome_type(outcome_value)
+    if isinstance(quota, ProviderQuotaBlockedPreflightResult):
+        return CycleAdmissionQuotaBlocked(notice=quota)
+    if isinstance(quota, ProviderQuotaDeferredPreflightResult):
+        return CycleAdmissionQuotaDeferred(notice=quota)
+    return CycleAdmissionAdmitted(route=route)
 
 
 __all__ = [

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
 )
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 def _with_cycle_presentation(
     result: ProviderAuthPreflightResult,
 ) -> ProviderAuthPreflightResult:
-    if not result.blocked:
+    if not isinstance(result, ProviderAuthBlockedPreflightResult):
         return result
     if result.provider == "anthropic":
         repair_action = (

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -32,7 +32,7 @@ def _with_cycle_presentation(
         return result.with_presentation(
             visible_message=(
                 "Cycle quota blocked: Codex usage is "
-                f"{result.used_percent:g}%, at or above the "
+                f"{result.usage.used_percent:g}%, at or above the "
                 f"{result.thresholds.hard_percent:g}% hard limit. "
                 "Illo will admit new runs automatically after usage falls below the limit."
             )
@@ -41,7 +41,7 @@ def _with_cycle_presentation(
         return result.with_presentation(
             visible_message=(
                 "Scheduled Cycle quota deferred: Codex usage is "
-                f"{result.used_percent:g}%, at or above the "
+                f"{result.usage.used_percent:g}%, at or above the "
                 f"{result.thresholds.soft_percent:g}% soft limit. "
                 "Illo will try again on a later scheduled run."
             )

--- a/brain/systems/cycles/quota_preflight.py
+++ b/brain/systems/cycles/quota_preflight.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
     ProviderQuotaPreflightResult,
     probe_provider_quota,
 )
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
 def _with_cycle_presentation(
     result: ProviderQuotaPreflightResult,
 ) -> ProviderQuotaPreflightResult:
-    if result.blocked:
+    if isinstance(result, ProviderQuotaBlockedPreflightResult):
         return result.with_presentation(
             visible_message=(
                 "Cycle quota blocked: Codex usage is "
@@ -35,7 +37,7 @@ def _with_cycle_presentation(
                 "Illo will admit new runs automatically after usage falls below the limit."
             )
         )
-    if result.deferred:
+    if isinstance(result, ProviderQuotaDeferredPreflightResult):
         return result.with_presentation(
             visible_message=(
                 "Scheduled Cycle quota deferred: Codex usage is "

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, select
 
 from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
 from brain.platform.integrations.provider_auth_preflight import (
-    ProviderAuthPreflightResult,
+    ProviderAuthBlockedPreflightResult,
 )
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
@@ -277,7 +277,7 @@ async def _async_append_cycle_auth_blocked_thread_message(
     idea: Idea,
     cycle: Cycle,
     cycle_run: CycleRun,
-    preflight: ProviderAuthPreflightResult,
+    preflight: ProviderAuthBlockedPreflightResult,
 ) -> tuple[dict, dict | None]:
     metadata = {
         "source": "cycle",

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -13,6 +13,7 @@ from typing import Any
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.effort import EFFORT_TIERS, EFFORT_TIER_SET
 from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
     skipped_provider_auth_preflight,
@@ -67,7 +68,7 @@ _SPAWN_WORKER_AUTH_PROVIDERS = frozenset({"anthropic", "openai"})
 def _with_spawn_worker_auth_presentation(
     result: ProviderAuthPreflightResult,
 ) -> ProviderAuthPreflightResult:
-    if not result.blocked:
+    if not isinstance(result, ProviderAuthBlockedPreflightResult):
         return result
 
     credential = result.credential or "provider"
@@ -575,7 +576,7 @@ async def _handle_spawn_worker(
                 org_id=parent.org_id,
                 model=str(child_policy["model"]),
             )
-            if preflight.blocked:
+            if isinstance(preflight, ProviderAuthBlockedPreflightResult):
                 shard = str(worker_metadata["worker_shard"])
                 failure = WorkerEvidenceFailure.for_admission(
                     worker_role=assignment.role,

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -12,7 +12,10 @@ from typing import Any
 from sqlalchemy import text
 
 from brain.platform.db.models.idea import Idea
-from brain.platform.integrations.provider_auth_preflight import async_probe_provider_auth
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
+    async_probe_provider_auth,
+)
 from brain.platform.providers.model_policy import (
     EFFORT_TIER_SET,
     async_get_default_model,
@@ -1141,7 +1144,7 @@ async def admit_work(
                 provider=provider,
                 model=model,
             )
-            if auth_preflight.blocked:
+            if isinstance(auth_preflight, ProviderAuthBlockedPreflightResult):
                 reason = (
                     f"{auth_preflight.error_code}: provider={provider} model={model} "
                     f"credential={auth_preflight.credential or 'unavailable'}"

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -50,12 +50,11 @@ def _stub_spawn_worker_auth_preflight(monkeypatch, worker_handlers):
     developer laptop and the auth_blocked path on credential-free CI.
     """
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthPassedPreflightResult,
     )
 
     async def passed_preflight(_session, *, model, **_kwargs):
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider="openai",
             model=model,
         )
@@ -336,7 +335,7 @@ async def test_run_admission_marks_idea_working_without_worker_details(monkeypat
 
 async def test_run_admission_rejects_uncredentialed_anthropic_before_creation(monkeypatch):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
     from brain.systems.runs.domain import AgentRunRequest
     from brain.systems.runs import work_intake
@@ -354,8 +353,7 @@ async def test_run_admission_rejects_uncredentialed_anthropic_before_creation(mo
         return request
 
     async def blocked_probe(_session, **kwargs):
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",
@@ -1761,7 +1759,7 @@ async def _captured_spawn_worker(
     **spawn_kwargs,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthPassedPreflightResult,
     )
     from brain.systems.runs.domain import RunProfile, RunRecipe
     from brain.systems.runs.evidence_health import WorkerEvidenceReceipt
@@ -1826,8 +1824,7 @@ async def _captured_spawn_worker(
 
     async def fake_preflight(*_args, **_kwargs):
         captured["preflight"] = dict(_kwargs)
-        return preflight_result or ProviderAuthPreflightResult(
-            status="passed",
+        return preflight_result or ProviderAuthPassedPreflightResult(
             provider="openai",
             model="openai/gpt-5.6-sol",
         )
@@ -2057,11 +2054,10 @@ async def test_spawn_worker_auth_preflight_rejects_missing_provider_credential_b
     monkeypatch,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
 
-    blocked = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    blocked = ProviderAuthBlockedPreflightResult(
         provider="anthropic",
         model="anthropic/claude-sonnet-4-6",
         credential="Anthropic API key",
@@ -2147,7 +2143,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
     monkeypatch,
 ):
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
@@ -2155,8 +2151,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
 
     async def blocked_probe(_session, **kwargs):
         captured.update(kwargs)
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",
@@ -2195,15 +2190,14 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
     from brain.systems.cycles import auth_preflight
     from brain.systems.cycles.admission import CycleProviderRoute
     from brain.platform.integrations.provider_auth_preflight import (
-        ProviderAuthPreflightResult,
+        ProviderAuthBlockedPreflightResult,
     )
 
     probes = []
 
     async def blocked_probe(*_args, **kwargs):
         probes.append(kwargs)
-        return ProviderAuthPreflightResult(
-            status="auth_blocked",
+        return ProviderAuthBlockedPreflightResult(
             provider="anthropic",
             model=kwargs["model"],
             credential="Anthropic API key",

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2132,7 +2132,7 @@ async def test_neutral_auth_probe_names_missing_anthropic_configuration(
         model="anthropic/claude-sonnet-4-6",
     )
 
-    assert result.status == "auth_blocked"
+    assert result.to_dict()["status"] == "auth_blocked"
     assert result.error_code == "provider_credential_unavailable"
     assert result.credential == "Anthropic API key"
     assert result.visible_message is None
@@ -2177,7 +2177,7 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
         "provider": "anthropic",
         "model": "anthropic/claude-sonnet-4-6",
     }
-    assert result.blocked is True
+    assert isinstance(result, ProviderAuthBlockedPreflightResult)
     assert result.repair_action == (
         "Add an Anthropic API key in Settings > Access, then retry the run."
     )
@@ -2219,7 +2219,7 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
         ),
     )
 
-    assert result.status == "auth_blocked"
+    assert isinstance(result, ProviderAuthBlockedPreflightResult)
     assert result.provider == "anthropic"
     assert probes[0]["provider"] == "anthropic"
     assert "Add an Anthropic API key" in result.visible_message

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from brain.platform.integrations.codex_usage import (
-    CodexKnownUsageReading,
+    CodexKnownUsage,
     CodexUnknownUsageReading,
     CodexUsageUnknownReason,
     read_codex_usage,
@@ -57,10 +57,9 @@ def test_reads_newest_real_codex_usage(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert isinstance(reading, CodexKnownUsageReading)
-    assert reading.status == "ok"
+    assert isinstance(reading, CodexKnownUsage)
+    assert reading.to_dict()["status"] == "ok"
     assert reading.used_percent == 31.0
-    assert reading.reason is None
     assert reading.observed_at == "2026-08-04T13:24:46Z"
     assert reading.limit_id == "codex"
     assert reading.plan_type == "pro"
@@ -72,10 +71,9 @@ def test_real_codex_usage_at_one_hundred_is_exhausted(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
-    assert isinstance(reading, CodexKnownUsageReading)
-    assert reading.status == "exhausted"
+    assert isinstance(reading, CodexKnownUsage)
+    assert reading.to_dict()["status"] == "exhausted"
     assert reading.used_percent == 100.0
-    assert reading.reason is None
 
 
 def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
@@ -95,9 +93,7 @@ def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "unexpected_limit_id"
-    assert reading.used_percent is None
     assert reading.limit_id == "premium"
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 31.0
@@ -111,9 +107,7 @@ def test_null_primary_on_codex_limit_is_unknown_not_zero_or_exhausted(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "primary_missing"
-    assert reading.used_percent is None
     assert reading.last_known_good is None
 
 
@@ -126,9 +120,7 @@ def test_malformed_newest_line_is_unknown_with_older_known_reading(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "malformed_line"
-    assert reading.used_percent is None
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 42.0
 
@@ -151,9 +143,7 @@ def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "auth_error"
-    assert reading.used_percent is None
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 52.0
 
@@ -162,9 +152,7 @@ def test_missing_sessions_directory_is_unknown(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "sessions_dir_missing"
-    assert reading.used_percent is None
 
 
 def test_only_newest_session_file_controls_current_verdict(tmp_path):
@@ -178,7 +166,6 @@ def test_only_newest_session_file_controls_current_verdict(tmp_path):
     reading = read_codex_usage(tmp_path)
 
     assert isinstance(reading, CodexUnknownUsageReading)
-    assert reading.status == "unknown"
     assert reading.reason == "token_count_missing"
     assert reading.last_known_good is not None
     assert reading.last_known_good.used_percent == 12.0
@@ -190,12 +177,12 @@ def test_codex_home_environment_selects_usage_root(tmp_path, monkeypatch):
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
     reading = read_codex_usage()
-    assert isinstance(reading, CodexKnownUsageReading)
+    assert isinstance(reading, CodexKnownUsage)
     assert reading.used_percent == 17.0
 
 
 def test_usage_reading_serialization_is_byte_compatible():
-    known = CodexKnownUsageReading(
+    known = CodexKnownUsage(
         used_percent=31.0,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/rollout.jsonl",

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import json
 import os
 
-from brain.platform.integrations.codex_usage import read_codex_usage
+import pytest
+
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsageReading,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+    read_codex_usage,
+)
 
 
 def _event(
@@ -50,6 +57,7 @@ def test_reads_newest_real_codex_usage(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexKnownUsageReading)
     assert reading.status == "ok"
     assert reading.used_percent == 31.0
     assert reading.reason is None
@@ -64,6 +72,7 @@ def test_real_codex_usage_at_one_hundred_is_exhausted(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexKnownUsageReading)
     assert reading.status == "exhausted"
     assert reading.used_percent == 100.0
     assert reading.reason is None
@@ -85,6 +94,7 @@ def test_degenerate_premium_payload_is_unknown_with_last_known_good(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "unexpected_limit_id"
     assert reading.used_percent is None
@@ -100,6 +110,7 @@ def test_null_primary_on_codex_limit_is_unknown_not_zero_or_exhausted(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "primary_missing"
     assert reading.used_percent is None
@@ -114,6 +125,7 @@ def test_malformed_newest_line_is_unknown_with_older_known_reading(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "malformed_line"
     assert reading.used_percent is None
@@ -138,6 +150,7 @@ def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "auth_error"
     assert reading.used_percent is None
@@ -148,6 +161,7 @@ def test_newer_auth_error_is_unknown_with_older_known_reading(tmp_path):
 def test_missing_sessions_directory_is_unknown(tmp_path):
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "sessions_dir_missing"
     assert reading.used_percent is None
@@ -163,6 +177,7 @@ def test_only_newest_session_file_controls_current_verdict(tmp_path):
 
     reading = read_codex_usage(tmp_path)
 
+    assert isinstance(reading, CodexUnknownUsageReading)
     assert reading.status == "unknown"
     assert reading.reason == "token_count_missing"
     assert reading.last_known_good is not None
@@ -174,4 +189,54 @@ def test_codex_home_environment_selects_usage_root(tmp_path, monkeypatch):
     _write_events(path, _event(17))
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
-    assert read_codex_usage().used_percent == 17.0
+    reading = read_codex_usage()
+    assert isinstance(reading, CodexKnownUsageReading)
+    assert reading.used_percent == 17.0
+
+
+def test_usage_reading_serialization_is_byte_compatible():
+    known = CodexKnownUsageReading(
+        used_percent=31.0,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+        plan_type="pro",
+    )
+    unknown = CodexUnknownUsageReading(
+        reason=CodexUsageUnknownReason.PRIMARY_MISSING,
+        observed_at="2026-08-04T13:28:13Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+        limit_id="codex",
+    )
+
+    assert json.dumps(known.to_dict(), separators=(",", ":")).encode() == (
+        b'{"status":"ok","used_percent":31.0,"reason":null,'
+        b'"observed_at":"2026-08-04T13:24:45Z",'
+        b'"source_path":"/tmp/codex/sessions/rollout.jsonl",'
+        b'"limit_id":"codex","plan_type":"pro","last_known_good":null}'
+    )
+    assert json.dumps(unknown.to_dict(), separators=(",", ":")).encode() == (
+        b'{"status":"unknown","used_percent":null,"reason":"primary_missing",'
+        b'"observed_at":"2026-08-04T13:28:13Z",'
+        b'"source_path":"/tmp/codex/sessions/rollout.jsonl",'
+        b'"limit_id":"codex","plan_type":null,"last_known_good":null}'
+    )
+
+
+def test_unknown_reasons_are_enumerable_and_reject_free_form_strings():
+    assert {reason.value for reason in CodexUsageUnknownReason} == {
+        "auth_error",
+        "malformed_line",
+        "primary_missing",
+        "rate_limits_missing",
+        "sessions_dir_empty",
+        "sessions_dir_missing",
+        "sessions_dir_unreadable",
+        "session_file_empty",
+        "session_file_unreadable",
+        "token_count_missing",
+        "unexpected_limit_id",
+        "used_percent_invalid",
+        "used_percent_missing",
+    }
+    with pytest.raises(TypeError):
+        CodexUnknownUsageReading(reason="new_reason")

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -5,11 +5,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from brain.platform.integrations.codex_usage import CodexKnownUsageReading
 from brain.platform.integrations.provider_auth_preflight import (
-    ProviderAuthPreflightResult,
+    ProviderAuthBlockedPreflightResult,
+    ProviderAuthPassedPreflightResult,
 )
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
 )
 from brain.systems.cycles import admission
@@ -24,6 +28,14 @@ def _cycle(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def _usage(used_percent: float) -> CodexKnownUsageReading:
+    return CodexKnownUsageReading(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+    )
 
 
 @pytest.mark.asyncio
@@ -119,21 +131,17 @@ async def test_cycle_admission_derives_one_route_shared_by_both_preflights(monke
 
     async def auth_preflight(_session, *, route):
         auth_routes.append(route)
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider=route.provider,
             model=route.model,
         )
 
     def quota_preflight(*, route, run):
         quota_routes.append((route, run))
-        return ProviderQuotaPreflightResult(
-            status="passed",
-            decision="admitted",
+        return ProviderQuotaPassedPreflightResult(
             provider=route.provider,
             model=route.model,
-            usage_status="ok",
-            used_percent=10.0,
+            usage=_usage(10.0),
             thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
             explicit_request=False,
         )
@@ -206,10 +214,11 @@ def test_cycle_route_rejects_noncanonical_construction(model, thinking):
 
 
 def test_cycle_rejection_union_rejects_contradictory_construction():
-    auth = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    auth = ProviderAuthBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.5",
+        credential="OpenAI Codex / ChatGPT",
+        error_code="provider_credential_unavailable",
         visible_message="Reconnect OpenAI.",
     )
 
@@ -241,20 +250,17 @@ def test_cycle_rejection_variants_reject_independent_settlement_fields(rejection
     [
         (
             admission.CycleAdmissionAuthBlocked,
-            ProviderAuthPreflightResult(
-                status="passed",
+            ProviderAuthPassedPreflightResult(
                 provider="openai",
                 model="openai/gpt-5.5",
             ),
         ),
         (
             admission.CycleAdmissionQuotaBlocked,
-            ProviderQuotaPreflightResult(
-                status="quota_deferred",
-                decision="deferred",
+            ProviderQuotaDeferredPreflightResult(
                 provider="openai",
                 model="openai/gpt-5.5",
-                usage_status="ok",
+                usage=_usage(80.0),
                 thresholds=ProviderQuotaThresholds(
                     soft_percent=75.0,
                     hard_percent=90.0,
@@ -263,12 +269,10 @@ def test_cycle_rejection_variants_reject_independent_settlement_fields(rejection
         ),
         (
             admission.CycleAdmissionQuotaDeferred,
-            ProviderQuotaPreflightResult(
-                status="quota_blocked",
-                decision="blocked",
+            ProviderQuotaBlockedPreflightResult(
                 provider="openai",
                 model="openai/gpt-5.5",
-                usage_status="ok",
+                usage=_usage(90.0),
                 thresholds=ProviderQuotaThresholds(
                     soft_percent=75.0,
                     hard_percent=90.0,
@@ -287,10 +291,11 @@ def test_cycle_rejection_variants_reject_mismatched_notices(
 
 @pytest.mark.asyncio
 async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
-    auth = ProviderAuthPreflightResult(
-        status="auth_blocked",
+    auth = ProviderAuthBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.5",
+        credential="OpenAI Codex / ChatGPT",
+        error_code="provider_credential_unavailable",
         visible_message="Reconnect OpenAI.",
     )
 
@@ -318,16 +323,16 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("status", "decision", "message", "expected_type"),
+    ("quota_type", "decision", "message", "expected_type"),
     [
         (
-            "quota_blocked",
+            ProviderQuotaBlockedPreflightResult,
             "blocked",
             "Quota is blocked.",
             admission.CycleAdmissionQuotaBlocked,
         ),
         (
-            "quota_deferred",
+            ProviderQuotaDeferredPreflightResult,
             "deferred",
             "Quota is deferred.",
             admission.CycleAdmissionQuotaDeferred,
@@ -336,25 +341,21 @@ async def test_cycle_admission_returns_complete_auth_rejection(monkeypatch):
 )
 async def test_cycle_admission_returns_complete_quota_rejection(
     monkeypatch,
-    status,
+    quota_type,
     decision,
     message,
     expected_type,
 ):
-    quota = ProviderQuotaPreflightResult(
-        status=status,
-        decision=decision,
+    quota = quota_type(
         provider="openai",
         model="openai/gpt-5.5",
-        usage_status="ok",
-        used_percent=90.0,
+        usage=_usage(90.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message=message,
     )
 
     async def auth_preflight(_session, *, route):
-        return ProviderAuthPreflightResult(
-            status="passed",
+        return ProviderAuthPassedPreflightResult(
             provider=route.provider,
             model=route.model,
         )

--- a/tests/test_cycle_admission.py
+++ b/tests/test_cycle_admission.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from brain.platform.integrations.codex_usage import CodexKnownUsageReading
+from brain.platform.integrations.codex_usage import CodexKnownUsage
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthBlockedPreflightResult,
     ProviderAuthPassedPreflightResult,
@@ -30,8 +30,8 @@ def _cycle(**overrides):
     return SimpleNamespace(**values)
 
 
-def _usage(used_percent: float) -> CodexKnownUsageReading:
-    return CodexKnownUsageReading(
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/rollout.jsonl",
@@ -243,50 +243,6 @@ def test_cycle_rejection_union_rejects_contradictory_construction():
 def test_cycle_rejection_variants_reject_independent_settlement_fields(rejection_type):
     with pytest.raises(TypeError):
         rejection_type(notice=object(), status="auth_blocked")
-
-
-@pytest.mark.parametrize(
-    ("rejection_type", "notice"),
-    [
-        (
-            admission.CycleAdmissionAuthBlocked,
-            ProviderAuthPassedPreflightResult(
-                provider="openai",
-                model="openai/gpt-5.5",
-            ),
-        ),
-        (
-            admission.CycleAdmissionQuotaBlocked,
-            ProviderQuotaDeferredPreflightResult(
-                provider="openai",
-                model="openai/gpt-5.5",
-                usage=_usage(80.0),
-                thresholds=ProviderQuotaThresholds(
-                    soft_percent=75.0,
-                    hard_percent=90.0,
-                ),
-            ),
-        ),
-        (
-            admission.CycleAdmissionQuotaDeferred,
-            ProviderQuotaBlockedPreflightResult(
-                provider="openai",
-                model="openai/gpt-5.5",
-                usage=_usage(90.0),
-                thresholds=ProviderQuotaThresholds(
-                    soft_percent=75.0,
-                    hard_percent=90.0,
-                ),
-            ),
-        ),
-    ],
-)
-def test_cycle_rejection_variants_reject_mismatched_notices(
-    rejection_type,
-    notice,
-):
-    with pytest.raises(ValueError):
-        rejection_type(notice=notice)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsageReading,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+)
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
+    ProviderQuotaUnknownPreflightResult,
 )
 from brain.systems.cycles.admission import CycleProviderRoute
 from brain.systems.cycles import quota_preflight
@@ -18,18 +25,23 @@ def _route(model: str = "openai/gpt-5.6-sol") -> CycleProviderRoute:
     )
 
 
+def _usage(used_percent: float) -> CodexKnownUsageReading:
+    return CodexKnownUsageReading(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path="/tmp/codex/sessions/rollout.jsonl",
+    )
+
+
 def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     captured = {}
 
     def probe(**kwargs):
         captured.update(kwargs)
-        return ProviderQuotaPreflightResult(
-            status="quota_deferred",
-            decision="deferred",
+        return ProviderQuotaDeferredPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="ok",
-            used_percent=80,
+            usage=_usage(80),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
         )
 
@@ -52,13 +64,10 @@ def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
 
     def probe(**kwargs):
         captured.update(kwargs)
-        return ProviderQuotaPreflightResult(
-            status="passed",
-            decision="admitted",
+        return ProviderQuotaPassedPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="ok",
-            used_percent=80,
+            usage=_usage(80),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
             explicit_request=kwargs["explicit_request"],
         )
@@ -81,13 +90,12 @@ def test_cycle_quota_consumes_resolved_route(monkeypatch):
 
     def probe(**kwargs):
         captured["probe"] = kwargs
-        return ProviderQuotaPreflightResult(
-            status="unknown",
-            decision="admitted",
+        return ProviderQuotaUnknownPreflightResult(
             provider=kwargs["provider"],
             model=kwargs["model"],
-            usage_status="unknown",
-            unknown_reason="sessions_dir_missing",
+            usage=CodexUnknownUsageReading(
+                reason=CodexUsageUnknownReason.SESSIONS_DIR_MISSING,
+            ),
             thresholds=ProviderQuotaThresholds(soft_percent=75, hard_percent=90),
         )
 

--- a/tests/test_cycle_quota_preflight.py
+++ b/tests/test_cycle_quota_preflight.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from brain.platform.integrations.codex_usage import (
-    CodexKnownUsageReading,
+    CodexKnownUsage,
     CodexUnknownUsageReading,
     CodexUsageUnknownReason,
 )
@@ -25,8 +25,8 @@ def _route(model: str = "openai/gpt-5.6-sol") -> CycleProviderRoute:
     )
 
 
-def _usage(used_percent: float) -> CodexKnownUsageReading:
-    return CodexKnownUsageReading(
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/rollout.jsonl",
@@ -54,7 +54,7 @@ def test_cycle_quota_marks_scheduled_origin_as_autonomous(monkeypatch):
     )
 
     assert captured["explicit_request"] is False
-    assert result.deferred is True
+    assert isinstance(result, ProviderQuotaDeferredPreflightResult)
     assert "80%" in result.visible_message
     assert "75% soft limit" in result.visible_message
 
@@ -81,7 +81,7 @@ def test_cycle_quota_marks_manual_origin_as_explicit(monkeypatch):
     )
 
     assert captured["explicit_request"] is True
-    assert result.decision == "admitted"
+    assert isinstance(result, ProviderQuotaPassedPreflightResult)
     assert result.visible_message is None
 
 
@@ -106,5 +106,4 @@ def test_cycle_quota_consumes_resolved_route(monkeypatch):
     )
 
     assert captured["probe"]["model"] == "openai/gpt-5.6-sol"
-    assert result.status == "unknown"
-    assert result.decision == "admitted"
+    assert isinstance(result, ProviderQuotaUnknownPreflightResult)

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -36,9 +36,14 @@ from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEven
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.db.models.org import Org, User
-from brain.platform.integrations.provider_auth_preflight import ProviderAuthPreflightResult
+from brain.platform.integrations.codex_usage import CodexKnownUsageReading
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPassedPreflightResult,
+)
 from brain.platform.integrations.provider_quota_preflight import (
-    ProviderQuotaPreflightResult,
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
     ProviderQuotaThresholds,
 )
 
@@ -72,22 +77,27 @@ REFLEX_ANSWER = (
 
 
 async def _passed_cycle_auth(_session, *, route):
-    return ProviderAuthPreflightResult(
-        status="passed",
+    return ProviderAuthPassedPreflightResult(
         provider=route.provider,
         model=route.model,
     )
 
 
+def _quota_usage(used_percent, *, source_path="/tmp/codex/session.jsonl"):
+    return CodexKnownUsageReading(
+        used_percent=used_percent,
+        observed_at="2026-08-04T13:24:45Z",
+        source_path=source_path,
+        plan_type="pro",
+    )
+
+
 def _passed_cycle_quota(*, route, run):
     del run
-    return ProviderQuotaPreflightResult(
-        status="passed",
-        decision="admitted",
+    return ProviderQuotaPassedPreflightResult(
         provider=route.provider,
         model=route.model,
-        usage_status="ok",
-        used_percent=10.0,
+        usage=_quota_usage(10.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         explicit_request=False,
     )
@@ -2251,17 +2261,10 @@ async def test_execute_cycle_run_hard_quota_blocks_and_records_one_notice(monkey
         idea=idea,
         expected_run_id=run.id,
     )
-    quota = ProviderQuotaPreflightResult(
-        status="quota_blocked",
-        decision="blocked",
+    quota = ProviderQuotaBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=92.0,
-        observed_at="2026-08-04T13:24:45Z",
-        source_path="/tmp/codex/session.jsonl",
-        limit_id="codex",
-        plan_type="pro",
+        usage=_quota_usage(92.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message=(
             "Cycle quota blocked: Codex usage is 92%, at or above the 90% hard limit."
@@ -2372,13 +2375,10 @@ async def test_cycle_quota_notice_deduplicates_per_episode_in_postgres(db_sessio
         runs.append(run)
     await db_session.flush()
 
-    quota = ProviderQuotaPreflightResult(
-        status="quota_blocked",
-        decision="blocked",
+    quota = ProviderQuotaBlockedPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=92.0,
+        usage=_quota_usage(92.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message="Scheduled Cycle quota blocked.",
     )
@@ -2423,13 +2423,10 @@ async def test_execute_scheduled_cycle_run_defers_at_soft_quota(monkeypatch):
         idea=idea,
         expected_run_id=run.id,
     )
-    quota = ProviderQuotaPreflightResult(
-        status="quota_deferred",
-        decision="deferred",
+    quota = ProviderQuotaDeferredPreflightResult(
         provider="openai",
         model="openai/gpt-5.6-sol",
-        usage_status="ok",
-        used_percent=80.0,
+        usage=_quota_usage(80.0),
         thresholds=ProviderQuotaThresholds(soft_percent=75.0, hard_percent=90.0),
         visible_message="Scheduled Cycle quota deferred.",
     )

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -36,7 +36,7 @@ from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEven
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea, IdeaThread
 from brain.platform.db.models.org import Org, User
-from brain.platform.integrations.codex_usage import CodexKnownUsageReading
+from brain.platform.integrations.codex_usage import CodexKnownUsage
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPassedPreflightResult,
 )
@@ -84,7 +84,7 @@ async def _passed_cycle_auth(_session, *, route):
 
 
 def _quota_usage(used_percent, *, source_path="/tmp/codex/session.jsonl"):
-    return CodexKnownUsageReading(
+    return CodexKnownUsage(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path=source_path,

--- a/tests/test_provider_auth_preflight.py
+++ b/tests/test_provider_auth_preflight.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthBlockedPreflightResult,
+    ProviderAuthPassedPreflightResult,
+)
+
+
+def test_auth_variants_fix_their_status_and_preserve_serialization():
+    blocked = ProviderAuthBlockedPreflightResult(
+        provider="anthropic",
+        model="anthropic/claude-sonnet-4-6",
+        credential="Anthropic API key",
+        error_code="provider_credential_unavailable",
+    )
+
+    assert blocked.to_dict() == {
+        "status": "auth_blocked",
+        "provider": "anthropic",
+        "model": "anthropic/claude-sonnet-4-6",
+        "credential": "Anthropic API key",
+        "error_code": "provider_credential_unavailable",
+        "repair_action": None,
+        "visible_message": None,
+    }
+    with pytest.raises(TypeError):
+        ProviderAuthPassedPreflightResult(
+            status="auth_blocked",
+            provider="anthropic",
+            model="anthropic/claude-sonnet-4-6",
+        )

--- a/tests/test_provider_quota_preflight.py
+++ b/tests/test_provider_quota_preflight.py
@@ -6,7 +6,6 @@ import pytest
 
 from brain.platform.integrations.codex_usage import (
     CodexKnownUsage,
-    CodexKnownUsageReading,
     CodexUnknownUsageReading,
     CodexUsageUnknownReason,
 )
@@ -20,8 +19,8 @@ from brain.platform.integrations.provider_quota_preflight import (
 )
 
 
-def _usage(used_percent: float) -> CodexKnownUsageReading:
-    return CodexKnownUsageReading(
+def _usage(used_percent: float) -> CodexKnownUsage:
+    return CodexKnownUsage(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
@@ -44,9 +43,9 @@ def test_below_soft_limit_is_admitted(monkeypatch):
     result = _probe()
 
     assert isinstance(result, ProviderQuotaPassedPreflightResult)
-    assert result.status == "passed"
-    assert result.decision == "admitted"
-    assert result.used_percent == 74.9
+    assert result.to_dict()["status"] == "passed"
+    assert result.to_dict()["decision"] == "admitted"
+    assert result.usage.used_percent == 74.9
     assert result.thresholds.to_dict() == {
         "soft_percent": 75.0,
         "hard_percent": 90.0,
@@ -61,11 +60,10 @@ def test_soft_limit_defers_scheduled_run_but_admits_explicit_run(monkeypatch):
 
     assert isinstance(scheduled, ProviderQuotaDeferredPreflightResult)
     assert isinstance(explicit, ProviderQuotaPassedPreflightResult)
-    assert scheduled.status == "quota_deferred"
-    assert scheduled.decision == "deferred"
-    assert scheduled.deferred is True
-    assert explicit.status == "passed"
-    assert explicit.decision == "admitted"
+    assert scheduled.to_dict()["status"] == "quota_deferred"
+    assert scheduled.to_dict()["decision"] == "deferred"
+    assert explicit.to_dict()["status"] == "passed"
+    assert explicit.to_dict()["decision"] == "admitted"
 
 
 def test_hard_limit_blocks_even_explicit_run(monkeypatch):
@@ -74,10 +72,9 @@ def test_hard_limit_blocks_even_explicit_run(monkeypatch):
     result = _probe(explicit_request=True)
 
     assert isinstance(result, ProviderQuotaBlockedPreflightResult)
-    assert result.status == "quota_blocked"
-    assert result.decision == "blocked"
-    assert result.blocked is True
-    assert result.used_percent == 90.0
+    assert result.to_dict()["status"] == "quota_blocked"
+    assert result.to_dict()["decision"] == "blocked"
+    assert result.usage.used_percent == 90.0
 
 
 def test_real_exhausted_reading_blocks(monkeypatch):
@@ -86,9 +83,9 @@ def test_real_exhausted_reading_blocks(monkeypatch):
     result = _probe()
 
     assert isinstance(result, ProviderQuotaBlockedPreflightResult)
-    assert result.usage.status == "exhausted"
-    assert result.decision == "blocked"
-    assert result.used_percent == 100.0
+    assert result.usage.to_dict()["status"] == "exhausted"
+    assert result.to_dict()["decision"] == "blocked"
+    assert result.usage.used_percent == 100.0
 
 
 def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
@@ -109,10 +106,10 @@ def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
     result = _probe()
 
     assert isinstance(result, ProviderQuotaUnknownPreflightResult)
-    assert result.status == "unknown"
-    assert result.decision == "admitted"
-    assert result.unknown_reason == "primary_missing"
-    assert result.last_known_good is reading.last_known_good
+    assert result.to_dict()["status"] == "unknown"
+    assert result.to_dict()["decision"] == "admitted"
+    assert result.usage.reason == "primary_missing"
+    assert result.usage.last_known_good is reading.last_known_good
     assert result.to_dict()["last_known_good"] == {
         "used_percent": 31,
         "observed_at": "2026-08-04T13:24:45Z",
@@ -129,7 +126,7 @@ def test_thresholds_are_configurable(monkeypatch):
 
     result = _probe()
 
-    assert result.decision == "deferred"
+    assert result.to_dict()["decision"] == "deferred"
     assert result.thresholds.to_dict() == {
         "soft_percent": 60.0,
         "hard_percent": 70.0,
@@ -169,9 +166,9 @@ def test_live_reader_recovers_automatically_after_window_reset(tmp_path, monkeyp
 
     assert isinstance(blocked, ProviderQuotaBlockedPreflightResult)
     assert isinstance(recovered, ProviderQuotaPassedPreflightResult)
-    assert blocked.decision == "blocked"
-    assert recovered.decision == "admitted"
-    assert recovered.used_percent == 3.0
+    assert blocked.to_dict()["decision"] == "blocked"
+    assert recovered.to_dict()["decision"] == "admitted"
+    assert recovered.usage.used_percent == 3.0
 
 
 def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
@@ -188,8 +185,8 @@ def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
     )
 
     assert isinstance(result, ProviderQuotaSkippedPreflightResult)
-    assert result.status == "skipped"
-    assert result.decision == "admitted"
+    assert result.to_dict()["status"] == "skipped"
+    assert result.to_dict()["decision"] == "admitted"
     assert result.to_dict()["usage_status"] is None
 
 

--- a/tests/test_provider_quota_preflight.py
+++ b/tests/test_provider_quota_preflight.py
@@ -2,13 +2,26 @@ from __future__ import annotations
 
 import json
 
-from brain.platform.integrations.codex_usage import CodexKnownUsage, CodexUsageReading
+import pytest
+
+from brain.platform.integrations.codex_usage import (
+    CodexKnownUsage,
+    CodexKnownUsageReading,
+    CodexUnknownUsageReading,
+    CodexUsageUnknownReason,
+)
 from brain.platform.integrations import provider_quota_preflight
+from brain.platform.integrations.provider_quota_preflight import (
+    ProviderQuotaBlockedPreflightResult,
+    ProviderQuotaDeferredPreflightResult,
+    ProviderQuotaPassedPreflightResult,
+    ProviderQuotaSkippedPreflightResult,
+    ProviderQuotaUnknownPreflightResult,
+)
 
 
-def _usage(used_percent: float) -> CodexUsageReading:
-    return CodexUsageReading(
-        status="exhausted" if used_percent >= 100 else "ok",
+def _usage(used_percent: float) -> CodexKnownUsageReading:
+    return CodexKnownUsageReading(
         used_percent=used_percent,
         observed_at="2026-08-04T13:24:45Z",
         source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
@@ -30,6 +43,7 @@ def test_below_soft_limit_is_admitted(monkeypatch):
 
     result = _probe()
 
+    assert isinstance(result, ProviderQuotaPassedPreflightResult)
     assert result.status == "passed"
     assert result.decision == "admitted"
     assert result.used_percent == 74.9
@@ -45,6 +59,8 @@ def test_soft_limit_defers_scheduled_run_but_admits_explicit_run(monkeypatch):
     scheduled = _probe(explicit_request=False)
     explicit = _probe(explicit_request=True)
 
+    assert isinstance(scheduled, ProviderQuotaDeferredPreflightResult)
+    assert isinstance(explicit, ProviderQuotaPassedPreflightResult)
     assert scheduled.status == "quota_deferred"
     assert scheduled.decision == "deferred"
     assert scheduled.deferred is True
@@ -57,6 +73,7 @@ def test_hard_limit_blocks_even_explicit_run(monkeypatch):
 
     result = _probe(explicit_request=True)
 
+    assert isinstance(result, ProviderQuotaBlockedPreflightResult)
     assert result.status == "quota_blocked"
     assert result.decision == "blocked"
     assert result.blocked is True
@@ -68,15 +85,15 @@ def test_real_exhausted_reading_blocks(monkeypatch):
 
     result = _probe()
 
-    assert result.usage_status == "exhausted"
+    assert isinstance(result, ProviderQuotaBlockedPreflightResult)
+    assert result.usage.status == "exhausted"
     assert result.decision == "blocked"
     assert result.used_percent == 100.0
 
 
 def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
-    reading = CodexUsageReading(
-        status="unknown",
-        reason="primary_missing",
+    reading = CodexUnknownUsageReading(
+        reason=CodexUsageUnknownReason.PRIMARY_MISSING,
         observed_at="2026-08-04T13:28:13Z",
         source_path="/tmp/codex/sessions/2026/08/04/rollout.jsonl",
         limit_id="codex",
@@ -91,11 +108,12 @@ def test_unknown_reading_fails_open_and_preserves_last_known_good(monkeypatch):
 
     result = _probe()
 
+    assert isinstance(result, ProviderQuotaUnknownPreflightResult)
     assert result.status == "unknown"
     assert result.decision == "admitted"
-    assert result.used_percent is None
     assert result.unknown_reason == "primary_missing"
-    assert result.last_known_good == {
+    assert result.last_known_good is reading.last_known_good
+    assert result.to_dict()["last_known_good"] == {
         "used_percent": 31,
         "observed_at": "2026-08-04T13:24:45Z",
         "source_path": "/tmp/codex/sessions/2026/08/04/rollout.jsonl",
@@ -149,6 +167,8 @@ def test_live_reader_recovers_automatically_after_window_reset(tmp_path, monkeyp
     write_usage(3)
     recovered = _probe()
 
+    assert isinstance(blocked, ProviderQuotaBlockedPreflightResult)
+    assert isinstance(recovered, ProviderQuotaPassedPreflightResult)
     assert blocked.decision == "blocked"
     assert recovered.decision == "admitted"
     assert recovered.used_percent == 3.0
@@ -167,6 +187,19 @@ def test_non_subscription_route_skips_codex_quota_reader(monkeypatch):
         explicit_request=False,
     )
 
+    assert isinstance(result, ProviderQuotaSkippedPreflightResult)
     assert result.status == "skipped"
     assert result.decision == "admitted"
-    assert result.usage_status is None
+    assert result.to_dict()["usage_status"] is None
+
+
+def test_quota_variants_do_not_accept_independent_status_or_decision_fields():
+    with pytest.raises(TypeError):
+        ProviderQuotaPassedPreflightResult(
+            status="quota_blocked",
+            decision="blocked",
+            provider="openai",
+            model="openai/gpt-5.6-sol",
+            thresholds=provider_quota_preflight.ProviderQuotaThresholds(75, 90),
+            usage=_usage(10),
+        )


### PR DESCRIPTION
Closes #665

**Stacked on #678** (`illo-qa/664-preflight-consolidation`). Merge #678 first; GitHub
retargets this to `main` automatically once it lands.

Why stacked rather than independent: #665 has to retype the call sites in
`brain/systems/cycles/{auth_preflight,quota_preflight,service}.py` and their tests —
the exact six files #678 rewrites. Built off `main` it would have conflicted on every
one.

## What it does

The preflight result contracts were strings with optional fields, so the types
permitted states that are not legal: `status="ok"` with no `used_percent`,
`status="unknown"` with no `reason`, and an unknown-reason vocabulary enforced only by
convention. After this PR those combinations cannot be constructed:

- A usage reading is either `CodexKnownUsage` (requires a percentage) or
  `CodexUnknownUsageReading` (requires a typed reason). One known-usage model serves
  both the current reading and `last_known_good`.
- `CodexUsageUnknownReason` is a `StrEnum`, so the vocabulary is enumerable from the
  type instead of by grepping `_unknown(` call sites.
- The variant **type** is the only in-memory discriminant. `status` and `decision` are
  no longer model API — they exist only inside `to_dict()`.
- Auth and quota results follow the same convention, so the two cannot drift.

**No behavior change**: no new policy, no changed thresholds, no renamed persisted key.

## The first attempt added the new contract next to the old one

I counted branching constructs with an AST pass over every non-test file this PR
touches: the first attempt came back **538 before, 538 after — identical in every
single file.** For a 1,000-line diff that number needed an explanation, so it got a
maintainability review, which found the cause: the new types had been layered on top
of the old flat contract rather than replacing it. Two blocking findings, both about
having two ways to say one thing:

- The open ABCs still exposed `status`, `decision`, `blocked` and `deferred` — and the
  last two had **no production callers left at all**. Now deleted; the bases are
  private and the exported aliases are closed unions.
- `CodexKnownUsage` and `CodexKnownUsageReading` duplicated the same five fields,
  while compatibility properties (`reason` on the known variant, `used_percent` on the
  unknown one) let callers keep treating the union as the old nullable struct. The
  duplicate model and those properties are gone; the flat shape is produced by one
  boundary serializer.

Also removed: the `_known_result` factory, the unsupported-decision fallback in
admission (it now dispatches by variant type), and three `__post_init__` invariant
checks that the narrowed notice types had made impossible to fail — along with the
tests that asserted those now-impossible constructions.

The final count is **538 → 537**, which is honest rather than impressive, and worth
stating plainly: the branch count was the wrong yardstick for this ticket. Each
surviving conditional in the Codex parser is a distinct failure mode that still has to
be detected. What shrank is the *contract surface* — the number of ways to describe a
preflight result went from two to one.

## Evidence

- **Fast suite: 4761 passed, 11 skipped** — the repo's own CI command
  (`pytest -m "not requires_db and not requires_browser and not live_provider"`). Three
  below the 4764 baseline, exactly the three deleted impossible-construction cases.
- **DB suite: 79 passed** — `pytest tests/ -m requires_db` against pgvector/pg16 on
  5433, the image and port CI uses.
- **`to_dict()` is byte-identical**, which is what keeps persisted `context_snapshot`
  payloads readable. Pinned by literal-bytes assertions for a known and an unknown
  reading in `tests/test_codex_usage.py`, key order included, and those expectations
  were **not** edited by either pass.
- Illegal construction raises: `tests/test_provider_auth_preflight.py` asserts
  `pytest.raises(TypeError)` on a passed-result built with a blocked status.
- Both lanes were run **locally on purpose**: a PR based on a feature branch gets no
  GitHub CI at all in this repo (#682, fixed in #683), so the checks section here will
  be empty. That is the bug, not a signal about this code.
