### PR TITLE
fix(triage): resolve the owner before filing a customer-support ticket (#688)

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
@@ -17,6 +17,29 @@ Two different places can hold work, and they are NOT the same thing:
 
 Decide as follows.
 
+### Pre-create ownership and readiness gate
+
+Immediately before every `create_github_issue` call, including calls for
+customer-support reports, apply the core operating doc's **Ownership** section
+to the evidence collected for the issue. That section is the single canonical
+resolver: do not copy its people or work-class rules into this playbook.
+
+- An explicit human assignment wins. Otherwise, resolve builder-first and use
+  the core specialization and load-balancing tie-breakers. Pass the resolved
+  GitHub login in `assignees` on the same `create_github_issue` call; do not
+  create the issue first and plan to assign it later.
+- For a customer-generation report, the investigation hypothesis must exist
+  before this gate runs. "No owner up front" is an investigation rule, not an
+  instruction to file the resulting issue unassigned.
+- Apply `ready-for-agent` in `labels` when the issue meets the definition in
+  the core **States** section: it is scoped enough for an autonomous agent to
+  implement and open a PR without human judgment, credentials, external
+  testing, or a manual design/release decision.
+- If the ownership evidence remains genuinely ambiguous, omit `assignees` and
+  add `Ownership: Unassigned — <specific ambiguity or missing evidence>.` to
+  the issue body. An empty assignee list without that explanation is not a
+  completed ownership decision.
+
 ### Customer-bug filing policy
 
 - **Customer-reported bugs have one declared destination.** The durable artifact
@@ -24,7 +47,8 @@ Decide as follows.
   mirror, never a substitute. Create the GitHub issue first, then mirror it with
   the returned issue number/URL and stable external id. The issue body must carry
   the customer's own words, the concrete impact (including credit loss), and the
-  Slack `origin_ref`; honor an explicit assignee request using the verified GitHub
+  Slack `origin_ref`; run the pre-create ownership and readiness gate above,
+  including honoring an explicit assignee request using the verified GitHub
   identity. If no more-specific tracker exists, use Domain `1` as the existing
   default. Never create a Domain during filing: propose the schema change for
   later review and complete the immediate mirror in Domain `1`.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/customer-support.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/customer-support.md
@@ -32,12 +32,15 @@ Do the mechanical investigation yourself, read-only, then act:
    [customer-bug filing policy](creating-work-items.md#customer-bug-filing-policy).
    For generation/API behavior, use `uwear-ai/uwear-backend`; add the payload
    evidence + hypothesis and point the owner at the payload to confirm or deny.
-   Apply an explicitly requested assignee only after the hypothesis is formed.
+   Run that playbook's **Pre-create ownership and readiness gate** after the
+   hypothesis is formed and before `create_github_issue`. Apply its result in
+   the create call, including an explicitly requested assignee when present.
 4. **Reply in-thread** on the alert with the resulting artifact references and a
    one-line hypothesis.
 
-**Owner: none up front.** Illo runs the first-pass investigation. Route to a
-human only when the fix needs product judgment, credentials, or a design/release
-decision — and attach the hypothesis when you do. Do not auto-assign a
-customer-generation issue to Axel merely because the output came from an AI
-model.
+**Owner: none during investigation; resolved before filing.** Illo runs the
+first-pass investigation. Once the hypothesis exists, the shared pre-create gate
+selects the human owner and readiness label from the core rules. Do not
+auto-assign a customer-generation issue to Axel merely because the output came
+from an AI model. If the shared gate cannot resolve ownership, file it
+unassigned with the required ambiguity statement in the issue body.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.11.0"
+version = "1.12.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -54,7 +54,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.11.0"
+    assert bundle.manifest.version == "1.12.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -271,6 +271,59 @@ def test_uwear_customer_bug_filing_has_one_declared_destination_and_complete_evi
         "resulting artifact references",
     ):
         assert expected in support_flat
+
+
+def test_uwear_customer_support_backend_generation_uses_shared_owner_gate():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    procedure = " ".join(bundle.skill_markdown.split())
+    filing = " ".join(
+        _uwear_triage_asset(bundle, "references/creating-work-items.md").split()
+    )
+    support = " ".join(
+        _uwear_triage_asset(bundle, "references/customer-support.md").split()
+    )
+
+    assert "Builder first" in procedure
+    assert "Axel = agent/LLM/MCP and AI-backend behavior" in procedure
+    assert "For generation/API behavior, use `uwear-ai/uwear-backend`" in support
+    assert "Pre-create ownership and readiness gate" in support
+    assert "Pass the resolved GitHub login in `assignees`" in filing
+    assert "Apply `ready-for-agent` in `labels`" in filing
+
+
+def test_uwear_customer_support_app_ui_uses_shared_owner_gate():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    procedure = " ".join(bundle.skill_markdown.split())
+    filing = " ".join(
+        _uwear_triage_asset(bundle, "references/creating-work-items.md").split()
+    )
+
+    assert "Reda = app/Studio UI, UX, visual, customer-facing app flows" in procedure
+    assert "apply the core operating doc's **Ownership** section" in filing
+    assert "the single canonical resolver" in filing
+
+
+def test_uwear_customer_support_ambiguous_owner_is_explained_in_issue_body():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    filing = " ".join(
+        _uwear_triage_asset(bundle, "references/creating-work-items.md").split()
+    )
+    support = " ".join(
+        _uwear_triage_asset(bundle, "references/customer-support.md").split()
+    )
+
+    assert "omit `assignees`" in filing
+    assert "Ownership: Unassigned — <specific ambiguity or missing evidence>." in filing
+    assert "required ambiguity statement in the issue body" in support
 
 
 def test_uwear_customer_bug_filing_policy_is_not_repeated_by_consumers():

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -336,6 +336,21 @@ def test_channel_monitor_framing_routes_feature_requests_to_tickets():
     assert "email/profile id" in run_message
 
 
+def test_channel_monitor_filing_keeps_shared_triage_ownership_contract():
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+    )
+
+    run_message = payload["payload"]["run_message"]
+    assert "Load the 'uwear-engineering-triage' skill" in run_message
+    assert "first for routing/ownership rules" in run_message
+    assert "creating work items" in run_message
+
+
 def test_channel_monitor_framing_preserves_alert_thread_provenance_on_tracker_records():
     from brain.systems.slack.triggers import build_slack_work_intake_payload
 


### PR DESCRIPTION
Closes #688

## What was actually wrong

Illo assigns owners on **18 of 18** tickets it files from the production-monitor lane and on **0 of 5** from the customer-support lane. A split that clean is not the model exercising bad judgment — it is one path never being asked to decide.

Both lanes already load the same `uwear-engineering-triage` bundle, and `create_github_issue` already accepts `assignees` and `labels`. The defect was one line of the support playbook:

> **Owner: none up front.**

The model was following its instructions exactly. That rule was written for the *investigation* phase — Illo does the first-pass dig before routing to a human — but nothing ever switched it off, so it stayed in force through the `create_github_issue` call and every customer ticket was filed unowned.

The tickets losing their owner are the ones from paying customers asking for refunds.

## The change

Four files, no Python behaviour change:

- **One shared pre-create gate** added to `creating-work-items.md`, on the path *both* lanes already use. It resolves the owner immediately before `create_github_issue`, passes the login in the same call, and applies `ready-for-agent` under the existing readiness rule. It deliberately **delegates to the core Ownership section rather than restating it** — the people and work-class rules stay in one place, so this playbook cannot drift from the resolver that already scores 18/18.
- **`customer-support.md`**: "Owner: none up front" becomes "none *during investigation*; resolved before filing." The investigation rule is preserved; it just stops leaking into the filing step. The existing guard against reflexively assigning generation bugs to Axel is kept verbatim.
- **Ambiguity must be stated.** If ownership genuinely cannot be resolved, the issue is filed unassigned *and* carries `Ownership: Unassigned — <reason>.` in the body — so a deliberate decision and a silent omission stop looking identical.
- Bundle version `1.11.0` → `1.12.0`.

## How to judge this

**This is a prompt-contract change, so please read the two playbook diffs rather than the tests.** They are short and they are the actual product. A test can prove the instruction is present and reaches the run message; only a real customer ticket can prove the model obeys it. I want to be straight about where the proof stops.

Tests added pin what is testable: the gate's presence and required clauses in the bundle, and a contract check that the production-monitor lane still carries the triage-skill requirement in its run message (so the 18/18 lane cannot silently regress while fixing the 0/5 one).

**Acceptance checks**
1. A customer-support ticket on a backend generation path files with `axel-havard` + `ready-for-agent`.
2. One on an app/Studio UI path files with `redawear`.
3. A genuinely ambiguous one files unassigned **and** says why in the body.
4. The production-monitor lane is unchanged — 18/18 must not regress.

**Verification**
- Full CI selection, run locally outside the Codex sandbox: **4750 passed, 11 skipped, 83 deselected** (247s). Codex's own run showed 1 failure + 5 errors, all `PermissionError: [Errno 1] Operation not permitted` binding `127.0.0.1` — sandbox artifacts, all clear on a normal run.
- `python -m brain.jobs.check_cycle_context_admission` — passed, all 3 cycles.

```
cd <worktree> && python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

## Two things deliberately left out

- **Ticket item 3 (record a refund/billing ask as an open ask with a named human owner) is not implemented here.** The open-ask surface is mid-rewrite in #676 and #685, so touching it now would collide. The hook belongs in `brain/systems/slack/monitored_intakes.py:430` — the ordinary monitored-channel policy uses `obligation=_no_obligation`, and `open_asks.py:154` excludes headless Slack monitors unless they carry an `ObligationSpec`. Worth its own ticket once those two land.
- **Ticket acceptance check 3 asks to backfill five live tickets** (`uwear-backend#1569`, `#1571`, `#1574` → Axel; `uwearaiapp#906`, `#814` → Reda). No GitHub writes were made by this change — that backfill is surfaced separately as a human action.

## After merge

The bundle ships in the image, so a normal deploy activates it for the Slack lanes. The Domain 37 record 1155 mirror is a separate copy and can drift; `brain/app/cli/activate_uwear_engineering_triage.py --check` verifies it read-only.
