### PR TITLE
refactor(vault): extract a repository-installation resolver from the mint

### DIFF
--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -16,7 +16,9 @@ from brain.systems.cortex.project_context.github import (
     GITHUB_API_BASE,
     GitHubConnectorError,
     _headers,
-    parse_github_repo_slug,
+)
+from brain.systems.vault.installation_resolver import (
+    repository_installation_resolver,
 )
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
@@ -39,19 +41,12 @@ DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {
     "checks": "read",
 }
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
-_INSTALLATION_CACHE_LIFETIME = timedelta(hours=1)
 _PEM_HASH_PREFIX_LENGTH = 16
 _MINT_STATUS_MESSAGES = {
     401: "GitHub rejected the GitHub App JWT.",
     403: "GitHub denied the GitHub App installation token request.",
     404: "GitHub App installation was not found.",
     422: "GitHub could not mint an installation token for the requested repositories or permissions.",
-}
-_DISCOVERY_STATUS_MESSAGES = {
-    401: "GitHub rejected the GitHub App JWT while finding the repository installation.",
-    403: "GitHub denied the GitHub App repository installation request.",
-    404: "GitHub App installation was not found for the repository.",
-    422: "GitHub could not find an installation for the repository.",
 }
 
 
@@ -103,16 +98,8 @@ class MintedInstallationToken:
     scope_key: str
 
 
-@dataclass(frozen=True)
-class CachedRepositoryInstallation:
-    installation_id: str
-    expires_at: datetime
-
-
 _TOKEN_CACHE: dict[str, MintedInstallationToken] = {}
 _MINT_LOCKS: dict[str, asyncio.Lock] = {}
-_INSTALLATION_CACHE: dict[str, CachedRepositoryInstallation] = {}
-_INSTALLATION_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def _now() -> datetime:
@@ -193,47 +180,6 @@ def _normalize_repositories(repositories: list[str] | tuple[str, ...]) -> list[s
     return cleaned
 
 
-def _normalize_repository_refs(
-    repositories: list[str] | tuple[str, ...],
-) -> list[tuple[str | None, str]]:
-    cleaned: list[tuple[str | None, str]] = []
-    seen: set[str] = set()
-    for repository in repositories:
-        value = str(repository or "").strip()
-        if not value:
-            continue
-        parts = value.split("/")
-        if len(parts) == 1:
-            canonical = parse_github_repo_slug(f"placeholder/{value}")
-            if canonical is None:
-                raise RuntimeSecretUnavailable(
-                    "GitHub App token field 'repositories' contained an invalid repository name"
-                )
-            owner = None
-            _placeholder, name = canonical.split("/", 1)
-        elif len(parts) == 2:
-            canonical = parse_github_repo_slug(value)
-            if canonical is None:
-                raise RuntimeSecretUnavailable(
-                    "GitHub App token field 'repositories' contained an invalid owner/repository name"
-                )
-            owner, name = canonical.split("/", 1)
-        else:
-            raise RuntimeSecretUnavailable(
-                "GitHub App token field 'repositories' must contain repository names or owner/repository names"
-            )
-        cache_identity = f"{owner}/{name}" if owner is not None else name
-        if cache_identity.lower() in seen:
-            continue
-        seen.add(cache_identity.lower())
-        cleaned.append((owner, name))
-    if not cleaned:
-        raise RuntimeSecretUnavailable(
-            "GitHub App token field 'repositories' is required"
-        )
-    return cleaned
-
-
 def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
     if permissions is None:
         raise RuntimeSecretUnavailable(
@@ -258,15 +204,18 @@ def _scope_key(
     repositories: list[str],
     permissions: dict[str, str],
 ) -> str:
-    private_key_hash = hashlib.sha256(cred.private_key_pem.encode("utf-8")).hexdigest()
     payload = {
         "installation_id": installation_id or cred.installation_id,
         "repositories": sorted(repositories),
         "permissions": sorted(permissions.items()),
-        "private_key_sha256": private_key_hash[:_PEM_HASH_PREFIX_LENGTH],
+        "private_key_sha256": _private_key_sha256(cred)[:_PEM_HASH_PREFIX_LENGTH],
     }
     serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _private_key_sha256(cred: GitHubAppCredential) -> str:
+    return hashlib.sha256(cred.private_key_pem.encode("utf-8")).hexdigest()
 
 
 def _lock_for_scope(scope_key: str) -> asyncio.Lock:
@@ -277,31 +226,10 @@ def _lock_for_scope(scope_key: str) -> asyncio.Lock:
     return lock
 
 
-def _installation_cache_key(
-    cred: GitHubAppCredential,
-    *,
-    owner: str,
-    repository: str,
-) -> str:
-    payload = {
-        "app_id": cred.app_id,
-        "client_id": cred.client_id,
-        "default_installation_id": cred.installation_id,
-        "private_key_sha256": hashlib.sha256(
-            cred.private_key_pem.encode("utf-8")
-        ).hexdigest(),
-        "repository": f"{owner}/{repository}".lower(),
-    }
-    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
-
-
-def _lock_for_installation(cache_key: str) -> asyncio.Lock:
-    lock = _INSTALLATION_LOCKS.get(cache_key)
-    if lock is None:
-        lock = asyncio.Lock()
-        _INSTALLATION_LOCKS[cache_key] = lock
-    return lock
+def reset_cache() -> None:
+    """Clear minted tokens and their lock registry."""
+    _TOKEN_CACHE.clear()
+    _MINT_LOCKS.clear()
 
 
 def _cache_is_fresh(
@@ -332,170 +260,14 @@ def _parse_expires_at(value: Any) -> datetime:
     return expires_at.astimezone(timezone.utc)
 
 
-def _github_app_error(
-    response: httpx.Response,
-    *,
-    status_messages: dict[int, str],
-    default_action: str,
-) -> GitHubConnectorError:
+def _mint_error(response: httpx.Response) -> GitHubConnectorError:
     return GitHubConnectorError(
         status_code=response.status_code,
-        message=status_messages.get(
+        message=_MINT_STATUS_MESSAGES.get(
             response.status_code,
-            f"GitHub returned {response.status_code} while {default_action}.",
+            f"GitHub returned {response.status_code} while minting an installation token.",
         ),
     )
-
-
-def _mint_error(response: httpx.Response) -> GitHubConnectorError:
-    return _github_app_error(
-        response,
-        status_messages=_MINT_STATUS_MESSAGES,
-        default_action="minting an installation token",
-    )
-
-
-def _discovery_error(response: httpx.Response) -> GitHubConnectorError:
-    return _github_app_error(
-        response,
-        status_messages=_DISCOVERY_STATUS_MESSAGES,
-        default_action="finding the repository installation",
-    )
-
-
-async def _fetch_repository_installation(
-    *,
-    owner: str,
-    repository: str,
-    app_jwt: str,
-) -> str:
-    path = f"/repos/{owner}/{repository}/installation"
-    try:
-        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
-            response = await client.request(
-                "GET",
-                f"{GITHUB_API_BASE}{path}",
-                headers=_headers(app_jwt),
-            )
-    except httpx.HTTPError:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="Could not reach GitHub while finding the repository installation.",
-        ) from None
-
-    if response.status_code != 200:
-        raise _discovery_error(response)
-    try:
-        payload = response.json()
-    except Exception:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub repository installation response was not valid JSON.",
-        ) from None
-    installation_id = payload.get("id") if isinstance(payload, dict) else None
-    if (
-        installation_id is None
-        or installation_id is True
-        or installation_id is False
-        or not str(installation_id).strip()
-    ):
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub repository installation response was missing id.",
-        )
-    try:
-        return str(int(str(installation_id).strip()))
-    except (TypeError, ValueError):
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub repository installation response had an invalid id.",
-        ) from None
-
-
-async def _fetch_installation_owner(
-    *,
-    installation_id: str,
-    app_jwt: str,
-) -> str:
-    path = f"/app/installations/{installation_id}"
-    try:
-        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
-            response = await client.request(
-                "GET",
-                f"{GITHUB_API_BASE}{path}",
-                headers=_headers(app_jwt),
-            )
-    except httpx.HTTPError:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="Could not reach GitHub while verifying the fallback installation.",
-        ) from None
-
-    if response.status_code != 200:
-        raise _discovery_error(response)
-    try:
-        payload = response.json()
-    except Exception:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub fallback installation response was not valid JSON.",
-        ) from None
-    account = payload.get("account") if isinstance(payload, dict) else None
-    owner = account.get("login") if isinstance(account, dict) else None
-    if not isinstance(owner, str) or not owner.strip():
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub fallback installation response was missing account login.",
-        )
-    return owner.strip()
-
-
-async def _resolve_repository_installation(
-    cred: GitHubAppCredential,
-    *,
-    owner: str | None,
-    repository: str,
-    app_jwt: str,
-    now: datetime,
-) -> str:
-    if owner is None:
-        return cred.installation_id
-
-    cache_key = _installation_cache_key(
-        cred,
-        owner=owner,
-        repository=repository,
-    )
-    cached = _INSTALLATION_CACHE.get(cache_key)
-    if cached is not None and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW:
-        return cached.installation_id
-
-    async with _lock_for_installation(cache_key):
-        cached = _INSTALLATION_CACHE.get(cache_key)
-        if cached is not None and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW:
-            return cached.installation_id
-        try:
-            installation_id = await _fetch_repository_installation(
-                owner=owner,
-                repository=repository,
-                app_jwt=app_jwt,
-            )
-        except GitHubConnectorError as discovery_error:
-            try:
-                fallback_owner = await _fetch_installation_owner(
-                    installation_id=cred.installation_id,
-                    app_jwt=app_jwt,
-                )
-            except GitHubConnectorError:
-                raise discovery_error
-            if fallback_owner.lower() != owner.lower():
-                raise discovery_error
-            installation_id = cred.installation_id
-        _INSTALLATION_CACHE[cache_key] = CachedRepositoryInstallation(
-            installation_id=installation_id,
-            expires_at=now + _INSTALLATION_CACHE_LIFETIME,
-        )
-        return installation_id
 
 
 async def _exchange_installation_token(
@@ -616,40 +388,19 @@ async def async_mint_installation_token(
     permissions: dict[str, str] = DEFAULT_INSTALLATION_PERMISSIONS,
 ) -> str:
     cred = GitHubAppCredential.from_blob(decrypted_blob)
-    repository_refs = _normalize_repository_refs(repositories)
     clean_permissions = _normalize_permissions(permissions)
     current = _utc_datetime(None)
     app_jwt = _build_app_jwt(cred, now=current)
-    repositories_by_installation: dict[str, list[tuple[str, str]]] = {}
-    for owner, repository in repository_refs:
-        installation_id = await _resolve_repository_installation(
-            cred,
-            owner=owner,
-            repository=repository,
-            app_jwt=app_jwt,
-            now=current,
-        )
-        installation_repositories = repositories_by_installation.setdefault(
-            installation_id,
-            [],
-        )
-        repository_identity = f"{owner}/{repository}" if owner is not None else repository
-        if (repository, repository_identity) not in installation_repositories:
-            installation_repositories.append((repository, repository_identity))
-
-    minted_tokens = [
-        await _mint_for_installation(
-            cred,
-            installation_id=installation_id,
-            repositories=[repository for repository, _identity in repository_refs],
-            scope_repositories=[identity for _repository, identity in repository_refs],
-            permissions=clean_permissions,
-            app_jwt=app_jwt,
-            now=current,
-        )
-        for installation_id, repository_refs in repositories_by_installation.items()
-    ]
-    if len(minted_tokens) != 1:
+    resolved_repositories = await repository_installation_resolver.resolve_many(
+        cred,
+        repositories=repositories,
+        app_jwt=app_jwt,
+        private_key_sha256=_private_key_sha256(cred),
+    )
+    installation_ids = {
+        resolved.installation_id for resolved in resolved_repositories
+    }
+    if len(installation_ids) != 1:
         raise GitHubConnectorError(
             status_code=422,
             message=(
@@ -657,12 +408,22 @@ async def async_mint_installation_token(
                 "one installation token."
             ),
         )
-    return minted_tokens[0].token
+    minted = await _mint_for_installation(
+        cred,
+        installation_id=installation_ids.pop(),
+        repositories=[resolved.repository for resolved in resolved_repositories],
+        scope_repositories=[
+            resolved.repository_slug for resolved in resolved_repositories
+        ],
+        permissions=clean_permissions,
+        app_jwt=app_jwt,
+        now=current,
+    )
+    return minted.token
 
 
 __all__ = [
     "DEFAULT_INSTALLATION_PERMISSIONS",
-    "CachedRepositoryInstallation",
     "GitHubAppCredential",
     "MintedInstallationToken",
     "_build_app_jwt",

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -18,6 +18,7 @@ from brain.systems.cortex.project_context.github import (
     _headers,
 )
 from brain.systems.vault.installation_resolver import (
+    RepositoryInstallationResolverInput,
     repository_installation_resolver,
 )
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
@@ -392,10 +393,14 @@ async def async_mint_installation_token(
     current = _utc_datetime(None)
     app_jwt = _build_app_jwt(cred, now=current)
     resolved_repositories = await repository_installation_resolver.resolve_many(
-        cred,
+        RepositoryInstallationResolverInput(
+            app_id=cred.app_id,
+            client_id=cred.client_id,
+            default_installation_id=cred.installation_id,
+            private_key_sha256=_private_key_sha256(cred),
+        ),
         repositories=repositories,
         app_jwt=app_jwt,
-        private_key_sha256=_private_key_sha256(cred),
     )
     installation_ids = {
         resolved.installation_id for resolved in resolved_repositories
@@ -411,7 +416,9 @@ async def async_mint_installation_token(
     minted = await _mint_for_installation(
         cred,
         installation_id=installation_ids.pop(),
-        repositories=[resolved.repository for resolved in resolved_repositories],
+        repositories=[
+            resolved.repository_name for resolved in resolved_repositories
+        ],
         scope_repositories=[
             resolved.repository_slug for resolved in resolved_repositories
         ],

--- a/brain/systems/vault/installation_resolver.py
+++ b/brain/systems/vault/installation_resolver.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Protocol
+from typing import Callable
 
 import httpx
 
@@ -29,16 +29,18 @@ _DISCOVERY_STATUS_MESSAGES = {
 }
 
 
-class _GitHubAppCredential(Protocol):
+@dataclass(frozen=True)
+class RepositoryInstallationResolverInput:
     app_id: str
-    installation_id: str
     client_id: str | None
+    default_installation_id: str
+    private_key_sha256: str
 
 
 @dataclass(frozen=True)
 class ResolvedRepositoryInstallation:
     installation_id: str
-    repository: str
+    repository_name: str
     repository_slug: str
 
 
@@ -97,22 +99,20 @@ class RepositoryInstallationResolver:
 
     async def resolve_many(
         self,
-        credential: _GitHubAppCredential,
+        resolver_input: RepositoryInstallationResolverInput,
         *,
         repositories: list[str] | tuple[str, ...],
         app_jwt: str,
-        private_key_sha256: str,
     ) -> list[ResolvedRepositoryInstallation]:
         repository_refs = _normalize_repository_slugs(repositories)
         now = self._current_time()
         installation_ids = await asyncio.gather(
             *(
                 self._resolve(
-                    credential,
+                    resolver_input,
                     owner=owner,
                     repository=repository,
                     app_jwt=app_jwt,
-                    private_key_sha256=private_key_sha256,
                     now=now,
                 )
                 for owner, repository in repository_refs
@@ -121,7 +121,7 @@ class RepositoryInstallationResolver:
         return [
             ResolvedRepositoryInstallation(
                 installation_id=installation_id,
-                repository=repository,
+                repository_name=repository,
                 repository_slug=f"{owner}/{repository}",
             )
             for (owner, repository), installation_id in zip(
@@ -146,19 +146,17 @@ class RepositoryInstallationResolver:
 
     async def _resolve(
         self,
-        credential: _GitHubAppCredential,
+        resolver_input: RepositoryInstallationResolverInput,
         *,
         owner: str,
         repository: str,
         app_jwt: str,
-        private_key_sha256: str,
         now: datetime,
     ) -> str:
         cache_key = self._cache_key(
-            credential,
+            resolver_input,
             owner=owner,
             repository=repository,
-            private_key_sha256=private_key_sha256,
         )
         cached = self._cache.get(cache_key)
         if self._cache_is_fresh(cached, now=now):
@@ -178,7 +176,7 @@ class RepositoryInstallationResolver:
                 )
             except GitHubConnectorError as discovery_error:
                 installation_id = await self._stored_installation_fallback(
-                    credential,
+                    resolver_input,
                     requested_owner=owner,
                     app_jwt=app_jwt,
                     discovery_error=discovery_error,
@@ -191,7 +189,7 @@ class RepositoryInstallationResolver:
 
     async def _stored_installation_fallback(
         self,
-        credential: _GitHubAppCredential,
+        resolver_input: RepositoryInstallationResolverInput,
         *,
         requested_owner: str,
         app_jwt: str,
@@ -200,28 +198,27 @@ class RepositoryInstallationResolver:
         """Use the stored id only after GitHub confirms its account owner."""
         try:
             fallback_owner = await self._fetch_installation_owner(
-                installation_id=credential.installation_id,
+                installation_id=resolver_input.default_installation_id,
                 app_jwt=app_jwt,
             )
         except GitHubConnectorError:
             raise discovery_error
         if fallback_owner.lower() != requested_owner.lower():
             raise discovery_error
-        return credential.installation_id
+        return resolver_input.default_installation_id
 
     @staticmethod
     def _cache_key(
-        credential: _GitHubAppCredential,
+        resolver_input: RepositoryInstallationResolverInput,
         *,
         owner: str,
         repository: str,
-        private_key_sha256: str,
     ) -> str:
         payload = {
-            "app_id": credential.app_id,
-            "client_id": credential.client_id,
-            "default_installation_id": credential.installation_id,
-            "private_key_sha256": private_key_sha256,
+            "app_id": resolver_input.app_id,
+            "client_id": resolver_input.client_id,
+            "default_installation_id": resolver_input.default_installation_id,
+            "private_key_sha256": resolver_input.private_key_sha256,
             "repository": f"{owner}/{repository}".lower(),
         }
         serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
@@ -349,5 +346,6 @@ repository_installation_resolver = RepositoryInstallationResolver()
 
 
 __all__ = [
+    "RepositoryInstallationResolverInput",
     "repository_installation_resolver",
 ]

--- a/brain/systems/vault/installation_resolver.py
+++ b/brain/systems/vault/installation_resolver.py
@@ -1,0 +1,353 @@
+"""Resolve GitHub App installations for canonical repository slugs."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Protocol
+
+import httpx
+
+from brain.platform.async_io import async_http_client
+from brain.systems.cortex.project_context.github import (
+    GITHUB_API_BASE,
+    GitHubConnectorError,
+    _headers,
+    parse_github_repo_slug,
+)
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
+
+_CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
+_CACHE_LIFETIME = timedelta(hours=1)
+_DISCOVERY_STATUS_MESSAGES = {
+    401: "GitHub rejected the GitHub App JWT while finding the repository installation.",
+    403: "GitHub denied the GitHub App repository installation request.",
+    404: "GitHub App installation was not found for the repository.",
+    422: "GitHub could not find an installation for the repository.",
+}
+
+
+class _GitHubAppCredential(Protocol):
+    app_id: str
+    installation_id: str
+    client_id: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedRepositoryInstallation:
+    installation_id: str
+    repository: str
+    repository_slug: str
+
+
+@dataclass(frozen=True)
+class _CachedRepositoryInstallation:
+    installation_id: str
+    expires_at: datetime
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_repository_slugs(
+    repositories: list[str] | tuple[str, ...],
+) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for repository in repositories:
+        value = str(repository or "").strip()
+        if not value:
+            continue
+        if value.count("/") != 1:
+            raise RuntimeSecretUnavailable(
+                "GitHub App token field 'repositories' must contain owner/repository names"
+            )
+        canonical = parse_github_repo_slug(value)
+        if canonical is None:
+            raise RuntimeSecretUnavailable(
+                "GitHub App token field 'repositories' contained an invalid owner/repository name"
+            )
+        owner, name = canonical.split("/", 1)
+        if canonical.lower() in seen:
+            continue
+        seen.add(canonical.lower())
+        normalized.append((owner, name))
+    if not normalized:
+        raise RuntimeSecretUnavailable(
+            "GitHub App token field 'repositories' is required"
+        )
+    return normalized
+
+
+class RepositoryInstallationResolver:
+    """Own repository installation discovery, caching, and fallback policy."""
+
+    def __init__(self, *, clock: Callable[[], datetime] | None = None) -> None:
+        self._clock = clock
+        self._cache: dict[str, _CachedRepositoryInstallation] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def reset(self) -> None:
+        """Clear cached resolutions and their lock registry."""
+        self._cache.clear()
+        self._locks.clear()
+
+    async def resolve_many(
+        self,
+        credential: _GitHubAppCredential,
+        *,
+        repositories: list[str] | tuple[str, ...],
+        app_jwt: str,
+        private_key_sha256: str,
+    ) -> list[ResolvedRepositoryInstallation]:
+        repository_refs = _normalize_repository_slugs(repositories)
+        now = self._current_time()
+        installation_ids = await asyncio.gather(
+            *(
+                self._resolve(
+                    credential,
+                    owner=owner,
+                    repository=repository,
+                    app_jwt=app_jwt,
+                    private_key_sha256=private_key_sha256,
+                    now=now,
+                )
+                for owner, repository in repository_refs
+            )
+        )
+        return [
+            ResolvedRepositoryInstallation(
+                installation_id=installation_id,
+                repository=repository,
+                repository_slug=f"{owner}/{repository}",
+            )
+            for (owner, repository), installation_id in zip(
+                repository_refs,
+                installation_ids,
+                strict=True,
+            )
+        ]
+
+    def _current_time(self) -> datetime:
+        current = self._clock() if self._clock is not None else _now()
+        if current.tzinfo is None:
+            return current.replace(tzinfo=timezone.utc)
+        return current.astimezone(timezone.utc)
+
+    def _lock_for(self, cache_key: str) -> asyncio.Lock:
+        lock = self._locks.get(cache_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[cache_key] = lock
+        return lock
+
+    async def _resolve(
+        self,
+        credential: _GitHubAppCredential,
+        *,
+        owner: str,
+        repository: str,
+        app_jwt: str,
+        private_key_sha256: str,
+        now: datetime,
+    ) -> str:
+        cache_key = self._cache_key(
+            credential,
+            owner=owner,
+            repository=repository,
+            private_key_sha256=private_key_sha256,
+        )
+        cached = self._cache.get(cache_key)
+        if self._cache_is_fresh(cached, now=now):
+            assert cached is not None
+            return cached.installation_id
+
+        async with self._lock_for(cache_key):
+            cached = self._cache.get(cache_key)
+            if self._cache_is_fresh(cached, now=now):
+                assert cached is not None
+                return cached.installation_id
+            try:
+                installation_id = await self._fetch_repository_installation(
+                    owner=owner,
+                    repository=repository,
+                    app_jwt=app_jwt,
+                )
+            except GitHubConnectorError as discovery_error:
+                installation_id = await self._stored_installation_fallback(
+                    credential,
+                    requested_owner=owner,
+                    app_jwt=app_jwt,
+                    discovery_error=discovery_error,
+                )
+            self._cache[cache_key] = _CachedRepositoryInstallation(
+                installation_id=installation_id,
+                expires_at=now + _CACHE_LIFETIME,
+            )
+            return installation_id
+
+    async def _stored_installation_fallback(
+        self,
+        credential: _GitHubAppCredential,
+        *,
+        requested_owner: str,
+        app_jwt: str,
+        discovery_error: GitHubConnectorError,
+    ) -> str:
+        """Use the stored id only after GitHub confirms its account owner."""
+        try:
+            fallback_owner = await self._fetch_installation_owner(
+                installation_id=credential.installation_id,
+                app_jwt=app_jwt,
+            )
+        except GitHubConnectorError:
+            raise discovery_error
+        if fallback_owner.lower() != requested_owner.lower():
+            raise discovery_error
+        return credential.installation_id
+
+    @staticmethod
+    def _cache_key(
+        credential: _GitHubAppCredential,
+        *,
+        owner: str,
+        repository: str,
+        private_key_sha256: str,
+    ) -> str:
+        payload = {
+            "app_id": credential.app_id,
+            "client_id": credential.client_id,
+            "default_installation_id": credential.installation_id,
+            "private_key_sha256": private_key_sha256,
+            "repository": f"{owner}/{repository}".lower(),
+        }
+        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _cache_is_fresh(
+        cached: _CachedRepositoryInstallation | None,
+        *,
+        now: datetime,
+    ) -> bool:
+        return (
+            cached is not None
+            and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW
+        )
+
+    @staticmethod
+    async def _fetch_repository_installation(
+        *,
+        owner: str,
+        repository: str,
+        app_jwt: str,
+    ) -> str:
+        path = f"/repos/{owner}/{repository}/installation"
+        try:
+            async with async_http_client(
+                timeout=httpx.Timeout(12.0, connect=5.0)
+            ) as client:
+                response = await client.request(
+                    "GET",
+                    f"{GITHUB_API_BASE}{path}",
+                    headers=_headers(app_jwt),
+                )
+        except httpx.HTTPError:
+            raise GitHubConnectorError(
+                status_code=502,
+                message=(
+                    "Could not reach GitHub while finding the repository installation."
+                ),
+            ) from None
+
+        if response.status_code != 200:
+            raise _discovery_error(response)
+        try:
+            payload = response.json()
+        except Exception:
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub repository installation response was not valid JSON.",
+            ) from None
+        installation_id = payload.get("id") if isinstance(payload, dict) else None
+        if (
+            installation_id is None
+            or installation_id is True
+            or installation_id is False
+            or not str(installation_id).strip()
+        ):
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub repository installation response was missing id.",
+            )
+        try:
+            return str(int(str(installation_id).strip()))
+        except (TypeError, ValueError):
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub repository installation response had an invalid id.",
+            ) from None
+
+    @staticmethod
+    async def _fetch_installation_owner(
+        *,
+        installation_id: str,
+        app_jwt: str,
+    ) -> str:
+        path = f"/app/installations/{installation_id}"
+        try:
+            async with async_http_client(
+                timeout=httpx.Timeout(12.0, connect=5.0)
+            ) as client:
+                response = await client.request(
+                    "GET",
+                    f"{GITHUB_API_BASE}{path}",
+                    headers=_headers(app_jwt),
+                )
+        except httpx.HTTPError:
+            raise GitHubConnectorError(
+                status_code=502,
+                message="Could not reach GitHub while verifying the fallback installation.",
+            ) from None
+
+        if response.status_code != 200:
+            raise _discovery_error(response)
+        try:
+            payload = response.json()
+        except Exception:
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub fallback installation response was not valid JSON.",
+            ) from None
+        account = payload.get("account") if isinstance(payload, dict) else None
+        owner = account.get("login") if isinstance(account, dict) else None
+        if not isinstance(owner, str) or not owner.strip():
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub fallback installation response was missing account login.",
+            )
+        return owner.strip()
+
+
+def _discovery_error(response: httpx.Response) -> GitHubConnectorError:
+    return GitHubConnectorError(
+        status_code=response.status_code,
+        message=_DISCOVERY_STATUS_MESSAGES.get(
+            response.status_code,
+            (
+                f"GitHub returned {response.status_code} while finding the repository "
+                "installation."
+            ),
+        ),
+    )
+
+
+repository_installation_resolver = RepositoryInstallationResolver()
+
+
+__all__ = [
+    "repository_installation_resolver",
+]

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -12,6 +12,7 @@ from jose import jwt
 
 from brain.systems.cortex.project_context.github import GITHUB_API_BASE, GitHubConnectorError
 from brain.systems.vault import github_app_mint as mint
+from brain.systems.vault import installation_resolver
 from brain.systems.vault.github_app_mint import (
     GitHubAppCredential,
     _build_app_jwt,
@@ -25,15 +26,11 @@ NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
 
 @pytest.fixture(autouse=True)
 def clear_mint_cache():
-    mint._TOKEN_CACHE.clear()
-    mint._MINT_LOCKS.clear()
-    mint._INSTALLATION_CACHE.clear()
-    mint._INSTALLATION_LOCKS.clear()
+    mint.reset_cache()
+    installation_resolver.repository_installation_resolver.reset()
     yield
-    mint._TOKEN_CACHE.clear()
-    mint._MINT_LOCKS.clear()
-    mint._INSTALLATION_CACHE.clear()
-    mint._INSTALLATION_LOCKS.clear()
+    mint.reset_cache()
+    installation_resolver.repository_installation_resolver.reset()
 
 
 @pytest.fixture
@@ -105,7 +102,17 @@ def _patch_http(monkeypatch, responses: list[httpx.Response], *, delay: float = 
     requests: list[dict] = []
     client = _HTTPClient(responses, requests, delay=delay)
     monkeypatch.setattr(mint, "async_http_client", lambda **_kwargs: client)
+    monkeypatch.setattr(
+        installation_resolver,
+        "async_http_client",
+        lambda **_kwargs: client,
+    )
     return requests
+
+
+def _patch_now(monkeypatch, clock) -> None:
+    monkeypatch.setattr(mint, "_now", clock)
+    monkeypatch.setattr(installation_resolver, "_now", clock)
 
 
 def _decode(token: str, public_pem: str) -> dict:
@@ -179,7 +186,7 @@ async def test_mint_discovers_repository_installation_before_exchange(
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
@@ -206,12 +213,26 @@ async def test_mint_discovers_repository_installation_before_exchange(
 
 
 @pytest.mark.asyncio
+async def test_mint_requires_canonical_repository_slugs(monkeypatch, rsa_keypair):
+    private_pem, _public_pem = rsa_keypair
+    requests = _patch_http(monkeypatch, [])
+
+    with pytest.raises(RuntimeSecretUnavailable, match="owner/repository"):
+        await async_mint_installation_token(
+            _blob(private_pem),
+            repositories=["uwear-backend"],
+        )
+
+    assert requests == []
+
+
+@pytest.mark.asyncio
 async def test_mint_falls_back_to_stored_installation_and_caches_the_resolution(
     monkeypatch,
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
@@ -257,7 +278,7 @@ async def test_mint_does_not_fallback_to_stored_installation_for_another_owner(
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
@@ -287,19 +308,17 @@ async def test_mint_does_not_fallback_to_stored_installation_for_another_owner(
 
 
 @pytest.mark.asyncio
-async def test_mint_splits_repositories_across_installations(
+async def test_mint_rejects_repositories_across_installations_before_exchange(
     monkeypatch,
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
             _installation_response(111),
             _installation_response(222),
-            _token_response("first-token", NOW + timedelta(hours=1)),
-            _token_response("second-token", NOW + timedelta(hours=1)),
         ],
     )
 
@@ -311,14 +330,7 @@ async def test_mint_splits_repositories_across_installations(
         )
 
     exchanges = [request for request in requests if request["method"] == "POST"]
-    assert [request["url"] for request in exchanges] == [
-        f"{GITHUB_API_BASE}/app/installations/111/access_tokens",
-        f"{GITHUB_API_BASE}/app/installations/222/access_tokens",
-    ]
-    assert [request["json"]["repositories"] for request in exchanges] == [
-        ["backend"],
-        ["frontend"],
-    ]
+    assert exchanges == []
 
 
 @pytest.mark.asyncio
@@ -327,7 +339,7 @@ async def test_repository_installation_discovery_is_cached_across_token_scopes(
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
@@ -364,7 +376,7 @@ async def test_repository_installation_cache_misses_after_pem_rotation(
         serialization.PrivateFormat.TraditionalOpenSSL,
         serialization.NoEncryption(),
     ).decode("ascii")
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
@@ -401,49 +413,68 @@ async def test_repository_installation_cache_misses_after_pem_rotation(
 async def test_mint_cache_reuses_until_expiry_window_then_remints(monkeypatch, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
     current = {"now": NOW}
-    monkeypatch.setattr(mint, "_now", lambda: current["now"])
+    _patch_now(monkeypatch, lambda: current["now"])
     requests = _patch_http(
         monkeypatch,
         [
+            _installation_response(456),
             _token_response("token-1", NOW + timedelta(hours=1)),
+            _installation_response(456),
             _token_response("token-2", NOW + timedelta(hours=2)),
         ],
     )
     blob = _blob(private_pem)
 
-    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-1"
-    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-1"
-    assert len(requests) == 1
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "token-1"
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "token-1"
+    assert len(requests) == 2
 
     current["now"] = NOW + timedelta(minutes=56)
-    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-2"
-    assert len(requests) == 2
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "token-2"
+    assert len(requests) == 4
 
 
 @pytest.mark.asyncio
 async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
+            _installation_response(456),
             _token_response("issues-token", NOW + timedelta(hours=1)),
+            _installation_response(456),
             _token_response("other-repo-token", NOW + timedelta(hours=1)),
             _token_response("metadata-token", NOW + timedelta(hours=1)),
         ],
     )
     blob = _blob(private_pem)
 
-    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "issues-token"
-    assert await async_mint_installation_token(blob, repositories=["uwear-mobile"]) == "other-repo-token"
     assert await async_mint_installation_token(
         blob,
-        repositories=["uwear-backend"],
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "issues-token"
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-ai/uwear-mobile"],
+    ) == "other-repo-token"
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-ai/uwear-backend"],
         permissions={"metadata": "read"},
     ) == "metadata-token"
 
     default_scope = {"issues": "write", "contents": "read", "pull_requests": "write", "checks": "read"}
-    assert [request["json"] for request in requests] == [
+    assert [request["json"] for request in requests if request["method"] == "POST"] == [
         {"repositories": ["uwear-backend"], "permissions": default_scope},
         {"repositories": ["uwear-mobile"], "permissions": default_scope},
         {"repositories": ["uwear-backend"], "permissions": {"metadata": "read"}},
@@ -456,10 +487,11 @@ async def test_mint_falls_back_to_read_only_pull_requests_for_older_installation
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
+            _installation_response(456),
             httpx.Response(422, json={"message": "Validation Failed"}),
             _token_response("read-only-pr-token", NOW + timedelta(hours=1)),
         ],
@@ -468,11 +500,12 @@ async def test_mint_falls_back_to_read_only_pull_requests_for_older_installation
 
     token = await async_mint_installation_token(
         blob,
-        repositories=["uwear-backend"],
+        repositories=["uwear-ai/uwear-backend"],
     )
 
     assert token == "read-only-pr-token"
-    assert [request["json"]["permissions"]["pull_requests"] for request in requests] == [
+    exchanges = [request for request in requests if request["method"] == "POST"]
+    assert [request["json"]["permissions"]["pull_requests"] for request in exchanges] == [
         "write",
         "read",
     ]
@@ -481,21 +514,27 @@ async def test_mint_falls_back_to_read_only_pull_requests_for_older_installation
 @pytest.mark.asyncio
 async def test_concurrent_mint_calls_share_one_http_exchange(monkeypatch, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
-        [_token_response("shared-token", NOW + timedelta(hours=1))],
+        [
+            _installation_response(456),
+            _token_response("shared-token", NOW + timedelta(hours=1)),
+        ],
         delay=0.01,
     )
     blob = _blob(private_pem)
 
     tokens = await asyncio.gather(*[
-        async_mint_installation_token(blob, repositories=["uwear-backend"])
+        async_mint_installation_token(
+            blob,
+            repositories=["uwear-ai/uwear-backend"],
+        )
         for _ in range(8)
     ])
 
     assert tokens == ["shared-token"] * 8
-    assert len(requests) == 1
+    assert len(requests) == 2
 
 
 @pytest.mark.asyncio
@@ -507,18 +546,26 @@ async def test_pem_rotation_misses_cache(monkeypatch, rsa_keypair):
         serialization.PrivateFormat.TraditionalOpenSSL,
         serialization.NoEncryption(),
     ).decode("ascii")
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
         [
+            _installation_response(456),
             _token_response("token-before-rotation", NOW + timedelta(hours=1)),
+            _installation_response(456),
             _token_response("token-after-rotation", NOW + timedelta(hours=1)),
         ],
     )
 
-    assert await async_mint_installation_token(_blob(first_private_pem), repositories=["uwear-backend"]) == "token-before-rotation"
-    assert await async_mint_installation_token(_blob(second_private_pem), repositories=["uwear-backend"]) == "token-after-rotation"
-    assert len(requests) == 2
+    assert await async_mint_installation_token(
+        _blob(first_private_pem),
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "token-before-rotation"
+    assert await async_mint_installation_token(
+        _blob(second_private_pem),
+        repositories=["uwear-ai/uwear-backend"],
+    ) == "token-after-rotation"
+    assert len(requests) == 4
 
 
 def test_from_blob_fails_closed_without_echoing_bad_secret_values():
@@ -579,14 +626,20 @@ async def test_exchange_errors_are_sanitized(monkeypatch, rsa_keypair, status_co
 @pytest.mark.asyncio
 async def test_mint_does_not_log_pem_jwt_or_minted_token(monkeypatch, caplog, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
-    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    _patch_now(monkeypatch, lambda: NOW)
     requests = _patch_http(
         monkeypatch,
-        [_token_response("minted-token-secret", NOW + timedelta(hours=1))],
+        [
+            _installation_response(456),
+            _token_response("minted-token-secret", NOW + timedelta(hours=1)),
+        ],
     )
 
     with caplog.at_level("DEBUG"):
-        token = await async_mint_installation_token(_blob(private_pem), repositories=["uwear-backend"])
+        token = await async_mint_installation_token(
+            _blob(private_pem),
+            repositories=["uwear-ai/uwear-backend"],
+        )
 
     app_jwt = requests[0]["headers"]["Authorization"].removeprefix("Bearer ")
     assert token == "minted-token-secret"

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from datetime import datetime, timedelta, timezone
 
@@ -209,6 +210,46 @@ async def test_mint_discovers_repository_installation_before_exchange(
     assert requests[1]["json"] == {
         "repositories": ["illospace"],
         "permissions": {"contents": "write"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_mint_does_not_pass_private_key_pem_to_resolver(
+    monkeypatch,
+    rsa_keypair,
+):
+    private_pem, _public_pem = rsa_keypair
+    _patch_now(monkeypatch, lambda: NOW)
+    _patch_http(
+        monkeypatch,
+        [
+            _installation_response(789),
+            _token_response("illospace-token", NOW + timedelta(hours=1)),
+        ],
+    )
+    resolver = installation_resolver.repository_installation_resolver
+    real_resolve_many = resolver.resolve_many
+    received_inputs = []
+
+    async def inspect_resolver_input(resolver_input, **kwargs):
+        assert not hasattr(resolver_input, "private_key_pem")
+        received_inputs.append(resolver_input)
+        return await real_resolve_many(resolver_input, **kwargs)
+
+    monkeypatch.setattr(resolver, "resolve_many", inspect_resolver_input)
+
+    await async_mint_installation_token(
+        _blob(private_pem),
+        repositories=["illospace/illospace"],
+    )
+
+    assert vars(received_inputs[0]) == {
+        "app_id": "123",
+        "client_id": "Iv23.client",
+        "default_installation_id": "456",
+        "private_key_sha256": hashlib.sha256(
+            private_pem.strip().encode("utf-8")
+        ).hexdigest(),
     }
 
 

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -639,12 +639,10 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
 ):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.github import _handle_create_github_issue
-    from brain.systems.vault import github_app_mint
+    from brain.systems.vault import github_app_mint, installation_resolver
 
-    github_app_mint._TOKEN_CACHE.clear()
-    github_app_mint._MINT_LOCKS.clear()
-    github_app_mint._INSTALLATION_CACHE.clear()
-    github_app_mint._INSTALLATION_LOCKS.clear()
+    github_app_mint.reset_cache()
+    installation_resolver.repository_installation_resolver.reset()
     app_blob = json.dumps({
         "app_id": "123",
         "client_id": "Iv23.client",
@@ -667,6 +665,10 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     client = _MockGitHubClient()
     monkeypatch.setattr(
         "brain.systems.vault.github_app_mint.async_http_client",
+        lambda **_kwargs: client,
+    )
+    monkeypatch.setattr(
+        "brain.systems.vault.installation_resolver.async_http_client",
         lambda **_kwargs: client,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #719.

Follow-up to the merged #720. `github_app_mint.py` had grown to **671 lines** owning two caches, two lock registries, discovery transport, fallback policy and token exchange. This splits it along those seams. Pure structure — no behavior change for any shape production uses.

`brain/systems/vault/github_app_mint.py`: **671 → 432 lines**. New `brain/systems/vault/installation_resolver.py`: 353 lines.

## The three findings, and what each became

1. **Plural mint flow (`:623`).** Gone. The mint now resolves installation ids concurrently, requires exactly one unique id, and mints once. Repositories spanning two installations still fail closed — now *before* any token exchange rather than after minting and discarding.
2. **Two repository shapes (`:196`, `:453`).** The internal boundary now requires canonical `owner/repository`. The bare-name shape (validated by inventing `placeholder/<name>`) is removed, and the stored-installation fallback is a narrow explicit policy that still verifies GitHub reports the same account owner before using the stored id.
3. **Fourth global cache (`:103`).** The resolver owns its cache, locks, clock, HTTP calls and a `reset()`. Tests reset through that method instead of clearing four private module dicts.

## The behavior change, and why it is safe

Requiring `owner/repository` means a **bare** repository name now fails closed instead of resolving. I checked the live data rather than assuming: `repositories=` is not a code literal — it comes from `binding.project_slug` (`brain/systems/vault/__init__.py:743`), i.e. DB rows. All five distinct `project_slug` values in `vault_project_bindings` on illo-dev are canonical:

```
illospace/illospace · uwear-ai/uwearaiapp · uwear-ai/uwear-backend
uwear-ai/uwear-mobile-app · uwear-ai/uwear-website
```

Zero bare names live, so nothing breaks. And the path being removed was not neutral: on `main` a bare name returned `cred.installation_id` with **no owner check at all** — the last remaining instance of the exact bug #720 exists to fix.

## Review fold

A cross-family maintainability review (Codex, xhigh) raised one **blocking** finding, folded in as the second commit: the resolver was handed the whole `GitHubAppCredential`, which carries `private_key_pem`. The `Protocol` narrowed only what a type checker saw and removed nothing at runtime, so the private key really did cross a boundary whose stated invariant is that it never leaves the mint. It now receives a four-field `RepositoryInstallationResolverInput` (`app_id`, `client_id`, `default_installation_id`, `private_key_sha256`) and nothing else; a boundary test fails if anyone passes the credential straight through again.

## Verification

`pytest tests/ -m "not requires_db and not requires_browser and not live_provider"` — **4751 passed, 11 skipped, 87 deselected** in 85s, run outside the Codex sandbox. Baseline before this branch was 4750; the extra one is the new boundary test. The diff touches no `frontend/**` file, so that lane is not selected.

## What to look at

- The stored-installation fallback still refuses a same-named repo in another org (`installation_resolver.py`, `_stored_installation_fallback`).
- Two different installation ids still raise before any POST.
- Token exchange receives **bare** names; discovery receives `owner/repository`. The rename `repository` → `repository_name` must not have swapped those.

## Deliberately left for a follow-up ticket

The same review raised three non-blocking items I kept out to hold this diff to #719's scope: the mint and resolver still each own a copy of the GitHub HTTP lifecycle and both import Cortex's private `_headers` (a neutral API client would fix both); `_exchange_installation_token` keeps a dual-mode signature and computes a second scope key, and `MintedInstallationToken.scope_key` / `installation_id` have no consumers; and the mint tests still patch internals of both modules rather than using a fake resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
