### PR TITLE
fix(vault): discover GitHub App installations by repository

### DIFF
--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -666,10 +666,10 @@ async def async_resolve_project_bound_env_tokens(
 ) -> dict[str, str]:
     """Return env-name/token pairs for matching org project bindings.
 
-    Matching bindings for the same GitHub App and env name mint one token
-    down-scoped to their combined repository names. Cross-repository GitHub
-    operations can therefore use one installation identity without widening
-    its permissions or repository access beyond the supplied bindings.
+    Matching bindings for the same GitHub App, env name, and installation mint
+    one token down-scoped to their combined repository names. Repositories from
+    different installations fail closed because one env name cannot carry more
+    than one installation token.
     ``github_app_permissions`` lets read-only maintenance callers narrow the
     minted token below the runtime default.
     """
@@ -741,7 +741,7 @@ async def _async_resolve_project_bound_env_tokens(
             if github_app_only and getattr(secret, "category", None) != "github_app":
                 continue
             if getattr(secret, "category", None) == "github_app":
-                repo_name = binding.project_slug.split("/")[-1]
+                repo_name = binding.project_slug
                 assignment_key = (binding.env_name, int(secret.id))
                 assignment = github_app_assignments.get(assignment_key)
                 if assignment is None:

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -16,6 +16,7 @@ from brain.systems.cortex.project_context.github import (
     GITHUB_API_BASE,
     GitHubConnectorError,
     _headers,
+    parse_github_repo_slug,
 )
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
@@ -38,7 +39,20 @@ DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {
     "checks": "read",
 }
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
+_INSTALLATION_CACHE_LIFETIME = timedelta(hours=1)
 _PEM_HASH_PREFIX_LENGTH = 16
+_MINT_STATUS_MESSAGES = {
+    401: "GitHub rejected the GitHub App JWT.",
+    403: "GitHub denied the GitHub App installation token request.",
+    404: "GitHub App installation was not found.",
+    422: "GitHub could not mint an installation token for the requested repositories or permissions.",
+}
+_DISCOVERY_STATUS_MESSAGES = {
+    401: "GitHub rejected the GitHub App JWT while finding the repository installation.",
+    403: "GitHub denied the GitHub App repository installation request.",
+    404: "GitHub App installation was not found for the repository.",
+    422: "GitHub could not find an installation for the repository.",
+}
 
 
 @dataclass(frozen=True)
@@ -89,8 +103,16 @@ class MintedInstallationToken:
     scope_key: str
 
 
+@dataclass(frozen=True)
+class CachedRepositoryInstallation:
+    installation_id: str
+    expires_at: datetime
+
+
 _TOKEN_CACHE: dict[str, MintedInstallationToken] = {}
 _MINT_LOCKS: dict[str, asyncio.Lock] = {}
+_INSTALLATION_CACHE: dict[str, CachedRepositoryInstallation] = {}
+_INSTALLATION_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def _now() -> datetime:
@@ -171,6 +193,47 @@ def _normalize_repositories(repositories: list[str] | tuple[str, ...]) -> list[s
     return cleaned
 
 
+def _normalize_repository_refs(
+    repositories: list[str] | tuple[str, ...],
+) -> list[tuple[str | None, str]]:
+    cleaned: list[tuple[str | None, str]] = []
+    seen: set[str] = set()
+    for repository in repositories:
+        value = str(repository or "").strip()
+        if not value:
+            continue
+        parts = value.split("/")
+        if len(parts) == 1:
+            canonical = parse_github_repo_slug(f"placeholder/{value}")
+            if canonical is None:
+                raise RuntimeSecretUnavailable(
+                    "GitHub App token field 'repositories' contained an invalid repository name"
+                )
+            owner = None
+            _placeholder, name = canonical.split("/", 1)
+        elif len(parts) == 2:
+            canonical = parse_github_repo_slug(value)
+            if canonical is None:
+                raise RuntimeSecretUnavailable(
+                    "GitHub App token field 'repositories' contained an invalid owner/repository name"
+                )
+            owner, name = canonical.split("/", 1)
+        else:
+            raise RuntimeSecretUnavailable(
+                "GitHub App token field 'repositories' must contain repository names or owner/repository names"
+            )
+        cache_identity = f"{owner}/{name}" if owner is not None else name
+        if cache_identity.lower() in seen:
+            continue
+        seen.add(cache_identity.lower())
+        cleaned.append((owner, name))
+    if not cleaned:
+        raise RuntimeSecretUnavailable(
+            "GitHub App token field 'repositories' is required"
+        )
+    return cleaned
+
+
 def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
     if permissions is None:
         raise RuntimeSecretUnavailable(
@@ -191,12 +254,13 @@ def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]
 def _scope_key(
     cred: GitHubAppCredential,
     *,
+    installation_id: str | None = None,
     repositories: list[str],
     permissions: dict[str, str],
 ) -> str:
     private_key_hash = hashlib.sha256(cred.private_key_pem.encode("utf-8")).hexdigest()
     payload = {
-        "installation_id": cred.installation_id,
+        "installation_id": installation_id or cred.installation_id,
         "repositories": sorted(repositories),
         "permissions": sorted(permissions.items()),
         "private_key_sha256": private_key_hash[:_PEM_HASH_PREFIX_LENGTH],
@@ -210,6 +274,33 @@ def _lock_for_scope(scope_key: str) -> asyncio.Lock:
     if lock is None:
         lock = asyncio.Lock()
         _MINT_LOCKS[scope_key] = lock
+    return lock
+
+
+def _installation_cache_key(
+    cred: GitHubAppCredential,
+    *,
+    owner: str,
+    repository: str,
+) -> str:
+    payload = {
+        "app_id": cred.app_id,
+        "client_id": cred.client_id,
+        "default_installation_id": cred.installation_id,
+        "private_key_sha256": hashlib.sha256(
+            cred.private_key_pem.encode("utf-8")
+        ).hexdigest(),
+        "repository": f"{owner}/{repository}".lower(),
+    }
+    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _lock_for_installation(cache_key: str) -> asyncio.Lock:
+    lock = _INSTALLATION_LOCKS.get(cache_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _INSTALLATION_LOCKS[cache_key] = lock
     return lock
 
 
@@ -241,20 +332,170 @@ def _parse_expires_at(value: Any) -> datetime:
     return expires_at.astimezone(timezone.utc)
 
 
-def _mint_error(response: httpx.Response) -> GitHubConnectorError:
-    messages = {
-        401: "GitHub rejected the GitHub App JWT.",
-        403: "GitHub denied the GitHub App installation token request.",
-        404: "GitHub App installation was not found.",
-        422: "GitHub could not mint an installation token for the requested repositories or permissions.",
-    }
+def _github_app_error(
+    response: httpx.Response,
+    *,
+    status_messages: dict[int, str],
+    default_action: str,
+) -> GitHubConnectorError:
     return GitHubConnectorError(
         status_code=response.status_code,
-        message=messages.get(
+        message=status_messages.get(
             response.status_code,
-            f"GitHub returned {response.status_code} while minting an installation token.",
+            f"GitHub returned {response.status_code} while {default_action}.",
         ),
     )
+
+
+def _mint_error(response: httpx.Response) -> GitHubConnectorError:
+    return _github_app_error(
+        response,
+        status_messages=_MINT_STATUS_MESSAGES,
+        default_action="minting an installation token",
+    )
+
+
+def _discovery_error(response: httpx.Response) -> GitHubConnectorError:
+    return _github_app_error(
+        response,
+        status_messages=_DISCOVERY_STATUS_MESSAGES,
+        default_action="finding the repository installation",
+    )
+
+
+async def _fetch_repository_installation(
+    *,
+    owner: str,
+    repository: str,
+    app_jwt: str,
+) -> str:
+    path = f"/repos/{owner}/{repository}/installation"
+    try:
+        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+            response = await client.request(
+                "GET",
+                f"{GITHUB_API_BASE}{path}",
+                headers=_headers(app_jwt),
+            )
+    except httpx.HTTPError:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="Could not reach GitHub while finding the repository installation.",
+        ) from None
+
+    if response.status_code != 200:
+        raise _discovery_error(response)
+    try:
+        payload = response.json()
+    except Exception:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub repository installation response was not valid JSON.",
+        ) from None
+    installation_id = payload.get("id") if isinstance(payload, dict) else None
+    if (
+        installation_id is None
+        or installation_id is True
+        or installation_id is False
+        or not str(installation_id).strip()
+    ):
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub repository installation response was missing id.",
+        )
+    try:
+        return str(int(str(installation_id).strip()))
+    except (TypeError, ValueError):
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub repository installation response had an invalid id.",
+        ) from None
+
+
+async def _fetch_installation_owner(
+    *,
+    installation_id: str,
+    app_jwt: str,
+) -> str:
+    path = f"/app/installations/{installation_id}"
+    try:
+        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+            response = await client.request(
+                "GET",
+                f"{GITHUB_API_BASE}{path}",
+                headers=_headers(app_jwt),
+            )
+    except httpx.HTTPError:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="Could not reach GitHub while verifying the fallback installation.",
+        ) from None
+
+    if response.status_code != 200:
+        raise _discovery_error(response)
+    try:
+        payload = response.json()
+    except Exception:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub fallback installation response was not valid JSON.",
+        ) from None
+    account = payload.get("account") if isinstance(payload, dict) else None
+    owner = account.get("login") if isinstance(account, dict) else None
+    if not isinstance(owner, str) or not owner.strip():
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub fallback installation response was missing account login.",
+        )
+    return owner.strip()
+
+
+async def _resolve_repository_installation(
+    cred: GitHubAppCredential,
+    *,
+    owner: str | None,
+    repository: str,
+    app_jwt: str,
+    now: datetime,
+) -> str:
+    if owner is None:
+        return cred.installation_id
+
+    cache_key = _installation_cache_key(
+        cred,
+        owner=owner,
+        repository=repository,
+    )
+    cached = _INSTALLATION_CACHE.get(cache_key)
+    if cached is not None and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW:
+        return cached.installation_id
+
+    async with _lock_for_installation(cache_key):
+        cached = _INSTALLATION_CACHE.get(cache_key)
+        if cached is not None and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW:
+            return cached.installation_id
+        try:
+            installation_id = await _fetch_repository_installation(
+                owner=owner,
+                repository=repository,
+                app_jwt=app_jwt,
+            )
+        except GitHubConnectorError as discovery_error:
+            try:
+                fallback_owner = await _fetch_installation_owner(
+                    installation_id=cred.installation_id,
+                    app_jwt=app_jwt,
+                )
+            except GitHubConnectorError:
+                raise discovery_error
+            if fallback_owner.lower() != owner.lower():
+                raise discovery_error
+            installation_id = cred.installation_id
+        _INSTALLATION_CACHE[cache_key] = CachedRepositoryInstallation(
+            installation_id=installation_id,
+            expires_at=now + _INSTALLATION_CACHE_LIFETIME,
+        )
+        return installation_id
 
 
 async def _exchange_installation_token(
@@ -262,23 +503,27 @@ async def _exchange_installation_token(
     *,
     repositories: list[str],
     permissions: dict[str, str],
+    installation_id: str | None = None,
+    app_jwt: str | None = None,
     now: datetime | int | float | None = None,
 ) -> MintedInstallationToken:
     clean_repositories = _normalize_repositories(repositories)
     clean_permissions = _normalize_permissions(permissions)
+    resolved_installation_id = installation_id or cred.installation_id
     scope_key = _scope_key(
         cred,
+        installation_id=resolved_installation_id,
         repositories=clean_repositories,
         permissions=clean_permissions,
     )
-    app_jwt = _build_app_jwt(cred, now=now)
-    path = f"/app/installations/{cred.installation_id}/access_tokens"
+    exchange_jwt = app_jwt or _build_app_jwt(cred, now=now)
+    path = f"/app/installations/{resolved_installation_id}/access_tokens"
     try:
         async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
             response = await client.request(
                 "POST",
                 f"{GITHUB_API_BASE}{path}",
-                headers=_headers(app_jwt),
+                headers=_headers(exchange_jwt),
                 json={
                     "repositories": clean_repositories,
                     "permissions": clean_permissions,
@@ -308,9 +553,60 @@ async def _exchange_installation_token(
     return MintedInstallationToken(
         token=token.strip(),
         expires_at=_parse_expires_at(payload.get("expires_at")),
-        installation_id=cred.installation_id,
+        installation_id=resolved_installation_id,
         scope_key=scope_key,
     )
+
+
+async def _mint_for_installation(
+    cred: GitHubAppCredential,
+    *,
+    installation_id: str,
+    repositories: list[str],
+    scope_repositories: list[str],
+    permissions: dict[str, str],
+    app_jwt: str,
+    now: datetime,
+) -> MintedInstallationToken:
+    scope_key = _scope_key(
+        cred,
+        installation_id=installation_id,
+        repositories=scope_repositories,
+        permissions=permissions,
+    )
+    cached = _TOKEN_CACHE.get(scope_key)
+    if _cache_is_fresh(cached, now=now):
+        return cached
+
+    async with _lock_for_scope(scope_key):
+        current = _utc_datetime(None)
+        cached = _TOKEN_CACHE.get(scope_key)
+        if _cache_is_fresh(cached, now=current):
+            return cached
+        try:
+            minted = await _exchange_installation_token(
+                cred,
+                repositories=repositories,
+                permissions=permissions,
+                installation_id=installation_id,
+                app_jwt=app_jwt,
+                now=current,
+            )
+        except GitHubConnectorError as exc:
+            if exc.status_code != 422 or permissions.get("pull_requests") != "write":
+                raise
+            fallback_permissions = dict(permissions)
+            fallback_permissions["pull_requests"] = "read"
+            minted = await _exchange_installation_token(
+                cred,
+                repositories=repositories,
+                permissions=fallback_permissions,
+                installation_id=installation_id,
+                app_jwt=app_jwt,
+                now=current,
+            )
+        _TOKEN_CACHE[scope_key] = minted
+        return minted
 
 
 async def async_mint_installation_token(
@@ -320,51 +616,53 @@ async def async_mint_installation_token(
     permissions: dict[str, str] = DEFAULT_INSTALLATION_PERMISSIONS,
 ) -> str:
     cred = GitHubAppCredential.from_blob(decrypted_blob)
-    clean_repositories = _normalize_repositories(repositories)
+    repository_refs = _normalize_repository_refs(repositories)
     clean_permissions = _normalize_permissions(permissions)
-    scope_key = _scope_key(
-        cred,
-        repositories=clean_repositories,
-        permissions=clean_permissions,
-    )
-
     current = _utc_datetime(None)
-    cached = _TOKEN_CACHE.get(scope_key)
-    if _cache_is_fresh(cached, now=current):
-        return cached.token
+    app_jwt = _build_app_jwt(cred, now=current)
+    repositories_by_installation: dict[str, list[tuple[str, str]]] = {}
+    for owner, repository in repository_refs:
+        installation_id = await _resolve_repository_installation(
+            cred,
+            owner=owner,
+            repository=repository,
+            app_jwt=app_jwt,
+            now=current,
+        )
+        installation_repositories = repositories_by_installation.setdefault(
+            installation_id,
+            [],
+        )
+        repository_identity = f"{owner}/{repository}" if owner is not None else repository
+        if (repository, repository_identity) not in installation_repositories:
+            installation_repositories.append((repository, repository_identity))
 
-    async with _lock_for_scope(scope_key):
-        current = _utc_datetime(None)
-        cached = _TOKEN_CACHE.get(scope_key)
-        if _cache_is_fresh(cached, now=current):
-            return cached.token
-        try:
-            minted = await _exchange_installation_token(
-                cred,
-                repositories=clean_repositories,
-                permissions=clean_permissions,
-                now=current,
-            )
-        except GitHubConnectorError as exc:
-            if (
-                exc.status_code != 422
-                or clean_permissions.get("pull_requests") != "write"
-            ):
-                raise
-            fallback_permissions = dict(clean_permissions)
-            fallback_permissions["pull_requests"] = "read"
-            minted = await _exchange_installation_token(
-                cred,
-                repositories=clean_repositories,
-                permissions=fallback_permissions,
-                now=current,
-            )
-        _TOKEN_CACHE[scope_key] = minted
-        return minted.token
+    minted_tokens = [
+        await _mint_for_installation(
+            cred,
+            installation_id=installation_id,
+            repositories=[repository for repository, _identity in repository_refs],
+            scope_repositories=[identity for _repository, identity in repository_refs],
+            permissions=clean_permissions,
+            app_jwt=app_jwt,
+            now=current,
+        )
+        for installation_id, repository_refs in repositories_by_installation.items()
+    ]
+    if len(minted_tokens) != 1:
+        raise GitHubConnectorError(
+            status_code=422,
+            message=(
+                "GitHub App repositories span multiple installations and cannot share "
+                "one installation token."
+            ),
+        )
+    return minted_tokens[0].token
 
 
 __all__ = [
     "DEFAULT_INSTALLATION_PERMISSIONS",
+    "CachedRepositoryInstallation",
     "GitHubAppCredential",
     "MintedInstallationToken",
     "_build_app_jwt",

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -27,9 +27,13 @@ NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
 def clear_mint_cache():
     mint._TOKEN_CACHE.clear()
     mint._MINT_LOCKS.clear()
+    mint._INSTALLATION_CACHE.clear()
+    mint._INSTALLATION_LOCKS.clear()
     yield
     mint._TOKEN_CACHE.clear()
     mint._MINT_LOCKS.clear()
+    mint._INSTALLATION_CACHE.clear()
+    mint._INSTALLATION_LOCKS.clear()
 
 
 @pytest.fixture
@@ -87,6 +91,14 @@ def _token_response(token: str, expires_at: datetime) -> httpx.Response:
         201,
         json={"token": token, "expires_at": expires_at.isoformat().replace("+00:00", "Z")},
     )
+
+
+def _installation_response(installation_id: int) -> httpx.Response:
+    return httpx.Response(200, json={"id": installation_id})
+
+
+def _installation_owner_response(owner: str) -> httpx.Response:
+    return httpx.Response(200, json={"account": {"login": owner}})
 
 
 def _patch_http(monkeypatch, responses: list[httpx.Response], *, delay: float = 0) -> list[dict]:
@@ -159,6 +171,230 @@ async def test_exchange_installation_token_request_shape(monkeypatch, rsa_keypai
     }
     app_jwt = request["headers"]["Authorization"].removeprefix("Bearer ")
     assert _decode(app_jwt, public_pem)["iss"] == "Iv23.client"
+
+
+@pytest.mark.asyncio
+async def test_mint_discovers_repository_installation_before_exchange(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _installation_response(789),
+            _token_response("illospace-token", NOW + timedelta(hours=1)),
+        ],
+    )
+
+    token = await async_mint_installation_token(
+        _blob(private_pem),
+        repositories=["illospace/illospace"],
+        permissions={"contents": "write"},
+    )
+
+    assert token == "illospace-token"
+    assert [(request["method"], request["url"]) for request in requests] == [
+        ("GET", f"{GITHUB_API_BASE}/repos/illospace/illospace/installation"),
+        ("POST", f"{GITHUB_API_BASE}/app/installations/789/access_tokens"),
+    ]
+    assert requests[1]["json"] == {
+        "repositories": ["illospace"],
+        "permissions": {"contents": "write"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_mint_falls_back_to_stored_installation_and_caches_the_resolution(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            httpx.Response(404, json={"message": "Not Found"}),
+            _installation_owner_response("uwear-ai"),
+            _token_response("fallback-token", NOW + timedelta(hours=1)),
+            _token_response("fallback-write-token", NOW + timedelta(hours=1)),
+        ],
+    )
+
+    token = await async_mint_installation_token(
+        _blob(private_pem),
+        repositories=["uwear-ai/uwear-backend"],
+        permissions={"contents": "read"},
+    )
+
+    assert token == "fallback-token"
+    assert await async_mint_installation_token(
+        _blob(private_pem),
+        repositories=["uwear-ai/uwear-backend"],
+        permissions={"contents": "write"},
+    ) == "fallback-write-token"
+    assert [(request["method"], request["url"]) for request in requests] == [
+        (
+            "GET",
+            f"{GITHUB_API_BASE}/repos/uwear-ai/uwear-backend/installation",
+        ),
+        ("GET", f"{GITHUB_API_BASE}/app/installations/456"),
+        (
+            "POST",
+            f"{GITHUB_API_BASE}/app/installations/456/access_tokens",
+        ),
+        (
+            "POST",
+            f"{GITHUB_API_BASE}/app/installations/456/access_tokens",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mint_does_not_fallback_to_stored_installation_for_another_owner(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            httpx.Response(404, json={"message": "Not Found"}),
+            _installation_owner_response("uwear-ai"),
+        ],
+    )
+
+    with pytest.raises(
+        GitHubConnectorError,
+        match="installation was not found for the repository",
+    ) as exc_info:
+        await async_mint_installation_token(
+            _blob(private_pem),
+            repositories=["illospace/illospace"],
+            permissions={"contents": "write"},
+        )
+
+    assert exc_info.value.status_code == 404
+    assert [(request["method"], request["url"]) for request in requests] == [
+        ("GET", f"{GITHUB_API_BASE}/repos/illospace/illospace/installation"),
+        ("GET", f"{GITHUB_API_BASE}/app/installations/456"),
+    ]
+    assert not any(
+        request["url"].endswith("/access_tokens") for request in requests
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_splits_repositories_across_installations(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _installation_response(111),
+            _installation_response(222),
+            _token_response("first-token", NOW + timedelta(hours=1)),
+            _token_response("second-token", NOW + timedelta(hours=1)),
+        ],
+    )
+
+    with pytest.raises(GitHubConnectorError, match="span multiple installations"):
+        await async_mint_installation_token(
+            _blob(private_pem),
+            repositories=["first-org/backend", "second-org/frontend"],
+            permissions={"contents": "read"},
+        )
+
+    exchanges = [request for request in requests if request["method"] == "POST"]
+    assert [request["url"] for request in exchanges] == [
+        f"{GITHUB_API_BASE}/app/installations/111/access_tokens",
+        f"{GITHUB_API_BASE}/app/installations/222/access_tokens",
+    ]
+    assert [request["json"]["repositories"] for request in exchanges] == [
+        ["backend"],
+        ["frontend"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_repository_installation_discovery_is_cached_across_token_scopes(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _installation_response(789),
+            _token_response("read-token", NOW + timedelta(hours=1)),
+            _token_response("write-token", NOW + timedelta(hours=1)),
+        ],
+    )
+    blob = _blob(private_pem)
+
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["illospace/illospace"],
+        permissions={"contents": "read"},
+    ) == "read-token"
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["illospace/illospace"],
+        permissions={"contents": "write"},
+    ) == "write-token"
+
+    assert [request["method"] for request in requests] == ["GET", "POST", "POST"]
+
+
+@pytest.mark.asyncio
+async def test_repository_installation_cache_misses_after_pem_rotation(
+    monkeypatch,
+    rsa_keypair,
+):
+    first_private_pem, _public_pem = rsa_keypair
+    second_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    second_private_pem = second_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _installation_response(789),
+            _token_response("first-token", NOW + timedelta(hours=1)),
+            _installation_response(987),
+            _token_response("rotated-token", NOW + timedelta(hours=1)),
+        ],
+    )
+
+    assert await async_mint_installation_token(
+        _blob(first_private_pem),
+        repositories=["illospace/illospace"],
+        permissions={"contents": "read"},
+    ) == "first-token"
+    assert await async_mint_installation_token(
+        _blob(second_private_pem),
+        repositories=["illospace/illospace"],
+        permissions={"contents": "read"},
+    ) == "rotated-token"
+
+    assert [request["method"] for request in requests] == [
+        "GET",
+        "POST",
+        "GET",
+        "POST",
+    ]
+    assert requests[3]["url"] == (
+        f"{GITHUB_API_BASE}/app/installations/987/access_tokens"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -562,7 +562,7 @@ async def test_job_minted_token_requests_read_only_contents_permission(
 
     assert token == "minted-app-token"
     mint.assert_awaited_once()
-    assert mint.await_args.kwargs["repositories"] == ["uwear-backend"]
+    assert mint.await_args.kwargs["repositories"] == ["uwear-ai/uwear-backend"]
     assert mint.await_args.kwargs["permissions"]["contents"] == "read"
     assert mint.await_args.kwargs["permissions"]["contents"] != "write"
 

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -155,6 +155,8 @@ class _MockGitHubClient:
                     "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
                 },
             )
+        if method == "GET" and url.endswith("/app/installations/456"):
+            return httpx.Response(200, json={"account": {"login": "uwear-ai"}})
         if url.endswith("/repos/uwear-ai/uwear-backend/issues"):
             return httpx.Response(
                 201,
@@ -437,7 +439,7 @@ async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, se
     assert mint_calls == [
         {
             "decrypted_blob": "github-app-blob",
-            "repositories": ["uwear-backend"],
+            "repositories": ["uwear-ai/uwear-backend"],
             "permissions": {"issues": "write", "contents": "read", "pull_requests": "write", "checks": "read"},
             "transaction_open": False,
         }
@@ -491,7 +493,7 @@ async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(pa
 
     async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
         assert decrypted_blob == "github-app-blob"
-        assert repositories == ["uwear-backend"]
+        assert repositories == ["uwear-ai/uwear-backend"]
         assert permissions == {"issues": "write", "contents": "read", "pull_requests": "write", "checks": "read"}
         return "minted-installation-token"
 
@@ -557,7 +559,7 @@ async def test_backfill_can_narrow_github_app_token_to_read_only_pr_access(
     assert env == {"GITHUB_TOKEN": "read-only-installation-token"}
     mint.assert_awaited_once_with(
         "github-app-blob",
-        repositories=["uwear-backend"],
+        repositories=["uwear-ai/uwear-backend"],
         permissions={"pull_requests": "read"},
     )
 
@@ -615,7 +617,10 @@ async def test_github_app_binding_mints_one_token_for_cross_repo_operation(
     assert env == {"GITHUB_TOKEN": "cross-repo-installation-token"}
     assert mint_calls == [{
         "decrypted_blob": "github-app-blob",
-        "repositories": ["uwear-backend", "uwear-coordination"],
+        "repositories": [
+            "uwear-ai/uwear-backend",
+            "uwear-ai/uwear-coordination",
+        ],
         "permissions": {
             "issues": "write",
             "contents": "read",
@@ -638,6 +643,8 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
 
     github_app_mint._TOKEN_CACHE.clear()
     github_app_mint._MINT_LOCKS.clear()
+    github_app_mint._INSTALLATION_CACHE.clear()
+    github_app_mint._INSTALLATION_LOCKS.clear()
     app_blob = json.dumps({
         "app_id": "123",
         "client_id": "Iv23.client",


### PR DESCRIPTION
Completes #717 — the squash there raced a branch push and merged only the heartbeat fallback commit; this PR carries the mint change that was meant to ride along.

## Problem (verified live on illo-dev)

The mint pins the uwear-ai installation id from the stored credential. Minting for `illospace/illospace` therefore scopes the token to **`uwear-ai/illospace`** (a same-named repo in the uwear-ai org), which makes the exchange succeed and every read succeed (the OSS repo is public) while every write to `Illospace/illospace` returns 403 — the exact failure the external heartbeat is hitting every 5 minutes right now.

## Change

Installation discovery per repository: the App JWT resolves `GET /repos/{owner}/{repo}/installation` and the exchange uses the discovered installation. Stored id stays the fallback only after GitHub confirms it belongs to the requested owner (a same-name repo in another org can never be silently substituted). Lookup cache keyed incl. PEM hash, ~55m TTL. Repos spanning installations in one env-var mint fail closed.

Follow-up maintainability refactor already tracked in #719.

Tests: 83 focused (mint, vault tokens, staging promotion, heartbeat) + full suite green pre-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)