### PR TITLE
refactor(cycles): give the timestamp rule one owner (#684)

### DIFF
--- a/brain/kernel/common/time.py
+++ b/brain/kernel/common/time.py
@@ -31,3 +31,14 @@ def assume_utc(value: datetime | None = None) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
+
+
+def assume_utc_optional(value: datetime | None) -> datetime | None:
+    """Normalize an optional timestamp to UTC while preserving ``None``.
+
+    Unlike :func:`assume_utc`, which replaces ``None`` with the current time,
+    this helper returns ``None`` unchanged. Unlike :func:`ensure_utc`, it
+    accepts naive timestamps and assumes that they already represent UTC.
+    """
+
+    return None if value is None else assume_utc(value)

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from brain.kernel.common.time import assume_utc
+from brain.kernel.common.time import assume_utc_optional
 from brain.systems.cycles.common import (
     OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
     SCHEDULED_CYCLE_ORIGIN,
@@ -53,7 +53,7 @@ def _iso(value: datetime | None) -> str | None:
 
 def cycle_scheduled_review_window(scheduled_for: datetime | None) -> dict[str, Any]:
     """Return the stable evidence window a scheduled cycle should inspect."""
-    end = assume_utc(scheduled_for) if scheduled_for is not None else None
+    end = assume_utc_optional(scheduled_for)
     start = end - timedelta(hours=SCHEDULED_REVIEW_WINDOW_HOURS) if end else None
     return {
         "anchor": "cycle_run.scheduled_for",
@@ -158,8 +158,9 @@ def cycle_launch_receipt(
     except (TypeError, ValueError, ZoneInfoNotFoundError):
         timezone_name = "UTC"
         local_timezone = ZoneInfo("UTC")
-    if scheduled_for is not None:
-        local_scheduled_for = assume_utc(scheduled_for).astimezone(
+    aware_scheduled_for = assume_utc_optional(scheduled_for)
+    if aware_scheduled_for is not None:
+        local_scheduled_for = aware_scheduled_for.astimezone(
             local_timezone
         ).isoformat()
     return {
@@ -168,9 +169,7 @@ def cycle_launch_receipt(
         "cycle_run_id": cycle_run_id,
         "origin": origin,
         "launch_context": launch,
-        "scheduled_for": _iso(
-            assume_utc(scheduled_for) if scheduled_for is not None else None
-        ),
+        "scheduled_for": _iso(aware_scheduled_for),
         "timezone": timezone_name,
         "local_scheduled_for": local_scheduled_for,
         "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from brain.kernel.common.time import assume_utc
 from brain.systems.cycles.common import (
     OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
     SCHEDULED_CYCLE_ORIGIN,
@@ -46,19 +47,13 @@ CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND = {
 VALID_CYCLE_RUN_KINDS = frozenset(CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND)
 
 
-def _aware_utc(value: datetime | None) -> datetime | None:
-    if value is not None and value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc) if value is not None else None
-
-
 def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
 
 
 def cycle_scheduled_review_window(scheduled_for: datetime | None) -> dict[str, Any]:
     """Return the stable evidence window a scheduled cycle should inspect."""
-    end = _aware_utc(scheduled_for)
+    end = assume_utc(scheduled_for) if scheduled_for is not None else None
     start = end - timedelta(hours=SCHEDULED_REVIEW_WINDOW_HOURS) if end else None
     return {
         "anchor": "cycle_run.scheduled_for",
@@ -164,7 +159,7 @@ def cycle_launch_receipt(
         timezone_name = "UTC"
         local_timezone = ZoneInfo("UTC")
     if scheduled_for is not None:
-        local_scheduled_for = _aware_utc(scheduled_for).astimezone(
+        local_scheduled_for = assume_utc(scheduled_for).astimezone(
             local_timezone
         ).isoformat()
     return {
@@ -173,7 +168,9 @@ def cycle_launch_receipt(
         "cycle_run_id": cycle_run_id,
         "origin": origin,
         "launch_context": launch,
-        "scheduled_for": _iso(_aware_utc(scheduled_for)),
+        "scheduled_for": _iso(
+            assume_utc(scheduled_for) if scheduled_for is not None else None
+        ),
         "timezone": timezone_name,
         "local_scheduled_for": local_scheduled_for,
         "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),

--- a/brain/systems/cycles/degradation.py
+++ b/brain/systems/cycles/degradation.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Iterable, Mapping
 from zoneinfo import ZoneInfo
 
-from brain.kernel.common.time import assume_utc
+from brain.kernel.common.time import assume_utc_optional
 
 
 DEGRADATION_ESCALATION_THRESHOLD = 3
@@ -18,7 +18,7 @@ REQUIRED_DIGEST_TIMEZONE = "America/Toronto"
 
 
 def _iso(value: datetime | None) -> str | None:
-    aware = assume_utc(value) if value is not None else None
+    aware = assume_utc_optional(value)
     return aware.isoformat() if aware is not None else None
 
 
@@ -106,7 +106,7 @@ def degradation_causes(
 def next_required_digest_at(scheduled_for: datetime) -> datetime:
     """Return the first required 08:00/13:00/18:00 ET digest after a run."""
 
-    scheduled_utc = assume_utc(scheduled_for) if scheduled_for is not None else None
+    scheduled_utc = assume_utc_optional(scheduled_for)
     if scheduled_utc is None:
         raise ValueError("scheduled_for is required")
     zone = ZoneInfo(REQUIRED_DIGEST_TIMEZONE)
@@ -158,7 +158,7 @@ def degradation_tracking_for_run(
     """Snapshot durable degradation state and mark escalations due in this run."""
 
     snapshot = _persistent_state(state)
-    scheduled_utc = assume_utc(scheduled_for) if scheduled_for is not None else None
+    scheduled_utc = assume_utc_optional(scheduled_for)
     mandatory: list[dict[str, Any]] = []
     for escalation in snapshot["pending_escalations"]:
         target_text = _text(escalation.get("next_required_digest_at"))
@@ -166,10 +166,11 @@ def degradation_tracking_for_run(
             target = datetime.fromisoformat(target_text) if target_text else None
         except ValueError:
             target = None
+        target_utc = assume_utc_optional(target)
         if (
             scheduled_utc is not None
-            and target is not None
-            and scheduled_utc >= assume_utc(target)
+            and target_utc is not None
+            and scheduled_utc >= target_utc
         ):
             mandatory.append(dict(escalation))
     snapshot["mandatory_in_current_digest"] = bool(mandatory)

--- a/brain/systems/cycles/degradation.py
+++ b/brain/systems/cycles/degradation.py
@@ -8,6 +8,8 @@ import re
 from typing import Any, Iterable, Mapping
 from zoneinfo import ZoneInfo
 
+from brain.kernel.common.time import assume_utc
+
 
 DEGRADATION_ESCALATION_THRESHOLD = 3
 DEGRADATION_TRACKING_SCHEMA_VERSION = 1
@@ -15,16 +17,8 @@ REQUIRED_DIGEST_HOURS = (8, 13, 18)
 REQUIRED_DIGEST_TIMEZONE = "America/Toronto"
 
 
-def _aware_utc(value: datetime | None) -> datetime | None:
-    if value is None:
-        return None
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
 def _iso(value: datetime | None) -> str | None:
-    aware = _aware_utc(value)
+    aware = assume_utc(value) if value is not None else None
     return aware.isoformat() if aware is not None else None
 
 
@@ -112,7 +106,7 @@ def degradation_causes(
 def next_required_digest_at(scheduled_for: datetime) -> datetime:
     """Return the first required 08:00/13:00/18:00 ET digest after a run."""
 
-    scheduled_utc = _aware_utc(scheduled_for)
+    scheduled_utc = assume_utc(scheduled_for) if scheduled_for is not None else None
     if scheduled_utc is None:
         raise ValueError("scheduled_for is required")
     zone = ZoneInfo(REQUIRED_DIGEST_TIMEZONE)
@@ -164,7 +158,7 @@ def degradation_tracking_for_run(
     """Snapshot durable degradation state and mark escalations due in this run."""
 
     snapshot = _persistent_state(state)
-    scheduled_utc = _aware_utc(scheduled_for)
+    scheduled_utc = assume_utc(scheduled_for) if scheduled_for is not None else None
     mandatory: list[dict[str, Any]] = []
     for escalation in snapshot["pending_escalations"]:
         target_text = _text(escalation.get("next_required_digest_at"))
@@ -172,7 +166,11 @@ def degradation_tracking_for_run(
             target = datetime.fromisoformat(target_text) if target_text else None
         except ValueError:
             target = None
-        if scheduled_utc is not None and target is not None and scheduled_utc >= _aware_utc(target):
+        if (
+            scheduled_utc is not None
+            and target is not None
+            and scheduled_utc >= assume_utc(target)
+        ):
             mandatory.append(dict(escalation))
     snapshot["mandatory_in_current_digest"] = bool(mandatory)
     snapshot["mandatory_causes"] = mandatory

--- a/brain/systems/cycles/health.py
+++ b/brain/systems/cycles/health.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.kernel.common.time import assume_utc
+from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUS_VALUES
 
@@ -27,9 +27,7 @@ def _utc_now() -> datetime:
 
 
 def _cycle_row_payload(cycle: Cycle, *, now: datetime) -> dict[str, Any]:
-    next_run_at = cycle.next_run_at
-    if next_run_at is not None and next_run_at.tzinfo is None:
-        next_run_at = assume_utc(next_run_at)
+    next_run_at = assume_utc_optional(cycle.next_run_at)
     overdue_seconds = int((now - next_run_at).total_seconds()) if next_run_at else None
     return {
         "id": cycle.id,
@@ -43,9 +41,7 @@ def _cycle_row_payload(cycle: Cycle, *, now: datetime) -> dict[str, Any]:
 
 
 def _cycle_run_row_payload(run: CycleRun, *, now: datetime) -> dict[str, Any]:
-    scheduled_for = run.scheduled_for
-    if scheduled_for is not None and scheduled_for.tzinfo is None:
-        scheduled_for = assume_utc(scheduled_for)
+    scheduled_for = assume_utc_optional(run.scheduled_for)
     stale_seconds = int((now - scheduled_for).total_seconds()) if scheduled_for else None
     return {
         "id": run.id,

--- a/brain/systems/cycles/health.py
+++ b/brain/systems/cycles/health.py
@@ -9,6 +9,7 @@ from typing import Any
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.time import assume_utc
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUS_VALUES
 
@@ -25,14 +26,10 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _aware_utc(value: datetime | None) -> datetime | None:
-    if value is not None and value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value
-
-
 def _cycle_row_payload(cycle: Cycle, *, now: datetime) -> dict[str, Any]:
-    next_run_at = _aware_utc(cycle.next_run_at)
+    next_run_at = cycle.next_run_at
+    if next_run_at is not None and next_run_at.tzinfo is None:
+        next_run_at = assume_utc(next_run_at)
     overdue_seconds = int((now - next_run_at).total_seconds()) if next_run_at else None
     return {
         "id": cycle.id,
@@ -46,7 +43,9 @@ def _cycle_row_payload(cycle: Cycle, *, now: datetime) -> dict[str, Any]:
 
 
 def _cycle_run_row_payload(run: CycleRun, *, now: datetime) -> dict[str, Any]:
-    scheduled_for = _aware_utc(run.scheduled_for)
+    scheduled_for = run.scheduled_for
+    if scheduled_for is not None and scheduled_for.tzinfo is None:
+        scheduled_for = assume_utc(scheduled_for)
     stale_seconds = int((now - scheduled_for).total_seconds()) if scheduled_for else None
     return {
         "id": run.id,

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -7,6 +7,7 @@ from typing import Any
 from sqlalchemy import func, select
 
 from brain.kernel.common.serialization import jsonable
+from brain.kernel.common.time import assume_utc
 from brain.platform.db.models.cycle import (
     Cycle,
     CycleGuidance,
@@ -377,8 +378,12 @@ async def finalize_stale_cycle_run(
         skip_reason=skip_reason,
         evaluator_type="recovery",
     )
-    cycle_last_run_at = _aware_utc(cycle.last_run_at)
-    scheduled_for = _aware_utc(run.scheduled_for)
+    cycle_last_run_at = cycle.last_run_at
+    if cycle_last_run_at is not None and cycle_last_run_at.tzinfo is None:
+        cycle_last_run_at = assume_utc(cycle_last_run_at)
+    scheduled_for = run.scheduled_for
+    if scheduled_for is not None and scheduled_for.tzinfo is None:
+        scheduled_for = assume_utc(scheduled_for)
     if cycle_last_run_at is None or (
         scheduled_for is not None and scheduled_for >= cycle_last_run_at
     ):
@@ -573,11 +578,3 @@ def cycle_run_evaluation_summary(
         detail = skip_reason or "unknown skip reason"
         return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}" + burn
     return f"Cycle run reached status {status} and was recorded in the Cycle ledger." + burn
-
-
-def _aware_utc(value):
-    from datetime import timezone
-
-    if value is not None and value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlalchemy import func, select
 
 from brain.kernel.common.serialization import jsonable
-from brain.kernel.common.time import assume_utc
+from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import (
     Cycle,
     CycleGuidance,
@@ -378,12 +378,8 @@ async def finalize_stale_cycle_run(
         skip_reason=skip_reason,
         evaluator_type="recovery",
     )
-    cycle_last_run_at = cycle.last_run_at
-    if cycle_last_run_at is not None and cycle_last_run_at.tzinfo is None:
-        cycle_last_run_at = assume_utc(cycle_last_run_at)
-    scheduled_for = run.scheduled_for
-    if scheduled_for is not None and scheduled_for.tzinfo is None:
-        scheduled_for = assume_utc(scheduled_for)
+    cycle_last_run_at = assume_utc_optional(cycle.last_run_at)
+    scheduled_for = assume_utc_optional(run.scheduled_for)
     if cycle_last_run_at is None or (
         scheduled_for is not None and scheduled_for >= cycle_last_run_at
     ):

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import func, select
 
 from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
+from brain.kernel.common.time import assume_utc
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
 )
@@ -444,12 +445,6 @@ async def async_run_cycle_now(
     return serialize_cycle_run(run)
 
 
-def _aware_utc(value: datetime | None) -> datetime | None:
-    if value is not None and value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value
-
-
 def _agent_run_terminal_cycle_status(agent_run: AgentRun | None) -> str | None:
     if agent_run is None:
         return None
@@ -601,7 +596,9 @@ async def async_recover_stale_cycle_runs_once(
         for run in active_runs:
             cycle = await uow.session.get(Cycle, run.cycle_id)
             if run.status == "queued":
-                scheduled_for = _aware_utc(run.scheduled_for)
+                scheduled_for = run.scheduled_for
+                if scheduled_for is not None and scheduled_for.tzinfo is None:
+                    scheduled_for = assume_utc(scheduled_for)
                 if scheduled_for is not None and scheduled_for < catchup_cutoff:
                     await _finalize_stale_cycle_run(
                         run,
@@ -650,16 +647,18 @@ def _advance_cycle_schedule(
 ) -> datetime | None:
     """Move one Cycle onto its next schedule slot."""
 
-    scheduled_for = _aware_utc(from_dt)
+    scheduled_for = from_dt
+    if scheduled_for is not None and scheduled_for.tzinfo is None:
+        scheduled_for = assume_utc(scheduled_for)
     if scheduled_for is None:
         raise ValueError("from_dt is required")
-    next_run_at = _aware_utc(
-        compute_next_run_at(
-            cycle.schedule_expr,
-            cycle.timezone,
-            from_dt=scheduled_for,
-        )
+    next_run_at = compute_next_run_at(
+        cycle.schedule_expr,
+        cycle.timezone,
+        from_dt=scheduled_for,
     )
+    if next_run_at is not None and next_run_at.tzinfo is None:
+        next_run_at = assume_utc(next_run_at)
     if next_run_at is not None and next_run_at <= scheduled_for:
         raise RuntimeError("schedule did not advance")
     cycle.next_run_at = next_run_at
@@ -750,8 +749,10 @@ async def async_advance_cycle_schedule_past_gap(
     advances ``next_run_at`` beyond the gap without creating ``CycleRun`` rows.
     """
 
-    gap_start = _aware_utc(gap_start)
-    now = _aware_utc(now)
+    if gap_start is not None and gap_start.tzinfo is None:
+        gap_start = assume_utc(gap_start)
+    if now is not None and now.tzinfo is None:
+        now = assume_utc(now)
     if gap_start is None or now is None:
         raise ValueError("gap_start and now are required")
     if gap_start > now:
@@ -779,7 +780,9 @@ async def async_advance_cycle_schedule_past_gap(
     limit = max(1, int(max_slots_per_cycle))
 
     for cycle in cycles:
-        scheduled_for = _aware_utc(cycle.next_run_at)
+        scheduled_for = cycle.next_run_at
+        if scheduled_for is not None and scheduled_for.tzinfo is None:
+            scheduled_for = assume_utc(scheduled_for)
         original_next_run_at = cycle.next_run_at
         original_enabled = cycle.enabled
         seen = 0
@@ -877,7 +880,9 @@ async def async_wake_cycle_now(*, name: str, org_id: str | None = None) -> str:
         # competing wake must judge the slot as of when it holds the row, or it
         # re-stamps a slot that is already due.
         now = datetime.now(timezone.utc)
-        pending_at = _aware_utc(cycle.next_run_at)
+        pending_at = cycle.next_run_at
+        if pending_at is not None and pending_at.tzinfo is None:
+            pending_at = assume_utc(pending_at)
         if pending_at is not None and pending_at <= now:
             return "already_pending"
         active_run_count = await _async_active_cycle_run_count(uow.session, cycle.id)

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import func, select
 
 from brain.contracts.statuses import TERMINAL_RUN_STATUS_VALUES
-from brain.kernel.common.time import assume_utc
+from brain.kernel.common.time import assume_utc_optional
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
 )
@@ -596,9 +596,7 @@ async def async_recover_stale_cycle_runs_once(
         for run in active_runs:
             cycle = await uow.session.get(Cycle, run.cycle_id)
             if run.status == "queued":
-                scheduled_for = run.scheduled_for
-                if scheduled_for is not None and scheduled_for.tzinfo is None:
-                    scheduled_for = assume_utc(scheduled_for)
+                scheduled_for = assume_utc_optional(run.scheduled_for)
                 if scheduled_for is not None and scheduled_for < catchup_cutoff:
                     await _finalize_stale_cycle_run(
                         run,
@@ -647,18 +645,16 @@ def _advance_cycle_schedule(
 ) -> datetime | None:
     """Move one Cycle onto its next schedule slot."""
 
-    scheduled_for = from_dt
-    if scheduled_for is not None and scheduled_for.tzinfo is None:
-        scheduled_for = assume_utc(scheduled_for)
+    scheduled_for = assume_utc_optional(from_dt)
     if scheduled_for is None:
         raise ValueError("from_dt is required")
-    next_run_at = compute_next_run_at(
-        cycle.schedule_expr,
-        cycle.timezone,
-        from_dt=scheduled_for,
+    next_run_at = assume_utc_optional(
+        compute_next_run_at(
+            cycle.schedule_expr,
+            cycle.timezone,
+            from_dt=scheduled_for,
+        )
     )
-    if next_run_at is not None and next_run_at.tzinfo is None:
-        next_run_at = assume_utc(next_run_at)
     if next_run_at is not None and next_run_at <= scheduled_for:
         raise RuntimeError("schedule did not advance")
     cycle.next_run_at = next_run_at
@@ -749,10 +745,8 @@ async def async_advance_cycle_schedule_past_gap(
     advances ``next_run_at`` beyond the gap without creating ``CycleRun`` rows.
     """
 
-    if gap_start is not None and gap_start.tzinfo is None:
-        gap_start = assume_utc(gap_start)
-    if now is not None and now.tzinfo is None:
-        now = assume_utc(now)
+    gap_start = assume_utc_optional(gap_start)
+    now = assume_utc_optional(now)
     if gap_start is None or now is None:
         raise ValueError("gap_start and now are required")
     if gap_start > now:
@@ -780,9 +774,7 @@ async def async_advance_cycle_schedule_past_gap(
     limit = max(1, int(max_slots_per_cycle))
 
     for cycle in cycles:
-        scheduled_for = cycle.next_run_at
-        if scheduled_for is not None and scheduled_for.tzinfo is None:
-            scheduled_for = assume_utc(scheduled_for)
+        scheduled_for = assume_utc_optional(cycle.next_run_at)
         original_next_run_at = cycle.next_run_at
         original_enabled = cycle.enabled
         seen = 0
@@ -880,9 +872,7 @@ async def async_wake_cycle_now(*, name: str, org_id: str | None = None) -> str:
         # competing wake must judge the slot as of when it holds the row, or it
         # re-stamps a slot that is already due.
         now = datetime.now(timezone.utc)
-        pending_at = cycle.next_run_at
-        if pending_at is not None and pending_at.tzinfo is None:
-            pending_at = assume_utc(pending_at)
+        pending_at = assume_utc_optional(cycle.next_run_at)
         if pending_at is not None and pending_at <= now:
             return "already_pending"
         active_run_count = await _async_active_cycle_run_count(uow.session, cycle.id)

--- a/tests/test_common_helpers.py
+++ b/tests/test_common_helpers.py
@@ -18,7 +18,7 @@ from brain.kernel.common.coercion import (
 )
 from brain.kernel.common.env import env_flag, env_float, env_int
 from brain.kernel.common.serialization import json_safe, jsonable, stable_digest
-from brain.kernel.common.time import assume_utc, ensure_utc, utcnow
+from brain.kernel.common.time import assume_utc, assume_utc_optional, ensure_utc, utcnow
 
 
 def test_coercion_helpers_preserve_legacy_defaults() -> None:
@@ -78,6 +78,17 @@ def test_datetime_and_time_helpers_are_timezone_aware() -> None:
         2,
         tzinfo=timezone.utc,
     )
+    # The three helpers differ only on the inputs nobody remembers to check.
+    # Pin them side by side so the next reader does not have to diff them.
+    assert assume_utc_optional(datetime(2026, 1, 2)) == datetime(
+        2026,
+        1,
+        2,
+        tzinfo=timezone.utc,
+    )
+    assert assume_utc_optional(None) is None
+    # assume_utc replaces None with *now*; assume_utc_optional preserves it.
+    assert assume_utc(None) is not None
 
 
 def test_env_helpers_support_strict_and_permissive_boolean_semantics() -> None:

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -823,7 +823,7 @@ async def test_due_cycle_with_long_running_previous_run_records_skip_in_ledger(
     assert len(ledger) == 2
     assert ledger[0] is active_run
     assert ledger[0].status == "running"
-    assert service._aware_utc(ledger[1].scheduled_for) == scheduled_for
+    assert _aware_utc_for_test(ledger[1].scheduled_for) == scheduled_for
     assert ledger[1].status == "skipped"
     assert ledger[1].skip_reason == "previous_run_active"
     assert ledger[1].context_snapshot["disposition"] == {
@@ -4188,7 +4188,7 @@ async def test_wake_cycle_now_skips_when_run_in_flight(
     assert disposition == "run_in_flight"
     # The wake re-reads the locked row, and SQLite has no timestamptz, so the
     # refreshed attribute comes back naive. Same instant, unmoved.
-    assert service._aware_utc(cycle.next_run_at) == future
+    assert _aware_utc_for_test(cycle.next_run_at) == future
 
 
 @pytest.mark.asyncio
@@ -4228,7 +4228,7 @@ async def test_wake_cycle_now_reports_already_pending_and_missing(
     )
 
     assert await service.async_wake_cycle_now(name="Pending Cycle") == "already_pending"
-    assert service._aware_utc(pending.next_run_at) == now - timedelta(minutes=5)
+    assert _aware_utc_for_test(pending.next_run_at) == now - timedelta(minutes=5)
     assert await service.async_wake_cycle_now(name="Disabled Cycle") == "not_found"
     assert await service.async_wake_cycle_now(name="No Such Cycle") == "not_found"
 


### PR DESCRIPTION
Closes #684.

## What this does

`brain/systems/cycles/` carried the same timestamp rule — `None` → `None`, naive → assume UTC, aware → convert to UTC — copy-pasted as a private `_aware_utc` in five modules. A correction landed in one file and silently missed four. This gives the rule one owner.

`assume_utc` already exists on the base branch (added by #685). It is not a drop-in: `assume_utc(None)` returns **now**, but every one of these callers holds a nullable column that needs `None` to survive. So this adds one sibling helper, `assume_utc_optional`, beside it in `brain/kernel/common/time.py`, and routes all 18 call sites through it.

## Stacked — this is a layer, not a standalone PR

Base is `illo-qa/673-split-open-asks` (#685), which is itself on `illo-qa/667-open-ask-terminal-states` (#676). It cannot be based on `main`: `assume_utc` does not exist there. Merging the train merges this.

## The behaviour question, and why collapsing it is safe

The five copies were **not** identical. `contracts.py` and `degradation.py` converted an aware non-UTC value to UTC; `service.py`, `memory.py` and `health.py` returned it unchanged. This PR collapses both to the converting rule — the rule #684's own body states.

That is safe because a non-UTC aware value cannot reach these call sites:

- `brain/systems/cycles/schedules.py::compute_next_run_at` ends **every** branch with `.astimezone(timezone.utc)` — the cron path directly, the one-time path via `_parse_one_time_run_at`. It returns UTC-aware or `None`, never a local zone.
- The only other sources are database reads (`cycle.next_run_at`, `cycle.last_run_at`, `run.scheduled_for`), which come back naive or UTC.

If that ever stops holding, the pinning test below is where it surfaces.

## Review note — the first pass was rejected and rebuilt

Commit `e4eb8faa` deleted the five `_aware_utc` definitions and inlined the rule at **24** call sites in two different idioms. It was green, and it passed the issue's literal check (`grep "def _aware_utc"` empty) while making the duplication the ticket exists to fix strictly worse — five owners became twenty-four. Commit `9d420d26` is the rebuild. Both are kept so the reasoning is visible.

## Verification — run by hand, because this PR gets no CI

**This PR's base is a feature branch, so GitHub runs zero checks on it** — the same gap #683 fixes. Every figure below was produced locally with the repo venv, outside the Codex sandbox (the sandbox reports phantom `127.0.0.1` bind failures):

```
python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
  -> 4752 passed, 11 skipped, 84 deselected in 84.49s
python -m brain.jobs.check_cycle_context_admission
  -> {"ok": true, "cycle_count": 3}
```

Base branch `illo-qa/673-split-open-asks` scores **the same 4752 passed / 11 skipped**, so this is a true no-op on behaviour.

## Acceptance checks

1. `git grep "def _aware_utc" brain` → empty. ✅
2. Helper lives in `brain/kernel/common/time.py`; `ensure_utc` untouched and still raises on naive input. ✅
3. `tests/test_common_helpers.py` pins all **three** helpers side by side — including `assume_utc(None)` → now versus `assume_utc_optional(None)` → `None`, which is the confusion this new helper introduces. ✅
4. Pure refactor, no test expectation edited. The three `tests/test_cycles_service.py` lines swap a call to the now-deleted `service._aware_utc` for the file's existing `_aware_utc_for_test`; every expected value is byte-identical. ✅

## Deliberately not done

- `brain/systems/runs/obligation_notices.py:44` has the same optional idiom. It belongs to #685's diff, so widening into it would make that PR's review harder. Worth a follow-up.
- `_iso` is still duplicated in `contracts.py` and `degradation.py`. Pre-existing, different rule, not this ticket.
