### PR TITLE
fix(heartbeat): accept any project-bound GitHub credential, not only a GitHub App

### DIFF
--- a/brain/jobs/pipelines/illo_heartbeat.py
+++ b/brain/jobs/pipelines/illo_heartbeat.py
@@ -35,6 +35,10 @@ PROJECT_SLUG = REPO_SLUG.lower()
 HEARTBEAT_BRANCH = "ops/heartbeat"
 HEARTBEAT_PATH = "heartbeat.json"
 HEARTBEAT_INSTALLATION_PERMISSIONS = {"contents": "write"}
+# No App is installed on the Illospace org (deliberate: the repo is public and
+# the private illo-bot App stays uwear-ai-only), so a static "github" binding
+# is an accepted credential for this one publish path.
+HEARTBEAT_SECRET_CATEGORIES = ("github_app", "github")
 HeartbeatPayload = LivenessSnapshot
 build_heartbeat_payload = build_liveness_snapshot
 
@@ -73,9 +77,12 @@ async def _heartbeat_actor() -> HeartbeatActor | None:
             .where(
                 func.lower(VaultProjectBinding.project_slug) == PROJECT_SLUG,
                 VaultProjectBinding.active.is_(True),
-                Secret.category == "github_app",
+                Secret.category.in_(HEARTBEAT_SECRET_CATEGORIES),
             )
-            .order_by(VaultProjectBinding.id.asc())
+            .order_by(
+                (Secret.category == "github_app").desc(),
+                VaultProjectBinding.id.asc(),
+            )
             .limit(1)
         )
         if binding is None:
@@ -105,6 +112,14 @@ async def _heartbeat_token(actor: HeartbeatActor) -> str | None:
         project_slug=PROJECT_SLUG,
         github_app_only=True,
         github_app_permissions=HEARTBEAT_INSTALLATION_PERMISSIONS,
+    )
+    token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
+    if token:
+        return token
+    env = await async_resolve_project_bound_env_tokens(
+        actor_user_id=actor.user_id,
+        org_id=actor.org_id,
+        project_slug=PROJECT_SLUG,
     )
     return str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip() or None
 
@@ -315,7 +330,7 @@ async def run_heartbeat(*, now: datetime | None = None) -> dict[str, Any]:
             "ok": False,
             "outcome": "skipped",
             "skip_kind": SchedulerSkipKind.CONFIGURATION.value,
-            "reason": f"No GitHub App project binding is configured for {PROJECT_SLUG}",
+            "reason": f"No GitHub credential project binding is configured for {PROJECT_SLUG}",
         }
     token = await _heartbeat_token(actor)
     if token is None:

--- a/tests/test_illo_heartbeat.py
+++ b/tests/test_illo_heartbeat.py
@@ -122,7 +122,7 @@ async def test_missing_project_binding_is_an_explicit_configuration_skip(monkeyp
     assert result["outcome"] == "skipped"
     assert result["skip_kind"] == "configuration"
     assert result["reason"] == (
-        "No GitHub App project binding is configured for illospace/illospace"
+        "No GitHub credential project binding is configured for illospace/illospace"
     )
     publish.assert_not_awaited()
 
@@ -182,6 +182,27 @@ async def test_emitter_requests_existing_app_token_with_contents_write(monkeypat
         project_slug="illospace/illospace",
         github_app_only=True,
         github_app_permissions={"contents": "write"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_emitter_falls_back_to_static_project_token_without_an_app(monkeypatch):
+    resolver = AsyncMock(side_effect=[{}, {"GH_TOKEN": "static-project-token"}])
+    monkeypatch.setattr(
+        illo_heartbeat,
+        "async_resolve_project_bound_env_tokens",
+        resolver,
+    )
+    actor = illo_heartbeat.HeartbeatActor(user_id="user-1", org_id="org-1")
+
+    token = await illo_heartbeat._heartbeat_token(actor)
+
+    assert token == "static-project-token"
+    assert resolver.await_count == 2
+    resolver.assert_awaited_with(
+        actor_user_id="user-1",
+        org_id="org-1",
+        project_slug="illospace/illospace",
     )
 
 


### PR DESCRIPTION
## Problem

`illo_external_heartbeat` fails every run with "No GitHub App project binding is configured for illospace/illospace" (honest since #715; before that it settled green). The job demands a `github_app` binding, but on 2026-07-08 the decision was made NOT to install the private `illo-bot` App on the public Illospace org. The feature and the decision conflict, so the external deadman has never had a heartbeat to watch (#512).

## Change

- `_heartbeat_actor` accepts `github_app` OR `github` category bindings for the repo, preferring the App when both exist.
- `_heartbeat_token` tries the App mint first, then falls back to the statically bound token (`GITHUB_TOKEN`/`GH_TOKEN`).
- Configuration-skip reason updated to match.

## Live state (verified on illo-dev today)

The existing `GH_TOKEN → GITHUB_TOKEN__AXEL_LEGACY` binding resolves, but the PAT itself returns **401** — it is dead. This PR makes the job work with whatever valid bound credential exists; a fresh token (fine-grained PAT scoped to this repo, Contents RW) must still be stored in the Vault for the heartbeat to publish. The watcher additionally needs the `SLACK_DEADMAN_WEBHOOK_URL` repo secret.

Tests: `tests/test_illo_heartbeat.py` — 15 passed (new fallback case included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)