### PR TITLE
fix(scheduler): alert when a job stops running, from outside the daemon (#687)

### DIFF
--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -14,9 +14,7 @@ from starlette.responses import JSONResponse
 
 from brain.app.api.config import CORS_ORIGINS, SECRET_KEY, validate_auth_config
 from brain.app.api.deps import get_db
-from brain.app.scheduler.overdue_monitor import (
-    async_scheduler_overdue_monitor_loop,
-)
+from brain.app.scheduler.overdue_monitor import SchedulerOverdueMonitor
 
 validate_auth_config()
 
@@ -202,11 +200,16 @@ async def lifespan(app):
 
     from brain.systems.cortex.events import set_publisher
     set_publisher(_schedule_product_event_publish)
+    scheduler_overdue_monitor = SchedulerOverdueMonitor()
     _scheduler_overdue_monitor_task = _main_loop.create_task(
-        async_scheduler_overdue_monitor_loop(),
-        name="scheduler-overdue-monitor",
+        scheduler_overdue_monitor.run(),
+        name=scheduler_overdue_monitor.name,
     )
-    logger.info("scheduler_overdue_monitor_started", host="api")
+    logger.info(
+        "scheduler_overdue_monitor_started",
+        host="api",
+        monitor=scheduler_overdue_monitor.name,
+    )
     await _ensure_starting_skill_bundle()
     if _should_start_run_event_consumer():
         _run_event_consumer_task = _main_loop.create_task(_run_event_consumer_loop())

--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -14,6 +14,9 @@ from starlette.responses import JSONResponse
 
 from brain.app.api.config import CORS_ORIGINS, SECRET_KEY, validate_auth_config
 from brain.app.api.deps import get_db
+from brain.app.scheduler.overdue_monitor import (
+    async_scheduler_overdue_monitor_loop,
+)
 
 validate_auth_config()
 
@@ -43,6 +46,7 @@ _OPS_TRIGGER_EVENTS = frozenset(
 _ops_pending = False
 _OPS_THROTTLE_SEC = 2.0
 _run_event_consumer_task: asyncio.Task | None = None
+_scheduler_overdue_monitor_task: asyncio.Task[None] | None = None
 _GLOBAL_WS_EVENT_ALLOWLIST: frozenset[str] = frozenset()
 
 # Reference to the main asyncio event loop, set during lifespan startup.
@@ -192,12 +196,17 @@ def _schedule_product_event_publish(event_type, data):
 @asynccontextmanager
 async def lifespan(app):
     """Wire the brain event bus to WebSocket broadcasting on startup."""
-    global _main_loop, _run_event_consumer_task
+    global _main_loop, _run_event_consumer_task, _scheduler_overdue_monitor_task
     _main_loop = asyncio.get_running_loop()
     inline_runner_started = False
 
     from brain.systems.cortex.events import set_publisher
     set_publisher(_schedule_product_event_publish)
+    _scheduler_overdue_monitor_task = _main_loop.create_task(
+        async_scheduler_overdue_monitor_loop(),
+        name="scheduler-overdue-monitor",
+    )
+    logger.info("scheduler_overdue_monitor_started", host="api")
     await _ensure_starting_skill_bundle()
     if _should_start_run_event_consumer():
         _run_event_consumer_task = _main_loop.create_task(_run_event_consumer_loop())
@@ -232,6 +241,18 @@ async def lifespan(app):
     try:
         yield
     finally:
+        if _scheduler_overdue_monitor_task is not None:
+            _scheduler_overdue_monitor_task.cancel()
+            try:
+                await _scheduler_overdue_monitor_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning(
+                    "scheduler_overdue_monitor_stop_failed",
+                    error=str(exc),
+                )
+            _scheduler_overdue_monitor_task = None
         if _run_event_consumer_task is not None:
             _run_event_consumer_task.cancel()
             try:

--- a/brain/app/scheduler/daemon.py
+++ b/brain/app/scheduler/daemon.py
@@ -26,9 +26,6 @@ from brain.app.scheduler.catalog import (
 from brain.app.scheduler.executor import async_drain_scheduler
 from brain.app.scheduler.cold_start import record_scheduler_liveness_checkpoint
 from brain.app.scheduler.runtime import (
-    RUN_STATUS_CLAIMED,
-    RUN_STATUS_EXECUTING,
-    RUN_STATUS_RUNNING,
     RUN_STATUS_SHELVED,
     async_reclaim_expired_leases,
     normalize_run_status,
@@ -139,28 +136,6 @@ async def _async_count_leases(
     return int(active), int(expired)
 
 
-async def _async_active_job_ids(
-    session: AsyncSession,
-    owner_mode: str,
-    now: datetime,
-) -> set[int]:
-    result = await session.scalars(
-        select(SchedulerRun.job_id)
-        .join(SchedulerLease, SchedulerRun.lease_id == SchedulerLease.id)
-        .join(SchedulerJob, SchedulerRun.job_id == SchedulerJob.id)
-        .where(
-            SchedulerJob.owner_mode == owner_mode,
-            SchedulerRun.status.in_(
-                (RUN_STATUS_CLAIMED, RUN_STATUS_RUNNING, RUN_STATUS_EXECUTING)
-            ),
-            SchedulerLease.released_at.is_(None),
-            SchedulerLease.expires_at > now,
-        )
-        .distinct()
-    )
-    return {int(job_id) for job_id in result.all()}
-
-
 def _scheduler_health_payload(
     *,
     owner_mode: str,
@@ -170,9 +145,7 @@ def _scheduler_health_payload(
     run_statuses: dict[str, int],
     active_leases: int,
     expired_leases: int,
-    active_job_ids: set[int] | None = None,
 ) -> dict[str, Any]:
-    active_job_ids = active_job_ids or set()
     scoped_jobs = _job_scope(jobs, owner_mode)
     alerts = []
     for job in scoped_jobs:
@@ -207,13 +180,7 @@ def _scheduler_health_payload(
     due_times: list[datetime] = []
     for job in scoped_jobs:
         next_run_at = _as_utc(job["next_run_at"])
-        if (
-            not job["enabled"]
-            or job["pause_reason"]
-            or next_run_at is None
-            or next_run_at > now
-            or job["id"] in active_job_ids
-        ):
+        if not job["enabled"] or job["pause_reason"] or next_run_at is None or next_run_at > now:
             continue
         due_times.append(next_run_at)
         lagging_jobs.append(
@@ -325,7 +292,6 @@ async def async_scheduler_health_snapshot(
     runs = await async_list_scheduler_runs(session, limit=recent_run_limit)
     run_statuses = await _async_count_run_statuses(session, owner_mode)
     active_leases, expired_leases = await _async_count_leases(session, owner_mode, now)
-    active_job_ids = await _async_active_job_ids(session, owner_mode, now)
     return _scheduler_health_payload(
         owner_mode=owner_mode,
         now=now,
@@ -334,7 +300,6 @@ async def async_scheduler_health_snapshot(
         run_statuses=run_statuses,
         active_leases=active_leases,
         expired_leases=expired_leases,
-        active_job_ids=active_job_ids,
     )
 
 

--- a/brain/app/scheduler/daemon.py
+++ b/brain/app/scheduler/daemon.py
@@ -26,6 +26,9 @@ from brain.app.scheduler.catalog import (
 from brain.app.scheduler.executor import async_drain_scheduler
 from brain.app.scheduler.cold_start import record_scheduler_liveness_checkpoint
 from brain.app.scheduler.runtime import (
+    RUN_STATUS_CLAIMED,
+    RUN_STATUS_EXECUTING,
+    RUN_STATUS_RUNNING,
     RUN_STATUS_SHELVED,
     async_reclaim_expired_leases,
     normalize_run_status,
@@ -136,6 +139,28 @@ async def _async_count_leases(
     return int(active), int(expired)
 
 
+async def _async_active_job_ids(
+    session: AsyncSession,
+    owner_mode: str,
+    now: datetime,
+) -> set[int]:
+    result = await session.scalars(
+        select(SchedulerRun.job_id)
+        .join(SchedulerLease, SchedulerRun.lease_id == SchedulerLease.id)
+        .join(SchedulerJob, SchedulerRun.job_id == SchedulerJob.id)
+        .where(
+            SchedulerJob.owner_mode == owner_mode,
+            SchedulerRun.status.in_(
+                (RUN_STATUS_CLAIMED, RUN_STATUS_RUNNING, RUN_STATUS_EXECUTING)
+            ),
+            SchedulerLease.released_at.is_(None),
+            SchedulerLease.expires_at > now,
+        )
+        .distinct()
+    )
+    return {int(job_id) for job_id in result.all()}
+
+
 def _scheduler_health_payload(
     *,
     owner_mode: str,
@@ -145,7 +170,9 @@ def _scheduler_health_payload(
     run_statuses: dict[str, int],
     active_leases: int,
     expired_leases: int,
+    active_job_ids: set[int] | None = None,
 ) -> dict[str, Any]:
+    active_job_ids = active_job_ids or set()
     scoped_jobs = _job_scope(jobs, owner_mode)
     alerts = []
     for job in scoped_jobs:
@@ -180,7 +207,13 @@ def _scheduler_health_payload(
     due_times: list[datetime] = []
     for job in scoped_jobs:
         next_run_at = _as_utc(job["next_run_at"])
-        if not job["enabled"] or job["pause_reason"] or next_run_at is None or next_run_at > now:
+        if (
+            not job["enabled"]
+            or job["pause_reason"]
+            or next_run_at is None
+            or next_run_at > now
+            or job["id"] in active_job_ids
+        ):
             continue
         due_times.append(next_run_at)
         lagging_jobs.append(
@@ -292,6 +325,7 @@ async def async_scheduler_health_snapshot(
     runs = await async_list_scheduler_runs(session, limit=recent_run_limit)
     run_statuses = await _async_count_run_statuses(session, owner_mode)
     active_leases, expired_leases = await _async_count_leases(session, owner_mode, now)
+    active_job_ids = await _async_active_job_ids(session, owner_mode, now)
     return _scheduler_health_payload(
         owner_mode=owner_mode,
         now=now,
@@ -300,6 +334,7 @@ async def async_scheduler_health_snapshot(
         run_statuses=run_statuses,
         active_leases=active_leases,
         expired_leases=expired_leases,
+        active_job_ids=active_job_ids,
     )
 
 

--- a/brain/app/scheduler/overdue_monitor.py
+++ b/brain/app/scheduler/overdue_monitor.py
@@ -1,0 +1,226 @@
+"""Alert when scheduler-owned jobs stop advancing."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import logging
+import os
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.app.scheduler.cold_start import scheduler_liveness_checkpoint
+from brain.app.scheduler.daemon import async_scheduler_health_snapshot
+from brain.app.scheduler.scheduler_failure_guard import (
+    SchedulerFailureGuardStateStore,
+)
+from brain.platform.db.models.scheduler import SchedulerJob
+from brain.systems.cortex.thread_links import public_app_base_url
+from brain.systems.failure_guard.core import (
+    FailureGuardStateStore,
+    FailureGuardTriggerKind,
+)
+from brain.systems.failure_guard.slack_delivery import (
+    FailureAlertPresentation,
+    FailureAlertSubject,
+    SlackFailureAlertPolicy,
+    async_deliver_failure_alert,
+)
+from brain.systems.slack.client import slack_web_client_from_runtime
+
+
+SCHEDULER_OVERDUE_AFTER = timedelta(minutes=15)
+SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS = 60.0
+OVERDUE_FREEZE_TRIGGER_KIND = FailureGuardTriggerKind("scheduler_overdue_freeze")
+UnitOfWork = None
+logger = logging.getLogger(__name__)
+
+HealthSnapshotProvider = Callable[..., Awaitable[dict[str, Any]]]
+LivenessCheckpointProvider = Callable[[Any], Awaitable[datetime | None]]
+AlertDelivery = Callable[..., Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerOverdueCheck:
+    """Observable outcome of one independent overdue check."""
+
+    overdue_job_keys: tuple[str, ...]
+    alert_sent: bool
+    last_tick_at: datetime | None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _unit_of_work_factory():
+    global UnitOfWork
+    if UnitOfWork is None:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork as _UnitOfWork
+
+        UnitOfWork = _UnitOfWork
+    return UnitOfWork
+
+
+def _overdue_jobs(snapshot: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    threshold_seconds = int(SCHEDULER_OVERDUE_AFTER.total_seconds())
+    return tuple(
+        job
+        for job in snapshot.get("lag", {}).get("lagging_jobs", ())
+        if int(job.get("lag_seconds", 0)) > threshold_seconds
+    )
+
+
+def _alert_summary(
+    jobs: tuple[dict[str, Any], ...],
+    *,
+    last_tick_at: datetime | None,
+) -> str:
+    job_lines = [
+        f"- {job['job_key']}: {int(job['lag_seconds']) // 60}m overdue "
+        f"(due {job['next_run_at']})"
+        for job in jobs
+    ]
+    tick_text = last_tick_at.isoformat() if last_tick_at else "unknown"
+    return "\n".join(("Overdue jobs:", *job_lines, f"Daemon last tick: {tick_text}"))
+
+
+async def async_check_scheduler_overdue_jobs(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+    health_snapshot: HealthSnapshotProvider = async_scheduler_health_snapshot,
+    liveness_checkpoint: LivenessCheckpointProvider = scheduler_liveness_checkpoint,
+    state_store: FailureGuardStateStore | None = None,
+    deliver_alert: AlertDelivery = async_deliver_failure_alert,
+) -> SchedulerOverdueCheck:
+    """Check scheduler progress from a process outside the scheduler daemon."""
+    now = now or _utc_now()
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    snapshot = await health_snapshot(session, now=now)
+    overdue_jobs = _overdue_jobs(snapshot)
+    last_tick_at = await liveness_checkpoint(session)
+    if state_store is None:
+        job_ids = [
+            int(job["id"])
+            for job in snapshot.get("jobs", ())
+            if job.get("id") is not None
+        ]
+        if not job_ids:
+            return SchedulerOverdueCheck(
+                overdue_job_keys=tuple(
+                    str(job["job_key"]) for job in overdue_jobs
+                ),
+                alert_sent=False,
+                last_tick_at=last_tick_at,
+            )
+        anchor_job_id = min(job_ids)
+        anchor_job = await session.scalar(
+            select(SchedulerJob)
+            .where(SchedulerJob.id == anchor_job_id)
+            .with_for_update()
+        )
+        if anchor_job is None:
+            return SchedulerOverdueCheck(
+                overdue_job_keys=tuple(
+                    str(job["job_key"]) for job in overdue_jobs
+                ),
+                alert_sent=False,
+                last_tick_at=last_tick_at,
+            )
+        state_store = SchedulerFailureGuardStateStore.for_job(
+            session,
+            anchor_job.id,
+        )
+
+    states = await state_store.load_trigger_states()
+    already_alerted = OVERDUE_FREEZE_TRIGGER_KIND in states
+    overdue_job_keys = tuple(str(job["job_key"]) for job in overdue_jobs)
+    if not overdue_jobs:
+        if already_alerted:
+            await state_store.delete_trigger_state(OVERDUE_FREEZE_TRIGGER_KIND)
+        return SchedulerOverdueCheck(
+            overdue_job_keys=(),
+            alert_sent=False,
+            last_tick_at=last_tick_at,
+        )
+    if already_alerted:
+        return SchedulerOverdueCheck(
+            overdue_job_keys=overdue_job_keys,
+            alert_sent=False,
+            last_tick_at=last_tick_at,
+        )
+
+    await deliver_alert(
+        policy=SlackFailureAlertPolicy(
+            provide_client=slack_web_client_from_runtime,
+            requested_by="scheduler_overdue_alert",
+            reason="Deliver an overdue scheduler job alert to the team.",
+            channel=(
+                os.getenv("ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL", "").strip()
+                or "#alerts"
+            ),
+            unknown_error_text="Scheduler jobs stopped advancing",
+        ),
+        subject=FailureAlertSubject(
+            identity_label="Job key",
+            identity=str(overdue_jobs[0]["job_key"]),
+            url_label="Scheduler",
+            url=f"{public_app_base_url()}/api/system/scheduler",
+            link_label="open scheduler state",
+        ),
+        presentation=FailureAlertPresentation(
+            title="Scheduler jobs overdue",
+            summary=_alert_summary(overdue_jobs, last_tick_at=last_tick_at),
+        ),
+        error_text="Scheduler jobs stopped advancing past next_run_at.",
+    )
+    await state_store.save_trigger_state(
+        OVERDUE_FREEZE_TRIGGER_KIND,
+        {"alerted_at": now.isoformat()},
+    )
+    return SchedulerOverdueCheck(
+        overdue_job_keys=overdue_job_keys,
+        alert_sent=True,
+        last_tick_at=last_tick_at,
+    )
+
+
+async def async_monitor_scheduler_overdue_jobs(
+    *,
+    now: datetime | None = None,
+) -> SchedulerOverdueCheck:
+    """Run one overdue check in its own worker-owned transaction."""
+    async with _unit_of_work_factory()() as uow:
+        return await async_check_scheduler_overdue_jobs(
+            uow.session,
+            now=now,
+        )
+
+
+async def async_scheduler_overdue_monitor_loop() -> None:
+    """Check overdue scheduler state on the independent API event loop."""
+    while True:
+        await asyncio.sleep(SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS)
+        try:
+            await async_monitor_scheduler_overdue_jobs()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - the next monitor interval retries
+            logger.exception("Scheduler overdue health check failed safely")
+
+
+__all__ = [
+    "OVERDUE_FREEZE_TRIGGER_KIND",
+    "SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS",
+    "SCHEDULER_OVERDUE_AFTER",
+    "SchedulerOverdueCheck",
+    "async_check_scheduler_overdue_jobs",
+    "async_monitor_scheduler_overdue_jobs",
+    "async_scheduler_overdue_monitor_loop",
+]

--- a/brain/app/scheduler/overdue_monitor.py
+++ b/brain/app/scheduler/overdue_monitor.py
@@ -1,4 +1,11 @@
-"""Alert when scheduler-owned jobs stop advancing."""
+"""Alert when scheduler-owned jobs stop advancing.
+
+The freeze latch is process-local and belongs to the one monitor hosted by the API
+lifespan. An API restart during a freeze can therefore repeat at most one alert.
+That duplicate is acceptable because it is strictly better than the failure this
+monitor exists to prevent: 34 hours of silence. Restart-safe or multi-replica
+deduplication needs a scheduler-global state table and a database migration.
+"""
 from __future__ import annotations
 
 import asyncio
@@ -7,22 +14,15 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
 import os
-from typing import Any
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.scheduler.cold_start import scheduler_liveness_checkpoint
-from brain.app.scheduler.daemon import async_scheduler_health_snapshot
-from brain.app.scheduler.scheduler_failure_guard import (
-    SchedulerFailureGuardStateStore,
+from brain.app.scheduler.read_models import (
+    SchedulerOverdueCandidate,
+    async_scheduler_overdue_candidates,
 )
-from brain.platform.db.models.scheduler import SchedulerJob
 from brain.systems.cortex.thread_links import public_app_base_url
-from brain.systems.failure_guard.core import (
-    FailureGuardStateStore,
-    FailureGuardTriggerKind,
-)
 from brain.systems.failure_guard.slack_delivery import (
     FailureAlertPresentation,
     FailureAlertSubject,
@@ -32,21 +32,22 @@ from brain.systems.failure_guard.slack_delivery import (
 from brain.systems.slack.client import slack_web_client_from_runtime
 
 
-SCHEDULER_OVERDUE_AFTER = timedelta(minutes=15)
-SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS = 60.0
-OVERDUE_FREEZE_TRIGGER_KIND = FailureGuardTriggerKind("scheduler_overdue_freeze")
-UnitOfWork = None
-logger = logging.getLogger(__name__)
-
-HealthSnapshotProvider = Callable[..., Awaitable[dict[str, Any]]]
-LivenessCheckpointProvider = Callable[[Any], Awaitable[datetime | None]]
+CandidateProvider = Callable[
+    ..., Awaitable[tuple[SchedulerOverdueCandidate, ...]]
+]
+LivenessCheckpointProvider = Callable[[AsyncSession], Awaitable[datetime | None]]
 AlertDelivery = Callable[..., Awaitable[None]]
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
-class SchedulerOverdueCheck:
-    """Observable outcome of one independent overdue check."""
+class _SchedulerOverdueObservation:
+    candidates: tuple[SchedulerOverdueCandidate, ...]
+    last_tick_at: datetime | None
 
+
+@dataclass(frozen=True, slots=True)
+class _SchedulerOverdueCheck:
     overdue_job_keys: tuple[str, ...]
     alert_sent: bool
     last_tick_at: datetime | None
@@ -56,171 +57,156 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _unit_of_work_factory():
-    global UnitOfWork
-    if UnitOfWork is None:
-        from brain.platform.db.repositories.unit_of_work import UnitOfWork as _UnitOfWork
-
-        UnitOfWork = _UnitOfWork
-    return UnitOfWork
-
-
-def _overdue_jobs(snapshot: dict[str, Any]) -> tuple[dict[str, Any], ...]:
-    threshold_seconds = int(SCHEDULER_OVERDUE_AFTER.total_seconds())
-    return tuple(
-        job
-        for job in snapshot.get("lag", {}).get("lagging_jobs", ())
-        if int(job.get("lag_seconds", 0)) > threshold_seconds
-    )
-
-
 def _alert_summary(
-    jobs: tuple[dict[str, Any], ...],
+    candidates: tuple[SchedulerOverdueCandidate, ...],
     *,
+    now: datetime,
     last_tick_at: datetime | None,
 ) -> str:
     job_lines = [
-        f"- {job['job_key']}: {int(job['lag_seconds']) // 60}m overdue "
-        f"(due {job['next_run_at']})"
-        for job in jobs
+        f"- {candidate.job_key}: {candidate.lag_seconds_at(now) // 60}m overdue "
+        f"(due {candidate.next_run_at.isoformat()})"
+        for candidate in candidates
     ]
     tick_text = last_tick_at.isoformat() if last_tick_at else "unknown"
     return "\n".join(("Overdue jobs:", *job_lines, f"Daemon last tick: {tick_text}"))
 
 
-async def async_check_scheduler_overdue_jobs(
-    session: AsyncSession,
-    *,
-    now: datetime | None = None,
-    health_snapshot: HealthSnapshotProvider = async_scheduler_health_snapshot,
-    liveness_checkpoint: LivenessCheckpointProvider = scheduler_liveness_checkpoint,
-    state_store: FailureGuardStateStore | None = None,
-    deliver_alert: AlertDelivery = async_deliver_failure_alert,
-) -> SchedulerOverdueCheck:
-    """Check scheduler progress from a process outside the scheduler daemon."""
-    now = now or _utc_now()
-    if now.tzinfo is None:
-        raise ValueError("now must be timezone-aware")
+class SchedulerOverdueMonitor:
+    """Own one API-process scheduler freeze latch and its monitoring loop."""
 
-    snapshot = await health_snapshot(session, now=now)
-    overdue_jobs = _overdue_jobs(snapshot)
-    last_tick_at = await liveness_checkpoint(session)
-    if state_store is None:
-        job_ids = [
-            int(job["id"])
-            for job in snapshot.get("jobs", ())
-            if job.get("id") is not None
-        ]
-        if not job_ids:
-            return SchedulerOverdueCheck(
-                overdue_job_keys=tuple(
-                    str(job["job_key"]) for job in overdue_jobs
-                ),
+    name = "scheduler_overdue_monitor"
+    overdue_after = timedelta(minutes=15)
+    check_interval_seconds = 60.0
+
+    def __init__(
+        self,
+        *,
+        candidate_provider: CandidateProvider = async_scheduler_overdue_candidates,
+        liveness_checkpoint: LivenessCheckpointProvider = scheduler_liveness_checkpoint,
+        deliver_alert: AlertDelivery = async_deliver_failure_alert,
+    ) -> None:
+        self._candidate_provider = candidate_provider
+        self._liveness_checkpoint = liveness_checkpoint
+        self._deliver_alert = deliver_alert
+        self._alerted_for_current_freeze = False
+
+    async def run(self) -> None:
+        """Check scheduler progress on the independent API event loop."""
+        while True:
+            await asyncio.sleep(self.check_interval_seconds)
+            try:
+                await self._run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - the next interval retries
+                logger.exception("Scheduler overdue health check failed safely")
+
+    async def _run_once(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> _SchedulerOverdueCheck:
+        """Read in one transaction, then evaluate and deliver after it closes."""
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+        reference_time = self._reference_time(now)
+        async with UnitOfWork() as uow:
+            observation = await self._observe(uow.session, now=reference_time)
+        return await self._evaluate(observation, now=reference_time)
+
+    async def _check(
+        self,
+        session: AsyncSession,
+        *,
+        now: datetime | None = None,
+    ) -> _SchedulerOverdueCheck:
+        """Evaluate one check with a caller-owned database session."""
+        reference_time = self._reference_time(now)
+        observation = await self._observe(session, now=reference_time)
+        return await self._evaluate(observation, now=reference_time)
+
+    async def _observe(
+        self,
+        session: AsyncSession,
+        *,
+        now: datetime,
+    ) -> _SchedulerOverdueObservation:
+        candidates = await self._candidate_provider(session, now=now)
+        return _SchedulerOverdueObservation(
+            candidates=candidates,
+            last_tick_at=await self._liveness_checkpoint(session),
+        )
+
+    async def _evaluate(
+        self,
+        observation: _SchedulerOverdueObservation,
+        *,
+        now: datetime,
+    ) -> _SchedulerOverdueCheck:
+        overdue_candidates = tuple(
+            candidate
+            for candidate in observation.candidates
+            if candidate.lag_seconds_at(now) > self.overdue_after.total_seconds()
+        )
+        overdue_job_keys = tuple(
+            candidate.job_key for candidate in overdue_candidates
+        )
+        if not overdue_candidates:
+            self._alerted_for_current_freeze = False
+            return _SchedulerOverdueCheck(
+                overdue_job_keys=(),
                 alert_sent=False,
-                last_tick_at=last_tick_at,
+                last_tick_at=observation.last_tick_at,
             )
-        anchor_job_id = min(job_ids)
-        anchor_job = await session.scalar(
-            select(SchedulerJob)
-            .where(SchedulerJob.id == anchor_job_id)
-            .with_for_update()
-        )
-        if anchor_job is None:
-            return SchedulerOverdueCheck(
-                overdue_job_keys=tuple(
-                    str(job["job_key"]) for job in overdue_jobs
-                ),
+        if self._alerted_for_current_freeze:
+            return _SchedulerOverdueCheck(
+                overdue_job_keys=overdue_job_keys,
                 alert_sent=False,
-                last_tick_at=last_tick_at,
+                last_tick_at=observation.last_tick_at,
             )
-        state_store = SchedulerFailureGuardStateStore.for_job(
-            session,
-            anchor_job.id,
-        )
 
-    states = await state_store.load_trigger_states()
-    already_alerted = OVERDUE_FREEZE_TRIGGER_KIND in states
-    overdue_job_keys = tuple(str(job["job_key"]) for job in overdue_jobs)
-    if not overdue_jobs:
-        if already_alerted:
-            await state_store.delete_trigger_state(OVERDUE_FREEZE_TRIGGER_KIND)
-        return SchedulerOverdueCheck(
-            overdue_job_keys=(),
-            alert_sent=False,
-            last_tick_at=last_tick_at,
-        )
-    if already_alerted:
-        return SchedulerOverdueCheck(
-            overdue_job_keys=overdue_job_keys,
-            alert_sent=False,
-            last_tick_at=last_tick_at,
-        )
-
-    await deliver_alert(
-        policy=SlackFailureAlertPolicy(
-            provide_client=slack_web_client_from_runtime,
-            requested_by="scheduler_overdue_alert",
-            reason="Deliver an overdue scheduler job alert to the team.",
-            channel=(
-                os.getenv("ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL", "").strip()
-                or "#alerts"
+        await self._deliver_alert(
+            policy=SlackFailureAlertPolicy(
+                provide_client=slack_web_client_from_runtime,
+                requested_by=self.name,
+                reason="Deliver an overdue scheduler job alert to the team.",
+                channel=(
+                    os.getenv("ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL", "").strip()
+                    or "#alerts"
+                ),
+                unknown_error_text="Scheduler jobs stopped advancing",
             ),
-            unknown_error_text="Scheduler jobs stopped advancing",
-        ),
-        subject=FailureAlertSubject(
-            identity_label="Job key",
-            identity=str(overdue_jobs[0]["job_key"]),
-            url_label="Scheduler",
-            url=f"{public_app_base_url()}/api/system/scheduler",
-            link_label="open scheduler state",
-        ),
-        presentation=FailureAlertPresentation(
-            title="Scheduler jobs overdue",
-            summary=_alert_summary(overdue_jobs, last_tick_at=last_tick_at),
-        ),
-        error_text="Scheduler jobs stopped advancing past next_run_at.",
-    )
-    await state_store.save_trigger_state(
-        OVERDUE_FREEZE_TRIGGER_KIND,
-        {"alerted_at": now.isoformat()},
-    )
-    return SchedulerOverdueCheck(
-        overdue_job_keys=overdue_job_keys,
-        alert_sent=True,
-        last_tick_at=last_tick_at,
-    )
-
-
-async def async_monitor_scheduler_overdue_jobs(
-    *,
-    now: datetime | None = None,
-) -> SchedulerOverdueCheck:
-    """Run one overdue check in its own worker-owned transaction."""
-    async with _unit_of_work_factory()() as uow:
-        return await async_check_scheduler_overdue_jobs(
-            uow.session,
-            now=now,
+            subject=FailureAlertSubject(
+                identity_label="Job key",
+                identity=overdue_candidates[0].job_key,
+                url_label="Scheduler",
+                url=f"{public_app_base_url()}/api/system/scheduler",
+                link_label="open scheduler state",
+            ),
+            presentation=FailureAlertPresentation(
+                title="Scheduler jobs overdue",
+                summary=_alert_summary(
+                    overdue_candidates,
+                    now=now,
+                    last_tick_at=observation.last_tick_at,
+                ),
+            ),
+            error_text="Scheduler jobs stopped advancing past next_run_at.",
+        )
+        self._alerted_for_current_freeze = True
+        return _SchedulerOverdueCheck(
+            overdue_job_keys=overdue_job_keys,
+            alert_sent=True,
+            last_tick_at=observation.last_tick_at,
         )
 
-
-async def async_scheduler_overdue_monitor_loop() -> None:
-    """Check overdue scheduler state on the independent API event loop."""
-    while True:
-        await asyncio.sleep(SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS)
-        try:
-            await async_monitor_scheduler_overdue_jobs()
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001 - the next monitor interval retries
-            logger.exception("Scheduler overdue health check failed safely")
+    @staticmethod
+    def _reference_time(now: datetime | None) -> datetime:
+        reference_time = now or _utc_now()
+        if reference_time.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        return reference_time
 
 
-__all__ = [
-    "OVERDUE_FREEZE_TRIGGER_KIND",
-    "SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS",
-    "SCHEDULER_OVERDUE_AFTER",
-    "SchedulerOverdueCheck",
-    "async_check_scheduler_overdue_jobs",
-    "async_monitor_scheduler_overdue_jobs",
-    "async_scheduler_overdue_monitor_loop",
-]
+__all__ = ["SchedulerOverdueMonitor"]

--- a/brain/app/scheduler/read_models.py
+++ b/brain/app/scheduler/read_models.py
@@ -1,0 +1,90 @@
+"""Focused read models for scheduler policy consumers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.app.scheduler.runtime import (
+    RUN_STATUS_CLAIMED,
+    RUN_STATUS_EXECUTING,
+    RUN_STATUS_RUNNING,
+)
+from brain.platform.db.models.scheduler import (
+    OWNER_MODE_SCHEDULER,
+    SchedulerJob,
+    SchedulerLease,
+    SchedulerRun,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerOverdueCandidate:
+    """One past-due scheduler job that is not actively running."""
+
+    job_key: str
+    next_run_at: datetime
+
+    def lag_seconds_at(self, now: datetime) -> int:
+        """Return how many whole seconds the job is past due."""
+        return max(0, int((_as_utc(now) - self.next_run_at).total_seconds()))
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def async_scheduler_overdue_candidates(
+    session: AsyncSession,
+    *,
+    now: datetime,
+) -> tuple[SchedulerOverdueCandidate, ...]:
+    """Select monitor candidates without changing canonical scheduler health."""
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    active_run = (
+        select(SchedulerRun.id)
+        .join(SchedulerLease, SchedulerRun.lease_id == SchedulerLease.id)
+        .where(
+            SchedulerRun.job_id == SchedulerJob.id,
+            SchedulerRun.status.in_(
+                (RUN_STATUS_CLAIMED, RUN_STATUS_RUNNING, RUN_STATUS_EXECUTING)
+            ),
+            SchedulerLease.released_at.is_(None),
+            SchedulerLease.expires_at > now,
+        )
+        .exists()
+    )
+    rows = (
+        await session.execute(
+            select(SchedulerJob.job_key, SchedulerJob.next_run_at)
+            .where(
+                SchedulerJob.owner_mode == OWNER_MODE_SCHEDULER,
+                SchedulerJob.enabled.is_(True),
+                SchedulerJob.pause_reason.is_(None),
+                SchedulerJob.next_run_at.is_not(None),
+                SchedulerJob.next_run_at <= now,
+                ~active_run,
+            )
+            .order_by(SchedulerJob.next_run_at, SchedulerJob.job_key)
+        )
+    ).all()
+    return tuple(
+        SchedulerOverdueCandidate(
+            job_key=str(job_key),
+            next_run_at=_as_utc(next_run_at),
+        )
+        for job_key, next_run_at in rows
+        if next_run_at is not None
+    )
+
+
+__all__ = [
+    "SchedulerOverdueCandidate",
+    "async_scheduler_overdue_candidates",
+]

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -182,6 +182,32 @@ async def test_lifespan_ensures_starting_skill_bundle():
     ensure_bundle.assert_awaited_once_with()
 
 
+@pytest.mark.asyncio
+async def test_lifespan_hosts_scheduler_overdue_monitor_outside_daemon():
+    monitor_started = asyncio.Event()
+
+    async def monitor_loop():
+        monitor_started.set()
+        await asyncio.Future()
+
+    with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
+        with patch("brain.app.api.main._should_start_run_event_consumer", return_value=False):
+            with patch("brain.systems.cortex.events.set_publisher"):
+                with patch(
+                    "brain.app.api.main._ensure_starting_skill_bundle",
+                    new=AsyncMock(),
+                ):
+                    with patch(
+                        "brain.app.api.main.async_scheduler_overdue_monitor_loop",
+                        new=monitor_loop,
+                    ):
+                        async with api_main.lifespan(app):
+                            await asyncio.wait_for(monitor_started.wait(), timeout=1)
+                            assert api_main._scheduler_overdue_monitor_task is not None
+
+    assert api_main._scheduler_overdue_monitor_task is None
+
+
 def test_inline_runner_honors_launcher_dispatcher_env(monkeypatch):
     monkeypatch.delenv("CORTEX_INLINE_RUNNER", raising=False)
     monkeypatch.setenv("CORTEX_INLINE_DISPATCHER", "1")

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -190,6 +190,10 @@ async def test_lifespan_hosts_scheduler_overdue_monitor_outside_daemon():
         monitor_started.set()
         await asyncio.Future()
 
+    monitor = MagicMock()
+    monitor.name = "scheduler_overdue_monitor"
+    monitor.run = monitor_loop
+
     with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
         with patch("brain.app.api.main._should_start_run_event_consumer", return_value=False):
             with patch("brain.systems.cortex.events.set_publisher"):
@@ -198,13 +202,18 @@ async def test_lifespan_hosts_scheduler_overdue_monitor_outside_daemon():
                     new=AsyncMock(),
                 ):
                     with patch(
-                        "brain.app.api.main.async_scheduler_overdue_monitor_loop",
-                        new=monitor_loop,
-                    ):
+                        "brain.app.api.main.SchedulerOverdueMonitor",
+                        return_value=monitor,
+                    ) as monitor_type:
                         async with api_main.lifespan(app):
                             await asyncio.wait_for(monitor_started.wait(), timeout=1)
                             assert api_main._scheduler_overdue_monitor_task is not None
+                            assert (
+                                api_main._scheduler_overdue_monitor_task.get_name()
+                                == "scheduler_overdue_monitor"
+                            )
 
+    monitor_type.assert_called_once_with()
     assert api_main._scheduler_overdue_monitor_task is None
 
 

--- a/tests/test_scheduler_overdue_monitor.py
+++ b/tests/test_scheduler_overdue_monitor.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brain.app.scheduler.daemon import async_scheduler_health_snapshot
+from brain.app.scheduler.overdue_monitor import (
+    OVERDUE_FREEZE_TRIGGER_KIND,
+    SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS,
+    async_check_scheduler_overdue_jobs,
+)
+from brain.platform.db.models.scheduler import SchedulerLease, SchedulerRun
+from tests.scheduler_test_support import (
+    make_scheduler_job,
+    make_scheduler_test_session,
+)
+
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def scheduler_session(async_sqlite_session_factory):
+    return await make_scheduler_test_session(async_sqlite_session_factory)
+
+
+class MemoryTriggerStateStore:
+    def __init__(self) -> None:
+        self.states = {}
+
+    async def load_trigger_states(self):
+        return dict(self.states)
+
+    async def save_trigger_state(self, trigger_kind, state):
+        self.states[trigger_kind] = dict(state)
+
+    async def delete_trigger_state(self, trigger_kind):
+        self.states.pop(trigger_kind, None)
+
+
+def test_overdue_monitor_checks_well_inside_twenty_minute_window():
+    assert SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS <= 5 * 60
+
+
+def _snapshot(*, lag_seconds: int) -> dict:
+    due_at = NOW - timedelta(seconds=lag_seconds)
+    return {
+        "daemon": {"owner_mode": "scheduler", "service_ready": True},
+        "lag": {
+            "lag_seconds": lag_seconds,
+            "oldest_due_at": due_at.isoformat(),
+            "lagging_jobs": [
+                {
+                    "job_key": "uwear_aws_health_scan",
+                    "family": "uwear_aws_health_scan",
+                    "next_run_at": due_at.isoformat(),
+                    "lag_seconds": lag_seconds,
+                    "pause_reason": None,
+                }
+            ],
+        },
+        "jobs": [{"id": 7, "job_key": "uwear_aws_health_scan"}],
+    }
+
+
+async def test_job_overdue_by_more_than_fifteen_minutes_alerts_with_tick_time():
+    state_store = MemoryTriggerStateStore()
+    deliveries = []
+    last_tick_at = NOW - timedelta(minutes=16)
+
+    async def health_snapshot(_session, *, now):
+        return _snapshot(lag_seconds=16 * 60)
+
+    async def liveness_checkpoint(_session):
+        return last_tick_at
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    result = await async_check_scheduler_overdue_jobs(
+        object(),
+        now=NOW,
+        health_snapshot=health_snapshot,
+        liveness_checkpoint=liveness_checkpoint,
+        state_store=state_store,
+        deliver_alert=deliver_alert,
+    )
+
+    assert result.alert_sent is True
+    assert result.overdue_job_keys == ("uwear_aws_health_scan",)
+    assert len(deliveries) == 1
+    alert = deliveries[0]
+    assert alert["subject"].identity == "uwear_aws_health_scan"
+    assert "16m overdue" in alert["presentation"].summary
+    assert last_tick_at.isoformat() in alert["presentation"].summary
+    assert OVERDUE_FREEZE_TRIGGER_KIND in state_store.states
+
+
+async def test_all_jobs_on_schedule_for_twenty_four_hours_produces_no_alert():
+    state_store = MemoryTriggerStateStore()
+    deliveries = []
+
+    async def health_snapshot(_session, *, now):
+        return _snapshot(lag_seconds=0)
+
+    async def liveness_checkpoint(_session):
+        return NOW
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    for hour in range(25):
+        result = await async_check_scheduler_overdue_jobs(
+            object(),
+            now=NOW + timedelta(hours=hour),
+            health_snapshot=health_snapshot,
+            liveness_checkpoint=liveness_checkpoint,
+            state_store=state_store,
+            deliver_alert=deliver_alert,
+        )
+        assert result.alert_sent is False
+        assert result.overdue_job_keys == ()
+    assert deliveries == []
+
+
+async def test_alert_fires_once_per_freeze_and_rearms_after_recovery():
+    state_store = MemoryTriggerStateStore()
+    deliveries = []
+    lag_seconds = 60 * 60
+
+    async def health_snapshot(_session, *, now):
+        return _snapshot(lag_seconds=lag_seconds)
+
+    async def liveness_checkpoint(_session):
+        return NOW
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    async def check(at: datetime):
+        return await async_check_scheduler_overdue_jobs(
+            object(),
+            now=at,
+            health_snapshot=health_snapshot,
+            liveness_checkpoint=liveness_checkpoint,
+            state_store=state_store,
+            deliver_alert=deliver_alert,
+        )
+
+    first = await check(NOW)
+    repeated = await check(NOW + timedelta(minutes=1))
+    lag_seconds = 0
+    recovered = await check(NOW + timedelta(minutes=2))
+    lag_seconds = 60 * 60
+    later_freeze = await check(NOW + timedelta(hours=2))
+
+    assert first.alert_sent is True
+    assert repeated.alert_sent is False
+    assert recovered.alert_sent is False
+    assert later_freeze.alert_sent is True
+    assert len(deliveries) == 2
+
+
+async def test_multiple_overdue_jobs_produce_one_freeze_alert():
+    state_store = MemoryTriggerStateStore()
+    deliveries = []
+
+    async def health_snapshot(_session, *, now):
+        snapshot = _snapshot(lag_seconds=60 * 60)
+        snapshot["lag"]["lagging_jobs"].append(
+            {
+                "job_key": "knowledge_index_sync",
+                "family": "knowledge_index_sync",
+                "next_run_at": (NOW - timedelta(minutes=45)).isoformat(),
+                "lag_seconds": 45 * 60,
+                "pause_reason": None,
+            }
+        )
+        return snapshot
+
+    async def liveness_checkpoint(_session):
+        return NOW - timedelta(hours=1)
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    result = await async_check_scheduler_overdue_jobs(
+        object(),
+        now=NOW,
+        health_snapshot=health_snapshot,
+        liveness_checkpoint=liveness_checkpoint,
+        state_store=state_store,
+        deliver_alert=deliver_alert,
+    )
+
+    assert result.overdue_job_keys == (
+        "uwear_aws_health_scan",
+        "knowledge_index_sync",
+    )
+    assert len(deliveries) == 1
+    assert "uwear_aws_health_scan" in deliveries[0]["presentation"].summary
+    assert "knowledge_index_sync" in deliveries[0]["presentation"].summary
+
+
+async def test_fresh_daemon_heartbeat_does_not_hide_stale_next_run_at():
+    state_store = MemoryTriggerStateStore()
+    deliveries = []
+
+    async def health_snapshot(_session, *, now):
+        snapshot = _snapshot(lag_seconds=60 * 60)
+        snapshot["daemon"].update(
+            process_alive=True,
+            heartbeat_at=NOW.isoformat(),
+        )
+        return snapshot
+
+    async def liveness_checkpoint(_session):
+        return NOW
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    result = await async_check_scheduler_overdue_jobs(
+        object(),
+        now=NOW,
+        health_snapshot=health_snapshot,
+        liveness_checkpoint=liveness_checkpoint,
+        state_store=state_store,
+        deliver_alert=deliver_alert,
+    )
+
+    assert result.alert_sent is True
+    assert result.last_tick_at == NOW
+    assert len(deliveries) == 1
+
+
+async def test_scheduler_snapshot_skips_job_with_active_run(scheduler_session):
+    job = make_scheduler_job(
+        job_key="long_running_job",
+        family="long_running_job",
+        program_key="long_running_job",
+        next_run_at=NOW - timedelta(hours=1),
+    )
+    scheduler_session.add(job)
+    await scheduler_session.flush()
+    run = SchedulerRun(
+        job_id=job.id,
+        scheduled_for=NOW - timedelta(hours=2),
+        window_start=NOW - timedelta(hours=2),
+        window_end=NOW - timedelta(hours=2),
+        status="running",
+        idempotency_key="long_running_job:2026-08-05T10:00:00+00:00",
+        started_at=NOW - timedelta(hours=2),
+    )
+    scheduler_session.add(run)
+    await scheduler_session.flush()
+    lease = SchedulerLease(
+        run_id=run.id,
+        owner_id="scheduler-worker",
+        owner_host="scheduler-host",
+        owner_pid=42,
+        acquired_at=NOW - timedelta(minutes=1),
+        heartbeat_at=NOW,
+        expires_at=NOW + timedelta(minutes=5),
+    )
+    scheduler_session.add(lease)
+    await scheduler_session.flush()
+    run.lease_id = lease.id
+    await scheduler_session.flush()
+
+    snapshot = await async_scheduler_health_snapshot(scheduler_session, now=NOW)
+
+    assert snapshot["lag"]["lagging_jobs"] == []
+    assert snapshot["health"]["status"] == "healthy"
+
+
+async def test_database_trigger_state_deduplicates_and_rearms(scheduler_session):
+    job = make_scheduler_job(
+        job_key="stalled_job",
+        family="stalled_job",
+        program_key="stalled_job",
+        next_run_at=NOW - timedelta(hours=1),
+    )
+    scheduler_session.add(job)
+    await scheduler_session.flush()
+    deliveries = []
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    async def check(at: datetime):
+        return await async_check_scheduler_overdue_jobs(
+            scheduler_session,
+            now=at,
+            deliver_alert=deliver_alert,
+        )
+
+    assert (await check(NOW)).alert_sent is True
+    assert (await check(NOW + timedelta(minutes=1))).alert_sent is False
+    job.next_run_at = NOW + timedelta(minutes=5)
+    await scheduler_session.flush()
+    assert (await check(NOW + timedelta(minutes=2))).alert_sent is False
+    job.next_run_at = NOW - timedelta(hours=1)
+    await scheduler_session.flush()
+    assert (await check(NOW + timedelta(hours=2))).alert_sent is True
+    assert len(deliveries) == 2

--- a/tests/test_scheduler_overdue_monitor.py
+++ b/tests/test_scheduler_overdue_monitor.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
 from brain.app.scheduler.daemon import async_scheduler_health_snapshot
-from brain.app.scheduler.overdue_monitor import (
-    OVERDUE_FREEZE_TRIGGER_KIND,
-    SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS,
-    async_check_scheduler_overdue_jobs,
+from brain.app.scheduler.overdue_monitor import SchedulerOverdueMonitor
+from brain.app.scheduler.read_models import (
+    SchedulerOverdueCandidate,
+    async_scheduler_overdue_candidates,
 )
 from brain.platform.db.models.scheduler import SchedulerLease, SchedulerRun
 from tests.scheduler_test_support import (
@@ -25,52 +26,28 @@ async def scheduler_session(async_sqlite_session_factory):
     return await make_scheduler_test_session(async_sqlite_session_factory)
 
 
-class MemoryTriggerStateStore:
-    def __init__(self) -> None:
-        self.states = {}
-
-    async def load_trigger_states(self):
-        return dict(self.states)
-
-    async def save_trigger_state(self, trigger_kind, state):
-        self.states[trigger_kind] = dict(state)
-
-    async def delete_trigger_state(self, trigger_kind):
-        self.states.pop(trigger_kind, None)
+def _candidate(
+    *,
+    now: datetime,
+    lag_seconds: int,
+    job_key: str = "uwear_aws_health_scan",
+) -> SchedulerOverdueCandidate:
+    return SchedulerOverdueCandidate(
+        job_key=job_key,
+        next_run_at=now - timedelta(seconds=lag_seconds),
+    )
 
 
 def test_overdue_monitor_checks_well_inside_twenty_minute_window():
-    assert SCHEDULER_OVERDUE_CHECK_INTERVAL_SECONDS <= 5 * 60
-
-
-def _snapshot(*, lag_seconds: int) -> dict:
-    due_at = NOW - timedelta(seconds=lag_seconds)
-    return {
-        "daemon": {"owner_mode": "scheduler", "service_ready": True},
-        "lag": {
-            "lag_seconds": lag_seconds,
-            "oldest_due_at": due_at.isoformat(),
-            "lagging_jobs": [
-                {
-                    "job_key": "uwear_aws_health_scan",
-                    "family": "uwear_aws_health_scan",
-                    "next_run_at": due_at.isoformat(),
-                    "lag_seconds": lag_seconds,
-                    "pause_reason": None,
-                }
-            ],
-        },
-        "jobs": [{"id": 7, "job_key": "uwear_aws_health_scan"}],
-    }
+    assert SchedulerOverdueMonitor.check_interval_seconds <= 5 * 60
 
 
 async def test_job_overdue_by_more_than_fifteen_minutes_alerts_with_tick_time():
-    state_store = MemoryTriggerStateStore()
     deliveries = []
     last_tick_at = NOW - timedelta(minutes=16)
 
-    async def health_snapshot(_session, *, now):
-        return _snapshot(lag_seconds=16 * 60)
+    async def candidates(_session, *, now):
+        return (_candidate(now=now, lag_seconds=16 * 60),)
 
     async def liveness_checkpoint(_session):
         return last_tick_at
@@ -78,31 +55,29 @@ async def test_job_overdue_by_more_than_fifteen_minutes_alerts_with_tick_time():
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
-    result = await async_check_scheduler_overdue_jobs(
-        object(),
-        now=NOW,
-        health_snapshot=health_snapshot,
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
         liveness_checkpoint=liveness_checkpoint,
-        state_store=state_store,
         deliver_alert=deliver_alert,
     )
+    result = await monitor._check(object(), now=NOW)
 
+    assert monitor.name == "scheduler_overdue_monitor"
     assert result.alert_sent is True
     assert result.overdue_job_keys == ("uwear_aws_health_scan",)
     assert len(deliveries) == 1
     alert = deliveries[0]
+    assert alert["policy"].requested_by == "scheduler_overdue_monitor"
     assert alert["subject"].identity == "uwear_aws_health_scan"
     assert "16m overdue" in alert["presentation"].summary
     assert last_tick_at.isoformat() in alert["presentation"].summary
-    assert OVERDUE_FREEZE_TRIGGER_KIND in state_store.states
 
 
 async def test_all_jobs_on_schedule_for_twenty_four_hours_produces_no_alert():
-    state_store = MemoryTriggerStateStore()
     deliveries = []
 
-    async def health_snapshot(_session, *, now):
-        return _snapshot(lag_seconds=0)
+    async def candidates(_session, *, now):
+        return (_candidate(now=now, lag_seconds=0),)
 
     async def liveness_checkpoint(_session):
         return NOW
@@ -110,27 +85,24 @@ async def test_all_jobs_on_schedule_for_twenty_four_hours_produces_no_alert():
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
+        liveness_checkpoint=liveness_checkpoint,
+        deliver_alert=deliver_alert,
+    )
     for hour in range(25):
-        result = await async_check_scheduler_overdue_jobs(
-            object(),
-            now=NOW + timedelta(hours=hour),
-            health_snapshot=health_snapshot,
-            liveness_checkpoint=liveness_checkpoint,
-            state_store=state_store,
-            deliver_alert=deliver_alert,
-        )
+        result = await monitor._check(object(), now=NOW + timedelta(hours=hour))
         assert result.alert_sent is False
         assert result.overdue_job_keys == ()
     assert deliveries == []
 
 
 async def test_alert_fires_once_per_freeze_and_rearms_after_recovery():
-    state_store = MemoryTriggerStateStore()
     deliveries = []
     lag_seconds = 60 * 60
 
-    async def health_snapshot(_session, *, now):
-        return _snapshot(lag_seconds=lag_seconds)
+    async def candidates(_session, *, now):
+        return (_candidate(now=now, lag_seconds=lag_seconds),)
 
     async def liveness_checkpoint(_session):
         return NOW
@@ -138,22 +110,17 @@ async def test_alert_fires_once_per_freeze_and_rearms_after_recovery():
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
-    async def check(at: datetime):
-        return await async_check_scheduler_overdue_jobs(
-            object(),
-            now=at,
-            health_snapshot=health_snapshot,
-            liveness_checkpoint=liveness_checkpoint,
-            state_store=state_store,
-            deliver_alert=deliver_alert,
-        )
-
-    first = await check(NOW)
-    repeated = await check(NOW + timedelta(minutes=1))
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
+        liveness_checkpoint=liveness_checkpoint,
+        deliver_alert=deliver_alert,
+    )
+    first = await monitor._check(object(), now=NOW)
+    repeated = await monitor._check(object(), now=NOW + timedelta(minutes=1))
     lag_seconds = 0
-    recovered = await check(NOW + timedelta(minutes=2))
+    recovered = await monitor._check(object(), now=NOW + timedelta(minutes=2))
     lag_seconds = 60 * 60
-    later_freeze = await check(NOW + timedelta(hours=2))
+    later_freeze = await monitor._check(object(), now=NOW + timedelta(hours=2))
 
     assert first.alert_sent is True
     assert repeated.alert_sent is False
@@ -163,21 +130,17 @@ async def test_alert_fires_once_per_freeze_and_rearms_after_recovery():
 
 
 async def test_multiple_overdue_jobs_produce_one_freeze_alert():
-    state_store = MemoryTriggerStateStore()
     deliveries = []
 
-    async def health_snapshot(_session, *, now):
-        snapshot = _snapshot(lag_seconds=60 * 60)
-        snapshot["lag"]["lagging_jobs"].append(
-            {
-                "job_key": "knowledge_index_sync",
-                "family": "knowledge_index_sync",
-                "next_run_at": (NOW - timedelta(minutes=45)).isoformat(),
-                "lag_seconds": 45 * 60,
-                "pause_reason": None,
-            }
+    async def candidates(_session, *, now):
+        return (
+            _candidate(now=now, lag_seconds=60 * 60),
+            _candidate(
+                now=now,
+                lag_seconds=45 * 60,
+                job_key="knowledge_index_sync",
+            ),
         )
-        return snapshot
 
     async def liveness_checkpoint(_session):
         return NOW - timedelta(hours=1)
@@ -185,14 +148,12 @@ async def test_multiple_overdue_jobs_produce_one_freeze_alert():
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
-    result = await async_check_scheduler_overdue_jobs(
-        object(),
-        now=NOW,
-        health_snapshot=health_snapshot,
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
         liveness_checkpoint=liveness_checkpoint,
-        state_store=state_store,
         deliver_alert=deliver_alert,
     )
+    result = await monitor._check(object(), now=NOW)
 
     assert result.overdue_job_keys == (
         "uwear_aws_health_scan",
@@ -204,16 +165,10 @@ async def test_multiple_overdue_jobs_produce_one_freeze_alert():
 
 
 async def test_fresh_daemon_heartbeat_does_not_hide_stale_next_run_at():
-    state_store = MemoryTriggerStateStore()
     deliveries = []
 
-    async def health_snapshot(_session, *, now):
-        snapshot = _snapshot(lag_seconds=60 * 60)
-        snapshot["daemon"].update(
-            process_alive=True,
-            heartbeat_at=NOW.isoformat(),
-        )
-        return snapshot
+    async def candidates(_session, *, now):
+        return (_candidate(now=now, lag_seconds=60 * 60),)
 
     async def liveness_checkpoint(_session):
         return NOW
@@ -221,21 +176,111 @@ async def test_fresh_daemon_heartbeat_does_not_hide_stale_next_run_at():
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
-    result = await async_check_scheduler_overdue_jobs(
-        object(),
-        now=NOW,
-        health_snapshot=health_snapshot,
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
         liveness_checkpoint=liveness_checkpoint,
-        state_store=state_store,
         deliver_alert=deliver_alert,
     )
+    result = await monitor._check(object(), now=NOW)
 
     assert result.alert_sent is True
     assert result.last_tick_at == NOW
     assert len(deliveries) == 1
 
 
-async def test_scheduler_snapshot_skips_job_with_active_run(scheduler_session):
+async def test_slack_delivery_starts_after_read_transaction_closes():
+    transaction_open = False
+
+    class FakeUnitOfWork:
+        session = object()
+
+        async def __aenter__(self):
+            nonlocal transaction_open
+            transaction_open = True
+            return self
+
+        async def __aexit__(self, *_exc):
+            nonlocal transaction_open
+            transaction_open = False
+
+    async def candidates(_session, *, now):
+        assert transaction_open is True
+        return (_candidate(now=now, lag_seconds=60 * 60),)
+
+    async def liveness_checkpoint(_session):
+        assert transaction_open is True
+        return NOW
+
+    async def deliver_alert(**_kwargs):
+        assert transaction_open is False
+
+    monitor = SchedulerOverdueMonitor(
+        candidate_provider=candidates,
+        liveness_checkpoint=liveness_checkpoint,
+        deliver_alert=deliver_alert,
+    )
+    with patch(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        FakeUnitOfWork,
+    ):
+        result = await monitor._run_once(now=NOW)
+
+    assert result.alert_sent is True
+
+
+async def test_monitor_projection_selects_only_eligible_scheduler_jobs(
+    scheduler_session,
+):
+    scheduler_session.add_all(
+        [
+            make_scheduler_job(
+                job_key="eligible",
+                family="eligible",
+                program_key="eligible",
+                next_run_at=NOW - timedelta(hours=1),
+            ),
+            make_scheduler_job(
+                job_key="disabled",
+                family="disabled",
+                program_key="disabled",
+                enabled=False,
+                next_run_at=NOW - timedelta(hours=1),
+            ),
+            make_scheduler_job(
+                job_key="paused",
+                family="paused",
+                program_key="paused",
+                pause_reason="operator pause",
+                next_run_at=NOW - timedelta(hours=1),
+            ),
+            make_scheduler_job(
+                job_key="future",
+                family="future",
+                program_key="future",
+                next_run_at=NOW + timedelta(minutes=1),
+            ),
+            make_scheduler_job(
+                job_key="cron_owned",
+                family="cron_owned",
+                program_key="cron_owned",
+                owner_mode="cron",
+                next_run_at=NOW - timedelta(hours=1),
+            ),
+        ]
+    )
+    await scheduler_session.flush()
+
+    candidates = await async_scheduler_overdue_candidates(
+        scheduler_session,
+        now=NOW,
+    )
+
+    assert tuple(candidate.job_key for candidate in candidates) == ("eligible",)
+
+
+async def test_monitor_skips_active_job_while_health_reports_canonical_lag(
+    scheduler_session,
+):
     job = make_scheduler_job(
         job_key="long_running_job",
         family="long_running_job",
@@ -270,12 +315,30 @@ async def test_scheduler_snapshot_skips_job_with_active_run(scheduler_session):
     await scheduler_session.flush()
 
     snapshot = await async_scheduler_health_snapshot(scheduler_session, now=NOW)
+    deliveries = []
 
-    assert snapshot["lag"]["lagging_jobs"] == []
-    assert snapshot["health"]["status"] == "healthy"
+    async def liveness_checkpoint(_session):
+        return NOW
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    monitor = SchedulerOverdueMonitor(
+        liveness_checkpoint=liveness_checkpoint,
+        deliver_alert=deliver_alert,
+    )
+    result = await monitor._check(scheduler_session, now=NOW)
+
+    assert [item["job_key"] for item in snapshot["lag"]["lagging_jobs"]] == [
+        "long_running_job"
+    ]
+    assert snapshot["health"]["status"] == "degraded"
+    assert result.alert_sent is False
+    assert result.overdue_job_keys == ()
+    assert deliveries == []
 
 
-async def test_database_trigger_state_deduplicates_and_rearms(scheduler_session):
+async def test_in_memory_latch_is_independent_of_job_identity(scheduler_session):
     job = make_scheduler_job(
         job_key="stalled_job",
         family="stalled_job",
@@ -286,22 +349,39 @@ async def test_database_trigger_state_deduplicates_and_rearms(scheduler_session)
     await scheduler_session.flush()
     deliveries = []
 
+    async def liveness_checkpoint(_session):
+        return NOW
+
     async def deliver_alert(**kwargs):
         deliveries.append(kwargs)
 
-    async def check(at: datetime):
-        return await async_check_scheduler_overdue_jobs(
-            scheduler_session,
-            now=at,
-            deliver_alert=deliver_alert,
-        )
+    monitor = SchedulerOverdueMonitor(
+        liveness_checkpoint=liveness_checkpoint,
+        deliver_alert=deliver_alert,
+    )
+    assert (await monitor._check(scheduler_session, now=NOW)).alert_sent is True
 
-    assert (await check(NOW)).alert_sent is True
-    assert (await check(NOW + timedelta(minutes=1))).alert_sent is False
-    job.next_run_at = NOW + timedelta(minutes=5)
+    await scheduler_session.delete(job)
+    replacement = make_scheduler_job(
+        job_key="replacement_stalled_job",
+        family="replacement_stalled_job",
+        program_key="replacement_stalled_job",
+        next_run_at=NOW - timedelta(hours=1),
+    )
+    scheduler_session.add(replacement)
     await scheduler_session.flush()
-    assert (await check(NOW + timedelta(minutes=2))).alert_sent is False
-    job.next_run_at = NOW - timedelta(hours=1)
+    assert (
+        await monitor._check(scheduler_session, now=NOW + timedelta(minutes=1))
+    ).alert_sent is False
+
+    replacement.next_run_at = NOW + timedelta(minutes=5)
     await scheduler_session.flush()
-    assert (await check(NOW + timedelta(hours=2))).alert_sent is True
+    assert (
+        await monitor._check(scheduler_session, now=NOW + timedelta(minutes=2))
+    ).alert_sent is False
+    replacement.next_run_at = NOW - timedelta(hours=1)
+    await scheduler_session.flush()
+    assert (
+        await monitor._check(scheduler_session, now=NOW + timedelta(hours=2))
+    ).alert_sent is True
     assert len(deliveries) == 2


### PR DESCRIPTION
Closes #687

## Why this exists

The scheduler daemon froze three times, each longer than the last: 36 minutes (2026-07-31), 17.5 hours, then **34.5 hours** ending this morning. Nobody found out until someone looked.

The reason nothing alerted is structural: **every detector that could have noticed lives inside the daemon that froze.** The external deadman (`illo_external_heartbeat`) is itself one of the frozen jobs, so it cannot report on the daemon it runs in.

What that 34-hour window cost, measured: production went unmonitored for 34h40m (four high-priority customer bug reports arrived inside it), the knowledge index froze with memory nodes 916–938 written but unindexed, and the stale-run reaper sat idle while run 14569 held a concurrency slot.

**The detail that matters for the fix:** every liveness surface reported healthy the whole time. Container `Up 43 hours`, `/api/health` 200, cycles completing on the worker thread, Illo answering a customer in 4m13s. A process check or a container health check would have caught none of it. Only `next_run_at` lag would.

This is the *detection* half. The freeze's root cause is #632 and is not touched here.

## The change

An overdue check that runs **on the API process event loop** — outside the daemon's failure domain. The API stayed alive through all 34 hours, so it can report on a daemon that cannot report on itself. Kill the scheduler alone and this still runs.

It flags any enabled job more than 15 minutes past `next_run_at`, alerts **once per freeze** (not once per overdue job — six lines for one root cause is noise), re-arms after recovery, and delivers through the failure-alert path `scheduler_jobs` already uses for jobs that *fail*. The inversion is the whole point: that path existed for jobs that fail and not for jobs that never run.

No new detector, no new Slack path, no migration.

## This took two rounds — the first version had the right behaviour and the wrong seams

A maintainability review returned CHANGES REQUIRED with three blocking findings, all fixed:

1. **The freeze latch was stored under an arbitrary job's row** (`anchor_job_id = min(job_ids)`). That FK is `ON DELETE CASCADE`, so deleting that unrelated job would wipe the flag and re-alert mid-freeze. Now a `SchedulerOverdueMonitor` object owns the latch in memory, with no job-id dependency. There is a regression test for exactly the delete-the-anchor-job case.
2. **That same job row was used as a mutex, and the lock was held across the Slack network call.** Both gone — Slack delivery now begins only after the read transaction closes.
3. **The mid-run exclusion had been added to the shared `_scheduler_health_payload`**, which silently changed what `/api/system/scheduler` and the daemon's own snapshot report as lag. Alert policy was redefining health for every consumer. `daemon.py` is now **untouched** by this PR; the monitor owns its own narrower policy via a typed projection in the new `read_models.py`.

## How to judge this

**Acceptance checks**
1. Hold the tick loop → an alert reaches `#alerts` within 20 minutes, naming an overdue `job_key` and the last tick time.
2. It still fires when the daemon is **alive but not ticking** — this is the one that matters, since process liveness and container health both reported healthy through the real 34-hour freeze. There is a dedicated test with a fresh heartbeat and a stale `next_run_at`.
3. Killing only the daemon leaves the check running.
4. No alert during normal operation, including no false positive from a job legitimately mid-run.

**Verification** — full CI selection, run locally: **4757 passed**, 11 skipped, 83 deselected. Baseline on `main` is 4746 and this adds exactly 11 tests with none removed, so the delta is fully accounted for. `check_cycle_context_admission` passes 3/3. (Codex's own runs show 6 `PermissionError` socket-bind failures; those are sandbox artifacts and are clean on a normal run.)

```
cd <worktree> && python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

## One deliberate trade-off, stated plainly

The latch is in memory, so **an API restart during a freeze can repeat one alert.** That is deliberate. The alternative within "no migration" was to store an "alerted at" timestamp in `scheduler_liveness_checkpoints.last_heartbeat_at` — a column whose name would then be lying. A duplicate alert is strictly better than the failure this ticket exists to fix, which was 34 hours of silence.

Restart-safe and multi-replica dedup needs a real scheduler-global state table, which needs a migration. Filed as a follow-up rather than smuggled in here.
