### PR TITLE
fix(knowledge): never index a memory node that no org can reach (#680)

### DIFF
--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -115,6 +115,7 @@ class KnowledgeEnumeration:
     drafts: list[KnowledgeDraft]
     cursor: dict[str, Any]
     failures: tuple[EnumerationFailure, ...] = ()
+    skipped: int = 0
 
 
 class KnowledgeConnector(Protocol):

--- a/brain/systems/knowledge/connectors/base.py
+++ b/brain/systems/knowledge/connectors/base.py
@@ -115,7 +115,6 @@ class KnowledgeEnumeration:
     drafts: list[KnowledgeDraft]
     cursor: dict[str, Any]
     failures: tuple[EnumerationFailure, ...] = ()
-    skipped: int = 0
 
 
 class KnowledgeConnector(Protocol):

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -77,7 +77,7 @@ def _draft_for_memory(
     )
 
 
-def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
+def _withdrawn_draft(node: MemoryNode, *, org_id: str) -> KnowledgeDraft:
     """Scrub a formerly shared mirror after its source becomes private."""
 
     return KnowledgeDraft(
@@ -92,7 +92,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
             "archived": True,
             "mirror_status": "visibility_withdrawn",
             "node_kind": node.node_kind,
-            "org_id": _required_org_id(node),
+            "org_id": org_id,
             "truth_status": node.truth_status,
             "visibility": node.visibility,
         },
@@ -130,31 +130,35 @@ class MemoryConnector:
         if not rows:
             return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
         source_refs = [f"memory_node:{node.id}" for node in rows]
-        existing_refs = set(
-            (
-                await session.scalars(
-                    select(KnowledgeItem.source_ref).where(
+        existing_org_ids = {
+            source_ref: extra["org_id"]
+            for source_ref, extra in (
+                await session.execute(
+                    select(KnowledgeItem.source_ref, KnowledgeItem.extra).where(
                         KnowledgeItem.source == self.source_key,
                         KnowledgeItem.source_ref.in_(source_refs),
                     )
                 )
             ).all()
-        )
+        }
         candidate_rows = [
             node
             for node in rows
             if node.visibility in _SHARED_VISIBILITIES
-            or f"memory_node:{node.id}" in existing_refs
+            or f"memory_node:{node.id}" in existing_org_ids
         ]
-        mirrorable_rows: list[MemoryNode] = []
+        draft_rows: list[MemoryNode] = []
+        active_rows: list[MemoryNode] = []
         for node in candidate_rows:
-            if node.org_id is None:
-                logger.warning(
-                    "Memory knowledge enumeration skipped node %s: org_id is missing",
-                    node.id,
-                )
-                continue
-            mirrorable_rows.append(node)
+            if node.visibility in _SHARED_VISIBILITIES:
+                if node.org_id is None:
+                    logger.warning(
+                        "Memory knowledge enumeration skipped node %s: org_id is missing",
+                        node.id,
+                    )
+                    continue
+                active_rows.append(node)
+            draft_rows.append(node)
         supersession_rows = (
             await session.execute(
                 select(
@@ -163,7 +167,7 @@ class MemoryConnector:
                 )
                 .where(
                     MemoryEdgeNode.source_node_id.in_(
-                        [node.id for node in mirrorable_rows]
+                        [node.id for node in active_rows]
                     )
                 )
                 .where(MemoryEdgeNode.edge_kind == "superseded_by")
@@ -177,14 +181,16 @@ class MemoryConnector:
         drafts = [
             _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
             if node.visibility in _SHARED_VISIBILITIES
-            else _withdrawn_draft(node)
-            for node in mirrorable_rows
+            else _withdrawn_draft(
+                node,
+                org_id=existing_org_ids[f"memory_node:{node.id}"],
+            )
+            for node in draft_rows
         ]
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,
             cursor=watermark.advanced_to(last.updated_at, last.id),
-            skipped=len(candidate_rows) - len(mirrorable_rows),
         )
 
 

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -30,6 +30,12 @@ _KNOWLEDGE_NODE_KINDS = ("content",)
 logger = logging.getLogger(__name__)
 
 
+def _candidate_node_query():
+    return select(MemoryNode).where(
+        MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS)
+    )
+
+
 def _required_org_id(node: MemoryNode) -> str:
     if node.org_id is None:
         raise ValueError(f"Memory node {node.id} has no organization")
@@ -110,25 +116,29 @@ class MemoryConnector:
     def __init__(self, *, max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE):
         self.max_items = max(1, int(max_items))
 
-    async def enumerate_changed(
+    async def draft_for_node(
         self,
         session: AsyncSession,
-        cursor: dict[str, Any],
-    ) -> KnowledgeEnumeration:
-        watermark = UpdatedAtCursor.from_mapping(cursor)
-        statement = (
-            select(MemoryNode)
-            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
-            .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
-            .limit(self.max_items)
-        )
-        changed_after = watermark.changed_after(MemoryNode.updated_at, MemoryNode.id)
-        if changed_after is not None:
-            statement = statement.where(changed_after)
+        *,
+        node_id: int,
+    ) -> KnowledgeDraft | None:
+        """Build one immediate-index draft with the sweep's eligibility rules."""
 
-        rows = list((await session.scalars(statement)).all())
+        node = await session.scalar(
+            _candidate_node_query().where(MemoryNode.id == node_id)
+        )
+        if node is None:
+            return None
+        drafts = await self._drafts_for_rows(session, [node])
+        return drafts[0] if drafts else None
+
+    async def _drafts_for_rows(
+        self,
+        session: AsyncSession,
+        rows: list[MemoryNode],
+    ) -> list[KnowledgeDraft]:
         if not rows:
-            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
+            return []
         source_refs = [f"memory_node:{node.id}" for node in rows]
         existing_org_ids = {
             source_ref: extra["org_id"]
@@ -178,7 +188,7 @@ class MemoryConnector:
             source_node_id: target_node_id
             for source_node_id, target_node_id in supersession_rows
         }
-        drafts = [
+        return [
             _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
             if node.visibility in _SHARED_VISIBILITIES
             else _withdrawn_draft(
@@ -187,6 +197,26 @@ class MemoryConnector:
             )
             for node in draft_rows
         ]
+
+    async def enumerate_changed(
+        self,
+        session: AsyncSession,
+        cursor: dict[str, Any],
+    ) -> KnowledgeEnumeration:
+        watermark = UpdatedAtCursor.from_mapping(cursor)
+        statement = (
+            _candidate_node_query()
+            .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
+            .limit(self.max_items)
+        )
+        changed_after = watermark.changed_after(MemoryNode.updated_at, MemoryNode.id)
+        if changed_after is not None:
+            statement = statement.where(changed_after)
+
+        rows = list((await session.scalars(statement)).all())
+        if not rows:
+            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
+        drafts = await self._drafts_for_rows(session, rows)
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -9,6 +9,7 @@ index has an ACL-aware read path.  The mirror is derived and additive: it reads
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sqlalchemy import select
@@ -26,6 +27,14 @@ from brain.systems.knowledge.connectors.base import (
 
 _SHARED_VISIBILITIES = ("org", "team")
 _KNOWLEDGE_NODE_KINDS = ("content",)
+logger = logging.getLogger(__name__)
+
+
+def _required_org_id(node: MemoryNode) -> str:
+    if node.org_id is None:
+        raise ValueError(f"Memory node {node.id} has no organization")
+    return str(node.org_id)
+
 
 def _draft_for_memory(
     node: MemoryNode,
@@ -52,7 +61,7 @@ def _draft_for_memory(
             "freshness_status": node.freshness_status,
             "memory_type": memory_kind,
             "node_kind": node.node_kind,
-            "org_id": str(node.org_id) if node.org_id is not None else None,
+            "org_id": _required_org_id(node),
             "scope": scope,
             "sensitivity": node.sensitivity,
             "source_backed": True,
@@ -83,7 +92,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
             "archived": True,
             "mirror_status": "visibility_withdrawn",
             "node_kind": node.node_kind,
-            "org_id": str(node.org_id) if node.org_id is not None else None,
+            "org_id": _required_org_id(node),
             "truth_status": node.truth_status,
             "visibility": node.visibility,
         },
@@ -131,6 +140,21 @@ class MemoryConnector:
                 )
             ).all()
         )
+        candidate_rows = [
+            node
+            for node in rows
+            if node.visibility in _SHARED_VISIBILITIES
+            or f"memory_node:{node.id}" in existing_refs
+        ]
+        mirrorable_rows: list[MemoryNode] = []
+        for node in candidate_rows:
+            if node.org_id is None:
+                logger.warning(
+                    "Memory knowledge enumeration skipped node %s: org_id is missing",
+                    node.id,
+                )
+                continue
+            mirrorable_rows.append(node)
         supersession_rows = (
             await session.execute(
                 select(
@@ -138,7 +162,9 @@ class MemoryConnector:
                     MemoryEdgeNode.target_node_id,
                 )
                 .where(
-                    MemoryEdgeNode.source_node_id.in_([node.id for node in rows])
+                    MemoryEdgeNode.source_node_id.in_(
+                        [node.id for node in mirrorable_rows]
+                    )
                 )
                 .where(MemoryEdgeNode.edge_kind == "superseded_by")
                 .order_by(MemoryEdgeNode.id.asc())
@@ -152,14 +178,13 @@ class MemoryConnector:
             _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
             if node.visibility in _SHARED_VISIBILITIES
             else _withdrawn_draft(node)
-            for node in rows
-            if node.visibility in _SHARED_VISIBILITIES
-            or f"memory_node:{node.id}" in existing_refs
+            for node in mirrorable_rows
         ]
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,
             cursor=watermark.advanced_to(last.updated_at, last.id),
+            skipped=len(candidate_rows) - len(mirrorable_rows),
         )
 
 

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -782,6 +782,7 @@ async def sync_connector(
         drafts = enumeration.drafts
         new_cursor = enumeration.cursor
         enumeration_failures = enumeration.failures
+        stats.skipped += enumeration.skipped
     except Exception as exc:
         stats.failed = 1
         logger.exception("Knowledge connector %s enumeration failed", source)

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -782,7 +782,6 @@ async def sync_connector(
         drafts = enumeration.drafts
         new_cursor = enumeration.cursor
         enumeration_failures = enumeration.failures
-        stats.skipped += enumeration.skipped
     except Exception as exc:
         stats.failed = 1
         logger.exception("Knowledge connector %s enumeration failed", source)

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -27,6 +27,7 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeConnector,
     KnowledgeDraft,
 )
+from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.distillation import (
     DISTILLATION_CURSOR_KEY,
     DISTILLATION_MANIFEST_VERSION,
@@ -704,6 +705,34 @@ async def _ingest_drafts(
             )
 
 
+async def index_memory_node(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> KnowledgeSyncStats:
+    """Upsert one committed memory node without advancing the sweep cursor."""
+
+    stats = KnowledgeSyncStats()
+    connector = MemoryConnector(max_items=1)
+    draft = await connector.draft_for_node(
+        session,
+        node_id=node_id,
+    )
+    if draft is None:
+        stats.skipped = 1
+        return stats
+
+    bounded_draft, _ = _bounded_draft(draft)
+    await _ingest_drafts(
+        session,
+        source=connector.source_key,
+        drafts=[(bounded_draft, True)],
+        stats=stats,
+        run_at=datetime.now(timezone.utc),
+    )
+    return stats
+
+
 async def sync_connector(
     session: AsyncSession,
     connector: KnowledgeConnector,
@@ -887,5 +916,6 @@ __all__ = [
     "build_embedding_text",
     "build_search_text",
     "content_digest",
+    "index_memory_node",
     "sync_connector",
 ]

--- a/brain/systems/reconstructive_memory/ingestion.py
+++ b/brain/systems/reconstructive_memory/ingestion.py
@@ -7,6 +7,7 @@ nodes, and graph edges in one transaction.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.db.repositories.reconstructive_memory import (
     AssertionDraft,
     EdgeDraft,
@@ -26,6 +28,10 @@ from brain.platform.db.repositories.reconstructive_memory import (
 )
 
 logger = logging.getLogger(__name__)
+
+_INFO_QUEUE_KEY = "illo_memory_knowledge_index_queue"
+_INFO_ARMED_KEY = "illo_memory_knowledge_index_listeners_armed"
+_POST_COMMIT_TASKS: set[asyncio.Task] = set()
 
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
 _STOP_WORDS = {
@@ -90,6 +96,115 @@ class IngestedMemorySource:
             "tag_node_ids": list(self.tag_node_ids),
             "edge_ids": list(self.edge_ids),
         }
+
+
+async def _index_committed_memory_node(node_id: int) -> None:
+    """Best-effort mirror write after the memory transaction is durable."""
+
+    from brain.systems.knowledge.service import index_memory_node
+
+    try:
+        async with UnitOfWork() as uow:
+            stats = await index_memory_node(uow.session, node_id=node_id)
+            if stats.failed:
+                logger.warning(
+                    "Immediate knowledge indexing degraded for committed memory node %s",
+                    node_id,
+                )
+    except Exception:
+        # Knowledge is a disposable mirror. A failed index write must never
+        # change the successful outcome of the committed memory ingest.
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_id,
+        )
+
+
+async def _index_committed_memory_nodes(node_ids: list[int]) -> None:
+    for node_id in node_ids:
+        await _index_committed_memory_node(node_id)
+
+
+def _reap_knowledge_index_task(task: asyncio.Task) -> None:
+    _POST_COMMIT_TASKS.discard(task)
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+def _spawn_knowledge_index_task(node_ids: list[int]) -> None:
+    try:
+        task = asyncio.ensure_future(_index_committed_memory_nodes(node_ids))
+        _POST_COMMIT_TASKS.add(task)
+        task.add_done_callback(_reap_knowledge_index_task)
+    except Exception:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_ids,
+        )
+
+
+def _schedule_post_commit_knowledge_index(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> bool:
+    """Queue immediate indexing for the session's next outer commit."""
+
+    try:
+        sync_session = getattr(session, "sync_session", None)
+        if sync_session is None:
+            return False
+        loop = asyncio.get_running_loop()
+        queue: list[int] = sync_session.info.setdefault(_INFO_QUEUE_KEY, [])
+        queue.append(int(node_id))
+        if sync_session.info.get(_INFO_ARMED_KEY):
+            return True
+
+        def _drain_into_task(target_session: Any) -> None:
+            # SQLAlchemy fires after_commit for a savepoint release too. The
+            # nested transaction is still available during that callback, so
+            # keep the queue until the outer transaction commits.
+            previous = target_session.get_nested_transaction()
+            if getattr(previous, "nested", False):
+                return
+            drained = list(dict.fromkeys(target_session.info.get(_INFO_QUEUE_KEY) or []))
+            target_session.info[_INFO_QUEUE_KEY] = []
+            if not drained:
+                return
+            try:
+                loop.call_soon_threadsafe(_spawn_knowledge_index_task, drained)
+            except Exception:
+                logger.exception(
+                    "Immediate knowledge indexing failed for committed memory node %s",
+                    drained,
+                )
+
+        def _on_rollback(target_session: Any, previous: Any) -> None:
+            if getattr(previous, "nested", False):
+                return
+            target_session.info[_INFO_QUEUE_KEY] = []
+
+        from sqlalchemy import event
+
+        event.listen(sync_session, "after_commit", _drain_into_task)
+        event.listen(sync_session, "after_soft_rollback", _on_rollback)
+        sync_session.info[_INFO_ARMED_KEY] = True
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Immediate knowledge indexing not armed for memory node %s (%s); "
+            "the periodic sweep will deliver it",
+            node_id,
+            exc,
+        )
+        return False
 
 
 async def ingest_memory_source(
@@ -254,7 +369,7 @@ async def ingest_memory_source(
             exc,
         )
 
-    return IngestedMemorySource(
+    result = IngestedMemorySource(
         source_id=source.id,
         span_ids=span_ids,
         content_node_id=content_node.id,
@@ -263,6 +378,11 @@ async def ingest_memory_source(
         tag_node_ids=tuple(node.id for node in tag_nodes),
         edge_ids=tuple(edge.id for edge in edges),
     )
+    _schedule_post_commit_knowledge_index(
+        session,
+        node_id=result.content_node_id,
+    )
+    return result
 
 
 def _clean_content(content: str) -> str:

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -538,6 +538,56 @@ async def test_memory_connector_reports_an_empty_searchable_corpus(session):
     assert state.last_stats == result.stats
 
 
+async def test_memory_connector_skips_orgless_nodes_and_keeps_organization_scope(
+    session,
+    embedding_runtime,
+    caplog,
+):
+    del embedding_runtime
+    updated_at = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    session.add_all(
+        [
+            _memory_node(
+                14,
+                updated_at,
+                title="Unreachable org-less memory",
+                org_id=None,
+                visibility="org",
+            ),
+            _memory_node(
+                15,
+                updated_at,
+                title="Reachable organization memory",
+                org_id=_ORG_ID,
+                visibility="org",
+            ),
+        ]
+    )
+    await session.flush()
+
+    with caplog.at_level(
+        "WARNING",
+        logger="brain.systems.knowledge.connectors.memory",
+    ):
+        result = await sync_connector(session, MemoryConnector(max_items=10))
+
+    items = list((await session.scalars(select(KnowledgeItem))).all())
+    embeddings = list((await session.scalars(select(KnowledgeItemEmbedding))).all())
+
+    assert result.stats == {
+        "ingested": 1,
+        "skipped": 1,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert [item.source_ref for item in items] == ["memory_node:15"]
+    assert [embedding.item_id for embedding in embeddings] == [items[0].id]
+    assert items[0].extra[KNOWLEDGE_SCOPE_EXTRA_KEY] == (
+        KnowledgeScope.ORGANIZATION.value
+    )
+    assert "skipped node 14: org_id is missing" in caplog.text
+
+
 async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(
     session,
     embedding_runtime,

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
@@ -10,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import numpy as np
 import pytest
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
 from brain.app.api.auth import get_current_user
@@ -30,7 +31,13 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+)
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
     EnumerationFailureKind,
@@ -49,7 +56,10 @@ from brain.systems.knowledge.connectors.github import (
 )
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
-from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
+from brain.systems.knowledge.service import (
+    RAW_TEXT_MAX_CHARS,
+    sync_connector,
+)
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
@@ -317,7 +327,10 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
+            MemorySource.__table__,
+            MemorySpan.__table__,
             MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
         ]
     )
@@ -579,6 +592,300 @@ async def test_memory_connector_skips_orgless_nodes_and_keeps_organization_scope
     )
     assert items[0].extra["org_id"] == _ORG_ID
     assert "skipped node 14: org_id is missing" in caplog.text
+
+
+def _committing_unit_of_work(session):
+    class _CommittingUnitOfWork:
+        async def __aenter__(self):
+            self.session = session
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            del exc, traceback
+            if exc_type is None:
+                await session.commit()
+            else:
+                await session.rollback()
+            return False
+
+    return _CommittingUnitOfWork
+
+
+async def _wait_for_memory_knowledge_index(memory_ingestion):
+    await asyncio.sleep(0)
+    if memory_ingestion._POST_COMMIT_TASKS:
+        await asyncio.gather(*list(memory_ingestion._POST_COMMIT_TASKS))
+
+
+async def _ingest_shared_memory_at_canonical_boundary(
+    session,
+    monkeypatch,
+    *,
+    content: str,
+    source_ref: str,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    monkeypatch.setattr(
+        memory_ingestion,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    result = await memory_ingestion.ingest_memory_source(
+        session,
+        content=content,
+        content_kind="decision",
+        source_kind="contract_test",
+        source_ref=source_ref,
+        org_id=_ORG_ID,
+        user_id="22222222-2222-4222-8222-222222222222",
+        visibility="team",
+        confidence=0.9,
+    )
+    await session.commit()
+    await _wait_for_memory_knowledge_index(memory_ingestion)
+    return result.to_dict()
+
+
+async def test_memory_ingest_indexes_committed_node_for_immediate_search(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    distinctive = "Zephyr quokka release ownership stays with the active worker."
+
+    payload = await _ingest_shared_memory_at_canonical_boundary(
+        session,
+        monkeypatch,
+        content=distinctive,
+        source_ref="immediate-knowledge-search",
+    )
+
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source == "memory",
+            KnowledgeItem.source_ref == source_ref,
+        )
+    )
+    search = await search_knowledge(session, "zephyr quokka", org_id=_ORG_ID)
+
+    assert item is not None
+    assert item.summary == distinctive
+    assert [result["source_ref"] for result in search["results"]] == [source_ref]
+
+
+async def test_memory_connector_immediate_and_sweep_eligibility_are_identical(
+    session,
+):
+    updated_at = datetime(2026, 8, 5, 14, 0, tzinfo=timezone.utc)
+    superseded = _memory_node(22, updated_at, visibility="team")
+    superseded.truth_status = "superseded"
+    rows = [
+        _memory_node(16, updated_at, visibility="org"),
+        _memory_node(17, updated_at, visibility="team"),
+        _memory_node(18, updated_at, node_kind="summary", visibility="org"),
+        _memory_node(19, updated_at, org_id=None, visibility="org"),
+        _memory_node(20, updated_at, visibility="private"),
+        _memory_node(21, updated_at, visibility="private"),
+        superseded,
+    ]
+    session.add_all(rows)
+    session.add(
+        KnowledgeItem(
+            source="memory",
+            kind="memory",
+            source_ref="memory_node:21",
+            title="Formerly shared memory",
+            summary="Formerly shared memory",
+            raw_text="Formerly shared memory",
+            search_text="Formerly shared memory",
+            extra={"org_id": _ORG_ID},
+            content_digest="former-shared-memory",
+        )
+    )
+    await session.flush()
+
+    connector = MemoryConnector(max_items=20)
+    immediate_drafts = {}
+    for row in rows:
+        draft = await connector.draft_for_node(session, node_id=row.id)
+        if draft is not None:
+            immediate_drafts[draft.source_ref] = draft
+    enumeration = await connector.enumerate_changed(session, {})
+    sweep_drafts = {draft.source_ref: draft for draft in enumeration.drafts}
+
+    assert immediate_drafts == sweep_drafts
+    assert set(immediate_drafts) == {
+        "memory_node:16",
+        "memory_node:17",
+        "memory_node:21",
+        "memory_node:22",
+    }
+    assert immediate_drafts["memory_node:21"].extra["mirror_status"] == (
+        "visibility_withdrawn"
+    )
+    assert immediate_drafts["memory_node:22"].archived_at == updated_at
+
+
+async def test_memory_index_waits_for_outer_commit_after_savepoint_release(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    async with session.begin_nested():
+        ingested = await memory_ingestion.ingest_memory_source(
+            session,
+            content="Savepoint release must not publish a memory projection early.",
+            content_kind="decision",
+            source_kind="contract_test",
+            org_id=_ORG_ID,
+            visibility="team",
+        )
+
+    await asyncio.sleep(0)
+    spawn_index.assert_not_called()
+
+    await session.commit()
+    await asyncio.sleep(0)
+    spawn_index.assert_called_once_with([ingested.content_node_id])
+
+
+async def test_memory_index_queue_is_cleared_on_outer_rollback(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    await memory_ingestion.ingest_memory_source(
+        session,
+        content="Rolled-back memory must never publish a knowledge projection.",
+        content_kind="decision",
+        source_kind="contract_test",
+        org_id=_ORG_ID,
+        visibility="team",
+    )
+    await session.rollback()
+    await asyncio.sleep(0)
+
+    spawn_index.assert_not_called()
+    assert session.sync_session.info[memory_ingestion._INFO_QUEUE_KEY] == []
+
+
+async def test_memory_sweep_and_cursor_rewalk_are_idempotent_after_immediate_ingest(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    payload = await _ingest_shared_memory_at_canonical_boundary(
+        session,
+        monkeypatch,
+        content="Cobalt narwhal decisions remain searchable after every reconciler pass.",
+        source_ref="immediate-then-sweep",
+    )
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    before = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+    )
+    assert before is not None
+    item_id = before.id
+    digest = before.content_digest
+
+    first_sweep = await sync_connector(session, MemoryConnector(max_items=20))
+    await session.execute(
+        delete(KnowledgeSyncState).where(KnowledgeSyncState.source == "memory")
+    )
+    await session.flush()
+    rewalk = await sync_connector(session, MemoryConnector(max_items=20))
+
+    items = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+            )
+        ).all()
+    )
+    embeddings = list(
+        (
+            await session.scalars(
+                select(KnowledgeItemEmbedding).where(
+                    KnowledgeItemEmbedding.item_id == item_id
+                )
+            )
+        ).all()
+    )
+    assert first_sweep.stats["ingested"] == 0
+    assert first_sweep.stats["skipped"] == 1
+    assert rewalk.stats["ingested"] == 0
+    assert rewalk.stats["skipped"] == 1
+    assert len(items) == 1
+    assert items[0].id == item_id
+    assert items[0].content_digest == digest
+    assert len(embeddings) == 1
+
+
+async def test_memory_index_failure_does_not_fail_committed_ingest(
+    session,
+    monkeypatch,
+    caplog,
+):
+    from brain.systems.knowledge import service as knowledge_service
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    monkeypatch.setattr(
+        memory_ingestion,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        knowledge_service,
+        "index_memory_node",
+        AsyncMock(side_effect=RuntimeError("knowledge mirror unavailable")),
+    )
+
+    with caplog.at_level("ERROR", logger=memory_ingestion.__name__):
+        result = await memory_ingestion.ingest_memory_source(
+            session,
+            content="Amber kestrel preservation remains durable during an index outage.",
+            content_kind="episode",
+            source_kind="contract_test",
+            source_ref="failed-immediate-index",
+            org_id=_ORG_ID,
+            user_id="22222222-2222-4222-8222-222222222222",
+            visibility="org",
+        )
+        await session.commit()
+        await _wait_for_memory_knowledge_index(memory_ingestion)
+
+    node = await session.get(MemoryNode, result.content_node_id)
+    assert node is not None
+    assert node.text == "Amber kestrel preservation remains durable during an index outage."
+    assert "Immediate knowledge indexing failed for committed memory node" in caplog.text
 
 
 async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -565,26 +565,19 @@ async def test_memory_connector_skips_orgless_nodes_and_keeps_organization_scope
     )
     await session.flush()
 
-    with caplog.at_level(
-        "WARNING",
-        logger="brain.systems.knowledge.connectors.memory",
-    ):
+    with caplog.at_level("WARNING"):
         result = await sync_connector(session, MemoryConnector(max_items=10))
 
     items = list((await session.scalars(select(KnowledgeItem))).all())
     embeddings = list((await session.scalars(select(KnowledgeItemEmbedding))).all())
 
-    assert result.stats == {
-        "ingested": 1,
-        "skipped": 1,
-        "failed": 0,
-        "truncated": 0,
-    }
+    assert result.stats["ingested"] == 1
     assert [item.source_ref for item in items] == ["memory_node:15"]
     assert [embedding.item_id for embedding in embeddings] == [items[0].id]
     assert items[0].extra[KNOWLEDGE_SCOPE_EXTRA_KEY] == (
         KnowledgeScope.ORGANIZATION.value
     )
+    assert items[0].extra["org_id"] == _ORG_ID
     assert "skipped node 14: org_id is missing" in caplog.text
 
 
@@ -764,6 +757,45 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
         "truth_status": "active",
         "visibility": "private",
     }
+
+
+async def test_memory_connector_scrubs_a_mirror_after_its_organization_is_removed(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    created_at = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+    node = _memory_node(
+        42,
+        created_at,
+        title="Shared organization decision",
+        text="This organization detail must be scrubbed after withdrawal.",
+        visibility="org",
+    )
+    session.add(node)
+    await session.flush()
+    connector = MemoryConnector(max_items=10)
+    await sync_connector(session, connector)
+
+    withdrawn_at = datetime(2026, 7, 21, 13, 0, tzinfo=timezone.utc)
+    node.visibility = "private"
+    node.org_id = None
+    node.updated_at = withdrawn_at
+    await session.flush()
+
+    result = await sync_connector(session, connector)
+    mirrored = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "memory_node:42")
+    )
+
+    assert result.stats["ingested"] == 1
+    assert result.corpus_empty is True
+    assert mirrored is not None
+    assert mirrored.archived_at.replace(tzinfo=timezone.utc) == withdrawn_at
+    assert mirrored.raw_text == ""
+    assert "organization detail" not in mirrored.search_text
+    assert mirrored.extra["mirror_status"] == "visibility_withdrawn"
+    assert mirrored.extra["org_id"] == _ORG_ID
 
 
 def test_reciprocal_rank_fusion_uses_recency_as_weight_not_candidate_gate():


### PR DESCRIPTION
Closes #680.

> *This was generated by AI. A human should review it before merge.*

## What this fixes

A memory node with no `org_id` was mirrored into `knowledge_items` with
`extra["org_id"] = None`. Search admits an item only when its org matches the
caller's, and `None` matches no org — so the item was **indexed, embedded, and
permanently unreachable**. Nothing surfaced it: sync reported it ingested, and
search simply never returned it.

**Zero such nodes exist today** — 0 of 938, counted on the live database. So this
is not a repair, it is closing the door: the state was *absent from the data* but
still *representable by the code*.

## The decision this ticket asked for, answered from the database

The ticket asked whether an org-less node is (1) global knowledge or (2) a
data-quality gap, and said explicitly not to answer it by reading code. Counted
on `illospace-postgres-1`:

| org-less | with org | total |
|---:|---:|---:|
| **0** | 938 | 938 |

Answer: **(2), a data-quality gap.** Option 1 would pin a semantic that nothing
exercises, and in a single-org workspace `organization` and `global` scope are
observationally identical anyway. Full reasoning in
[this comment](https://github.com/Illospace/illospace/issues/680#issuecomment-5192417444).

So the memory connector keeps declaring `KnowledgeScope.ORGANIZATION` — **this PR
changes nothing about what the 938 real nodes do.**

## What changed

One production file, `brain/systems/knowledge/connectors/memory.py`:

- A shared node with no `org_id` is **not mirrored**. It is skipped with a
  warning naming the node id.
- `_required_org_id()` raises at the draft-construction boundary, so a null org
  cannot reach an active knowledge item even if the selection logic is changed
  later.
- Mirroring and withdrawal are now modelled separately (see below).

No migration, no schema change, no change to `KnowledgeScope`, the search filter,
or any other connector. Tightening `memory_nodes.org_id` to `NOT NULL` is a
separate call — the connector guard delivers the safety without one.

## Review caught a leak that the tests could not

The first implementation applied the org guard **before** choosing between
mirroring and withdrawal. A node that was mirrored while it had an org, then went
private *and* lost its `org_id`, was skipped instead of withdrawn — so its stale
knowledge item **stayed visible to its former organization**. That is the same
bug class this ticket exists to kill, reintroduced on the withdrawal path.

Fixed: active mirroring requires an org on the node; **withdrawal never does** —
it takes the org from the existing mirror, which is non-null by construction
because this guard is what prevents a null-org item from being written. There is
a regression test for exactly this transition, and it fails against the first
commit (`b27ed548`) and passes now.

A first attempt also added a `skipped` counter to `KnowledgeEnumeration`, a
dataclass five connectors return and one would set, folded into a `stats.skipped`
that already means "unchanged". That was my instruction and it was wrong — it
conflated healthy with invalid. Reverted; the warning log is the whole reporting
surface.

## Verification

Both lanes run by hand, because **this PR gets no CI** — its base is a feature
branch, which is #682 / #683.

- Fast lane, the repo's own CI command: **4753 passed, 11 skipped, 0 failed.**
  Base branch is 4751 and this adds exactly 2 tests, 0 removed (82 insertions,
  0 deletions under `tests/`).
- DB lane on a clean `pgvector/pgvector:pg16` container, migrated to this
  branch's head `0050`: see the comment below.

## Acceptance checks

1. An org-less memory node is never written to the index — assert on the absence
   of both the `KnowledgeItem` and its embedding, not just a count.
2. A node with a real org is still mirrored and still declares
   `KnowledgeScope.ORGANIZATION` — no behaviour change for the 938 real nodes.
3. A previously mirrored node that goes private **and** org-less is still
   withdrawn, so its existing item is scrubbed rather than stranded.
4. No migration and no new alembic revision — deliberate, since revision ids are
   contested by other open PRs.

## Note for the reviewer

`existing_org_ids` reads `KnowledgeItem.extra["org_id"]` directly rather than
`.get()`. That is intentional: this connector is the only writer for its
`source_key` and always sets the key, so a missing key means a genuinely
malformed item and should fail loudly (the enumeration error is caught and
logged by `sync_connector`) rather than silently withdraw with a null org.

## Stacking

Based on `illo-qa/674-skills-knowledge-connector` (#679), not `main`. The
`KnowledgeScope` contract this builds on exists only there, and `memory.py` is
owned by that PR — a `main`-based branch would collide. **Merge #679 first.**
