### PR TITLE
feat(knowledge): index a memory node at ingest, not 30 minutes later (#699)

### DIFF
--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1134,6 +1134,28 @@ async def async_tool_brain_encode(
     return result
 
 
+async def _index_committed_memory_node(node_id: int) -> None:
+    """Best-effort mirror write after the memory transaction is durable."""
+
+    from brain.systems.knowledge.service import index_memory_node
+
+    try:
+        async with UnitOfWork() as uow:
+            stats = await index_memory_node(uow.session, node_id=node_id)
+            if stats.failed:
+                logger.warning(
+                    "Immediate knowledge indexing degraded for committed memory node %s",
+                    node_id,
+                )
+    except Exception:
+        # Knowledge is a disposable mirror. A failed index write must never
+        # change the successful outcome of the committed memory ingest.
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_id,
+        )
+
+
 async def async_tool_memory_ingest_source(
     content: str,
     content_kind: str = "episode",
@@ -1175,6 +1197,10 @@ async def async_tool_memory_ingest_source(
             evidence=evidence or {},
             authority_principal=user_id,
         )
+    # This call is deliberately after UnitOfWork.__aexit__ commits the outer
+    # transaction. SQLAlchemy after_commit events also run for savepoint
+    # releases, so they cannot prove that the memory row is globally visible.
+    await _index_committed_memory_node(result.content_node_id)
     payload = result.to_dict()
     payload["content_kind"] = content_kind
     payload["source_kind"] = source_kind

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1134,28 +1134,6 @@ async def async_tool_brain_encode(
     return result
 
 
-async def _index_committed_memory_node(node_id: int) -> None:
-    """Best-effort mirror write after the memory transaction is durable."""
-
-    from brain.systems.knowledge.service import index_memory_node
-
-    try:
-        async with UnitOfWork() as uow:
-            stats = await index_memory_node(uow.session, node_id=node_id)
-            if stats.failed:
-                logger.warning(
-                    "Immediate knowledge indexing degraded for committed memory node %s",
-                    node_id,
-                )
-    except Exception:
-        # Knowledge is a disposable mirror. A failed index write must never
-        # change the successful outcome of the committed memory ingest.
-        logger.exception(
-            "Immediate knowledge indexing failed for committed memory node %s",
-            node_id,
-        )
-
-
 async def async_tool_memory_ingest_source(
     content: str,
     content_kind: str = "episode",
@@ -1197,10 +1175,6 @@ async def async_tool_memory_ingest_source(
             evidence=evidence or {},
             authority_principal=user_id,
         )
-    # This call is deliberately after UnitOfWork.__aexit__ commits the outer
-    # transaction. SQLAlchemy after_commit events also run for savepoint
-    # releases, so they cannot prove that the memory row is globally visible.
-    await _index_committed_memory_node(result.content_node_id)
     payload = result.to_dict()
     payload["content_kind"] = content_kind
     payload["source_kind"] = source_kind

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -30,6 +30,12 @@ _KNOWLEDGE_NODE_KINDS = ("content",)
 logger = logging.getLogger(__name__)
 
 
+def _candidate_node_query():
+    return select(MemoryNode).where(
+        MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS)
+    )
+
+
 def _required_org_id(node: MemoryNode) -> str:
     if node.org_id is None:
         raise ValueError(f"Memory node {node.id} has no organization")
@@ -119,10 +125,7 @@ class MemoryConnector:
         """Build one immediate-index draft with the sweep's eligibility rules."""
 
         node = await session.scalar(
-            select(MemoryNode).where(
-                MemoryNode.id == node_id,
-                MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS),
-            )
+            _candidate_node_query().where(MemoryNode.id == node_id)
         )
         if node is None:
             return None
@@ -202,8 +205,7 @@ class MemoryConnector:
     ) -> KnowledgeEnumeration:
         watermark = UpdatedAtCursor.from_mapping(cursor)
         statement = (
-            select(MemoryNode)
-            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
+            _candidate_node_query()
             .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
             .limit(self.max_items)
         )

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -110,25 +110,32 @@ class MemoryConnector:
     def __init__(self, *, max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE):
         self.max_items = max(1, int(max_items))
 
-    async def enumerate_changed(
+    async def draft_for_node(
         self,
         session: AsyncSession,
-        cursor: dict[str, Any],
-    ) -> KnowledgeEnumeration:
-        watermark = UpdatedAtCursor.from_mapping(cursor)
-        statement = (
-            select(MemoryNode)
-            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
-            .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
-            .limit(self.max_items)
-        )
-        changed_after = watermark.changed_after(MemoryNode.updated_at, MemoryNode.id)
-        if changed_after is not None:
-            statement = statement.where(changed_after)
+        *,
+        node_id: int,
+    ) -> KnowledgeDraft | None:
+        """Build one immediate-index draft with the sweep's eligibility rules."""
 
-        rows = list((await session.scalars(statement)).all())
+        node = await session.scalar(
+            select(MemoryNode).where(
+                MemoryNode.id == node_id,
+                MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS),
+            )
+        )
+        if node is None:
+            return None
+        drafts = await self._drafts_for_rows(session, [node])
+        return drafts[0] if drafts else None
+
+    async def _drafts_for_rows(
+        self,
+        session: AsyncSession,
+        rows: list[MemoryNode],
+    ) -> list[KnowledgeDraft]:
         if not rows:
-            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
+            return []
         source_refs = [f"memory_node:{node.id}" for node in rows]
         existing_org_ids = {
             source_ref: extra["org_id"]
@@ -178,7 +185,7 @@ class MemoryConnector:
             source_node_id: target_node_id
             for source_node_id, target_node_id in supersession_rows
         }
-        drafts = [
+        return [
             _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
             if node.visibility in _SHARED_VISIBILITIES
             else _withdrawn_draft(
@@ -187,6 +194,27 @@ class MemoryConnector:
             )
             for node in draft_rows
         ]
+
+    async def enumerate_changed(
+        self,
+        session: AsyncSession,
+        cursor: dict[str, Any],
+    ) -> KnowledgeEnumeration:
+        watermark = UpdatedAtCursor.from_mapping(cursor)
+        statement = (
+            select(MemoryNode)
+            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
+            .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
+            .limit(self.max_items)
+        )
+        changed_after = watermark.changed_after(MemoryNode.updated_at, MemoryNode.id)
+        if changed_after is not None:
+            statement = statement.where(changed_after)
+
+        rows = list((await session.scalars(statement)).all())
+        if not rows:
+            return KnowledgeEnumeration(drafts=[], cursor=dict(cursor))
+        drafts = await self._drafts_for_rows(session, rows)
         last = rows[-1]
         return KnowledgeEnumeration(
             drafts=drafts,

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -27,6 +27,7 @@ from brain.systems.knowledge.connectors.base import (
     KnowledgeConnector,
     KnowledgeDraft,
 )
+from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.distillation import (
     DISTILLATION_CURSOR_KEY,
     DISTILLATION_MANIFEST_VERSION,
@@ -704,6 +705,34 @@ async def _ingest_drafts(
             )
 
 
+async def index_memory_node(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> KnowledgeSyncStats:
+    """Upsert one committed memory node without advancing the sweep cursor."""
+
+    stats = KnowledgeSyncStats()
+    connector = MemoryConnector(max_items=1)
+    draft = await connector.draft_for_node(
+        session,
+        node_id=node_id,
+    )
+    if draft is None:
+        stats.skipped = 1
+        return stats
+
+    bounded_draft, _ = _bounded_draft(draft)
+    await _ingest_drafts(
+        session,
+        source=connector.source_key,
+        drafts=[(bounded_draft, True)],
+        stats=stats,
+        run_at=datetime.now(timezone.utc),
+    )
+    return stats
+
+
 async def sync_connector(
     session: AsyncSession,
     connector: KnowledgeConnector,
@@ -887,5 +916,6 @@ __all__ = [
     "build_embedding_text",
     "build_search_text",
     "content_digest",
+    "index_memory_node",
     "sync_connector",
 ]

--- a/brain/systems/reconstructive_memory/ingestion.py
+++ b/brain/systems/reconstructive_memory/ingestion.py
@@ -7,6 +7,7 @@ nodes, and graph edges in one transaction.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.db.repositories.reconstructive_memory import (
     AssertionDraft,
     EdgeDraft,
@@ -26,6 +28,10 @@ from brain.platform.db.repositories.reconstructive_memory import (
 )
 
 logger = logging.getLogger(__name__)
+
+_INFO_QUEUE_KEY = "illo_memory_knowledge_index_queue"
+_INFO_ARMED_KEY = "illo_memory_knowledge_index_listeners_armed"
+_POST_COMMIT_TASKS: set[asyncio.Task] = set()
 
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
 _STOP_WORDS = {
@@ -90,6 +96,115 @@ class IngestedMemorySource:
             "tag_node_ids": list(self.tag_node_ids),
             "edge_ids": list(self.edge_ids),
         }
+
+
+async def _index_committed_memory_node(node_id: int) -> None:
+    """Best-effort mirror write after the memory transaction is durable."""
+
+    from brain.systems.knowledge.service import index_memory_node
+
+    try:
+        async with UnitOfWork() as uow:
+            stats = await index_memory_node(uow.session, node_id=node_id)
+            if stats.failed:
+                logger.warning(
+                    "Immediate knowledge indexing degraded for committed memory node %s",
+                    node_id,
+                )
+    except Exception:
+        # Knowledge is a disposable mirror. A failed index write must never
+        # change the successful outcome of the committed memory ingest.
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_id,
+        )
+
+
+async def _index_committed_memory_nodes(node_ids: list[int]) -> None:
+    for node_id in node_ids:
+        await _index_committed_memory_node(node_id)
+
+
+def _reap_knowledge_index_task(task: asyncio.Task) -> None:
+    _POST_COMMIT_TASKS.discard(task)
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+def _spawn_knowledge_index_task(node_ids: list[int]) -> None:
+    try:
+        task = asyncio.ensure_future(_index_committed_memory_nodes(node_ids))
+        _POST_COMMIT_TASKS.add(task)
+        task.add_done_callback(_reap_knowledge_index_task)
+    except Exception:
+        logger.exception(
+            "Immediate knowledge indexing failed for committed memory node %s",
+            node_ids,
+        )
+
+
+def _schedule_post_commit_knowledge_index(
+    session: AsyncSession,
+    *,
+    node_id: int,
+) -> bool:
+    """Queue immediate indexing for the session's next outer commit."""
+
+    try:
+        sync_session = getattr(session, "sync_session", None)
+        if sync_session is None:
+            return False
+        loop = asyncio.get_running_loop()
+        queue: list[int] = sync_session.info.setdefault(_INFO_QUEUE_KEY, [])
+        queue.append(int(node_id))
+        if sync_session.info.get(_INFO_ARMED_KEY):
+            return True
+
+        def _drain_into_task(target_session: Any) -> None:
+            # SQLAlchemy fires after_commit for a savepoint release too. The
+            # nested transaction is still available during that callback, so
+            # keep the queue until the outer transaction commits.
+            previous = target_session.get_nested_transaction()
+            if getattr(previous, "nested", False):
+                return
+            drained = list(dict.fromkeys(target_session.info.get(_INFO_QUEUE_KEY) or []))
+            target_session.info[_INFO_QUEUE_KEY] = []
+            if not drained:
+                return
+            try:
+                loop.call_soon_threadsafe(_spawn_knowledge_index_task, drained)
+            except Exception:
+                logger.exception(
+                    "Immediate knowledge indexing failed for committed memory node %s",
+                    drained,
+                )
+
+        def _on_rollback(target_session: Any, previous: Any) -> None:
+            if getattr(previous, "nested", False):
+                return
+            target_session.info[_INFO_QUEUE_KEY] = []
+
+        from sqlalchemy import event
+
+        event.listen(sync_session, "after_commit", _drain_into_task)
+        event.listen(sync_session, "after_soft_rollback", _on_rollback)
+        sync_session.info[_INFO_ARMED_KEY] = True
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Immediate knowledge indexing not armed for memory node %s (%s); "
+            "the periodic sweep will deliver it",
+            node_id,
+            exc,
+        )
+        return False
 
 
 async def ingest_memory_source(
@@ -254,7 +369,7 @@ async def ingest_memory_source(
             exc,
         )
 
-    return IngestedMemorySource(
+    result = IngestedMemorySource(
         source_id=source.id,
         span_ids=span_ids,
         content_node_id=content_node.id,
@@ -263,6 +378,11 @@ async def ingest_memory_source(
         tag_node_ids=tuple(node.id for node in tag_nodes),
         edge_ids=tuple(edge.id for edge in edges),
     )
+    _schedule_post_commit_knowledge_index(
+        session,
+        node_id=result.content_node_id,
+    )
+    return result
 
 
 def _clean_content(content: str) -> str:

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
@@ -57,7 +58,6 @@ from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import (
     RAW_TEXT_MAX_CHARS,
-    index_memory_node,
     sync_connector,
 )
 from brain.systems.external_agents import service as external_agents
@@ -611,23 +611,30 @@ def _committing_unit_of_work(session):
     return _CommittingUnitOfWork
 
 
-async def _ingest_shared_memory_through_mcp(
+async def _wait_for_memory_knowledge_index(memory_ingestion):
+    await asyncio.sleep(0)
+    if memory_ingestion._POST_COMMIT_TASKS:
+        await asyncio.gather(*list(memory_ingestion._POST_COMMIT_TASKS))
+
+
+async def _ingest_shared_memory_at_canonical_boundary(
     session,
     monkeypatch,
     *,
     content: str,
     source_ref: str,
 ):
-    from brain.app.mcp import server as mcp_server
     from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
 
     monkeypatch.setattr(
-        mcp_server,
+        memory_ingestion,
         "UnitOfWork",
         _committing_unit_of_work(session),
     )
     monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
-    return await mcp_server.async_tool_memory_ingest_source(
+    result = await memory_ingestion.ingest_memory_source(
+        session,
         content=content,
         content_kind="decision",
         source_kind="contract_test",
@@ -637,6 +644,9 @@ async def _ingest_shared_memory_through_mcp(
         visibility="team",
         confidence=0.9,
     )
+    await session.commit()
+    await _wait_for_memory_knowledge_index(memory_ingestion)
+    return result.to_dict()
 
 
 async def test_memory_ingest_indexes_committed_node_for_immediate_search(
@@ -647,7 +657,7 @@ async def test_memory_ingest_indexes_committed_node_for_immediate_search(
     del embedding_runtime
     distinctive = "Zephyr quokka release ownership stays with the active worker."
 
-    payload = await _ingest_shared_memory_through_mcp(
+    payload = await _ingest_shared_memory_at_canonical_boundary(
         session,
         monkeypatch,
         content=distinctive,
@@ -668,45 +678,120 @@ async def test_memory_ingest_indexes_committed_node_for_immediate_search(
     assert [result["source_ref"] for result in search["results"]] == [source_ref]
 
 
-@pytest.mark.parametrize(
-    ("node_id", "node_kind", "org_id", "visibility"),
-    [
-        (16, "content", None, "org"),
-        (17, "content", _ORG_ID, "private"),
-        (18, "summary", _ORG_ID, "org"),
-    ],
-)
-async def test_immediate_memory_index_reuses_connector_eligibility(
+async def test_memory_connector_immediate_and_sweep_eligibility_are_identical(
     session,
-    embedding_runtime,
-    node_id,
-    node_kind,
-    org_id,
-    visibility,
 ):
-    del embedding_runtime
+    updated_at = datetime(2026, 8, 5, 14, 0, tzinfo=timezone.utc)
+    superseded = _memory_node(22, updated_at, visibility="team")
+    superseded.truth_status = "superseded"
+    rows = [
+        _memory_node(16, updated_at, visibility="org"),
+        _memory_node(17, updated_at, visibility="team"),
+        _memory_node(18, updated_at, node_kind="summary", visibility="org"),
+        _memory_node(19, updated_at, org_id=None, visibility="org"),
+        _memory_node(20, updated_at, visibility="private"),
+        _memory_node(21, updated_at, visibility="private"),
+        superseded,
+    ]
+    session.add_all(rows)
     session.add(
-        _memory_node(
-            node_id,
-            datetime(2026, 8, 5, 14, node_id, tzinfo=timezone.utc),
-            node_kind=node_kind,
-            org_id=org_id,
-            visibility=visibility,
+        KnowledgeItem(
+            source="memory",
+            kind="memory",
+            source_ref="memory_node:21",
+            title="Formerly shared memory",
+            summary="Formerly shared memory",
+            raw_text="Formerly shared memory",
+            search_text="Formerly shared memory",
+            extra={"org_id": _ORG_ID},
+            content_digest="former-shared-memory",
         )
     )
-    await session.commit()
+    await session.flush()
 
-    stats = await index_memory_node(session, node_id=node_id)
-    await session.commit()
+    connector = MemoryConnector(max_items=20)
+    immediate_drafts = {}
+    for row in rows:
+        draft = await connector.draft_for_node(session, node_id=row.id)
+        if draft is not None:
+            immediate_drafts[draft.source_ref] = draft
+    enumeration = await connector.enumerate_changed(session, {})
+    sweep_drafts = {draft.source_ref: draft for draft in enumeration.drafts}
 
-    item = await session.scalar(
-        select(KnowledgeItem).where(
-            KnowledgeItem.source == "memory",
-            KnowledgeItem.source_ref == f"memory_node:{node_id}",
-        )
+    assert immediate_drafts == sweep_drafts
+    assert set(immediate_drafts) == {
+        "memory_node:16",
+        "memory_node:17",
+        "memory_node:21",
+        "memory_node:22",
+    }
+    assert immediate_drafts["memory_node:21"].extra["mirror_status"] == (
+        "visibility_withdrawn"
     )
-    assert stats.ingested == 0
-    assert item is None
+    assert immediate_drafts["memory_node:22"].archived_at == updated_at
+
+
+async def test_memory_index_waits_for_outer_commit_after_savepoint_release(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    async with session.begin_nested():
+        ingested = await memory_ingestion.ingest_memory_source(
+            session,
+            content="Savepoint release must not publish a memory projection early.",
+            content_kind="decision",
+            source_kind="contract_test",
+            org_id=_ORG_ID,
+            visibility="team",
+        )
+
+    await asyncio.sleep(0)
+    spawn_index.assert_not_called()
+
+    await session.commit()
+    await asyncio.sleep(0)
+    spawn_index.assert_called_once_with([ingested.content_node_id])
+
+
+async def test_memory_index_queue_is_cleared_on_outer_rollback(
+    session,
+    monkeypatch,
+):
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
+
+    spawn_index = MagicMock()
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        memory_ingestion,
+        "_spawn_knowledge_index_task",
+        spawn_index,
+    )
+
+    await memory_ingestion.ingest_memory_source(
+        session,
+        content="Rolled-back memory must never publish a knowledge projection.",
+        content_kind="decision",
+        source_kind="contract_test",
+        org_id=_ORG_ID,
+        visibility="team",
+    )
+    await session.rollback()
+    await asyncio.sleep(0)
+
+    spawn_index.assert_not_called()
+    assert session.sync_session.info[memory_ingestion._INFO_QUEUE_KEY] == []
 
 
 async def test_memory_sweep_and_cursor_rewalk_are_idempotent_after_immediate_ingest(
@@ -715,7 +800,7 @@ async def test_memory_sweep_and_cursor_rewalk_are_idempotent_after_immediate_ing
     monkeypatch,
 ):
     del embedding_runtime
-    payload = await _ingest_shared_memory_through_mcp(
+    payload = await _ingest_shared_memory_at_canonical_boundary(
         session,
         monkeypatch,
         content="Cobalt narwhal decisions remain searchable after every reconciler pass.",
@@ -767,12 +852,12 @@ async def test_memory_index_failure_does_not_fail_committed_ingest(
     monkeypatch,
     caplog,
 ):
-    from brain.app.mcp import server as mcp_server
     from brain.systems.knowledge import service as knowledge_service
     from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+    from brain.systems.reconstructive_memory import ingestion as memory_ingestion
 
     monkeypatch.setattr(
-        mcp_server,
+        memory_ingestion,
         "UnitOfWork",
         _committing_unit_of_work(session),
     )
@@ -783,17 +868,21 @@ async def test_memory_index_failure_does_not_fail_committed_ingest(
         AsyncMock(side_effect=RuntimeError("knowledge mirror unavailable")),
     )
 
-    with caplog.at_level("ERROR", logger="mcp_brain"):
-        payload = await mcp_server.async_tool_memory_ingest_source(
+    with caplog.at_level("ERROR", logger=memory_ingestion.__name__):
+        result = await memory_ingestion.ingest_memory_source(
+            session,
             content="Amber kestrel preservation remains durable during an index outage.",
+            content_kind="episode",
             source_kind="contract_test",
             source_ref="failed-immediate-index",
             org_id=_ORG_ID,
             user_id="22222222-2222-4222-8222-222222222222",
             visibility="org",
         )
+        await session.commit()
+        await _wait_for_memory_knowledge_index(memory_ingestion)
 
-    node = await session.get(MemoryNode, payload["content_node_id"])
+    node = await session.get(MemoryNode, result.content_node_id)
     assert node is not None
     assert node.text == "Amber kestrel preservation remains durable during an index outage."
     assert "Immediate knowledge indexing failed for committed memory node" in caplog.text

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import numpy as np
 import pytest
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
 from brain.app.api.auth import get_current_user
@@ -30,7 +30,13 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+)
 from brain.systems.knowledge.connectors.base import (
     EnumerationFailure,
     EnumerationFailureKind,
@@ -49,7 +55,11 @@ from brain.systems.knowledge.connectors.github import (
 )
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
-from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
+from brain.systems.knowledge.service import (
+    RAW_TEXT_MAX_CHARS,
+    index_memory_node,
+    sync_connector,
+)
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
@@ -317,7 +327,10 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
+            MemorySource.__table__,
+            MemorySpan.__table__,
             MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
         ]
     )
@@ -579,6 +592,211 @@ async def test_memory_connector_skips_orgless_nodes_and_keeps_organization_scope
     )
     assert items[0].extra["org_id"] == _ORG_ID
     assert "skipped node 14: org_id is missing" in caplog.text
+
+
+def _committing_unit_of_work(session):
+    class _CommittingUnitOfWork:
+        async def __aenter__(self):
+            self.session = session
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            del exc, traceback
+            if exc_type is None:
+                await session.commit()
+            else:
+                await session.rollback()
+            return False
+
+    return _CommittingUnitOfWork
+
+
+async def _ingest_shared_memory_through_mcp(
+    session,
+    monkeypatch,
+    *,
+    content: str,
+    source_ref: str,
+):
+    from brain.app.mcp import server as mcp_server
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+
+    monkeypatch.setattr(
+        mcp_server,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    return await mcp_server.async_tool_memory_ingest_source(
+        content=content,
+        content_kind="decision",
+        source_kind="contract_test",
+        source_ref=source_ref,
+        org_id=_ORG_ID,
+        user_id="22222222-2222-4222-8222-222222222222",
+        visibility="team",
+        confidence=0.9,
+    )
+
+
+async def test_memory_ingest_indexes_committed_node_for_immediate_search(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    distinctive = "Zephyr quokka release ownership stays with the active worker."
+
+    payload = await _ingest_shared_memory_through_mcp(
+        session,
+        monkeypatch,
+        content=distinctive,
+        source_ref="immediate-knowledge-search",
+    )
+
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source == "memory",
+            KnowledgeItem.source_ref == source_ref,
+        )
+    )
+    search = await search_knowledge(session, "zephyr quokka", org_id=_ORG_ID)
+
+    assert item is not None
+    assert item.summary == distinctive
+    assert [result["source_ref"] for result in search["results"]] == [source_ref]
+
+
+@pytest.mark.parametrize(
+    ("node_id", "node_kind", "org_id", "visibility"),
+    [
+        (16, "content", None, "org"),
+        (17, "content", _ORG_ID, "private"),
+        (18, "summary", _ORG_ID, "org"),
+    ],
+)
+async def test_immediate_memory_index_reuses_connector_eligibility(
+    session,
+    embedding_runtime,
+    node_id,
+    node_kind,
+    org_id,
+    visibility,
+):
+    del embedding_runtime
+    session.add(
+        _memory_node(
+            node_id,
+            datetime(2026, 8, 5, 14, node_id, tzinfo=timezone.utc),
+            node_kind=node_kind,
+            org_id=org_id,
+            visibility=visibility,
+        )
+    )
+    await session.commit()
+
+    stats = await index_memory_node(session, node_id=node_id)
+    await session.commit()
+
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source == "memory",
+            KnowledgeItem.source_ref == f"memory_node:{node_id}",
+        )
+    )
+    assert stats.ingested == 0
+    assert item is None
+
+
+async def test_memory_sweep_and_cursor_rewalk_are_idempotent_after_immediate_ingest(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    payload = await _ingest_shared_memory_through_mcp(
+        session,
+        monkeypatch,
+        content="Cobalt narwhal decisions remain searchable after every reconciler pass.",
+        source_ref="immediate-then-sweep",
+    )
+    source_ref = f"memory_node:{payload['content_node_id']}"
+    before = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+    )
+    assert before is not None
+    item_id = before.id
+    digest = before.content_digest
+
+    first_sweep = await sync_connector(session, MemoryConnector(max_items=20))
+    await session.execute(
+        delete(KnowledgeSyncState).where(KnowledgeSyncState.source == "memory")
+    )
+    await session.flush()
+    rewalk = await sync_connector(session, MemoryConnector(max_items=20))
+
+    items = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem).where(KnowledgeItem.source_ref == source_ref)
+            )
+        ).all()
+    )
+    embeddings = list(
+        (
+            await session.scalars(
+                select(KnowledgeItemEmbedding).where(
+                    KnowledgeItemEmbedding.item_id == item_id
+                )
+            )
+        ).all()
+    )
+    assert first_sweep.stats["ingested"] == 0
+    assert first_sweep.stats["skipped"] == 1
+    assert rewalk.stats["ingested"] == 0
+    assert rewalk.stats["skipped"] == 1
+    assert len(items) == 1
+    assert items[0].id == item_id
+    assert items[0].content_digest == digest
+    assert len(embeddings) == 1
+
+
+async def test_memory_index_failure_does_not_fail_committed_ingest(
+    session,
+    monkeypatch,
+    caplog,
+):
+    from brain.app.mcp import server as mcp_server
+    from brain.systems.knowledge import service as knowledge_service
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+
+    monkeypatch.setattr(
+        mcp_server,
+        "UnitOfWork",
+        _committing_unit_of_work(session),
+    )
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    monkeypatch.setattr(
+        knowledge_service,
+        "index_memory_node",
+        AsyncMock(side_effect=RuntimeError("knowledge mirror unavailable")),
+    )
+
+    with caplog.at_level("ERROR", logger="mcp_brain"):
+        payload = await mcp_server.async_tool_memory_ingest_source(
+            content="Amber kestrel preservation remains durable during an index outage.",
+            source_kind="contract_test",
+            source_ref="failed-immediate-index",
+            org_id=_ORG_ID,
+            user_id="22222222-2222-4222-8222-222222222222",
+            visibility="org",
+        )
+
+    node = await session.get(MemoryNode, payload["content_node_id"])
+    assert node is not None
+    assert node.text == "Amber kestrel preservation remains durable during an index outage."
+    assert "Immediate knowledge indexing failed for committed memory node" in caplog.text
 
 
 async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(


### PR DESCRIPTION
Closes #699

A memory node written through the inbound preserve path was durable immediately but invisible to `knowledge.search` until the next `knowledge_index_sync` tick (`*/30`). Normal cost was up to 30 minutes. Under a scheduler freeze it became hours — during the 2026-08-04 freeze (#632 / #687), nodes 916–938 sat written but unindexed for **34+ hours**.

External Claude Code sessions now preserve session knowledge through this path at every session end. The preserve→recall loop is only as fresh as the mirror, so this indexes the node as soon as its transaction commits.

## Stacked — this is a layer, not a standalone PR

Base is `illo-qa/680-orgless-memory-guard` (#695), which is on `illo-qa/674-skills-knowledge-connector` (#679). Merging that train merges this.

**Why it is stacked rather than independent:** #695 added the org-reachability guard to the memory connector. A separate immediate-index path that skipped that guard would silently re-introduce #680's bug through a new door. This branch reuses the guard instead, which only works on top of it.

## How to see it work

No UI. From the repo root, on this branch:

```
venv/bin/pytest tests/test_knowledge_index.py -q
```

To watch the real loop end to end, preserve a memory through the MCP path (`illo_submit` with `desired_outcome=preserve_knowledge`, or the `memory_ingest_source` tool) with a distinctive phrase, then immediately `search_knowledge` for that phrase. Before this change you would get nothing until the next `*/30` tick; now it returns the node. The mirror write is best-effort and asynchronous, so allow a moment for it — the ticket's bar is ~1 minute, not instant.

## Acceptance checks

1. A node written through the preserve path lands in `knowledge_items` without waiting for `knowledge_index_sync`, and `knowledge.search` returns it.
2. A node the sweep would skip — private, org-less, wrong node kind, withdrawn — is skipped by the immediate path too. Pinned by a parity test that fails if the two paths ever disagree.
3. No double-indexing: the `*/30` sweep still walks correctly after an immediate index, and deleting the `knowledge_sync_state` cursor still re-walks cleanly. The upsert is on `(source, source_ref)` = `("memory", "memory_node:<id>")` and the immediate path does not advance the cursor.
4. A failing index write never fails a durable memory write.

## Verification

`pytest tests/ -m "not requires_db and not requires_browser and not live_provider"` → **4728 passed, 11 skipped, 83 deselected**, run outside the Codex sandbox. Same count as this branch's base, because the new savepoint test offsets the exclusion test that the parity matrix replaced.

The diff touches `brain/**` and `tests/**`, so it also selects the **db** lane, which needs Postgres and did not run locally — CI on this PR is the check for it. No `frontend/**` files, so that lane does not apply.

## Review — two blocking findings were folded

A cross-family maintainability review returned **CHANGES REQUIRED**. Both blocking findings were real:

**The projection hung off one MCP transport function.** The first shape called the index from `async_tool_memory_ingest_source` only, so the other `ingest_memory_source` callers — curation, meta-evolution, and the reconstructive-memory repository behind the API and CLI — silently kept the very staleness this ticket removes, and every future caller would have had to remember an unrelated knowledge projection. It now lives at the `ingest_memory_source` boundary, so all callers get it.

The post-commit hook **reuses the idiom this repo already has** in `runs/obligation_notices.py` and `briefing/deliver.py` rather than inventing a third: a queue in `session.info`, an `after_commit` listener that returns early while a nested transaction is live, `after_soft_rollback` clearing the queue, and defensive arming that falls back to the `*/30` sweep. That listener detail is the load-bearing one — SQLAlchemy fires `after_commit` on savepoint release too, which is exactly why the issue ruled out a naive `after_commit` hook. A test now pins it: an index scheduled inside a savepoint must not fire when that savepoint is released, only when the outer transaction commits.

**Eligibility was not fully single-owner.** `draft_for_node` and `enumerate_changed` shared `_drafts_for_rows` but still built their own node-kind predicate, so a query-level eligibility change could update one path and miss the other. Both now start from one shared candidate query.

A third, non-blocking finding was also folded: the original test only replayed three exclusions against the immediate path, so two independent implementations with matching rules would both have passed — it could not detect the drift the finding above describes. It is replaced by a parity matrix across org/team, node kind, missing org, private visibility, withdrawal and supersession.

## Known boundary

Indexing is best-effort and fire-and-forget: the node is queued and written after the outer commit, off the request path. If the process dies between commit and the mirror write, the node stays durable and the `*/30` sweep picks it up — the sweep remains the reconciler, by design. Knowledge is a disposable index, never the source of truth.
