### PR TITLE
fix(slack): answer a direct liveness probe on an interrupt path (#512 item 3)

### DIFF
--- a/brain/jobs/pipelines/illo_heartbeat.py
+++ b/brain/jobs/pipelines/illo_heartbeat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import StrEnum
 import json
 import logging
@@ -20,6 +20,10 @@ from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import GITHUB_API_BASE
+from brain.systems.liveness_state import (
+    LivenessSnapshot,
+    build_liveness_snapshot,
+)
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
 
@@ -30,39 +34,14 @@ PROJECT_SLUG = REPO_SLUG.lower()
 HEARTBEAT_BRANCH = "ops/heartbeat"
 HEARTBEAT_PATH = "heartbeat.json"
 HEARTBEAT_INSTALLATION_PERMISSIONS = {"contents": "write"}
-_KNOWN_SURFACES = {
-    "ai_timeline",
-    "api",
-    "cortex",
-    "headless",
-    "illo",
-    "mcp",
-    "scheduler",
-    "slack",
-    "thread_discussion",
-}
+HeartbeatPayload = LivenessSnapshot
+build_heartbeat_payload = build_liveness_snapshot
 
 
 @dataclass(frozen=True)
 class HeartbeatActor:
     user_id: str
     org_id: str
-
-
-@dataclass(frozen=True)
-class HeartbeatPayload:
-    """The complete public heartbeat document accepted by the write boundary."""
-
-    ts: str
-    last_run_id: int | None
-    last_surface: str
-
-    def as_public_dict(self) -> dict[str, str | int | None]:
-        return {
-            "ts": self.ts,
-            "last_run_id": self.last_run_id,
-            "last_surface": self.last_surface,
-        }
 
 
 class HeartbeatPublishOutcome(StrEnum):
@@ -83,46 +62,6 @@ class HeartbeatGitHubError(RuntimeError):
     def __init__(self, status_code: int, operation: str):
         super().__init__(f"GitHub returned {status_code} while {operation}")
         self.status_code = status_code
-
-
-def _utc_z(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    else:
-        value = value.astimezone(timezone.utc)
-    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
-
-
-def _coarse_surface(run: AgentRunRow | Any | None) -> str:
-    if run is None:
-        return "unknown"
-    metadata = run.metadata_ if isinstance(getattr(run, "metadata_", None), dict) else {}
-    target_ref = run.target_ref if isinstance(getattr(run, "target_ref", None), dict) else {}
-    for key in (
-        "originating_surface",
-        "source_surface",
-        "triggering_surface",
-        "origin",
-    ):
-        value = str(metadata.get(key) or target_ref.get(key) or "").strip().lower()
-        if value in _KNOWN_SURFACES:
-            return value
-    return "unknown"
-
-
-def build_heartbeat_payload(
-    latest_run: AgentRunRow | Any | None,
-    *,
-    now: datetime | None = None,
-) -> HeartbeatPayload:
-    """Build the complete public payload; no other fields may be emitted."""
-    clock = now or datetime.now(timezone.utc)
-    run_id = getattr(latest_run, "id", None)
-    return HeartbeatPayload(
-        ts=_utc_z(clock),
-        last_run_id=int(run_id) if run_id is not None else None,
-        last_surface=_coarse_surface(latest_run),
-    )
 
 
 async def _heartbeat_actor() -> HeartbeatActor | None:

--- a/brain/systems/liveness_state.py
+++ b/brain/systems/liveness_state.py
@@ -1,0 +1,104 @@
+"""Minimal process liveness state shared by internal and public consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunRow
+
+
+_KNOWN_SURFACES = {
+    "ai_timeline",
+    "api",
+    "cortex",
+    "headless",
+    "illo",
+    "mcp",
+    "scheduler",
+    "slack",
+    "thread_discussion",
+}
+
+
+@dataclass(frozen=True)
+class LivenessSnapshot:
+    """A bounded snapshot that does not expose run content or customer data."""
+
+    ts: str
+    last_run_id: int | None
+    last_surface: str
+
+    def as_public_dict(self) -> dict[str, str | int | None]:
+        return {
+            "ts": self.ts,
+            "last_run_id": self.last_run_id,
+            "last_surface": self.last_surface,
+        }
+
+
+def _utc_z(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _coarse_surface(run: AgentRunRow | Any | None) -> str:
+    if run is None:
+        return "unknown"
+    metadata = run.metadata_ if isinstance(getattr(run, "metadata_", None), dict) else {}
+    target_ref = run.target_ref if isinstance(getattr(run, "target_ref", None), dict) else {}
+    for key in (
+        "originating_surface",
+        "source_surface",
+        "triggering_surface",
+        "origin",
+    ):
+        value = str(metadata.get(key) or target_ref.get(key) or "").strip().lower()
+        if value in _KNOWN_SURFACES:
+            return value
+    return "unknown"
+
+
+def build_liveness_snapshot(
+    latest_run: AgentRunRow | Any | None,
+    *,
+    now: datetime | None = None,
+) -> LivenessSnapshot:
+    """Build the complete bounded snapshot shared by all liveness surfaces."""
+
+    clock = now or datetime.now(timezone.utc)
+    run_id = getattr(latest_run, "id", None)
+    return LivenessSnapshot(
+        ts=_utc_z(clock),
+        last_run_id=int(run_id) if run_id is not None else None,
+        last_surface=_coarse_surface(latest_run),
+    )
+
+
+async def latest_liveness_snapshot(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> LivenessSnapshot:
+    """Read the latest run and return the shared bounded snapshot."""
+
+    latest_run = await session.scalar(
+        select(AgentRunRow)
+        .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
+        .limit(1)
+    )
+    return build_liveness_snapshot(latest_run, now=now)
+
+
+__all__ = [
+    "LivenessSnapshot",
+    "build_liveness_snapshot",
+    "latest_liveness_snapshot",
+]

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 from typing import Any, Mapping
-import uuid
 
 from sqlalchemy import select
 
@@ -28,10 +27,14 @@ from brain.systems.slack.client import (
     slack_bot_token_from_env,
 )
 from brain.systems.slack.ingress import normalize_slack_socket_event
+from brain.systems.slack.interrupt_delivery import (
+    interrupt_delivery_from_inbound,
+    post_interrupt_reply,
+    should_add_reflex_ack,
+)
 from brain.systems.slack.monitored_intakes import (
     enrich_monitored_intake,
     is_monitored_intake,
-    monitored_intake_policy,
 )
 from brain.systems.slack.monitors import (
     disabled_intake_origins,
@@ -362,9 +365,7 @@ async def process_normalized_slack_envelope(
 ) -> dict[str, Any]:
     """Run every Slack ingress adapter through one normalized-envelope owner."""
 
-    policy = monitored_intake_policy(envelope)
     monitored_intake = is_monitored_intake(envelope)
-    interrupt = policy.interrupt if policy is not None else None
     existing_run_for_message = await _has_slack_run_for_envelope(session, connection, envelope)
     existing_inbound = await _has_inbound_event_for_envelope(
         session,
@@ -376,16 +377,6 @@ async def process_normalized_slack_envelope(
         connection=connection,
         envelope=envelope,
     )
-    acknowledged = False
-    if (monitored_intake and interrupt is None) or acknowledge_all:
-        # Reflex acknowledgement: leave a 👀 on every observed message so the
-        # channel knows Illo has seen it, independent of whether the ensuing
-        # triage run decides to reply.
-        acknowledged = await _acknowledge_monitored_message(
-            config,
-            envelope,
-            client=acknowledgement_client,
-        )
     if monitored_intake and existing_inbound is None:
         await enrich_monitored_intake(
             envelope,
@@ -398,12 +389,25 @@ async def process_normalized_slack_envelope(
         envelope=envelope,
         ingress_context=dict(ingress_context),
     )
-    interrupt_reply = None
-    if interrupt is not None and not inbound.get("idempotent_replay"):
-        interrupt_reply = await _post_interrupt_reply(
+    delivery_directive = interrupt_delivery_from_inbound(inbound)
+    acknowledged = False
+    if should_add_reflex_ack(
+        delivery_directive,
+        default=monitored_intake or acknowledge_all,
+    ):
+        # Reflex acknowledgement: leave a 👀 on every observed message so the
+        # channel knows Illo has seen it, independent of whether the ensuing
+        # triage run decides to reply.
+        acknowledged = await _acknowledge_monitored_message(
             config,
             envelope,
-            text=interrupt.reply(dict(envelope.get("payload") or {})),
+            client=acknowledgement_client,
+        )
+    interrupt_reply = None
+    if delivery_directive is not None and not inbound.get("idempotent_replay"):
+        interrupt_reply = await post_interrupt_reply(
+            config.bot_token,
+            delivery_directive,
             client=acknowledgement_client,
         )
     if (
@@ -736,35 +740,6 @@ def _admitted_slack_run(inbound: Mapping[str, Any]) -> bool:
     outcome = inbound.get("ilo_outcome")
     outcome = outcome if isinstance(outcome, Mapping) else {}
     return outcome.get("operation") == "slack_run_admitted" and outcome.get("run_id") is not None
-
-
-async def _post_interrupt_reply(
-    config: SlackConnectorConfig,
-    envelope: Mapping[str, Any],
-    *,
-    text: str,
-    client: Any | None = None,
-) -> Mapping[str, Any]:
-    payload = dict(envelope.get("payload") or {})
-    response_target = dict(payload.get("response_target") or {})
-    channel_id = str(response_target.get("channel_id") or payload.get("channel_id") or "").strip()
-    thread_ts = str(response_target.get("thread_ts") or "").strip() or None
-    if not channel_id:
-        raise ValueError("Slack interrupt reply requires a channel id")
-    idempotency_key = str(envelope.get("idempotency_key") or "").strip()
-    client_msg_id = str(
-        uuid.uuid5(
-            uuid.NAMESPACE_URL,
-            f"illospace:slack-interrupt:{idempotency_key}",
-        )
-    )
-    active_client = client or SlackWebClient(config.bot_token)
-    return await active_client.post_message(
-        channel=channel_id,
-        text=text,
-        thread_ts=thread_ts,
-        client_msg_id=client_msg_id,
-    )
 
 
 async def _set_processing_status(config: SlackConnectorConfig, envelope: Mapping[str, Any]) -> None:

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 from typing import Any, Mapping
+import uuid
 
 from sqlalchemy import select
 
@@ -30,6 +31,7 @@ from brain.systems.slack.ingress import normalize_slack_socket_event
 from brain.systems.slack.monitored_intakes import (
     enrich_monitored_intake,
     is_monitored_intake,
+    monitored_intake_policy,
 )
 from brain.systems.slack.monitors import (
     disabled_intake_origins,
@@ -360,7 +362,9 @@ async def process_normalized_slack_envelope(
 ) -> dict[str, Any]:
     """Run every Slack ingress adapter through one normalized-envelope owner."""
 
+    policy = monitored_intake_policy(envelope)
     monitored_intake = is_monitored_intake(envelope)
+    interrupt = policy.interrupt if policy is not None else None
     existing_run_for_message = await _has_slack_run_for_envelope(session, connection, envelope)
     existing_inbound = await _has_inbound_event_for_envelope(
         session,
@@ -373,7 +377,7 @@ async def process_normalized_slack_envelope(
         envelope=envelope,
     )
     acknowledged = False
-    if monitored_intake or acknowledge_all:
+    if (monitored_intake and interrupt is None) or acknowledge_all:
         # Reflex acknowledgement: leave a 👀 on every observed message so the
         # channel knows Illo has seen it, independent of whether the ensuing
         # triage run decides to reply.
@@ -394,6 +398,14 @@ async def process_normalized_slack_envelope(
         envelope=envelope,
         ingress_context=dict(ingress_context),
     )
+    interrupt_reply = None
+    if interrupt is not None and not inbound.get("idempotent_replay"):
+        interrupt_reply = await _post_interrupt_reply(
+            config,
+            envelope,
+            text=interrupt.reply(dict(envelope.get("payload") or {})),
+            client=acknowledgement_client,
+        )
     if (
         set_processing_status
         and not monitored_intake
@@ -404,6 +416,7 @@ async def process_normalized_slack_envelope(
     return {
         "acknowledged": acknowledged,
         "inbound": inbound,
+        "interrupt_reply": interrupt_reply,
     }
 
 
@@ -723,6 +736,35 @@ def _admitted_slack_run(inbound: Mapping[str, Any]) -> bool:
     outcome = inbound.get("ilo_outcome")
     outcome = outcome if isinstance(outcome, Mapping) else {}
     return outcome.get("operation") == "slack_run_admitted" and outcome.get("run_id") is not None
+
+
+async def _post_interrupt_reply(
+    config: SlackConnectorConfig,
+    envelope: Mapping[str, Any],
+    *,
+    text: str,
+    client: Any | None = None,
+) -> Mapping[str, Any]:
+    payload = dict(envelope.get("payload") or {})
+    response_target = dict(payload.get("response_target") or {})
+    channel_id = str(response_target.get("channel_id") or payload.get("channel_id") or "").strip()
+    thread_ts = str(response_target.get("thread_ts") or "").strip() or None
+    if not channel_id:
+        raise ValueError("Slack interrupt reply requires a channel id")
+    idempotency_key = str(envelope.get("idempotency_key") or "").strip()
+    client_msg_id = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"illospace:slack-interrupt:{idempotency_key}",
+        )
+    )
+    active_client = client or SlackWebClient(config.bot_token)
+    return await active_client.post_message(
+        channel=channel_id,
+        text=text,
+        thread_ts=thread_ts,
+        client_msg_id=client_msg_id,
+    )
 
 
 async def _set_processing_status(config: SlackConnectorConfig, envelope: Mapping[str, Any]) -> None:

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -10,12 +10,11 @@ from brain.kernel.common.coercion import as_mapping, optional_text
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.org import User
+from brain.systems.liveness_state import latest_liveness_snapshot
 from brain.systems.inbound.handlers import (
-    InboundCompletion,
     InboundEventCompleter,
     InboundHandlerContext,
 )
-from brain.systems.inbound.status import STATUS_PROCESSED
 from brain.systems.inbound.surface_admission import (
     SurfaceAdmissionSpec,
     SurfaceIdentity,
@@ -33,10 +32,12 @@ from brain.systems.slack.identity import (
     SlackIdentitySource,
     normalize_slack_identities,
 )
-from brain.systems.slack.monitored_intakes import monitored_intake_policy
+from brain.systems.slack.monitored_intakes import (
+    ImmediateReplyPolicy,
+    monitored_intake_policy,
+)
 from brain.systems.slack.triggers import (
     SLACK_MESSAGE_ENVELOPE_KIND,
-    SLACK_REPLY_TOOL,
     build_slack_work_intake_payload,
 )
 from brain.systems.user_domains.service import DomainError, DomainNotFound
@@ -55,36 +56,14 @@ async def process_slack_message_envelope(
     """Admit an Illo run for a normalized Slack mention or DM."""
 
     policy = monitored_intake_policy(normalized)
-    if policy is not None and policy.interrupt is not None:
-        payload = dict(normalized.get("payload") or {})
-        response_target = dict(payload.get("response_target") or {})
-        return await complete(
-            InboundCompletion(
-                status=STATUS_PROCESSED,
-                action_type=policy.interrupt.action_type,
-                action_result={
-                    "operation": policy.interrupt.operation,
-                    "event_id": str(event.id),
-                    "origin": normalized.get("origin"),
-                },
-                confidence=1.0,
-                target={
-                    "kind": SLACK_MESSAGE_ENVELOPE_KIND,
-                    "channel_id": response_target.get("channel_id"),
-                    "thread_ts": response_target.get("thread_ts"),
-                },
-                tool_use={"type": SLACK_REPLY_TOOL, "status": "interrupt"},
-                reasoning_summary=(
-                    "A typed Slack intake policy routed this direct liveness "
-                    "probe to a deterministic process-local reply."
-                ),
-                reusable_pattern_candidate={
-                    "kind": SLACK_MESSAGE_ENVELOPE_KIND,
-                    "origin": normalized.get("origin"),
-                    "source_kind": context.source_kind,
-                },
-            )
+    if isinstance(policy, ImmediateReplyPolicy):
+        disposition = policy.build_disposition(
+            normalized,
+            event_id=str(event.id),
+            source_kind=context.source_kind,
+            snapshot=await latest_liveness_snapshot(session),
         )
+        return await complete(disposition.completion)
 
     return await admit_surface_envelope(
         session,

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -11,9 +11,11 @@ from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.handlers import (
+    InboundCompletion,
     InboundEventCompleter,
     InboundHandlerContext,
 )
+from brain.systems.inbound.status import STATUS_PROCESSED
 from brain.systems.inbound.surface_admission import (
     SurfaceAdmissionSpec,
     SurfaceIdentity,
@@ -31,8 +33,10 @@ from brain.systems.slack.identity import (
     SlackIdentitySource,
     normalize_slack_identities,
 )
+from brain.systems.slack.monitored_intakes import monitored_intake_policy
 from brain.systems.slack.triggers import (
     SLACK_MESSAGE_ENVELOPE_KIND,
+    SLACK_REPLY_TOOL,
     build_slack_work_intake_payload,
 )
 from brain.systems.user_domains.service import DomainError, DomainNotFound
@@ -49,6 +53,38 @@ async def process_slack_message_envelope(
     complete: InboundEventCompleter,
 ) -> dict[str, Any]:
     """Admit an Illo run for a normalized Slack mention or DM."""
+
+    policy = monitored_intake_policy(normalized)
+    if policy is not None and policy.interrupt is not None:
+        payload = dict(normalized.get("payload") or {})
+        response_target = dict(payload.get("response_target") or {})
+        return await complete(
+            InboundCompletion(
+                status=STATUS_PROCESSED,
+                action_type=policy.interrupt.action_type,
+                action_result={
+                    "operation": policy.interrupt.operation,
+                    "event_id": str(event.id),
+                    "origin": normalized.get("origin"),
+                },
+                confidence=1.0,
+                target={
+                    "kind": SLACK_MESSAGE_ENVELOPE_KIND,
+                    "channel_id": response_target.get("channel_id"),
+                    "thread_ts": response_target.get("thread_ts"),
+                },
+                tool_use={"type": SLACK_REPLY_TOOL, "status": "interrupt"},
+                reasoning_summary=(
+                    "A typed Slack intake policy routed this direct liveness "
+                    "probe to a deterministic process-local reply."
+                ),
+                reusable_pattern_candidate={
+                    "kind": SLACK_MESSAGE_ENVELOPE_KIND,
+                    "origin": normalized.get("origin"),
+                    "source_kind": context.source_kind,
+                },
+            )
+        )
 
     return await admit_surface_envelope(
         session,

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -6,11 +6,12 @@ import logging
 from typing import Any, Mapping
 
 from brain.systems.slack.monitored_intakes import (
+    ImmediateReplyPolicy,
     MonitoredIntakeMatch,
+    configurable_monitored_intake_origins,
     enrich_monitored_intake_payload,
     recognize_monitored_intake,
     slack_response_thread_ts,
-    typed_monitored_intake_origins,
     visible_slack_content,
 )
 
@@ -95,7 +96,7 @@ def _event_origin(
         and (
             monitored_intake is None
             or subtype
-            not in monitored_intake.policy.allowed_ignored_subtypes
+            not in monitored_intake.policy.recognition.allowed_ignored_subtypes
         )
     ):
         return None
@@ -103,9 +104,9 @@ def _event_origin(
         return None
     if (
         monitored_intake is not None
-        and monitored_intake.policy.interrupt is not None
+        and isinstance(monitored_intake.policy, ImmediateReplyPolicy)
     ):
-        return monitored_intake.policy.origin
+        return monitored_intake.policy.recognition.origin
     is_bot = bool(event.get("bot_id"))
     # Direct human invitations to participate: explicit mentions and DMs.
     if not is_bot:
@@ -126,7 +127,7 @@ def _event_origin(
     ):
         if monitored_intake is None:
             return None
-        return monitored_intake.policy.origin
+        return monitored_intake.policy.recognition.origin
     return None
 
 
@@ -138,9 +139,9 @@ def _event_kind(
         return "direct_message"
     if (
         monitored_intake is not None
-        and origin == monitored_intake.policy.origin
+        and origin == monitored_intake.policy.recognition.origin
     ):
-        return monitored_intake.policy.event_kind
+        return monitored_intake.policy.recognition.event_kind
     return "mention"
 
 
@@ -198,8 +199,8 @@ def normalize_slack_socket_event(
     # explicit mentions and DMs resolve their own origin above and stay
     # actionable even when their text happens to decode as a typed intake.
     if (
-        origin == monitored_intake.policy.origin
-        and origin in typed_monitored_intake_origins()
+        origin == monitored_intake.policy.recognition.origin
+        and origin in configurable_monitored_intake_origins()
         and origin in disabled
     ):
         logger.info(
@@ -211,7 +212,7 @@ def normalize_slack_socket_event(
         return None
     message_text = (
         monitored_intake.text
-        if origin == monitored_intake.policy.origin
+        if origin == monitored_intake.policy.recognition.origin
         else visible_content.message_text
     )
 
@@ -238,7 +239,7 @@ def normalize_slack_socket_event(
             channel_type,
             thread_ts,
             message_ts,
-            is_monitored=origin == monitored_intake.policy.origin,
+            is_monitored=origin == monitored_intake.policy.recognition.origin,
         ),
         "visibility": "public",
     }
@@ -263,7 +264,7 @@ def normalize_slack_socket_event(
         "surface": surface,
         "response_target": response_target,
     }
-    if origin == monitored_intake.policy.origin:
+    if origin == monitored_intake.policy.recognition.origin:
         enrich_monitored_intake_payload(
             normalized_payload,
             monitored_intake,

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -101,6 +101,11 @@ def _event_origin(
         return None
     if _is_own_slack_message(event, bot_user_id=bot_user_id, api_app_id=api_app_id):
         return None
+    if (
+        monitored_intake is not None
+        and monitored_intake.policy.interrupt is not None
+    ):
+        return monitored_intake.policy.origin
     is_bot = bool(event.get("bot_id"))
     # Direct human invitations to participate: explicit mentions and DMs.
     if not is_bot:
@@ -164,14 +169,18 @@ def normalize_slack_socket_event(
 
     payload = _socket_payload(socket_payload)
     event = _slack_event(socket_payload)
+    resolved_bot_user_id = _bot_user_id(socket_payload, bot_user_id)
     visible_content = visible_slack_content(event)
-    monitored_intake = recognize_monitored_intake(event, visible_content)
+    monitored_intake = recognize_monitored_intake(
+        event,
+        visible_content,
+        bot_user_id=resolved_bot_user_id,
+    )
     disabled = frozenset(
         str(intake).strip()
         for intake in (disabled_intakes or ())
         if str(intake).strip()
     )
-    resolved_bot_user_id = _bot_user_id(socket_payload, bot_user_id)
     api_app_id = str(payload.get("api_app_id") or "").strip() or None
     monitored = frozenset(
         str(channel).strip() for channel in (monitored_channels or ()) if str(channel).strip()

--- a/brain/systems/slack/interrupt_delivery.py
+++ b/brain/systems/slack/interrupt_delivery.py
@@ -1,0 +1,132 @@
+"""Deliver typed Slack interrupt replies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Mapping
+import uuid
+
+from brain.systems.slack.client import SlackWebClient
+
+
+class SlackAcknowledgementMode(StrEnum):
+    """Visible reflex acknowledgement requested by an inbound disposition."""
+
+    SUPPRESS = "suppress"
+    EYES_REACTION = "eyes_reaction"
+
+
+@dataclass(frozen=True, slots=True)
+class SlackInterruptReply:
+    channel_id: str
+    thread_ts: str | None
+    text: str
+    idempotency_key: str
+
+    def to_payload(self) -> dict[str, str | None]:
+        return {
+            "channel_id": self.channel_id,
+            "thread_ts": self.thread_ts,
+            "text": self.text,
+            "idempotency_key": self.idempotency_key,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "SlackInterruptReply":
+        return cls(
+            channel_id=str(payload.get("channel_id") or "").strip(),
+            thread_ts=str(payload.get("thread_ts") or "").strip() or None,
+            text=str(payload.get("text") or ""),
+            idempotency_key=str(payload.get("idempotency_key") or "").strip(),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SlackInterruptDeliveryDirective:
+    acknowledgement: SlackAcknowledgementMode
+    reply: SlackInterruptReply
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "kind": "slack_interrupt_reply",
+            "acknowledgement": self.acknowledgement.value,
+            "reply": self.reply.to_payload(),
+        }
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> "SlackInterruptDeliveryDirective | None":
+        if payload.get("kind") != "slack_interrupt_reply":
+            return None
+        acknowledgement = SlackAcknowledgementMode(
+            str(payload.get("acknowledgement") or "")
+        )
+        reply = payload.get("reply")
+        if not isinstance(reply, Mapping):
+            raise ValueError("Slack interrupt delivery requires reply data")
+        return cls(
+            acknowledgement=acknowledgement,
+            reply=SlackInterruptReply.from_payload(reply),
+        )
+
+
+def interrupt_delivery_from_inbound(
+    inbound: Mapping[str, Any],
+) -> SlackInterruptDeliveryDirective | None:
+    outcome = inbound.get("ilo_outcome")
+    if not isinstance(outcome, Mapping):
+        return None
+    directive = outcome.get("delivery_directive")
+    if not isinstance(directive, Mapping):
+        return None
+    return SlackInterruptDeliveryDirective.from_payload(directive)
+
+
+def should_add_reflex_ack(
+    directive: SlackInterruptDeliveryDirective | None,
+    *,
+    default: bool,
+) -> bool:
+    if directive is None:
+        return default
+    return directive.acknowledgement is SlackAcknowledgementMode.EYES_REACTION
+
+
+def _interrupt_client_msg_id(idempotency_key: str) -> str:
+    return str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"illospace:slack-interrupt:{idempotency_key}",
+        )
+    )
+
+
+async def post_interrupt_reply(
+    bot_token: str,
+    directive: SlackInterruptDeliveryDirective,
+    *,
+    client: Any | None = None,
+) -> Mapping[str, Any]:
+    reply = directive.reply
+    if not reply.channel_id:
+        raise ValueError("Slack interrupt reply requires a channel id")
+    active_client = client or SlackWebClient(bot_token)
+    return await active_client.post_message(
+        channel=reply.channel_id,
+        text=reply.text,
+        thread_ts=reply.thread_ts,
+        client_msg_id=_interrupt_client_msg_id(reply.idempotency_key),
+    )
+
+
+__all__ = [
+    "SlackAcknowledgementMode",
+    "SlackInterruptDeliveryDirective",
+    "SlackInterruptReply",
+    "interrupt_delivery_from_inbound",
+    "post_interrupt_reply",
+    "should_add_reflex_ack",
+]

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
+import re
 from typing import Any, Awaitable, Callable, Mapping
 
 from brain.systems.runs.obligation_specs import (
@@ -33,7 +34,16 @@ from brain.systems.slack.monitors import contact_form_lead_mandate
 logger = logging.getLogger(__name__)
 
 SLACK_CHANNEL_MESSAGE_ORIGIN = "slack.channel_message"
+DIRECT_LIVENESS_PROBE_ORIGIN = "slack.direct_liveness_probe"
 SLACK_REPLY_TOOL = "post_slack_reply"
+
+DIRECT_LIVENESS_PROBE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:are\s+you\s+(?:still\s+)?alive|you\s+(?:still\s+)?alive|still\s+alive)[\s?!.,:;…]*", re.IGNORECASE),
+    re.compile(r"(?:are\s+you\s+dead|you\s+dead)[\s?!.,:;…]*", re.IGNORECASE),
+    re.compile(r"(?:are\s+you\s+(?:still\s+)?there|you\s+(?:still\s+)?there|still\s+there)[\s?!.,:;…]*", re.IGNORECASE),
+    re.compile(r"(?:are\s+you\s+up|you\s+up|still\s+up)[\s?!.,:;…]*", re.IGNORECASE),
+)
+DIRECT_LIVENESS_PROBE_REPLY = "Yes — Illo is alive and received this probe."
 
 _NO_MATCH = object()
 
@@ -64,6 +74,20 @@ class ContactFormLeadRecognition:
 @dataclass(frozen=True, slots=True)
 class ChannelMessageRecognition:
     text: str
+
+
+@dataclass(frozen=True, slots=True)
+class DirectLivenessProbeRecognition:
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class SlackIntakeInterrupt:
+    """A deterministic reply that bypasses AgentRun execution."""
+
+    action_type: str
+    operation: str
+    reply: Callable[[Mapping[str, Any]], str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,7 +125,10 @@ class MonitoredIntakePolicy:
 
     origin: str
     event_kind: str
-    recognize: Callable[[Mapping[str, Any], SlackVisibleContent], Any]
+    recognize: Callable[
+        [Mapping[str, Any], SlackVisibleContent, str | None],
+        Any,
+    ]
     text: Callable[[Any], str]
     enrich_payload: Callable[[dict[str, Any], Any], None]
     enrich: Callable[
@@ -118,6 +145,7 @@ class MonitoredIntakePolicy:
         ObligationSpec | None,
     ]
     allowed_ignored_subtypes: frozenset[str] = frozenset()
+    interrupt: SlackIntakeInterrupt | None = None
 
 
 def visible_slack_content(
@@ -136,11 +164,13 @@ def visible_slack_content(
 def recognize_monitored_intake(
     event: Mapping[str, Any],
     content: SlackVisibleContent,
+    *,
+    bot_user_id: str | None = None,
 ) -> MonitoredIntakeMatch:
     """Return the first typed policy match; the ordinary alert policy is fallback."""
 
     for policy in MONITORED_INTAKE_POLICIES:
-        decoded = policy.recognize(event, content)
+        decoded = policy.recognize(event, content, bot_user_id)
         if decoded is not _NO_MATCH:
             return MonitoredIntakeMatch(policy=policy, decoded=decoded)
     raise RuntimeError("monitored intake registry requires a fallback policy")
@@ -239,6 +269,7 @@ def slack_response_thread_ts(
 def _recognize_contact_form(
     event: Mapping[str, Any],
     content: SlackVisibleContent,
+    _bot_user_id: str | None,
 ) -> ContactFormLeadRecognition | object:
     lead = ContactFormLead.decode(content.contact_form_text)
     if lead is None:
@@ -352,6 +383,7 @@ def _contact_form_obligation(
 def _recognize_channel_message(
     _event: Mapping[str, Any],
     content: SlackVisibleContent,
+    _bot_user_id: str | None,
 ) -> ChannelMessageRecognition:
     return ChannelMessageRecognition(text=content.message_text)
 
@@ -446,10 +478,93 @@ def _no_obligation(
     return None
 
 
+def _recognize_direct_liveness_probe(
+    event: Mapping[str, Any],
+    content: SlackVisibleContent,
+    bot_user_id: str | None,
+) -> DirectLivenessProbeRecognition | object:
+    text = content.message_text.strip()
+    channel_type = _clean(event.get("channel_type"))
+    if channel_type != "im":
+        mention = f"<@{_clean(bot_user_id)}>" if _clean(bot_user_id) else ""
+        if not mention or not text.startswith(mention):
+            return _NO_MATCH
+        text = text[len(mention):].lstrip(" \t,:;-—")
+    elif bot_user_id:
+        mention = f"<@{_clean(bot_user_id)}>"
+        if text.startswith(mention):
+            text = text[len(mention):].lstrip(" \t,:;-—")
+    if not any(pattern.fullmatch(text) for pattern in DIRECT_LIVENESS_PROBE_PATTERNS):
+        return _NO_MATCH
+    return DirectLivenessProbeRecognition(text=content.message_text)
+
+
+def _direct_liveness_probe_text(
+    recognition: DirectLivenessProbeRecognition,
+) -> str:
+    return recognition.text
+
+
+def _enrich_direct_liveness_probe_payload(
+    _payload: dict[str, Any],
+    _recognition: DirectLivenessProbeRecognition,
+) -> None:
+    return None
+
+
+async def _enrich_direct_liveness_probe(
+    _envelope: dict[str, Any],
+    _context: MonitoredIntakeContext,
+) -> None:
+    return None
+
+
+def _render_direct_liveness_probe(
+    _payload: Mapping[str, Any],
+    _slack_trigger_payload: Mapping[str, Any],
+) -> RenderedMonitoredIntake:
+    return RenderedMonitoredIntake(
+        run_message="Direct liveness probes are answered by the Slack interrupt path.",
+        metadata={},
+    )
+
+
+def _direct_liveness_probe_routing(
+    _payload: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return {
+        "origin": "slack_teammate",
+        "required_response_tool": SLACK_REPLY_TOOL,
+        "final_answer_target_surface": "slack",
+    }
+
+
+def _direct_liveness_probe_reply(
+    _payload: Mapping[str, Any],
+) -> str:
+    return DIRECT_LIVENESS_PROBE_REPLY
+
+
 # A third monitored intake is integrated by adding one policy entry here. The
 # policy owns recognition, enrichment, rendering, routing, and obligations;
 # ingress, connector, triggers, and run shaping dispatch through this registry.
 MONITORED_INTAKE_POLICIES: tuple[MonitoredIntakePolicy, ...] = (
+    MonitoredIntakePolicy(
+        origin=DIRECT_LIVENESS_PROBE_ORIGIN,
+        event_kind="direct_liveness_probe",
+        recognize=_recognize_direct_liveness_probe,
+        text=_direct_liveness_probe_text,
+        enrich_payload=_enrich_direct_liveness_probe_payload,
+        enrich=_enrich_direct_liveness_probe,
+        render=_render_direct_liveness_probe,
+        routing=_direct_liveness_probe_routing,
+        obligation=_no_obligation,
+        interrupt=SlackIntakeInterrupt(
+            action_type="slack.liveness_probe_interrupt",
+            operation="slack_liveness_probe_interrupt",
+            reply=_direct_liveness_probe_reply,
+        ),
+    ),
     MonitoredIntakePolicy(
         origin=CONTACT_FORM_LEAD_ORIGIN,
         event_kind=CONTACT_FORM_LEAD_ORIGIN,
@@ -483,7 +598,10 @@ def typed_monitored_intake_origins() -> frozenset[str]:
     return frozenset(
         policy.origin
         for policy in MONITORED_INTAKE_POLICIES
-        if policy.origin != SLACK_CHANNEL_MESSAGE_ORIGIN
+        if (
+            policy.origin != SLACK_CHANNEL_MESSAGE_ORIGIN
+            and policy.interrupt is None
+        )
     )
 
 
@@ -559,10 +677,14 @@ def _slack_message_datetime(message_ts: str) -> datetime | None:
 
 
 __all__ = [
+    "DIRECT_LIVENESS_PROBE_ORIGIN",
+    "DIRECT_LIVENESS_PROBE_PATTERNS",
+    "DIRECT_LIVENESS_PROBE_REPLY",
     "MONITORED_INTAKE_POLICIES",
     "MonitoredIntakeMatch",
     "MonitoredIntakePolicy",
     "MonitoredIntakeRoute",
+    "SlackIntakeInterrupt",
     "SLACK_CHANNEL_MESSAGE_ORIGIN",
     "SlackVisibleContent",
     "enrich_monitored_intake",

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -8,6 +8,9 @@ import logging
 import re
 from typing import Any, Awaitable, Callable, Mapping
 
+from brain.systems.inbound.handlers import InboundCompletion
+from brain.systems.inbound.status import STATUS_PROCESSED
+from brain.systems.liveness_state import LivenessSnapshot
 from brain.systems.runs.obligation_specs import (
     ObligationAnswerer,
     ObligationSettlementPolicy,
@@ -28,6 +31,11 @@ from brain.systems.slack.contact_form_leads import (
     CONTACT_FORM_LEAD_ORIGIN,
     ContactFormLead,
 )
+from brain.systems.slack.interrupt_delivery import (
+    SlackAcknowledgementMode,
+    SlackInterruptDeliveryDirective,
+    SlackInterruptReply,
+)
 from brain.systems.slack.monitors import contact_form_lead_mandate
 
 
@@ -43,8 +51,6 @@ DIRECT_LIVENESS_PROBE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?:are\s+you\s+(?:still\s+)?there|you\s+(?:still\s+)?there|still\s+there)[\s?!.,:;…]*", re.IGNORECASE),
     re.compile(r"(?:are\s+you\s+up|you\s+up|still\s+up)[\s?!.,:;…]*", re.IGNORECASE),
 )
-DIRECT_LIVENESS_PROBE_REPLY = "Yes — Illo is alive and received this probe."
-
 _NO_MATCH = object()
 
 
@@ -82,12 +88,18 @@ class DirectLivenessProbeRecognition:
 
 
 @dataclass(frozen=True, slots=True)
-class SlackIntakeInterrupt:
-    """A deterministic reply that bypasses AgentRun execution."""
+class MonitoredIntakeRecognition:
+    """Shared classification data for one ordered Slack intake recognizer."""
 
-    action_type: str
-    operation: str
-    reply: Callable[[Mapping[str, Any]], str]
+    origin: str
+    event_kind: str
+    recognize: Callable[
+        [Mapping[str, Any], SlackVisibleContent, str | None],
+        Any,
+    ]
+    text: Callable[[Any], str]
+    allowed_ignored_subtypes: frozenset[str] = frozenset()
+    can_disable: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,7 +109,7 @@ class MonitoredIntakeMatch:
 
     @property
     def text(self) -> str:
-        return self.policy.text(self.decoded)
+        return self.policy.recognition.text(self.decoded)
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,16 +132,10 @@ class MonitoredIntakeContext:
 
 
 @dataclass(frozen=True, slots=True)
-class MonitoredIntakePolicy:
-    """All behavior that varies by monitored intake type."""
+class RunIntakePolicy:
+    """Recognition and shaping behavior for an admitted AgentRun."""
 
-    origin: str
-    event_kind: str
-    recognize: Callable[
-        [Mapping[str, Any], SlackVisibleContent, str | None],
-        Any,
-    ]
-    text: Callable[[Any], str]
+    recognition: MonitoredIntakeRecognition
     enrich_payload: Callable[[dict[str, Any], Any], None]
     enrich: Callable[
         [dict[str, Any], MonitoredIntakeContext],
@@ -144,8 +150,77 @@ class MonitoredIntakePolicy:
         [Mapping[str, Any], Mapping[str, Any]],
         ObligationSpec | None,
     ]
-    allowed_ignored_subtypes: frozenset[str] = frozenset()
-    interrupt: SlackIntakeInterrupt | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ImmediateReplyDisposition:
+    """One immediate action, including completion and visible Slack behavior."""
+
+    completion: InboundCompletion
+    delivery: SlackInterruptDeliveryDirective
+
+
+@dataclass(frozen=True, slots=True)
+class ImmediateReplyPolicy:
+    """Recognition and completion behavior for a reply without an AgentRun."""
+
+    recognition: MonitoredIntakeRecognition
+    action_type: str
+    operation: str
+    render_reply: Callable[[LivenessSnapshot], str]
+    acknowledgement: SlackAcknowledgementMode
+
+    def build_disposition(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        event_id: str,
+        source_kind: str | None,
+        snapshot: LivenessSnapshot,
+    ) -> ImmediateReplyDisposition:
+        payload = _mapping(envelope.get("payload"))
+        response_target = _mapping(payload.get("response_target"))
+        delivery = SlackInterruptDeliveryDirective(
+            acknowledgement=self.acknowledgement,
+            reply=SlackInterruptReply(
+                channel_id=_clean(
+                    response_target.get("channel_id") or payload.get("channel_id")
+                ),
+                thread_ts=_clean(response_target.get("thread_ts")) or None,
+                text=self.render_reply(snapshot),
+                idempotency_key=_clean(envelope.get("idempotency_key")),
+            ),
+        )
+        completion = InboundCompletion(
+            status=STATUS_PROCESSED,
+            action_type=self.action_type,
+            action_result={
+                "operation": self.operation,
+                "event_id": event_id,
+                "origin": envelope.get("origin"),
+                "delivery_directive": delivery.to_payload(),
+            },
+            confidence=1.0,
+            target={
+                "kind": "slack_message",
+                "channel_id": response_target.get("channel_id"),
+                "thread_ts": response_target.get("thread_ts"),
+            },
+            tool_use={"type": SLACK_REPLY_TOOL, "status": "interrupt"},
+            reasoning_summary=(
+                "A typed Slack intake policy routed this direct liveness "
+                "probe to a deterministic process-local reply."
+            ),
+            reusable_pattern_candidate={
+                "kind": "slack_message",
+                "origin": envelope.get("origin"),
+                "source_kind": source_kind,
+            },
+        )
+        return ImmediateReplyDisposition(completion=completion, delivery=delivery)
+
+
+MonitoredIntakePolicy = RunIntakePolicy | ImmediateReplyPolicy
 
 
 def visible_slack_content(
@@ -170,7 +245,8 @@ def recognize_monitored_intake(
     """Return the first typed policy match; the ordinary alert policy is fallback."""
 
     for policy in MONITORED_INTAKE_POLICIES:
-        decoded = policy.recognize(event, content, bot_user_id)
+        recognition = policy.recognition
+        decoded = recognition.recognize(event, content, bot_user_id)
         if decoded is not _NO_MATCH:
             return MonitoredIntakeMatch(policy=policy, decoded=decoded)
     raise RuntimeError("monitored intake registry requires a fallback policy")
@@ -180,7 +256,8 @@ def enrich_monitored_intake_payload(
     payload: dict[str, Any],
     match: MonitoredIntakeMatch,
 ) -> None:
-    match.policy.enrich_payload(payload, match.decoded)
+    if isinstance(match.policy, RunIntakePolicy):
+        match.policy.enrich_payload(payload, match.decoded)
 
 
 async def enrich_monitored_intake(
@@ -190,7 +267,7 @@ async def enrich_monitored_intake(
     bot_token: str,
 ) -> None:
     policy = monitored_intake_policy(envelope)
-    if policy is None:
+    if not isinstance(policy, RunIntakePolicy):
         return
     await policy.enrich(
         envelope,
@@ -206,7 +283,7 @@ def route_monitored_intake(
     slack_trigger_payload: Mapping[str, Any],
 ) -> MonitoredIntakeRoute | None:
     policy = monitored_intake_policy(payload)
-    if policy is None:
+    if not isinstance(policy, RunIntakePolicy):
         return None
     rendered = policy.render(payload, slack_trigger_payload)
     metadata = {
@@ -235,11 +312,11 @@ def monitored_intake_policy(
     event_kind = _clean(source.get("event_kind"))
     if origin:
         for policy in MONITORED_INTAKE_POLICIES:
-            if origin == policy.origin:
+            if origin == policy.recognition.origin:
                 return policy
         return None
     for policy in MONITORED_INTAKE_POLICIES:
-        if event_kind == policy.event_kind:
+        if event_kind == policy.recognition.event_kind:
             return policy
     return None
 
@@ -505,103 +582,74 @@ def _direct_liveness_probe_text(
     return recognition.text
 
 
-def _enrich_direct_liveness_probe_payload(
-    _payload: dict[str, Any],
-    _recognition: DirectLivenessProbeRecognition,
-) -> None:
-    return None
-
-
-async def _enrich_direct_liveness_probe(
-    _envelope: dict[str, Any],
-    _context: MonitoredIntakeContext,
-) -> None:
-    return None
-
-
-def _render_direct_liveness_probe(
-    _payload: Mapping[str, Any],
-    _slack_trigger_payload: Mapping[str, Any],
-) -> RenderedMonitoredIntake:
-    return RenderedMonitoredIntake(
-        run_message="Direct liveness probes are answered by the Slack interrupt path.",
-        metadata={},
+def _direct_liveness_probe_reply(
+    snapshot: LivenessSnapshot,
+) -> str:
+    last_run_id = str(snapshot.last_run_id) if snapshot.last_run_id is not None else "none"
+    # Honesty boundary: handling this message proves that the API process ran;
+    # it does not prove that the scheduler or any other process is ticking.
+    return (
+        "Yes — the Illo API process handled this message. "
+        f"Liveness snapshot: timestamp `{snapshot.ts}`, last run ID `{last_run_id}`, "
+        f"coarse last surface `{snapshot.last_surface}`. "
+        "This confirms API message handling; it does not confirm that the scheduler is ticking."
     )
 
 
-def _direct_liveness_probe_routing(
-    _payload: Mapping[str, Any],
-) -> Mapping[str, Any]:
-    return {
-        "origin": "slack_teammate",
-        "required_response_tool": SLACK_REPLY_TOOL,
-        "final_answer_target_surface": "slack",
-    }
-
-
-def _direct_liveness_probe_reply(
-    _payload: Mapping[str, Any],
-) -> str:
-    return DIRECT_LIVENESS_PROBE_REPLY
-
-
-# A third monitored intake is integrated by adding one policy entry here. The
-# policy owns recognition, enrichment, rendering, routing, and obligations;
-# ingress, connector, triggers, and run shaping dispatch through this registry.
+# Recognition order lives in one registry. Each entry then selects exactly one
+# action shape: admit a run or complete with an immediate reply.
 MONITORED_INTAKE_POLICIES: tuple[MonitoredIntakePolicy, ...] = (
-    MonitoredIntakePolicy(
-        origin=DIRECT_LIVENESS_PROBE_ORIGIN,
-        event_kind="direct_liveness_probe",
-        recognize=_recognize_direct_liveness_probe,
-        text=_direct_liveness_probe_text,
-        enrich_payload=_enrich_direct_liveness_probe_payload,
-        enrich=_enrich_direct_liveness_probe,
-        render=_render_direct_liveness_probe,
-        routing=_direct_liveness_probe_routing,
-        obligation=_no_obligation,
-        interrupt=SlackIntakeInterrupt(
-            action_type="slack.liveness_probe_interrupt",
-            operation="slack_liveness_probe_interrupt",
-            reply=_direct_liveness_probe_reply,
+    ImmediateReplyPolicy(
+        recognition=MonitoredIntakeRecognition(
+            origin=DIRECT_LIVENESS_PROBE_ORIGIN,
+            event_kind="direct_liveness_probe",
+            recognize=_recognize_direct_liveness_probe,
+            text=_direct_liveness_probe_text,
         ),
+        action_type="slack.liveness_probe_interrupt",
+        operation="slack_liveness_probe_interrupt",
+        render_reply=_direct_liveness_probe_reply,
+        acknowledgement=SlackAcknowledgementMode.SUPPRESS,
     ),
-    MonitoredIntakePolicy(
-        origin=CONTACT_FORM_LEAD_ORIGIN,
-        event_kind=CONTACT_FORM_LEAD_ORIGIN,
-        recognize=_recognize_contact_form,
-        text=_contact_form_text,
+    RunIntakePolicy(
+        recognition=MonitoredIntakeRecognition(
+            origin=CONTACT_FORM_LEAD_ORIGIN,
+            event_kind=CONTACT_FORM_LEAD_ORIGIN,
+            recognize=_recognize_contact_form,
+            text=_contact_form_text,
+            allowed_ignored_subtypes=frozenset({"bot_message"}),
+            can_disable=True,
+        ),
         enrich_payload=_enrich_contact_form_payload,
         enrich=_enrich_contact_form,
         render=_render_contact_form,
         routing=_contact_form_routing,
         obligation=_contact_form_obligation,
-        allowed_ignored_subtypes=frozenset({"bot_message"}),
     ),
-    MonitoredIntakePolicy(
-        origin=SLACK_CHANNEL_MESSAGE_ORIGIN,
-        event_kind="channel_message",
-        recognize=_recognize_channel_message,
-        text=_channel_message_text,
+    RunIntakePolicy(
+        recognition=MonitoredIntakeRecognition(
+            origin=SLACK_CHANNEL_MESSAGE_ORIGIN,
+            event_kind="channel_message",
+            recognize=_recognize_channel_message,
+            text=_channel_message_text,
+            allowed_ignored_subtypes=frozenset({"bot_message"}),
+        ),
         enrich_payload=_enrich_channel_message_payload,
         enrich=_enrich_channel_message,
         render=_render_channel_message,
         routing=_channel_message_routing,
         obligation=_no_obligation,
-        allowed_ignored_subtypes=frozenset({"bot_message"}),
     ),
 )
 
 
-def typed_monitored_intake_origins() -> frozenset[str]:
-    """Return registry origins that precede the channel-message fallback."""
+def configurable_monitored_intake_origins() -> frozenset[str]:
+    """Return passive intake origins that a Slack connection can disable."""
 
     return frozenset(
-        policy.origin
+        policy.recognition.origin
         for policy in MONITORED_INTAKE_POLICIES
-        if (
-            policy.origin != SLACK_CHANNEL_MESSAGE_ORIGIN
-            and policy.interrupt is None
-        )
+        if policy.recognition.can_disable
     )
 
 
@@ -679,14 +727,17 @@ def _slack_message_datetime(message_ts: str) -> datetime | None:
 __all__ = [
     "DIRECT_LIVENESS_PROBE_ORIGIN",
     "DIRECT_LIVENESS_PROBE_PATTERNS",
-    "DIRECT_LIVENESS_PROBE_REPLY",
+    "ImmediateReplyDisposition",
+    "ImmediateReplyPolicy",
     "MONITORED_INTAKE_POLICIES",
     "MonitoredIntakeMatch",
     "MonitoredIntakePolicy",
+    "MonitoredIntakeRecognition",
     "MonitoredIntakeRoute",
-    "SlackIntakeInterrupt",
+    "RunIntakePolicy",
     "SLACK_CHANNEL_MESSAGE_ORIGIN",
     "SlackVisibleContent",
+    "configurable_monitored_intake_origins",
     "enrich_monitored_intake",
     "enrich_monitored_intake_payload",
     "is_monitored_intake",
@@ -694,6 +745,5 @@ __all__ = [
     "recognize_monitored_intake",
     "route_monitored_intake",
     "slack_response_thread_ts",
-    "typed_monitored_intake_origins",
     "visible_slack_content",
 ]

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -97,12 +97,12 @@ def contact_form_lead_mandate(
     return value or None
 
 
-def _typed_intake_origins() -> frozenset[str]:
+def _configurable_intake_origins() -> frozenset[str]:
     from brain.systems.slack.monitored_intakes import (
-        typed_monitored_intake_origins,
+        configurable_monitored_intake_origins,
     )
 
-    return typed_monitored_intake_origins()
+    return configurable_monitored_intake_origins()
 
 
 def disabled_intake_origins(
@@ -113,7 +113,7 @@ def disabled_intake_origins(
     raw = _slack_metadata(connection).get(DISABLED_INTAKES_KEY)
     if not isinstance(raw, (list, tuple, set, frozenset)):
         return set()
-    valid_origins = _typed_intake_origins()
+    valid_origins = _configurable_intake_origins()
     return {
         origin
         for item in raw
@@ -212,7 +212,7 @@ async def clear_contact_form_lead_mandate(
     )
 
 
-def _validated_typed_intake_origin(intake: str) -> str:
+def _validated_configurable_intake_origin(intake: str) -> str:
     from brain.systems.slack.monitored_intakes import (
         SLACK_CHANNEL_MESSAGE_ORIGIN,
     )
@@ -225,7 +225,7 @@ def _validated_typed_intake_origin(intake: str) -> str:
             f"{SLACK_CHANNEL_MESSAGE_ORIGIN} is the fallback intake; "
             "use unmonitor_channel for channel-level monitoring"
         )
-    valid_origins = _typed_intake_origins()
+    valid_origins = _configurable_intake_origins()
     if clean_intake not in valid_origins:
         valid = ", ".join(sorted(valid_origins)) or "(none)"
         raise SlackMonitorConfigError(
@@ -243,7 +243,7 @@ async def _write_intake_enabled(
     enabled: bool,
     org_id: str | None = None,
 ) -> dict[str, Any]:
-    clean_intake = _validated_typed_intake_origin(intake)
+    clean_intake = _validated_configurable_intake_origin(intake)
     connection = await _connection_for_org(session, connection_id, org_id)
     disabled_intakes = disabled_intake_origins(connection)
     if enabled:

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -147,7 +147,7 @@ def slack_event_type(payload: Mapping[str, Any]) -> str:
     }:
         return origin
     if monitored_policy is not None:
-        return monitored_policy.origin
+        return monitored_policy.recognition.origin
     event_kind = _clean(payload.get("event_kind"))
     if event_kind == "direct_message":
         return "slack.direct_message"

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -30,16 +30,28 @@ def _contact_form_text(*, include_phone: bool = True) -> str:
 
 def test_typed_intakes_and_alert_fallback_share_one_registry():
     from brain.systems.slack.monitored_intakes import (
+        ImmediateReplyPolicy,
         MONITORED_INTAKE_POLICIES,
+        RunIntakePolicy,
+        configurable_monitored_intake_origins,
     )
 
-    assert [policy.origin for policy in MONITORED_INTAKE_POLICIES] == [
+    assert [policy.recognition.origin for policy in MONITORED_INTAKE_POLICIES] == [
         "slack.direct_liveness_probe",
         "contact_form_lead",
         "slack.channel_message",
     ]
-    for policy in MONITORED_INTAKE_POLICIES:
-        assert callable(policy.recognize)
+    assert isinstance(MONITORED_INTAKE_POLICIES[0], ImmediateReplyPolicy)
+    assert not hasattr(MONITORED_INTAKE_POLICIES[0], "enrich")
+    assert all(
+        isinstance(policy, RunIntakePolicy)
+        for policy in MONITORED_INTAKE_POLICIES[1:]
+    )
+    assert configurable_monitored_intake_origins() == frozenset(
+        {"contact_form_lead"}
+    )
+    for policy in MONITORED_INTAKE_POLICIES[1:]:
+        assert callable(policy.recognition.recognize)
         assert callable(policy.enrich)
         assert callable(policy.render)
         assert callable(policy.routing)

--- a/tests/test_contact_form_monitor.py
+++ b/tests/test_contact_form_monitor.py
@@ -28,12 +28,13 @@ def _contact_form_text(*, include_phone: bool = True) -> str:
     return "\n".join(fields)
 
 
-def test_alert_and_contact_form_are_peer_policies_in_one_registry():
+def test_typed_intakes_and_alert_fallback_share_one_registry():
     from brain.systems.slack.monitored_intakes import (
         MONITORED_INTAKE_POLICIES,
     )
 
     assert [policy.origin for policy in MONITORED_INTAKE_POLICIES] == [
+        "slack.direct_liveness_probe",
         "contact_form_lead",
         "slack.channel_message",
     ]

--- a/tests/test_slack_liveness_probe.py
+++ b/tests/test_slack_liveness_probe.py
@@ -7,9 +7,28 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from brain.systems.liveness_state import LivenessSnapshot
+from brain.systems.slack.interrupt_delivery import (
+    SlackAcknowledgementMode,
+    SlackInterruptDeliveryDirective,
+    SlackInterruptReply,
+)
 from tests.slack_monitor_fixtures import (
     FakeSlackConnection,
     socket_mode_channel_message,
+)
+
+
+LIVENESS_SNAPSHOT = LivenessSnapshot(
+    ts="2026-08-05T18:00:00Z",
+    last_run_id=512,
+    last_surface="slack",
+)
+LIVENESS_REPLY = (
+    "Yes — the Illo API process handled this message. "
+    "Liveness snapshot: timestamp `2026-08-05T18:00:00Z`, last run ID `512`, "
+    "coarse last surface `slack`. "
+    "This confirms API message handling; it does not confirm that the scheduler is ticking."
 )
 
 
@@ -17,10 +36,11 @@ from tests.slack_monitor_fixtures import (
 async def test_monitored_direct_liveness_probe_replies_on_interrupt_path(
     monkeypatch,
 ):
-    from brain.systems.slack import connector
+    from brain.systems.slack import connector, interrupt_delivery
 
     submitted = []
     posts = []
+    reactions = []
 
     class FakeSlackClient:
         def __init__(self, _token):
@@ -29,6 +49,10 @@ async def test_monitored_direct_liveness_probe_replies_on_interrupt_path(
         async def post_message(self, **kwargs):
             posts.append(kwargs)
             return {"ok": True, "channel": kwargs["channel"], "ts": "1716900001.000300"}
+
+        async def add_reaction(self, **kwargs):
+            reactions.append(kwargs)
+            return {"ok": True}
 
     async def submit_inbound_envelope(
         _session,
@@ -41,10 +65,24 @@ async def test_monitored_direct_liveness_probe_replies_on_interrupt_path(
         return {
             "status": "processed",
             "idempotent_replay": False,
-            "ilo_outcome": {"operation": "slack_liveness_probe_interrupt"},
+            "ilo_outcome": {
+                "operation": "slack_liveness_probe_interrupt",
+                "delivery_directive": SlackInterruptDeliveryDirective(
+                    acknowledgement=SlackAcknowledgementMode.SUPPRESS,
+                    reply=SlackInterruptReply(
+                        channel_id="C_ALERTS",
+                        thread_ts="1716900000.000200",
+                        text=LIVENESS_REPLY,
+                        idempotency_key=(
+                            "slack:T789:C_ALERTS:1716900000.000200"
+                        ),
+                    ),
+                ).to_payload(),
+            },
         }
 
     monkeypatch.setattr(connector, "SlackWebClient", FakeSlackClient)
+    monkeypatch.setattr(interrupt_delivery, "SlackWebClient", FakeSlackClient)
     monkeypatch.setattr(
         connector,
         "submit_inbound_envelope",
@@ -71,10 +109,11 @@ async def test_monitored_direct_liveness_probe_replies_on_interrupt_path(
     assert result["ignored"] is False
     assert submitted[0]["origin"] == "slack.direct_liveness_probe"
     assert submitted[0]["payload"]["event_kind"] == "direct_liveness_probe"
+    assert reactions == []
     assert posts == [
         {
             "channel": "C_ALERTS",
-            "text": "Yes — Illo is alive and received this probe.",
+            "text": LIVENESS_REPLY,
             "thread_ts": "1716900000.000200",
             "client_msg_id": str(
                 uuid.uuid5(
@@ -111,7 +150,9 @@ async def test_liveness_probe_inbound_completes_without_admitting_agent_run(
         return {"status": value.status, "ilo_outcome": dict(value.action_result)}
 
     admit = AsyncMock()
+    snapshot = AsyncMock(return_value=LIVENESS_SNAPSHOT)
     monkeypatch.setattr(inbound, "admit_surface_envelope", admit)
+    monkeypatch.setattr(inbound, "latest_liveness_snapshot", snapshot)
 
     result = await inbound.process_slack_message_envelope(
         object(),
@@ -136,6 +177,12 @@ async def test_liveness_probe_inbound_completes_without_admitting_agent_run(
         "type": "post_slack_reply",
         "status": "interrupt",
     }
+    directive = result["ilo_outcome"]["delivery_directive"]
+    assert directive["acknowledgement"] == "suppress"
+    assert directive["reply"]["text"] == LIVENESS_REPLY
+    assert directive["reply"]["channel_id"] == "C_ALERTS"
+    assert directive["reply"]["thread_ts"] == "1716900000.000200"
+    snapshot.assert_awaited_once()
     admit.assert_not_awaited()
 
 
@@ -161,12 +208,15 @@ async def test_liveness_probe_inbound_completes_without_admitting_agent_run(
         ),
     ],
 )
-def test_direct_liveness_probe_uses_interrupt_policy_on_dm_and_ordinary_channel(
+@pytest.mark.asyncio
+async def test_direct_liveness_probe_replies_without_agent_run_on_dm_and_ordinary_channel(
+    monkeypatch,
     event_overrides,
     expected_thread_ts,
 ):
+    from brain.systems.inbound.handlers import InboundHandlerContext
+    from brain.systems.slack import inbound
     from brain.systems.slack.ingress import normalize_slack_socket_event
-    from brain.systems.slack.monitored_intakes import monitored_intake_policy
 
     envelope = normalize_slack_socket_event(
         socket_mode_channel_message(**event_overrides),
@@ -176,8 +226,39 @@ def test_direct_liveness_probe_uses_interrupt_policy_on_dm_and_ordinary_channel(
 
     assert envelope is not None
     assert envelope["origin"] == "slack.direct_liveness_probe"
-    assert monitored_intake_policy(envelope).interrupt is not None
     assert envelope["payload"]["response_target"]["thread_ts"] == expected_thread_ts
+
+    async def complete(value):
+        return {"status": value.status, "ilo_outcome": dict(value.action_result)}
+
+    admit = AsyncMock()
+    monkeypatch.setattr(inbound, "admit_surface_envelope", admit)
+    monkeypatch.setattr(
+        inbound,
+        "latest_liveness_snapshot",
+        AsyncMock(return_value=LIVENESS_SNAPSHOT),
+    )
+
+    result = await inbound.process_slack_message_envelope(
+        object(),
+        context=InboundHandlerContext(
+            connection_id="conn-1",
+            org_id="org-1",
+            owner_user_id="user-1",
+            token_id=None,
+            scopes=None,
+            display_name="Slack",
+            source_kind="slack",
+        ),
+        event=type("InboundEvent", (), {"id": "event-1"})(),
+        normalized=envelope,
+        complete=complete,
+    )
+
+    reply = result["ilo_outcome"]["delivery_directive"]["reply"]
+    assert reply["text"] == LIVENESS_REPLY
+    assert reply["thread_ts"] == expected_thread_ts
+    admit.assert_not_awaited()
 
 
 @pytest.mark.parametrize(
@@ -196,6 +277,34 @@ def test_direct_liveness_probe_uses_interrupt_policy_on_dm_and_ordinary_channel(
                 "text": "<@BOTHER> are you alive?",
             },
             "slack.channel_message",
+        ),
+        (
+            {
+                "type": "app_mention",
+                "text": "<@BILLO> are you up for pairing?",
+            },
+            "slack.app_mention",
+        ),
+        (
+            {
+                "type": "app_mention",
+                "text": "<@BILLO> are you there to review this?",
+            },
+            "slack.app_mention",
+        ),
+        (
+            {
+                "type": "app_mention",
+                "text": "<@BILLO> are you dead set on this approach?",
+            },
+            "slack.app_mention",
+        ),
+        (
+            {
+                "type": "app_mention",
+                "text": "<@BILLO> are you alive? Please review the failed deploy.",
+            },
+            "slack.app_mention",
         ),
     ],
 )

--- a/tests/test_slack_liveness_probe.py
+++ b/tests/test_slack_liveness_probe.py
@@ -1,0 +1,242 @@
+"""Direct Slack liveness probes bypass AgentRun execution."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.slack_monitor_fixtures import (
+    FakeSlackConnection,
+    socket_mode_channel_message,
+)
+
+
+@pytest.mark.asyncio
+async def test_monitored_direct_liveness_probe_replies_on_interrupt_path(
+    monkeypatch,
+):
+    from brain.systems.slack import connector
+
+    submitted = []
+    posts = []
+
+    class FakeSlackClient:
+        def __init__(self, _token):
+            pass
+
+        async def post_message(self, **kwargs):
+            posts.append(kwargs)
+            return {"ok": True, "channel": kwargs["channel"], "ts": "1716900001.000300"}
+
+    async def submit_inbound_envelope(
+        _session,
+        *,
+        connection,
+        envelope,
+        ingress_context,
+    ):
+        submitted.append(envelope)
+        return {
+            "status": "processed",
+            "idempotent_replay": False,
+            "ilo_outcome": {"operation": "slack_liveness_probe_interrupt"},
+        }
+
+    monkeypatch.setattr(connector, "SlackWebClient", FakeSlackClient)
+    monkeypatch.setattr(
+        connector,
+        "submit_inbound_envelope",
+        submit_inbound_envelope,
+    )
+    connection = FakeSlackConnection(
+        metadata={"slack": {"monitored_channels": ["C_ALERTS"]}}
+    )
+
+    result = await connector.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=socket_mode_channel_message(
+            type="app_mention",
+            text="<@BILLO> are you alive?",
+        ),
+        config=connector.SlackConnectorConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            bot_user_id="BILLO",
+        ),
+    )
+
+    assert result["ignored"] is False
+    assert submitted[0]["origin"] == "slack.direct_liveness_probe"
+    assert submitted[0]["payload"]["event_kind"] == "direct_liveness_probe"
+    assert posts == [
+        {
+            "channel": "C_ALERTS",
+            "text": "Yes — Illo is alive and received this probe.",
+            "thread_ts": "1716900000.000200",
+            "client_msg_id": str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    "illospace:slack-interrupt:slack:T789:C_ALERTS:1716900000.000200",
+                )
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_liveness_probe_inbound_completes_without_admitting_agent_run(
+    monkeypatch,
+):
+    from brain.systems.inbound.handlers import InboundHandlerContext
+    from brain.systems.slack import inbound
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        socket_mode_channel_message(
+            type="app_mention",
+            text="<@BILLO> are you alive?",
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+    assert envelope is not None
+    completion = None
+
+    async def complete(value):
+        nonlocal completion
+        completion = value
+        return {"status": value.status, "ilo_outcome": dict(value.action_result)}
+
+    admit = AsyncMock()
+    monkeypatch.setattr(inbound, "admit_surface_envelope", admit)
+
+    result = await inbound.process_slack_message_envelope(
+        object(),
+        context=InboundHandlerContext(
+            connection_id="conn-1",
+            org_id="org-1",
+            owner_user_id="user-1",
+            token_id=None,
+            scopes=None,
+            display_name="Slack",
+            source_kind="slack",
+        ),
+        event=type("InboundEvent", (), {"id": "event-1"})(),
+        normalized=envelope,
+        complete=complete,
+    )
+
+    assert result["status"] == "processed"
+    assert result["ilo_outcome"]["operation"] == "slack_liveness_probe_interrupt"
+    assert completion.action_type == "slack.liveness_probe_interrupt"
+    assert completion.tool_use == {
+        "type": "post_slack_reply",
+        "status": "interrupt",
+    }
+    admit.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("event_overrides", "expected_thread_ts"),
+    [
+        (
+            {
+                "type": "message",
+                "channel": "D_ILLO",
+                "channel_type": "im",
+                "text": "Are you there?!",
+            },
+            None,
+        ),
+        (
+            {
+                "type": "app_mention",
+                "channel": "C_ORDINARY",
+                "text": "<@BILLO>, YOU ALIVE...",
+            },
+            "1716900000.000200",
+        ),
+    ],
+)
+def test_direct_liveness_probe_uses_interrupt_policy_on_dm_and_ordinary_channel(
+    event_overrides,
+    expected_thread_ts,
+):
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+    from brain.systems.slack.monitored_intakes import monitored_intake_policy
+
+    envelope = normalize_slack_socket_event(
+        socket_mode_channel_message(**event_overrides),
+        bot_user_id="BILLO",
+        monitored_channels=set(),
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.direct_liveness_probe"
+    assert monitored_intake_policy(envelope).interrupt is not None
+    assert envelope["payload"]["response_target"]["thread_ts"] == expected_thread_ts
+
+
+@pytest.mark.parametrize(
+    ("event_overrides", "expected_origin"),
+    [
+        (
+            {
+                "type": "app_mention",
+                "text": "<@BILLO> keep the worker alive while you deploy this fix",
+            },
+            "slack.app_mention",
+        ),
+        (
+            {
+                "type": "message",
+                "text": "<@BOTHER> are you alive?",
+            },
+            "slack.channel_message",
+        ),
+    ],
+)
+def test_liveness_probe_near_misses_keep_their_normal_route(
+    event_overrides,
+    expected_origin,
+):
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        socket_mode_channel_message(**event_overrides),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == expected_origin
+
+
+def test_ordinary_monitored_intake_routing_is_unchanged_for_non_probe():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    envelope = normalize_slack_socket_event(
+        socket_mode_channel_message(
+            text="Payments API is throwing 500s in prod",
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+    assert envelope is not None
+
+    work = build_slack_work_intake_payload(
+        org_id="org-1",
+        authority_user_id="user-1",
+        payload=envelope["payload"],
+    )
+    metadata = work["payload"]["metadata"]
+
+    assert envelope["origin"] == "slack.channel_message"
+    assert metadata["origin"] == "slack_channel_monitor"
+    assert metadata["slack_monitor"] is True
+    assert metadata["headless"] is True
+    assert "required_response_tool" not in metadata


### PR DESCRIPTION
## What this fixes

Issue #512 item 3, and **only** item 3.

On 2026-07-24 Reda asked `@Illo are you alive?` while Illo was **healthy**, and the
answer arrived **38 minutes later**. A direct mention in a monitored channel is routed
by the monitored-intake registry into a lane whose cadence is a sweep, so the reply was
bounded by the sweep rather than by the ask.

## Why this was still open

Items 1, 2, 4 and 5 of #512 — the heartbeat emitter and the external GitHub Actions
watcher — shipped in PR #520 back in July. Item 3 was **explicitly scoped out of that
PR and never re-filed**, so it has sat unbuilt while #512 was reported run after run as
"blocked on the `SLACK_DEADMAN_WEBHOOK_URL` secret." That secret gates verification of
items 1/2/4/5. It never gated this.

`Refs #512` rather than `Closes #512`: the secret is still unset, so the deadman half
of the issue remains unverified.

## The shape

The existing `MONITORED_INTAKE_POLICIES` registry already owns "how does a recognized
Slack intake get handled." This **extends** that registry rather than adding a parallel
branch:

- A typed `direct_liveness_probe` policy, matched **ahead of** the ordinary
  channel-message fallback.
- `MonitoredIntakePolicy` gains an optional `SlackIntakeInterrupt` — a deterministic
  reply that bypasses AgentRun admission. The registry stays the one place that decides
  what an intake means.
- The resolved bot user id is threaded through recognition, so a probe is recognized
  only when it **directly addresses Illo** (an explicit mention, or a DM).
- Recognition is a `fullmatch` against a small named pattern set, so an ordinary work
  request that merely contains the word "alive" does not match.
- The reply goes out through the existing Slack client with a deterministic
  `client_msg_id` derived from the idempotency key, and the reflex 👀 acknowledgement is
  skipped for interrupts — they answer instead of promising to.

## How to judge it (no code reading required)

This is backend-only; there is no UI and no preview URL. After it deploys:

1. In a **monitored** channel (e.g. `#alerts`), post `@Illo are you alive?`.
   Expect a reply **in seconds**, on the same thread — not on the next sweep.
2. In a **DM**, post `are you there?`. Same immediate reply.
3. Post an ordinary request that happens to contain the word — e.g.
   `@Illo is the staging deploy still alive and serving traffic?`. Expect the
   **normal** agent run, not the canned liveness reply. This is the check that matters
   most: a false positive costs a real answer.
4. Post an ordinary monitored-channel message. Expect the 👀 reflex ack and the usual
   triage run, unchanged.

## It was reshaped after review — the first shape was rejected

A cross-family maintainability review of the first commit returned **"do not merge this
shape"**, with two blocking findings. Both are fixed in `43d62af5`, and I verified each
fix rather than taking the worker's word:

| Finding | Fix | Verified |
|---|---|---|
| `MonitoredIntakePolicy` overloaded with a second execution mode; three no-op hooks existed only to satisfy the dataclass | Split into a tagged union — shared `MonitoredIntakeRecognition`, plus `RunIntakePolicy` and `ImmediateReplyPolicy`. An immediate reply now **cannot** carry enrichment/rendering/routing/obligation hooks | union present; dead-hook count **0** |
| `connector.py` crossed 1,000 lines (969 → 1,011) | Interrupt delivery + deterministic message-id moved to `slack/interrupt_delivery.py` | **986 lines** |

Four important findings were folded in the same pass: the origins filter now expresses
"user-disableable" rather than reply-mode; the interrupt disposition has one owner;
near-miss tests were added for `up` / `there` / `dead`; and the ack-suppression test now
actually pins the behavior (the old fake client had no `add_reaction`, so production
swallowed the failure and the test proved nothing).

**The reply is no longer a constant.** The heartbeat snapshot moved into a shared
`brain/systems/liveness_state.py`, consumed by both the heartbeat job and this reply, so
the probe answers with a real timestamp, last run id, and coarse last surface.

## Tests

Run exactly what CI runs (the diff selects the backend and db lanes; no frontend files):

```
python3 -m brain.jobs.check_cycle_context_admission
python3 -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

- **4757 passed**, 11 skipped, 83 deselected on this branch.
- **4746 passed** on a clean `origin/main` worktree, measured the same way.
- Delta **+11** — the 7 original new tests plus 4 near-miss cases from the review. Nothing
  else moved.

Measured **outside** the Codex sandbox on purpose: inside it the same suite reports
`1 failed / 5 errors`, all of them loopback-bind denials on `127.0.0.1` that the sandbox
blocks. That is a sandbox artifact, not a code failure — the clean 4757 is the real number.

New tests cover: the probe on the interrupt path in a monitored channel; inbound completing
**without admitting an agent run**; DM and ordinary-channel probes; near-misses keeping
their normal route; ack suppression; and ordinary monitored-intake routing unchanged.

## Honesty boundary — worth knowing

"Alive" here means **the API process handled your message**. It is not a statement that
the scheduler is ticking: a frozen scheduler behind a live API still answers *yes*. The
reply says so, and the external deadman (already merged, PR #520) is what covers the
process actually being dead.

## Provenance

The implementing worker's Codex stream disconnected after 250k tokens, before it could
commit or run tests; its work was salvaged, reviewed, tested and committed by the
orchestrator. One fix pass followed the review. A second maintainability review was **not**
run on the reshaped commit — the blocking findings were verified individually instead.
