### PR TITLE
fix(triage): file the ticket first, resolve the owner second (#702)

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
@@ -17,28 +17,48 @@ Two different places can hold work, and they are NOT the same thing:
 
 Decide as follows.
 
-### Pre-create ownership and readiness gate
+### Filing floor — create the issue first
 
-Immediately before every `create_github_issue` call, including calls for
-customer-support reports, apply the core operating doc's **Ownership** section
-to the evidence collected for the issue. That section is the single canonical
-resolver: do not copy its people or work-class rules into this playbook.
+For every ticket-worthy customer-support report, **filing is unconditional**.
+After the required investigation and duplicate check, choose the best-supported
+repo from the available evidence and call `create_github_issue` immediately.
+Create the issue before ownership resolution and before any routing question.
+Uncertainty about the owner or exact route does not delay filing: state the
+uncertainty in the issue body and keep the work visible.
+
+Create the customer-support issue without `assignees`. Ownership and readiness
+are post-create enrichment on an issue that already exists. Preserve any explicit
+assignee request in the evidence so the post-create step can honor it.
+
+### Post-create ownership and readiness enrichment
+
+Immediately after `create_github_issue` returns the issue number and URL, apply
+the core operating doc's **Ownership** section to the evidence collected for the
+filed issue. That section is the single canonical resolver: do not copy its
+people or work-class rules into this playbook.
 
 - An explicit human assignment wins. Otherwise, resolve builder-first and use
-  the core specialization and load-balancing tie-breakers. Pass the resolved
-  GitHub login in `assignees` on the same `create_github_issue` call; do not
-  create the issue first and plan to assign it later.
-- For a customer-generation report, the investigation hypothesis must exist
-  before this gate runs. "No owner up front" is an investigation rule, not an
-  instruction to file the resulting issue unassigned.
-- Apply `ready-for-agent` in `labels` when the issue meets the definition in
-  the core **States** section: it is scoped enough for an autonomous agent to
-  implement and open a PR without human judgment, credentials, external
-  testing, or a manual design/release decision.
-- If the ownership evidence remains genuinely ambiguous, omit `assignees` and
-  add `Ownership: Unassigned — <specific ambiguity or missing evidence>.` to
-  the issue body. An empty assignee list without that explanation is not a
-  completed ownership decision.
+  the core specialization and load-balancing tie-breakers. When ownership
+  resolves, call `update_github_issue` with the resolved GitHub login in
+  `assignees_add` during the same run.
+- For a customer-generation report, use the investigation hypothesis as
+  ownership evidence. "No owner up front" remains an investigation rule; it
+  does not remove the mandatory post-create ownership attempt.
+- Apply `ready-for-agent` with `update_github_issue` when the filed issue meets
+  the definition in the core **States** section: it is scoped enough for an
+  autonomous agent to implement and open a PR without human judgment,
+  credentials, external testing, or a manual design/release decision.
+- **Mandatory branch — I don't know the owner.** This branch requires no owner
+  to be known and never blocks filing; the issue already exists. Keep it
+  unassigned, add `Ownership: Unassigned — <specific ambiguity or missing
+  evidence>.` to the issue body with `update_github_issue`, and state exactly
+  what ownership or routing fact remains unresolved.
+- A routing question is never a substitute for filing. Ask it only after the
+  issue exists. Register it as an open ask with a named human owner and an
+  explicit expiry so the terminal-state machinery tracks it, then @-mention
+  that human in Slack and cite the filed issue. Do not let a newly opened
+  routing question carry `answers_open_ask: false` unless its `open_asks` row
+  was registered separately.
 
 ### Customer-bug filing policy
 
@@ -47,11 +67,11 @@ resolver: do not copy its people or work-class rules into this playbook.
   mirror, never a substitute. Create the GitHub issue first, then mirror it with
   the returned issue number/URL and stable external id. The issue body must carry
   the customer's own words, the concrete impact (including credit loss), and the
-  Slack `origin_ref`; run the pre-create ownership and readiness gate above,
+  Slack `origin_ref`; follow the filing floor and post-create enrichment above,
   including honoring an explicit assignee request using the verified GitHub
-  identity. If no more-specific tracker exists, use Domain `1` as the existing
-  default. Never create a Domain during filing: propose the schema change for
-  later review and complete the immediate mirror in Domain `1`.
+  identity after the issue exists. If no more-specific tracker exists, use Domain
+  `1` as the existing default. Never create a Domain during filing: propose the
+  schema change for later review and complete the immediate mirror in Domain `1`.
 - **One problem = one issue — check before filing.** Before calling
   `create_github_issue`, search open AND closed GitHub issues and Domain 1
   tracker records for the same tracked error signature, Rollbar id (prefer
@@ -74,8 +94,11 @@ resolver: do not copy its people or work-class rules into this playbook.
   403/404): do NOT claim an issue was filed. A retention tracker record + handoff
   may keep the work from being lost, but the reply must say **the requested GitHub
   issue was not created** and name the exact blocker.
-- **Repo or incident unclear:** ask first; capture an internal record only if the
-  signal must not be lost.
+- **Repo or incident remains uncertain after investigation:** for a ticket-worthy
+  customer-support report, choose the best-supported repo, file there, and state
+  the unresolved routing fact in the issue body. Ask a routing question only
+  after filing and follow the tracked open-ask requirements above. For other
+  intake, capture an internal record if the signal must not be lost.
 
 Never describe an internal tracker record as a GitHub issue. Only say a GitHub
 issue was opened when `create_github_issue` succeeded and you can cite its number

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/customer-support.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/customer-support.md
@@ -28,19 +28,30 @@ Do the mechanical investigation yourself, read-only, then act:
    (e.g. the try-on prompt/settings never specified the missing detail; the
    reference image lacked it; the model dropped it; a QA/status signal explains
    it).
-3. **Open the durable work item.** Follow the canonical
+3. **File first, unconditionally.** Follow the canonical
    [customer-bug filing policy](creating-work-items.md#customer-bug-filing-policy).
    For generation/API behavior, use `uwear-ai/uwear-backend`; add the payload
    evidence + hypothesis and point the owner at the payload to confirm or deny.
-   Run that playbook's **Pre-create ownership and readiness gate** after the
-   hypothesis is formed and before `create_github_issue`. Apply its result in
-   the create call, including an explicitly requested assignee when present.
-4. **Reply in-thread** on the alert with the resulting artifact references and a
+   After the hypothesis is formed, call `create_github_issue` before resolving
+   ownership or asking a routing question. Filing does not wait for an owner or
+   a human confirmation.
+4. **Resolve ownership on the filed issue.** After `create_github_issue` returns
+   the issue number and URL, run that playbook's **Post-create ownership and
+   readiness enrichment**. Attempt ownership with the unchanged builder-first,
+   specialization, and load-balancing rules, then update the filed issue.
+5. **Reply in-thread** on the alert with the resulting artifact references and a
    one-line hypothesis.
 
-**Owner: none during investigation; resolved before filing.** Illo runs the
-first-pass investigation. Once the hypothesis exists, the shared pre-create gate
-selects the human owner and readiness label from the core rules. Do not
-auto-assign a customer-generation issue to Axel merely because the output came
-from an AI model. If the shared gate cannot resolve ownership, file it
-unassigned with the required ambiguity statement in the issue body.
+**Owner: none during investigation and at initial filing; resolution follows
+filing.** Illo runs the first-pass investigation. The issue exists before the
+shared ownership step selects a human owner and readiness label from the core
+rules. Do not auto-assign a customer-generation issue to Axel merely because the
+output came from an AI model.
+
+**Mandatory branch — I don't know the owner.** No owner needs to be known to
+reach this branch. Keep the filed issue unassigned, include the required
+`Ownership: Unassigned — <specific ambiguity or missing evidence>.` statement in
+the issue body, and state exactly what ownership or routing fact is unresolved.
+If a routing question is useful, file the issue first, register the question as
+an open ask with a named human owner and an explicit expiry, and @-mention that
+human in Slack. The question never replaces or delays the issue.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.12.0"
+version = "1.13.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"

--- a/brain/systems/slack/channel_monitor_rendering.py
+++ b/brain/systems/slack/channel_monitor_rendering.py
@@ -53,6 +53,20 @@ def slack_channel_monitor_message(
         SUPPORT_INTAKE_RECALL_MANDATE,
         "",
         "Classify this message and act accordingly:",
+        "- Filing is the floor for every ticket-worthy customer-support report. After the "
+        "required investigation and duplicate check, choose the best-supported repo from the "
+        "available evidence and create the GitHub issue before ownership resolution or any "
+        "routing question. An unknown owner is not a blocker: file unassigned, include the "
+        "required ownership-ambiguity statement in the issue body, and enrich ownership on the "
+        "filed issue in the same run.",
+        "- If you ask a routing question for a customer-support issue, the issue must already "
+        "exist. Register the question as an open ask with a named human owner and an explicit "
+        "expiry so terminal-state tracking applies, @-mention that human in Slack, and cite the "
+        "filed issue. Do not let a newly opened routing question carry answers_open_ask=false "
+        "unless its open_asks row was registered separately.",
+        "- A customer-support intake without a created or updated durable work item is DEGRADED, "
+        "not a healthy completion. Name the missing artifact and the exact write blocker in the "
+        "run self-review.",
         "- A human explicitly stating a durable presentation/behaviour preference requires a "
         "visible reply. Follow the durable-preference contract above before the general triage "
         "branches below.",
@@ -72,15 +86,18 @@ def slack_channel_monitor_message(
         "'repo and incident clear': file the issue in that repo in the same run. Include the "
         "investigation findings in the issue body — not just a link to Slack — so the analysis is "
         "captured in the work item instead of being left only in Slack.",
-        "- A human request/report or apparent request for work that is actionable but "
+        "- A non-customer human request or apparent request for work that is actionable but "
         "underspecified because the target repo or incident is unclear: do NOT stay silent and do "
         "NOT return 'No visible action taken.' Ask exactly ONE focused clarifying question "
-        "in-thread with post_slack_reply, then act on the answer. Proximity to an existing alert "
-        "alone does not turn an apparent human request into alert commentary. This branch does "
-        "not apply to casual chatter or genuine commentary that does not ask for work.",
+        "in-thread with post_slack_reply and register it as a tracked open ask. A ticket-worthy "
+        "customer-support report never enters this wait-for-clarification branch; follow the "
+        "filing-floor rule above. Proximity to an existing alert alone does not turn an apparent "
+        "human request into alert commentary. This branch does not apply to casual chatter or "
+        "genuine commentary that does not ask for work.",
         "- A message that @-mentions Illo must NEVER end in silence or 'No visible action taken.' "
-        "Either file the issue or post a visible reply; if the details are insufficient to file, "
-        "ask exactly ONE focused clarifying question in-thread.",
+        "Either file the issue or post a visible reply; if the details are insufficient for a "
+        "non-customer request, ask exactly ONE focused clarifying question in-thread. A customer "
+        "support intake still follows the filing-floor rule above.",
         "- A user-submitted feature request or product idea (feedback relayed by a bot such as "
         "Retool — e.g. '*New:* Idea' or '*New:* Feedback' with a user email and profile id — is "
         "a real customer ask, NOT chatter and NOT low-signal): if the ask is concrete and "

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -54,7 +54,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.12.0"
+    assert bundle.manifest.version == "1.13.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -267,13 +267,13 @@ def test_uwear_customer_bug_filing_has_one_declared_destination_and_complete_evi
         "[customer-bug filing policy](creating-work-items.md#customer-bug-filing-policy)",
         "`uwear-ai/uwear-backend`",
         "payload evidence + hypothesis",
-        "after the hypothesis is formed",
+        "After the hypothesis is formed",
         "resulting artifact references",
     ):
         assert expected in support_flat
 
 
-def test_uwear_customer_support_backend_generation_uses_shared_owner_gate():
+def test_uwear_customer_support_files_before_resolving_owner():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle
 
@@ -286,15 +286,50 @@ def test_uwear_customer_support_backend_generation_uses_shared_owner_gate():
         _uwear_triage_asset(bundle, "references/customer-support.md").split()
     )
 
+    support_filing = "**File first, unconditionally.**"
+    support_ownership = "**Resolve ownership on the filed issue.**"
+    filing_floor = "### Filing floor — create the issue first"
+    ownership_enrichment = "### Post-create ownership and readiness enrichment"
+
+    assert support.index(support_filing) < support.index(support_ownership)
+    assert filing.index(filing_floor) < filing.index(ownership_enrichment)
     assert "Builder first" in procedure
     assert "Axel = agent/LLM/MCP and AI-backend behavior" in procedure
     assert "For generation/API behavior, use `uwear-ai/uwear-backend`" in support
-    assert "Pre-create ownership and readiness gate" in support
-    assert "Pass the resolved GitHub login in `assignees`" in filing
-    assert "Apply `ready-for-agent` in `labels`" in filing
+    assert "call `create_github_issue` before resolving ownership" in support
+    assert "resolve builder-first" in filing
+    assert "mandatory post-create ownership attempt" in filing
+    assert "`update_github_issue`" in filing
+    assert "`assignees_add`" in filing
+    assert "Apply `ready-for-agent` with `update_github_issue`" in filing
 
 
-def test_uwear_customer_support_app_ui_uses_shared_owner_gate():
+def test_uwear_customer_support_never_conditions_filing_on_owner_resolution():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    filing = " ".join(
+        _uwear_triage_asset(bundle, "references/creating-work-items.md").split()
+    )
+    support = " ".join(
+        _uwear_triage_asset(bundle, "references/customer-support.md").split()
+    )
+    combined = f"{filing} {support}"
+
+    for forbidden in (
+        "Pre-create ownership and readiness gate",
+        "Immediately before every `create_github_issue`",
+        "resolved before filing",
+        "before `create_github_issue`",
+        "Once the hypothesis exists",
+        "once confirmed",
+        "ask first; capture an internal record",
+    ):
+        assert forbidden not in combined
+
+
+def test_uwear_customer_support_app_ui_uses_shared_post_create_owner_rules():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle
 
@@ -321,9 +356,14 @@ def test_uwear_customer_support_ambiguous_owner_is_explained_in_issue_body():
         _uwear_triage_asset(bundle, "references/customer-support.md").split()
     )
 
-    assert "omit `assignees`" in filing
+    assert "**Mandatory branch — I don't know the owner.**" in filing
+    assert "This branch requires no owner to be known and never blocks filing" in filing
+    assert "Keep it unassigned" in filing
     assert "Ownership: Unassigned — <specific ambiguity or missing evidence>." in filing
-    assert "required ambiguity statement in the issue body" in support
+    assert "**Mandatory branch — I don't know the owner.**" in support
+    assert "No owner needs to be known to reach this branch" in support
+    assert "state exactly what ownership or routing fact is unresolved" in support
+    assert "The question never replaces or delays the issue" in support
 
 
 def test_uwear_customer_bug_filing_policy_is_not_repeated_by_consumers():

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -364,7 +364,7 @@ def test_channel_monitor_framing_routes_feature_requests_to_tickets():
     assert "email/profile id" in run_message
 
 
-def test_channel_monitor_filing_keeps_shared_triage_ownership_contract():
+def test_channel_monitor_customer_support_files_before_any_routing_question():
     from brain.systems.slack.triggers import build_slack_work_intake_payload
 
     payload = build_slack_work_intake_payload(
@@ -374,6 +374,19 @@ def test_channel_monitor_filing_keeps_shared_triage_ownership_contract():
     )
 
     run_message = payload["payload"]["run_message"]
+    filing_floor = "Filing is the floor for every ticket-worthy customer-support report."
+    routing_question = "If you ask a routing question for a customer-support issue"
+
+    assert run_message.index(filing_floor) < run_message.index(routing_question)
+    assert "create the GitHub issue before ownership resolution" in run_message
+    assert "An unknown owner is not a blocker" in run_message
+    assert "file unassigned" in run_message
+    assert "the issue must already exist" in run_message
+    assert "Register the question as an open ask" in run_message
+    assert "named human owner and an explicit expiry" in run_message
+    assert "@-mention that human" in run_message
+    assert "answers_open_ask=false" in run_message
+    assert "without a created or updated durable work item is DEGRADED" in run_message
     assert "Load the 'uwear-engineering-triage' skill" in run_message
     assert "first for routing/ownership rules" in run_message
     assert "creating work items" in run_message


### PR DESCRIPTION
Closes #702

## What broke

A paying customer's request arrived at 06:05 EDT and sat **3 hours with no ticket, no owner and no reply**. Illo's entire response was one Slack question addressed to nobody, ending "…once confirmed."

This was a regression from our own PR #690 (merged 9 hours earlier). #688 asked for "customer tickets are filed with no owner" to stop; #690 made ownership a **pre-create gate**, and the gate became a stopping point. A ticket with no owner was at least visible on the board. An unfiled ticket is invisible.

## The real cause was not the file the ticket named

#690 only changed skill-bundle markdown. But the merged text **already contained** the correct fallback ("file it unassigned with the required ambiguity statement") — and the agent still did not take it. So adding another sentence saying the same thing would have failed the same way.

The path actually taken lives in `brain/systems/slack/channel_monitor_rendering.py`: a branch that says an underspecified request should "ask exactly ONE focused clarifying question in-thread." The customer report matched that branch, so asking a question *was* compliant behaviour. That branch is now closed to customer-support intake.

## What changed

- **Order inverted.** Filing is unconditional and comes first; ownership resolution is now enrichment that runs **on an issue that already exists**. The gate is renamed pre-create → **post-create**.
- **"I don't know the owner" is a named mandatory branch**, adjacent to the gate, with a concrete action: file unassigned, include the ambiguity statement, state what is unresolved.
- **A routing question can never replace filing.** If Illo asks one, the issue must already exist, the question must be registered as an open ask with a named owner and expiry (the #667 terminal-state machinery only tracks questions actually registered — this one carried `answers_open_ask: "false"`), and a human must be @-mentioned.
- **A customer intake with no work item is now DEGRADED**, not a healthy completion.
- #688's win is preserved: ownership is still attempted, and the builder-first / specialization rules are untouched. Only the **order** and the **failure mode** changed.

## Verification

- Full CI selection, not a subset: `4801 passed, 11 skipped, 0 failed` (112s).
- The new tests fail against `main`. They assert **relative order** (`support.index(file_first) < support.index(resolve_owner)`) rather than substring presence — presence is what passed all through the outage — and pin the removed conditional phrasings, including the literal `"once confirmed"`, so they cannot come back.

## Acceptance checks

1. A customer report whose owner cannot be resolved produces a **filed, unassigned** GitHub issue carrying the `Ownership: Unassigned — <ambiguity>` statement.
2. A routing question posted for a customer issue cites an already-filed issue number, is registered as an open ask with an owner and expiry, and @-mentions a human.
3. A customer intake that ends with no created/updated work item self-reports as DEGRADED.
4. #688 does not regress: when ownership *is* resolvable, the issue still ends up assigned by the same builder-first rules.

## Reviewer note

`slack_channel_monitor_message()` is accumulating instruction strings in one list; this PR appends three more. Not fixed here (it would bury the regression fix), but it is the next maintainability problem in that file.
