### PR TITLE
feat(knowledge): let the recall harvester produce non-GitHub candidates (#723)

### DIFF
--- a/brain/systems/knowledge/recall_eval_harvester.py
+++ b/brain/systems/knowledge/recall_eval_harvester.py
@@ -17,7 +17,7 @@ to read one and does not introduce a schema change.
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -53,7 +53,6 @@ _TERMINAL_RUN_STATUSES = (
     *TERMINAL_RUN_STATUS_VALUES,
     *LEGACY_AGENT_RUN_STATUS_VALUES,
 )
-_NON_GITHUB_KNOWLEDGE_SOURCES = ("slack", "memory")
 
 
 @dataclass(frozen=True)
@@ -143,6 +142,46 @@ def _github_evidence(item: KnowledgeItem) -> tuple[EvidencePointer, ...]:
     return tuple(pointers)
 
 
+def _single_item_evidence(item: KnowledgeItem) -> tuple[EvidencePointer, ...]:
+    return (
+        EvidencePointer(source=item.source, source_ref=item.source_ref),
+    )
+
+
+@dataclass(frozen=True)
+class _KnowledgeItemSource:
+    source: str
+    candidate_source: str
+    extra_predicates: tuple[Any, ...]
+    evidence_builder: Callable[[KnowledgeItem], tuple[EvidencePointer, ...]]
+
+
+# Exclude skills: connectors/skills.py writes global rows without org scope.
+_HARVESTED_KNOWLEDGE_ITEM_SOURCES = (
+    _KnowledgeItemSource(
+        source="github",
+        candidate_source="closed_github_issue",
+        extra_predicates=(
+            KnowledgeItem.kind == "issue",
+            KnowledgeItem.extra["state"].as_string() == "closed",
+        ),
+        evidence_builder=_github_evidence,
+    ),
+    _KnowledgeItemSource(
+        source="slack",
+        candidate_source="slack_knowledge_item",
+        extra_predicates=(),
+        evidence_builder=_single_item_evidence,
+    ),
+    _KnowledgeItemSource(
+        source="memory",
+        candidate_source="memory_knowledge_item",
+        extra_predicates=(),
+        evidence_builder=_single_item_evidence,
+    ),
+)
+
+
 def _knowledge_item_question(item: KnowledgeItem) -> str:
     extra = item.extra if isinstance(item.extra, Mapping) else {}
     distillation = extra.get("distillation")
@@ -161,6 +200,52 @@ def _looks_like_question(value: str) -> bool:
     )
 
 
+async def _harvest_knowledge_item_candidates(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    limit: int,
+    source: _KnowledgeItemSource,
+) -> list[KnowledgeRecallCandidate]:
+    items = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem)
+                .where(
+                    KnowledgeItem.source == source.source,
+                    KnowledgeItem.archived_at.is_(None),
+                    KnowledgeItem.extra["org_id"].as_string() == org_id,
+                    *source.extra_predicates,
+                )
+                .order_by(
+                    KnowledgeItem.source_updated_at.desc(),
+                    KnowledgeItem.id.desc(),
+                )
+                .limit(limit)
+            )
+        ).all()
+    )
+    candidates: list[KnowledgeRecallCandidate] = []
+    for item in items:
+        question = _knowledge_item_question(item)
+        if not question:
+            continue
+        candidates.append(
+            KnowledgeRecallCandidate(
+                candidate_id=f"knowledge-item:{item.source_ref}",
+                question=question,
+                candidate_source=source.candidate_source,
+                acceptable_evidence=source.evidence_builder(item),
+                ground_truth_status="provisional",
+                context={
+                    "title": item.title,
+                    "resolution": item.resolution,
+                },
+            )
+        )
+    return candidates
+
+
 async def harvest_knowledge_recall_candidates(
     session: AsyncSession,
     *,
@@ -175,44 +260,6 @@ async def harvest_knowledge_recall_candidates(
         raise ValueError("org_id is required")
     limit = max(1, min(int(limit_per_source), 200))
 
-    github_rows = list(
-        (
-            await session.scalars(
-                select(KnowledgeItem)
-                .where(
-                    KnowledgeItem.source == "github",
-                    KnowledgeItem.kind == "issue",
-                    KnowledgeItem.archived_at.is_(None),
-                    KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
-                    KnowledgeItem.extra["state"].as_string() == "closed",
-                )
-                .order_by(
-                    KnowledgeItem.source_updated_at.desc(),
-                    KnowledgeItem.id.desc(),
-                )
-                .limit(limit)
-            )
-        ).all()
-    )
-    non_github_rows: dict[str, list[KnowledgeItem]] = {}
-    for source in _NON_GITHUB_KNOWLEDGE_SOURCES:
-        non_github_rows[source] = list(
-            (
-                await session.scalars(
-                    select(KnowledgeItem)
-                    .where(
-                        KnowledgeItem.source == source,
-                        KnowledgeItem.archived_at.is_(None),
-                        KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
-                    )
-                    .order_by(
-                        KnowledgeItem.source_updated_at.desc(),
-                        KnowledgeItem.id.desc(),
-                    )
-                    .limit(limit)
-                )
-            ).all()
-        )
     run_rows = list(
         (
             await session.scalars(
@@ -228,46 +275,15 @@ async def harvest_knowledge_recall_candidates(
     )
 
     candidates: list[KnowledgeRecallCandidate] = []
-    for item in github_rows:
-        question = _knowledge_item_question(item)
-        if not question:
-            continue
-        candidates.append(
-            KnowledgeRecallCandidate(
-                candidate_id=f"knowledge-item:{item.source_ref}",
-                question=question,
-                candidate_source="closed_github_issue",
-                acceptable_evidence=_github_evidence(item),
-                ground_truth_status="provisional",
-                context={
-                    "title": item.title,
-                    "resolution": item.resolution,
-                },
+    for source in _HARVESTED_KNOWLEDGE_ITEM_SOURCES:
+        candidates.extend(
+            await _harvest_knowledge_item_candidates(
+                session,
+                org_id=clean_org_id,
+                limit=limit,
+                source=source,
             )
         )
-    for source, items in non_github_rows.items():
-        for item in items:
-            question = _knowledge_item_question(item)
-            if not question:
-                continue
-            candidates.append(
-                KnowledgeRecallCandidate(
-                    candidate_id=f"knowledge-item:{item.source_ref}",
-                    question=question,
-                    candidate_source=f"{source}_knowledge_item",
-                    acceptable_evidence=(
-                        EvidencePointer(
-                            source=item.source,
-                            source_ref=item.source_ref,
-                        ),
-                    ),
-                    ground_truth_status="provisional",
-                    context={
-                        "title": item.title,
-                        "resolution": item.resolution,
-                    },
-                )
-            )
     run_candidates = [
         KnowledgeRecallCandidate(
             candidate_id=f"agent-run:{run.id}",

--- a/brain/systems/knowledge/recall_eval_harvester.py
+++ b/brain/systems/knowledge/recall_eval_harvester.py
@@ -1,8 +1,9 @@
 """Harvest candidate knowledge-recall questions from sources that exist today.
 
-Closed GitHub issue candidates are harvested from ``knowledge_items`` and carry
-provisional known-best pointers to the indexed issue and any resolving pull
-requests recorded by the connector. AgentRun candidates are harvested from old
+Indexed GitHub, Slack, and shared-memory candidates are harvested from
+``knowledge_items`` and carry provisional known-best pointers to their source
+rows. GitHub candidates also include any resolving pull requests recorded by
+the connector. AgentRun candidates are harvested from old
 ``agent_runs.input_message`` transcripts, but deliberately carry no known-best
 evidence: a curator must attach stable ``source`` + ``source_ref`` pointers
 before promoting one into the scored set.
@@ -15,6 +16,7 @@ to read one and does not introduce a schema change.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -51,6 +53,7 @@ _TERMINAL_RUN_STATUSES = (
     *TERMINAL_RUN_STATUS_VALUES,
     *LEGACY_AGENT_RUN_STATUS_VALUES,
 )
+_NON_GITHUB_KNOWLEDGE_SOURCES = ("slack", "memory")
 
 
 @dataclass(frozen=True)
@@ -86,6 +89,15 @@ class KnowledgeRecallCandidateSet:
             candidate.candidate_source == "closed_github_issue"
             for candidate in self.candidates
         )
+        run_count = sum(
+            candidate.candidate_source == "agent_run_transcript"
+            for candidate in self.candidates
+        )
+        evidence_source_counts: Counter[str] = Counter()
+        for candidate in self.candidates:
+            evidence_source_counts.update(
+                {pointer.source for pointer in candidate.acceptable_evidence}
+            )
         return {
             "artifact_type": "knowledge-recall-candidates",
             "schema_version": 1,
@@ -93,10 +105,13 @@ class KnowledgeRecallCandidateSet:
             "summary": {
                 "total": len(self.candidates),
                 "closed_github_issues": github_count,
-                "agent_run_transcripts": len(self.candidates) - github_count,
+                "agent_run_transcripts": run_count,
                 "needs_ground_truth": sum(
                     candidate.ground_truth_status == "needs_labeling"
                     for candidate in self.candidates
+                ),
+                "evidence_source_counts": dict(
+                    sorted(evidence_source_counts.items())
                 ),
             },
             "org_id": self.org_id,
@@ -128,7 +143,7 @@ def _github_evidence(item: KnowledgeItem) -> tuple[EvidencePointer, ...]:
     return tuple(pointers)
 
 
-def _github_question(item: KnowledgeItem) -> str:
+def _knowledge_item_question(item: KnowledgeItem) -> str:
     extra = item.extra if isinstance(item.extra, Mapping) else {}
     distillation = extra.get("distillation")
     if isinstance(distillation, Mapping):
@@ -153,7 +168,7 @@ async def harvest_knowledge_recall_candidates(
     limit_per_source: int = 25,
     generated_at: str | None = None,
 ) -> KnowledgeRecallCandidateSet:
-    """Return reviewable candidates; only GitHub candidates have ground truth."""
+    """Return org-scoped reviewable candidates with source-backed evidence."""
 
     clean_org_id = str(org_id or "").strip()
     if not clean_org_id:
@@ -179,6 +194,25 @@ async def harvest_knowledge_recall_candidates(
             )
         ).all()
     )
+    non_github_rows: dict[str, list[KnowledgeItem]] = {}
+    for source in _NON_GITHUB_KNOWLEDGE_SOURCES:
+        non_github_rows[source] = list(
+            (
+                await session.scalars(
+                    select(KnowledgeItem)
+                    .where(
+                        KnowledgeItem.source == source,
+                        KnowledgeItem.archived_at.is_(None),
+                        KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
+                    )
+                    .order_by(
+                        KnowledgeItem.source_updated_at.desc(),
+                        KnowledgeItem.id.desc(),
+                    )
+                    .limit(limit)
+                )
+            ).all()
+        )
     run_rows = list(
         (
             await session.scalars(
@@ -195,7 +229,7 @@ async def harvest_knowledge_recall_candidates(
 
     candidates: list[KnowledgeRecallCandidate] = []
     for item in github_rows:
-        question = _github_question(item)
+        question = _knowledge_item_question(item)
         if not question:
             continue
         candidates.append(
@@ -211,6 +245,29 @@ async def harvest_knowledge_recall_candidates(
                 },
             )
         )
+    for source, items in non_github_rows.items():
+        for item in items:
+            question = _knowledge_item_question(item)
+            if not question:
+                continue
+            candidates.append(
+                KnowledgeRecallCandidate(
+                    candidate_id=f"knowledge-item:{item.source_ref}",
+                    question=question,
+                    candidate_source=f"{source}_knowledge_item",
+                    acceptable_evidence=(
+                        EvidencePointer(
+                            source=item.source,
+                            source_ref=item.source_ref,
+                        ),
+                    ),
+                    ground_truth_status="provisional",
+                    context={
+                        "title": item.title,
+                        "resolution": item.resolution,
+                    },
+                )
+            )
     run_candidates = [
         KnowledgeRecallCandidate(
             candidate_id=f"agent-run:{run.id}",

--- a/tests/test_knowledge_recall_eval.py
+++ b/tests/test_knowledge_recall_eval.py
@@ -1403,21 +1403,50 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
         ],
     }
     issue.resolution = "Resolved by merged PR Illospace/illospace#607"
-    knowledge_session.add(issue)
-    knowledge_session.add(
-        AgentRunRow(
-            id=44,
-            org_id=_ORG_ID,
-            thread_id="thread-44",
-            profile="default",
-            recipe="fast",
-            status="blocked",
-            input_message="Why did the deploy lose all AgentRun capacity?",
-            target_ref={},
-            workspace_ref={},
-            model_policy={},
-            metadata_={},
-        )
+    other_org_issue = _item(
+        587,
+        "github:OtherOrg/other-repo#587",
+        "Why did another org lose capacity?",
+    )
+    other_org_issue.extra = {
+        "org_id": "22222222-2222-4222-8222-222222222222",
+        "state": "closed",
+    }
+    archived_issue = _item(
+        588,
+        "github:Illospace/illospace#588",
+        "Why did the archived issue lose capacity?",
+    )
+    archived_issue.extra = {"org_id": _ORG_ID, "state": "closed"}
+    archived_issue.archived_at = datetime(2026, 7, 31, tzinfo=timezone.utc)
+    matching_run = AgentRunRow(
+        id=44,
+        org_id=_ORG_ID,
+        thread_id="thread-44",
+        profile="default",
+        recipe="fast",
+        status="blocked",
+        input_message="Why did the deploy lose all AgentRun capacity?",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={},
+    )
+    other_org_run = AgentRunRow(
+        id=45,
+        org_id="22222222-2222-4222-8222-222222222222",
+        thread_id="thread-45",
+        profile="default",
+        recipe="fast",
+        status="blocked",
+        input_message="Why did another org lose all AgentRun capacity?",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={},
+    )
+    knowledge_session.add_all(
+        [issue, other_org_issue, archived_issue, matching_run, other_org_run]
     )
     await knowledge_session.flush()
 
@@ -1459,6 +1488,14 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
     assert run_candidate["question"] == "Why did the deploy lose all AgentRun capacity?"
     assert run_candidate["acceptable_evidence"] == []
     assert run_candidate["ground_truth_status"] == "needs_labeling"
+    excluded_candidate_ids = {
+        "knowledge-item:github:OtherOrg/other-repo#587",
+        "knowledge-item:github:Illospace/illospace#588",
+        "agent-run:45",
+    }
+    assert excluded_candidate_ids.isdisjoint(
+        candidate["candidate_id"] for candidate in payload["candidates"]
+    )
 
 
 async def test_harvester_harvests_org_scoped_non_github_evidence(

--- a/tests/test_knowledge_recall_eval.py
+++ b/tests/test_knowledge_recall_eval.py
@@ -1438,6 +1438,7 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
         "closed_github_issues": 1,
         "agent_run_transcripts": 1,
         "needs_ground_truth": 1,
+        "evidence_source_counts": {"github": 1},
     }
     github_candidate, run_candidate = payload["candidates"]
     assert (
@@ -1460,9 +1461,118 @@ async def test_harvester_uses_indexed_github_provenance_and_labels_runs_for_revi
     assert run_candidate["ground_truth_status"] == "needs_labeling"
 
 
-async def test_harvester_caps_run_candidates_independently(
+async def test_harvester_harvests_org_scoped_non_github_evidence(
     knowledge_session,
 ):
+    slack = _item(
+        600,
+        "slack:T123:C456:1712345678.000100",
+        "Slack #incidents: Checkout stopped responding",
+    )
+    slack.source = "slack"
+    slack.kind = "slack_thread"
+    slack.extra = {
+        "org_id": _ORG_ID,
+        "distillation": {
+            "question": "Why did checkout stop responding?",
+        },
+    }
+    memory = _item(601, "memory_node:601", "How do we recover checkout?")
+    memory.source = "memory"
+    memory.kind = "memory"
+    memory.extra = {"org_id": _ORG_ID}
+
+    excluded_rows = []
+    for item_id, source, source_ref in (
+        (602, "slack", "slack:T999:C999:1712345678.000200"),
+        (603, "memory", "memory_node:603"),
+    ):
+        other_org = _item(item_id, source_ref, f"Other org {source} question?")
+        other_org.source = source
+        other_org.extra = {"org_id": "22222222-2222-4222-8222-222222222222"}
+        excluded_rows.append(other_org)
+
+        archived = _item(
+            item_id + 10,
+            f"{source_ref}:archived",
+            f"Archived {source} question?",
+        )
+        archived.source = source
+        archived.extra = {"org_id": _ORG_ID}
+        archived.archived_at = datetime(2026, 7, 31, tzinfo=timezone.utc)
+        excluded_rows.append(archived)
+
+    no_question = _item(620, "memory_node:620", "   ")
+    no_question.source = "memory"
+    no_question.extra = {"org_id": _ORG_ID}
+    knowledge_session.add_all([slack, memory, no_question, *excluded_rows])
+    await knowledge_session.flush()
+
+    payload = (
+        await harvest_knowledge_recall_candidates(
+            knowledge_session,
+            org_id=_ORG_ID,
+            limit_per_source=10,
+            generated_at=_FIXED_TIME,
+        )
+    ).to_dict()
+
+    assert [candidate["question"] for candidate in payload["candidates"]] == [
+        "Why did checkout stop responding?",
+        "How do we recover checkout?",
+    ]
+    assert [
+        candidate["acceptable_evidence"] for candidate in payload["candidates"]
+    ] == [
+        [
+            {
+                "source": "slack",
+                "source_ref": "slack:T123:C456:1712345678.000100",
+            }
+        ],
+        [{"source": "memory", "source_ref": "memory_node:601"}],
+    ]
+    assert all(
+        candidate["ground_truth_status"] == "provisional"
+        for candidate in payload["candidates"]
+    )
+    assert [
+        candidate["candidate_source"] for candidate in payload["candidates"]
+    ] == ["slack_knowledge_item", "memory_knowledge_item"]
+    assert payload["summary"] == {
+        "total": 2,
+        "closed_github_issues": 0,
+        "agent_run_transcripts": 0,
+        "needs_ground_truth": 0,
+        "evidence_source_counts": {"memory": 1, "slack": 1},
+    }
+
+
+async def test_harvester_caps_each_source_independently(
+    knowledge_session,
+):
+    for item_id in range(1, 4):
+        github = _item(
+            700 + item_id,
+            f"github:Illospace/illospace#{700 + item_id}",
+            f"What happened in issue {item_id}?",
+        )
+        github.extra = {"org_id": _ORG_ID, "state": "closed"}
+        slack = _item(
+            710 + item_id,
+            f"slack:T123:C456:1712345678.000{item_id}",
+            f"What happened in Slack thread {item_id}?",
+        )
+        slack.source = "slack"
+        slack.kind = "slack_thread"
+        memory = _item(
+            720 + item_id,
+            f"memory_node:{720 + item_id}",
+            f"What happened in memory {item_id}?",
+        )
+        memory.source = "memory"
+        memory.kind = "memory"
+        knowledge_session.add_all([github, slack, memory])
     for run_id in range(1, 4):
         knowledge_session.add(
             AgentRunRow(
@@ -1491,4 +1601,16 @@ async def test_harvester_caps_run_candidates_independently(
     ).to_dict()
 
     assert payload["summary"]["agent_run_transcripts"] == 2
-    assert len(payload["candidates"]) == 2
+    assert payload["summary"]["evidence_source_counts"] == {
+        "github": 2,
+        "memory": 2,
+        "slack": 2,
+    }
+    candidate_sources = [
+        candidate["candidate_source"] for candidate in payload["candidates"]
+    ]
+    assert candidate_sources.count("closed_github_issue") == 2
+    assert candidate_sources.count("slack_knowledge_item") == 2
+    assert candidate_sources.count("memory_knowledge_item") == 2
+    assert candidate_sources.count("agent_run_transcript") == 2
+    assert len(payload["candidates"]) == 8


### PR DESCRIPTION
> *This was generated by AI during a routine run (R3), 2026-08-07.*

Precondition slice 1 of #723. **#723 stays open after this merges** — see "What this does not do".

## The finding that motivated it

#578's deletion gate ("retire memory's duplicate recall path once knowledge-base recall is measured to be at least as good") is unmeasurable, because the scored corpus is **29 cases / 58 evidence refs, 58 of them `github`**. Memory's distinctive content is never the right answer, so the harness compares the GitHub connector against itself.

That was recorded as a curation problem. It is not — it is **built into the harvester**. `harvest_knowledge_recall_candidates` had exactly two producers: closed GitHub issues, which get real evidence pointers, and agent-run transcripts, which deliberately get none. **No amount of curating could have changed the source mix, because nothing else could ever carry ground truth.**

The corpus on illo-dev is 14,319 items — slack 7054, domain_records 3512, github 3458, memory 242, skills 53. The material was always there; the harvester could not reach it.

## What changed

- Slack and memory are now harvested as candidates carrying their own `EvidencePointer`, with `ground_truth_status="provisional"` — the same status GitHub candidates get, because the pointer is equally real.
- All three knowledge-item sources go through **one producer**. A small frozen descriptor supplies the per-source differences (extra predicates, candidate label, evidence builder); the org-scope and `archived_at IS NULL` predicates are written **once**.
- `limit_per_source` finally means what its name says — each source gets an independent maximum. Previously it bounded one GitHub query and one run query.
- The summary gains `evidence_source_counts`, the ratio this whole ticket exists to move. Existing keys still work, and `agent_run_transcripts` is now counted directly instead of derived as `total - github` (that derivation would have silently gone wrong the moment a third source appeared).
- `skills` is deliberately excluded, **with a comment saying why**: `connectors/skills.py` writes global rows with no org-scoping field, so harvesting them would breach the org boundary.

## Out of scope here — deliberately

- **No question text was written or paraphrased.** Questions come from the distiller or the item title. The seed file's phrasing rule (symptom-only wording, no symbol names or file paths) came out of an adversarial review that graded a first draft *0 honest / 27 leaky*; enforcing it is a curator's job at promotion time, and machine paraphrase would defeat it silently.
- **`knowledge_recall_seed_v2.json` is untouched** — verified in the diff.
- **No scoring, ranking, or eval-contract change.**
- **Nothing about the deletion is decided here.** #723 is explicit that permanent coexistence is an acceptable outcome. This only makes the question answerable.

## Review found two blocking issues; both are fixed

A Codex maintainability review of the first commit held the PR: GitHub had been left as a **second, duplicated** code path with its own copy of the org and archive predicates, and the exclusion fixtures only covered the new sources. Both are addressed in `721a19ca` — hence the shared producer above, plus wrong-org GitHub, archived GitHub, and wrong-org AgentRun fixtures.

## Acceptance checks

1. Harvested candidates carry `acceptable_evidence` with `source` in `slack` and `memory`, not only `github`.
2. Every source is org-scoped and excludes archived rows — each proven by a test that puts a **non-matching row in the fixture** and asserts its absence, rather than by absence alone.
3. `limit_per_source` bounds each source independently; `evidence_source_counts` counts a candidate once per source even when it carries both an issue and a fixing-PR pointer.
4. `git diff --name-only` lists only the harvester and its test module.

## Verification

Fast suite: **4746 passed, 11 skipped** (6 excluded — sandbox blocks a localhost socket bind; 4746 + 6 ≈ the 4751 baseline plus the new tests). The diff touches `brain/**` and `tests/**`, so GitHub CI selects both the backend-fast lane and the Postgres DB lane; no migration is added, so `alembic heads` is unchanged.

## Next step after this merges

The curation pass: run the harvester against the live corpus, promote non-GitHub candidates through the same leak review the current set passed, then re-run `recall_eval.py` and compare the two arms. That needs live-corpus access and human judgement, so it is not a worktree task.
