### PR TITLE
fix(ci): make the CI result gate fail closed, with needs as the job registry (#709)

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -211,17 +211,14 @@ jobs:
     if: always()
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Check selected CI jobs
         run: |
-          for result in \
+          set -euo pipefail
+          bash scripts/ci_result_gate.sh \
             "${{ needs.changes.result }}" \
             "${{ needs.backend-fast.result }}" \
             "${{ needs.frontend.result }}" \
             "${{ needs.db-contract.result }}"
-          do
-            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
-              echo "A selected CI job failed or was cancelled."
-              exit 1
-            fi
-          done
-          echo "Selected CI jobs passed."

--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -215,10 +215,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check selected CI jobs
-        run: |
-          set -euo pipefail
-          bash scripts/ci_result_gate.sh \
-            "${{ needs.changes.result }}" \
-            "${{ needs.backend-fast.result }}" \
-            "${{ needs.frontend.result }}" \
-            "${{ needs.db-contract.result }}"
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: bash scripts/ci_result_gate.sh

--- a/scripts/ci_result_gate.sh
+++ b/scripts/ci_result_gate.sh
@@ -2,35 +2,91 @@
 
 set -euo pipefail
 
-changes_result=${1-}
-backend_fast_result=${2-}
-frontend_result=${3-}
-db_contract_result=${4-}
+needs_json=${NEEDS_JSON-}
 
-printf 'changes=%s\n' "$changes_result"
-printf 'backend-fast=%s\n' "$backend_fast_result"
-printf 'frontend=%s\n' "$frontend_result"
-printf 'db-contract=%s\n' "$db_contract_result"
+if [ -z "$needs_json" ]; then
+  if [ "${NEEDS_JSON+x}" = "x" ]; then
+    input_state="<empty>"
+  else
+    input_state="<unset>"
+  fi
 
-if [ "$changes_result" != "success" ]; then
   printf '%s\n' \
-    "CI result failed: changes=$changes_result; rule: changes must be exactly success because job selection must complete."
+    "CI result failed: NEEDS_JSON=$input_state; rule: NEEDS_JSON must contain a non-empty valid JSON object."
   exit 1
 fi
 
-check_suite_result() {
-  local job_name=$1
-  local result=$2
+if ! jq -e -s 'length == 1 and (.[0] | type == "object")' \
+  >/dev/null 2>&1 <<<"$needs_json"; then
+  printf '%s\n' \
+    "CI result failed: NEEDS_JSON=<invalid>; rule: NEEDS_JSON must contain a non-empty valid JSON object."
+  exit 1
+fi
 
-  if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-    printf '%s\n' \
-      "CI result failed: $job_name=$result; rule: suite result must be exactly success or skipped."
-    return 1
-  fi
-}
+jq -r '
+  def job_result:
+    if type == "object" then
+      if has("result") then .result else "" end
+    else
+      ""
+    end;
 
-check_suite_result "backend-fast" "$backend_fast_result"
-check_suite_result "frontend" "$frontend_result"
-check_suite_result "db-contract" "$db_contract_result"
+  to_entries
+  | sort_by(.key)[]
+  | (.value | job_result) as $result
+  | .key + "=" + ($result | tostring)
+' <<<"$needs_json"
+
+if ! jq -e 'has("changes")' >/dev/null <<<"$needs_json"; then
+  printf '%s\n' \
+    "CI result failed: changes=<missing>; rule: the needs context must include the changes job."
+  exit 1
+fi
+
+changes_result=$(jq -r '
+  def job_result:
+    if type == "object" then
+      if has("result") then .result else "" end
+    else
+      ""
+    end;
+
+  .changes
+  | job_result
+  | tostring
+' <<<"$needs_json")
+
+if [ "$changes_result" != "success" ]; then
+  printf '%s\n' \
+    "CI result failed: changes=$changes_result; rule: the changes result must be exactly success."
+  exit 1
+fi
+
+invalid_entry=$(jq -r '
+  def job_result:
+    if type == "object" then
+      if has("result") then .result else "" end
+    else
+      ""
+    end;
+
+  ([
+    to_entries
+    | sort_by(.key)[]
+    | select(.key != "changes")
+    | (.value | job_result) as $result
+    | select($result != "success" and $result != "skipped")
+    | {job: .key, result: $result}
+  ][0] // empty)
+  | [.job, (.result | tostring)]
+  | @tsv
+' <<<"$needs_json")
+
+if [ -n "$invalid_entry" ]; then
+  IFS=$'\t' read -r invalid_job invalid_result <<<"$invalid_entry"
+  printf '%s\n' \
+    "CI result failed: $invalid_job=$invalid_result; rule: every non-changes job result must be exactly success or skipped."
+  exit 1
+fi
 
 echo "Selected CI jobs passed."

--- a/scripts/ci_result_gate.sh
+++ b/scripts/ci_result_gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+changes_result=${1-}
+backend_fast_result=${2-}
+frontend_result=${3-}
+db_contract_result=${4-}
+
+printf 'changes=%s\n' "$changes_result"
+printf 'backend-fast=%s\n' "$backend_fast_result"
+printf 'frontend=%s\n' "$frontend_result"
+printf 'db-contract=%s\n' "$db_contract_result"
+
+if [ "$changes_result" != "success" ]; then
+  printf '%s\n' \
+    "CI result failed: changes=$changes_result; rule: changes must be exactly success because job selection must complete."
+  exit 1
+fi
+
+check_suite_result() {
+  local job_name=$1
+  local result=$2
+
+  if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+    printf '%s\n' \
+      "CI result failed: $job_name=$result; rule: suite result must be exactly success or skipped."
+    return 1
+  fi
+}
+
+check_suite_result "backend-fast" "$backend_fast_result"
+check_suite_result "frontend" "$frontend_result"
+check_suite_result "db-contract" "$db_contract_result"
+
+echo "Selected CI jobs passed."

--- a/tests/test_ci_result_gate.py
+++ b/tests/test_ci_result_gate.py
@@ -1,0 +1,80 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / "scripts" / "ci_result_gate.sh"
+
+
+def _run_gate(
+    changes: str,
+    backend_fast: str,
+    frontend: str,
+    db_contract: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GATE), changes, backend_fast, frontend, db_contract],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("changes", ["cancelled", "failure", "skipped"])
+def test_incomplete_job_selection_fails_when_suites_are_skipped(changes: str):
+    result = _run_gate(changes, "skipped", "skipped", "skipped")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert result.stdout.splitlines()[:4] == [
+        f"changes={changes}",
+        "backend-fast=skipped",
+        "frontend=skipped",
+        "db-contract=skipped",
+    ]
+    assert (
+        f"CI result failed: changes={changes}; rule: changes must be exactly "
+        "success because job selection must complete."
+    ) in result.stdout
+
+
+def test_successful_selection_allows_deliberately_skipped_suite():
+    result = _run_gate("success", "success", "skipped", "success")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.splitlines() == [
+        "changes=success",
+        "backend-fast=success",
+        "frontend=skipped",
+        "db-contract=success",
+        "Selected CI jobs passed.",
+    ]
+
+
+def test_failed_suite_fails_after_successful_selection():
+    result = _run_gate("success", "failure", "success", "success")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert result.stdout.splitlines()[:4] == [
+        "changes=success",
+        "backend-fast=failure",
+        "frontend=success",
+        "db-contract=success",
+    ]
+    assert (
+        "CI result failed: backend-fast=failure; rule: suite result must be "
+        "exactly success or skipped."
+    ) in result.stdout
+
+
+@pytest.mark.parametrize("backend_fast", ["", "cancelled", "timed_out"])
+def test_unaccepted_suite_result_fails(backend_fast: str):
+    result = _run_gate("success", backend_fast, "success", "success")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert (
+        f"CI result failed: backend-fast={backend_fast}; rule: suite result must "
+        "be exactly success or skipped."
+    ) in result.stdout

--- a/tests/test_ci_result_gate.py
+++ b/tests/test_ci_result_gate.py
@@ -1,5 +1,8 @@
+import json
+import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -9,72 +12,174 @@ GATE = ROOT / "scripts" / "ci_result_gate.sh"
 
 
 def _run_gate(
-    changes: str,
-    backend_fast: str,
-    frontend: str,
-    db_contract: str,
+    needs: dict[str, Any] | str | None,
 ) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("NEEDS_JSON", None)
+    if needs is not None:
+        env["NEEDS_JSON"] = (
+            json.dumps(needs, indent=2) if isinstance(needs, dict) else needs
+        )
+
     return subprocess.run(
-        ["bash", str(GATE), changes, backend_fast, frontend, db_contract],
+        ["bash", str(GATE)],
         cwd=ROOT,
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
 
 @pytest.mark.parametrize("changes", ["cancelled", "failure", "skipped"])
 def test_incomplete_job_selection_fails_when_suites_are_skipped(changes: str):
-    result = _run_gate(changes, "skipped", "skipped", "skipped")
+    result = _run_gate(
+        {
+            "changes": {"result": changes},
+            "backend-fast": {"result": "skipped"},
+            "frontend": {"result": "skipped"},
+            "db-contract": {"result": "skipped"},
+        }
+    )
 
     assert result.returncode == 1, result.stdout + result.stderr
-    assert result.stdout.splitlines()[:4] == [
-        f"changes={changes}",
+    assert result.stdout.splitlines()[:-1] == [
         "backend-fast=skipped",
-        "frontend=skipped",
+        f"changes={changes}",
         "db-contract=skipped",
+        "frontend=skipped",
     ]
-    assert (
-        f"CI result failed: changes={changes}; rule: changes must be exactly "
-        "success because job selection must complete."
-    ) in result.stdout
+    failure = result.stdout.splitlines()[-1]
+    assert f"changes={changes}" in failure
+    assert "must be exactly success" in failure
 
 
 def test_successful_selection_allows_deliberately_skipped_suite():
-    result = _run_gate("success", "success", "skipped", "success")
+    result = _run_gate(
+        {
+            "changes": {"result": "success"},
+            "backend-fast": {"result": "success"},
+            "frontend": {"result": "skipped"},
+            "db-contract": {"result": "success"},
+        }
+    )
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert result.stdout.splitlines() == [
-        "changes=success",
         "backend-fast=success",
-        "frontend=skipped",
+        "changes=success",
         "db-contract=success",
+        "frontend=skipped",
         "Selected CI jobs passed.",
     ]
 
 
 def test_failed_suite_fails_after_successful_selection():
-    result = _run_gate("success", "failure", "success", "success")
+    result = _run_gate(
+        {
+            "changes": {"result": "success"},
+            "backend-fast": {"result": "failure"},
+            "frontend": {"result": "success"},
+            "db-contract": {"result": "success"},
+        }
+    )
 
     assert result.returncode == 1, result.stdout + result.stderr
-    assert result.stdout.splitlines()[:4] == [
-        "changes=success",
+    assert result.stdout.splitlines()[:-1] == [
         "backend-fast=failure",
-        "frontend=success",
+        "changes=success",
         "db-contract=success",
+        "frontend=success",
     ]
-    assert (
-        "CI result failed: backend-fast=failure; rule: suite result must be "
-        "exactly success or skipped."
-    ) in result.stdout
+    failure = result.stdout.splitlines()[-1]
+    assert "backend-fast=failure" in failure
+    assert "must be exactly success or skipped" in failure
 
 
 @pytest.mark.parametrize("backend_fast", ["", "cancelled", "timed_out"])
 def test_unaccepted_suite_result_fails(backend_fast: str):
-    result = _run_gate("success", backend_fast, "success", "success")
+    result = _run_gate(
+        {
+            "changes": {"result": "success"},
+            "backend-fast": {"result": backend_fast},
+            "frontend": {"result": "success"},
+            "db-contract": {"result": "success"},
+        }
+    )
 
     assert result.returncode == 1, result.stdout + result.stderr
-    assert (
-        f"CI result failed: backend-fast={backend_fast}; rule: suite result must "
-        "be exactly success or skipped."
-    ) in result.stdout
+    assert result.stdout.splitlines()[:-1] == [
+        f"backend-fast={backend_fast}",
+        "changes=success",
+        "db-contract=success",
+        "frontend=success",
+    ]
+    failure = result.stdout.splitlines()[-1]
+    assert f"backend-fast={backend_fast}" in failure
+    assert "must be exactly success or skipped" in failure
+
+
+def test_new_job_is_checked_without_adding_its_name_to_the_gate():
+    result = _run_gate(
+        {
+            "changes": {"result": "success"},
+            "backend-fast": {"result": "success"},
+            "frontend": {"result": "skipped"},
+            "db-contract": {"result": "success"},
+            "new-suite": {"result": "failure"},
+        }
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert result.stdout.splitlines()[:-1] == [
+        "backend-fast=success",
+        "changes=success",
+        "db-contract=success",
+        "frontend=skipped",
+        "new-suite=failure",
+    ]
+    failure = result.stdout.splitlines()[-1]
+    assert "new-suite=failure" in failure
+    assert "must be exactly success or skipped" in failure
+
+
+def test_missing_changes_job_fails():
+    result = _run_gate(
+        {
+            "backend-fast": {"result": "success"},
+            "frontend": {"result": "skipped"},
+            "db-contract": {"result": "success"},
+        }
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert result.stdout.splitlines()[:-1] == [
+        "backend-fast=success",
+        "db-contract=success",
+        "frontend=skipped",
+    ]
+    failure = result.stdout.splitlines()[-1]
+    assert "changes=<missing>" in failure
+    assert "must include" in failure
+
+
+@pytest.mark.parametrize(
+    ("needs", "value"),
+    [
+        (None, "<unset>"),
+        ("", "<empty>"),
+        ("not valid JSON", "<invalid>"),
+        ('{"changes": {"result": "success"}}{}', "<invalid>"),
+    ],
+)
+def test_missing_empty_or_malformed_needs_json_fails(
+    needs: str | None,
+    value: str,
+):
+    result = _run_gate(needs)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    failure = result.stdout.splitlines()[-1]
+    assert "NEEDS_JSON" in failure
+    assert value in failure
+    assert "valid JSON object" in failure


### PR DESCRIPTION
Closes #709.

## What was wrong

`Brain CI`'s `CI result` job — the single check a human reads to decide "did the tests pass" — reported **success when no test ran**.

The guard was a deny-list. It failed only on the two literal strings `failure` and `cancelled`, so every other value passed. `Detect changed areas` is the job that selects which suites run; when it dies, the three suites see empty selection outputs, skip, and the gate reads three benign `skipped` values and prints "Selected CI jobs passed".

Live on PR #708, head `42a678d`, run [31118459372](https://github.com/Illospace/illospace/actions/runs/31118459372), 2026-08-06T16:03Z:

| job | conclusion |
|---|---|
| Detect changed areas | **cancelled** — *"The job was not acquired by Runner of type hosted even after multiple attempts"* |
| Backend fast suite | skipped |
| Frontend check and build | skipped |
| Backend DB suite | skipped |
| **CI result** | **success** |

Zero of ~4800 tests ran and the aggregate check went green. The trigger was GitHub runner allocation, so it recurs on its own schedule.

Same family as #682 (stacked PRs ran no CI at all), one level down: there the checks were absent, here they are present and lying.

## What this does

The guard becomes an allow-list, extracted to `scripts/ci_result_gate.sh` so it can be tested:

- `changes` must be exactly `success`. It carries no `if:` condition, so it runs on every triggering event — any other value means job selection never happened and no downstream `skipped` can be trusted.
- Every other job must be exactly `success` or `skipped`, and `skipped` only counts because the rule above already proved the selection ran and deliberately did not pick that area.
- Every job and its result is printed before the verdict, on both paths, so the next occurrence is diagnosable from this job's own log instead of the REST API.

**`needs:` is the job registry — there is no second list.** The whole `needs` context is handed to the script as `NEEDS_JSON: ${{ toJSON(needs) }}` and the job set is derived from it. Add a job to `needs:` and it is validated automatically; there is nowhere to forget to add it. That second fail-open (in the job *list*, rather than the job *results*) is what the first draft of this fix still had, and `test_new_job_is_checked_without_adding_its_name_to_the_gate` is the regression that pins it shut.

## See it yourself — no diff reading required

The gate is one shell command. On this branch:

```bash
NEEDS_JSON='{"changes":{"result":"cancelled"},"backend-fast":{"result":"skipped"},"frontend":{"result":"skipped"},"db-contract":{"result":"skipped"}}' bash scripts/ci_result_gate.sh ; echo "exit=$?"
```

That is the exact vector that shipped green this morning. It now prints each job, then `CI result failed: changes=cancelled; rule: the changes result must be exactly success.` and `exit=1`.

```bash
NEEDS_JSON='{"changes":{"result":"success"},"backend-fast":{"result":"success"},"frontend":{"result":"skipped"},"db-contract":{"result":"success"}}' bash scripts/ci_result_gate.sh ; echo "exit=$?"
```

An ordinary backend-only PR: `Selected CI jobs passed.` and `exit=0`.

## Acceptance checks

1. `changes` cancelled, failed, skipped, or absent → `CI result` is **red**, whatever the suites say.
2. A PR touching only `frontend/**` still passes with both backend suites `skipped` — legitimate path-filter skips must not become failures.
3. A genuinely failing backend suite still fails, unchanged.
4. The gate's log names each job and its result on the passing path and the failing path.

All four are asserted in `tests/test_ci_result_gate.py`, 14 cases: the four rules above, an unlisted fifth job that fails, an empty result string, a missing `changes` key, and unset / empty / malformed `NEEDS_JSON`.

## Verification

Every lane this diff selects, run locally on `ccea9da`:

| lane | result |
|---|---|
| Backend fast suite | **4845 passed**, 11 skipped (73s) |
| Backend DB suite | **80 passed**; `alembic upgrade head` clean against pgvector/pg16 |
| Frontend check and build | **248 passed**; `svelte-check` 6697 files, **0 errors 0 warnings**; build ok |
| Cycle context admission | ok |

The frontend lane is not incidental: `.github/workflows/brain-ci.yml` sits in both the `backend` and `frontend` paths-filters, so this PR selects all three lanes and exercises the new gate on a full fan-out.

## Assumptions

- `changes` genuinely always runs. Verified: the job has no `if:` — only its *steps* are conditioned on `github.event_name != 'workflow_dispatch'` — so `success` is the only correct result on every trigger.
- The added `actions/checkout@v4` step in `ci-result` does not weaken the gate. For `pull_request` events the workflow file itself already comes from the PR's merge ref, so the script is no more PR-authored than the inline shell it replaces. Independently reviewed and cleared.
- `jq` is preinstalled on GitHub-hosted `ubuntu-latest` runners, and on this machine. A contributor without `jq` sees `tests/test_ci_result_gate.py` fail rather than skip — worth a `pytest.importorskip`-style guard if that ever bites, but not worth pre-empting.

## Not addressed here

- **#708's own head commit still has no CI coverage.** This PR fixes the gate; it cannot retroactively test that commit. #708 needs a real CI run before it merges — [commented there](https://github.com/Illospace/illospace/pull/708#issuecomment-5207518953).
- `Deployment Smoke` lost its runner in the same event and correctly surfaced red on the PR, so it needs no change.
