### PR TITLE
refactor(vault): give GitHub App HTTP one owner (#722)

### DIFF
--- a/brain/contracts/github.py
+++ b/brain/contracts/github.py
@@ -1,0 +1,16 @@
+"""Import-safe GitHub integration contracts shared across layers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GitHubConnectorError(Exception):
+    status_code: int
+    message: str
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+
+__all__ = ["GitHubConnectorError"]

--- a/brain/platform/integrations/github_app.py
+++ b/brain/platform/integrations/github_app.py
@@ -1,0 +1,222 @@
+"""Small HTTP client for the GitHub App calls used by Vault."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import httpx
+
+from brain.contracts.github import GitHubConnectorError
+from brain.platform.async_io import async_http_client
+
+GITHUB_API_BASE = "https://api.github.com"
+
+_DISCOVERY_STATUS_MESSAGES = {
+    401: "GitHub rejected the GitHub App JWT while finding the repository installation.",
+    403: "GitHub denied the GitHub App repository installation request.",
+    404: "GitHub App installation was not found for the repository.",
+    422: "GitHub could not find an installation for the repository.",
+}
+_MINT_STATUS_MESSAGES = {
+    401: "GitHub rejected the GitHub App JWT.",
+    403: "GitHub denied the GitHub App installation token request.",
+    404: "GitHub App installation was not found.",
+    422: "GitHub could not mint an installation token for the requested repositories or permissions.",
+}
+
+
+class GitHubAppAPIClient:
+    """Own HTTP construction and decoding for Vault's GitHub App calls."""
+
+    def __init__(
+        self,
+        *,
+        transport_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        self._transport_factory = transport_factory
+
+    async def find_repository_installation(
+        self,
+        *,
+        owner: str,
+        repository: str,
+        app_jwt: str,
+    ) -> str:
+        payload = await self._request_json(
+            "GET",
+            f"/repos/{owner}/{repository}/installation",
+            app_jwt=app_jwt,
+            expected_status=200,
+            status_messages=_DISCOVERY_STATUS_MESSAGES,
+            status_action="finding the repository installation",
+            transport_message=(
+                "Could not reach GitHub while finding the repository installation."
+            ),
+            invalid_json_message=(
+                "GitHub repository installation response was not valid JSON."
+            ),
+        )
+        installation_id = payload.get("id") if isinstance(payload, dict) else None
+        if (
+            installation_id is None
+            or installation_id is True
+            or installation_id is False
+            or not str(installation_id).strip()
+        ):
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub repository installation response was missing id.",
+            )
+        try:
+            return str(int(str(installation_id).strip()))
+        except (TypeError, ValueError):
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub repository installation response had an invalid id.",
+            ) from None
+
+    async def get_installation_owner(
+        self,
+        *,
+        installation_id: str,
+        app_jwt: str,
+    ) -> str:
+        payload = await self._request_json(
+            "GET",
+            f"/app/installations/{installation_id}",
+            app_jwt=app_jwt,
+            expected_status=200,
+            status_messages=_DISCOVERY_STATUS_MESSAGES,
+            status_action="finding the repository installation",
+            transport_message=(
+                "Could not reach GitHub while verifying the fallback installation."
+            ),
+            invalid_json_message=(
+                "GitHub fallback installation response was not valid JSON."
+            ),
+        )
+        account = payload.get("account") if isinstance(payload, dict) else None
+        owner = account.get("login") if isinstance(account, dict) else None
+        if not isinstance(owner, str) or not owner.strip():
+            raise GitHubConnectorError(
+                status_code=502,
+                message=(
+                    "GitHub fallback installation response was missing account login."
+                ),
+            )
+        return owner.strip()
+
+    async def create_installation_token(
+        self,
+        *,
+        installation_id: str,
+        repositories: list[str],
+        permissions: dict[str, str],
+        app_jwt: str,
+    ) -> tuple[str, datetime]:
+        payload = await self._request_json(
+            "POST",
+            f"/app/installations/{installation_id}/access_tokens",
+            app_jwt=app_jwt,
+            json={
+                "repositories": repositories,
+                "permissions": permissions,
+            },
+            expected_status=201,
+            status_messages=_MINT_STATUS_MESSAGES,
+            status_action="minting an installation token",
+            transport_message="Could not reach GitHub.",
+            invalid_json_message=(
+                "GitHub installation token response was not valid JSON."
+            ),
+        )
+        token = payload.get("token") if isinstance(payload, dict) else None
+        if not isinstance(token, str) or not token.strip():
+            raise GitHubConnectorError(
+                status_code=502,
+                message="GitHub installation token response was missing token.",
+            )
+        return token.strip(), _parse_expires_at(payload.get("expires_at"))
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        app_jwt: str,
+        expected_status: int,
+        status_messages: dict[int, str],
+        status_action: str,
+        transport_message: str,
+        invalid_json_message: str,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        transport_factory = self._transport_factory or async_http_client
+        try:
+            async with transport_factory(
+                timeout=httpx.Timeout(12.0, connect=5.0)
+            ) as client:
+                response = await client.request(
+                    method,
+                    f"{GITHUB_API_BASE}{path}",
+                    headers=_headers(app_jwt),
+                    json=json,
+                )
+        except httpx.HTTPError:
+            raise GitHubConnectorError(
+                status_code=502,
+                message=transport_message,
+            ) from None
+
+        if response.status_code != expected_status:
+            raise GitHubConnectorError(
+                status_code=response.status_code,
+                message=status_messages.get(
+                    response.status_code,
+                    f"GitHub returned {response.status_code} while {status_action}.",
+                ),
+            )
+        try:
+            return response.json()
+        except Exception:
+            raise GitHubConnectorError(
+                status_code=502,
+                message=invalid_json_message,
+            ) from None
+
+
+def _headers(app_jwt: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "illo-brain-project-context",
+        "Authorization": f"Bearer {app_jwt}",
+    }
+
+
+def _parse_expires_at(value: Any) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response was missing expires_at.",
+        )
+    try:
+        expires_at = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response had an invalid expires_at.",
+        ) from None
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at.astimezone(timezone.utc)
+
+
+github_app_api_client = GitHubAppAPIClient()
+
+
+__all__ = [
+    "GITHUB_API_BASE",
+    "GitHubAppAPIClient",
+    "github_app_api_client",
+]

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 
 import httpx
 
+from brain.contracts.github import GitHubConnectorError
 from brain.kernel.common.pagination import InvalidPageToken, decode_page_token, encode_page_token
 from brain.platform.async_io import async_http_client, sync_http_client
 
@@ -80,15 +81,6 @@ query GetIssueClosingPullRequests(
   }
 }
 """.strip()
-
-
-@dataclass
-class GitHubConnectorError(Exception):
-    status_code: int
-    message: str
-
-    def __post_init__(self) -> None:
-        super().__init__(self.message)
 
 
 @dataclass(frozen=True, slots=True)

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -8,15 +8,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-import httpx
 from jose import jwt
 
-from brain.platform.async_io import async_http_client
-from brain.systems.cortex.project_context.github import (
-    GITHUB_API_BASE,
-    GitHubConnectorError,
-    _headers,
-)
+from brain.contracts.github import GitHubConnectorError
+from brain.platform.integrations.github_app import github_app_api_client
 from brain.systems.vault.installation_resolver import (
     RepositoryInstallationResolverInput,
     repository_installation_resolver,
@@ -43,12 +38,6 @@ DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {
 }
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
 _PEM_HASH_PREFIX_LENGTH = 16
-_MINT_STATUS_MESSAGES = {
-    401: "GitHub rejected the GitHub App JWT.",
-    403: "GitHub denied the GitHub App installation token request.",
-    404: "GitHub App installation was not found.",
-    422: "GitHub could not mint an installation token for the requested repositories or permissions.",
-}
 
 
 @dataclass(frozen=True)
@@ -95,8 +84,6 @@ class GitHubAppCredential:
 class MintedInstallationToken:
     token: str
     expires_at: datetime
-    installation_id: str
-    scope_key: str
 
 
 _TOKEN_CACHE: dict[str, MintedInstallationToken] = {}
@@ -162,25 +149,6 @@ def _build_app_jwt(
         ) from None
 
 
-def _normalize_repositories(repositories: list[str] | tuple[str, ...]) -> list[str]:
-    cleaned: list[str] = []
-    for repo in repositories:
-        name = str(repo or "").strip()
-        if not name:
-            continue
-        if "/" in name:
-            raise RuntimeSecretUnavailable(
-                "GitHub App token field 'repositories' must contain bare repository names"
-            )
-        if name not in cleaned:
-            cleaned.append(name)
-    if not cleaned:
-        raise RuntimeSecretUnavailable(
-            "GitHub App token field 'repositories' is required"
-        )
-    return cleaned
-
-
 def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
     if permissions is None:
         raise RuntimeSecretUnavailable(
@@ -201,12 +169,12 @@ def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]
 def _scope_key(
     cred: GitHubAppCredential,
     *,
-    installation_id: str | None = None,
+    installation_id: str,
     repositories: list[str],
     permissions: dict[str, str],
 ) -> str:
     payload = {
-        "installation_id": installation_id or cred.installation_id,
+        "installation_id": installation_id,
         "repositories": sorted(repositories),
         "permissions": sorted(permissions.items()),
         "private_key_sha256": _private_key_sha256(cred)[:_PEM_HASH_PREFIX_LENGTH],
@@ -243,91 +211,23 @@ def _cache_is_fresh(
     return minted.expires_at - now > _CACHE_FRESHNESS_WINDOW
 
 
-def _parse_expires_at(value: Any) -> datetime:
-    if not isinstance(value, str) or not value.strip():
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub installation token response was missing expires_at.",
-        )
-    try:
-        expires_at = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
-    except ValueError:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub installation token response had an invalid expires_at.",
-        ) from None
-    if expires_at.tzinfo is None:
-        expires_at = expires_at.replace(tzinfo=timezone.utc)
-    return expires_at.astimezone(timezone.utc)
-
-
-def _mint_error(response: httpx.Response) -> GitHubConnectorError:
-    return GitHubConnectorError(
-        status_code=response.status_code,
-        message=_MINT_STATUS_MESSAGES.get(
-            response.status_code,
-            f"GitHub returned {response.status_code} while minting an installation token.",
-        ),
-    )
-
-
 async def _exchange_installation_token(
-    cred: GitHubAppCredential,
     *,
     repositories: list[str],
     permissions: dict[str, str],
-    installation_id: str | None = None,
-    app_jwt: str | None = None,
-    now: datetime | int | float | None = None,
+    installation_id: str,
+    app_jwt: str,
+    now: datetime,
 ) -> MintedInstallationToken:
-    clean_repositories = _normalize_repositories(repositories)
-    clean_permissions = _normalize_permissions(permissions)
-    resolved_installation_id = installation_id or cred.installation_id
-    scope_key = _scope_key(
-        cred,
-        installation_id=resolved_installation_id,
-        repositories=clean_repositories,
-        permissions=clean_permissions,
+    token, expires_at = await github_app_api_client.create_installation_token(
+        installation_id=installation_id,
+        repositories=repositories,
+        permissions=permissions,
+        app_jwt=app_jwt,
     )
-    exchange_jwt = app_jwt or _build_app_jwt(cred, now=now)
-    path = f"/app/installations/{resolved_installation_id}/access_tokens"
-    try:
-        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
-            response = await client.request(
-                "POST",
-                f"{GITHUB_API_BASE}{path}",
-                headers=_headers(exchange_jwt),
-                json={
-                    "repositories": clean_repositories,
-                    "permissions": clean_permissions,
-                },
-            )
-    except httpx.HTTPError:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="Could not reach GitHub.",
-        ) from None
-
-    if response.status_code != 201:
-        raise _mint_error(response)
-    try:
-        payload = response.json()
-    except Exception:
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub installation token response was not valid JSON.",
-        ) from None
-    token = payload.get("token") if isinstance(payload, dict) else None
-    if not isinstance(token, str) or not token.strip():
-        raise GitHubConnectorError(
-            status_code=502,
-            message="GitHub installation token response was missing token.",
-        )
     return MintedInstallationToken(
-        token=token.strip(),
-        expires_at=_parse_expires_at(payload.get("expires_at")),
-        installation_id=resolved_installation_id,
-        scope_key=scope_key,
+        token=token,
+        expires_at=expires_at,
     )
 
 
@@ -358,7 +258,6 @@ async def _mint_for_installation(
             return cached
         try:
             minted = await _exchange_installation_token(
-                cred,
                 repositories=repositories,
                 permissions=permissions,
                 installation_id=installation_id,
@@ -371,7 +270,6 @@ async def _mint_for_installation(
             fallback_permissions = dict(permissions)
             fallback_permissions["pull_requests"] = "read"
             minted = await _exchange_installation_token(
-                cred,
                 repositories=repositories,
                 permissions=fallback_permissions,
                 installation_id=installation_id,

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -211,26 +211,6 @@ def _cache_is_fresh(
     return minted.expires_at - now > _CACHE_FRESHNESS_WINDOW
 
 
-async def _exchange_installation_token(
-    *,
-    repositories: list[str],
-    permissions: dict[str, str],
-    installation_id: str,
-    app_jwt: str,
-    now: datetime,
-) -> MintedInstallationToken:
-    token, expires_at = await github_app_api_client.create_installation_token(
-        installation_id=installation_id,
-        repositories=repositories,
-        permissions=permissions,
-        app_jwt=app_jwt,
-    )
-    return MintedInstallationToken(
-        token=token,
-        expires_at=expires_at,
-    )
-
-
 async def _mint_for_installation(
     cred: GitHubAppCredential,
     *,
@@ -257,24 +237,34 @@ async def _mint_for_installation(
         if _cache_is_fresh(cached, now=current):
             return cached
         try:
-            minted = await _exchange_installation_token(
-                repositories=repositories,
-                permissions=permissions,
-                installation_id=installation_id,
-                app_jwt=app_jwt,
-                now=current,
+            token, expires_at = (
+                await github_app_api_client.create_installation_token(
+                    installation_id=installation_id,
+                    repositories=repositories,
+                    permissions=permissions,
+                    app_jwt=app_jwt,
+                )
+            )
+            minted = MintedInstallationToken(
+                token=token,
+                expires_at=expires_at,
             )
         except GitHubConnectorError as exc:
             if exc.status_code != 422 or permissions.get("pull_requests") != "write":
                 raise
             fallback_permissions = dict(permissions)
             fallback_permissions["pull_requests"] = "read"
-            minted = await _exchange_installation_token(
-                repositories=repositories,
-                permissions=fallback_permissions,
-                installation_id=installation_id,
-                app_jwt=app_jwt,
-                now=current,
+            token, expires_at = (
+                await github_app_api_client.create_installation_token(
+                    installation_id=installation_id,
+                    repositories=repositories,
+                    permissions=fallback_permissions,
+                    app_jwt=app_jwt,
+                )
+            )
+            minted = MintedInstallationToken(
+                token=token,
+                expires_at=expires_at,
             )
         _TOKEN_CACHE[scope_key] = minted
         return minted
@@ -332,6 +322,5 @@ __all__ = [
     "GitHubAppCredential",
     "MintedInstallationToken",
     "_build_app_jwt",
-    "_exchange_installation_token",
     "async_mint_installation_token",
 ]

--- a/brain/systems/vault/installation_resolver.py
+++ b/brain/systems/vault/installation_resolver.py
@@ -6,27 +6,15 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Callable
+from typing import Callable, Protocol
 
-import httpx
-
-from brain.platform.async_io import async_http_client
-from brain.systems.cortex.project_context.github import (
-    GITHUB_API_BASE,
-    GitHubConnectorError,
-    _headers,
-    parse_github_repo_slug,
-)
+from brain.contracts.github import GitHubConnectorError
+from brain.platform.integrations.github_app import github_app_api_client
+from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
 _CACHE_LIFETIME = timedelta(hours=1)
-_DISCOVERY_STATUS_MESSAGES = {
-    401: "GitHub rejected the GitHub App JWT while finding the repository installation.",
-    403: "GitHub denied the GitHub App repository installation request.",
-    404: "GitHub App installation was not found for the repository.",
-    422: "GitHub could not find an installation for the repository.",
-}
 
 
 @dataclass(frozen=True)
@@ -48,6 +36,23 @@ class ResolvedRepositoryInstallation:
 class _CachedRepositoryInstallation:
     installation_id: str
     expires_at: datetime
+
+
+class RepositoryInstallationTransport(Protocol):
+    async def find_repository_installation(
+        self,
+        *,
+        owner: str,
+        repository: str,
+        app_jwt: str,
+    ) -> str: ...
+
+    async def get_installation_owner(
+        self,
+        *,
+        installation_id: str,
+        app_jwt: str,
+    ) -> str: ...
 
 
 def _now() -> datetime:
@@ -87,8 +92,14 @@ def _normalize_repository_slugs(
 class RepositoryInstallationResolver:
     """Own repository installation discovery, caching, and fallback policy."""
 
-    def __init__(self, *, clock: Callable[[], datetime] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        transport: RepositoryInstallationTransport | None = None,
+    ) -> None:
         self._clock = clock
+        self._transport = transport or github_app_api_client
         self._cache: dict[str, _CachedRepositoryInstallation] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -169,7 +180,7 @@ class RepositoryInstallationResolver:
                 assert cached is not None
                 return cached.installation_id
             try:
-                installation_id = await self._fetch_repository_installation(
+                installation_id = await self._transport.find_repository_installation(
                     owner=owner,
                     repository=repository,
                     app_jwt=app_jwt,
@@ -197,7 +208,7 @@ class RepositoryInstallationResolver:
     ) -> str:
         """Use the stored id only after GitHub confirms its account owner."""
         try:
-            fallback_owner = await self._fetch_installation_owner(
+            fallback_owner = await self._transport.get_installation_owner(
                 installation_id=resolver_input.default_installation_id,
                 app_jwt=app_jwt,
             )
@@ -235,117 +246,13 @@ class RepositoryInstallationResolver:
             and cached.expires_at - now > _CACHE_FRESHNESS_WINDOW
         )
 
-    @staticmethod
-    async def _fetch_repository_installation(
-        *,
-        owner: str,
-        repository: str,
-        app_jwt: str,
-    ) -> str:
-        path = f"/repos/{owner}/{repository}/installation"
-        try:
-            async with async_http_client(
-                timeout=httpx.Timeout(12.0, connect=5.0)
-            ) as client:
-                response = await client.request(
-                    "GET",
-                    f"{GITHUB_API_BASE}{path}",
-                    headers=_headers(app_jwt),
-                )
-        except httpx.HTTPError:
-            raise GitHubConnectorError(
-                status_code=502,
-                message=(
-                    "Could not reach GitHub while finding the repository installation."
-                ),
-            ) from None
-
-        if response.status_code != 200:
-            raise _discovery_error(response)
-        try:
-            payload = response.json()
-        except Exception:
-            raise GitHubConnectorError(
-                status_code=502,
-                message="GitHub repository installation response was not valid JSON.",
-            ) from None
-        installation_id = payload.get("id") if isinstance(payload, dict) else None
-        if (
-            installation_id is None
-            or installation_id is True
-            or installation_id is False
-            or not str(installation_id).strip()
-        ):
-            raise GitHubConnectorError(
-                status_code=502,
-                message="GitHub repository installation response was missing id.",
-            )
-        try:
-            return str(int(str(installation_id).strip()))
-        except (TypeError, ValueError):
-            raise GitHubConnectorError(
-                status_code=502,
-                message="GitHub repository installation response had an invalid id.",
-            ) from None
-
-    @staticmethod
-    async def _fetch_installation_owner(
-        *,
-        installation_id: str,
-        app_jwt: str,
-    ) -> str:
-        path = f"/app/installations/{installation_id}"
-        try:
-            async with async_http_client(
-                timeout=httpx.Timeout(12.0, connect=5.0)
-            ) as client:
-                response = await client.request(
-                    "GET",
-                    f"{GITHUB_API_BASE}{path}",
-                    headers=_headers(app_jwt),
-                )
-        except httpx.HTTPError:
-            raise GitHubConnectorError(
-                status_code=502,
-                message="Could not reach GitHub while verifying the fallback installation.",
-            ) from None
-
-        if response.status_code != 200:
-            raise _discovery_error(response)
-        try:
-            payload = response.json()
-        except Exception:
-            raise GitHubConnectorError(
-                status_code=502,
-                message="GitHub fallback installation response was not valid JSON.",
-            ) from None
-        account = payload.get("account") if isinstance(payload, dict) else None
-        owner = account.get("login") if isinstance(account, dict) else None
-        if not isinstance(owner, str) or not owner.strip():
-            raise GitHubConnectorError(
-                status_code=502,
-                message="GitHub fallback installation response was missing account login.",
-            )
-        return owner.strip()
-
-
-def _discovery_error(response: httpx.Response) -> GitHubConnectorError:
-    return GitHubConnectorError(
-        status_code=response.status_code,
-        message=_DISCOVERY_STATUS_MESSAGES.get(
-            response.status_code,
-            (
-                f"GitHub returned {response.status_code} while finding the repository "
-                "installation."
-            ),
-        ),
-    )
-
 
 repository_installation_resolver = RepositoryInstallationResolver()
 
 
 __all__ = [
+    "RepositoryInstallationResolver",
     "RepositoryInstallationResolverInput",
+    "ResolvedRepositoryInstallation",
     "repository_installation_resolver",
 ]

--- a/tests/test_github_app_api.py
+++ b/tests/test_github_app_api.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from brain.contracts.github import GitHubConnectorError
+from brain.platform.integrations.github_app import GITHUB_API_BASE, GitHubAppAPIClient
+
+EXPIRES_AT = datetime(2026, 7, 8, 13, 0, tzinfo=timezone.utc)
+
+
+class _HTTPClient:
+    def __init__(
+        self,
+        outcomes: list[httpx.Response | httpx.HTTPError],
+        requests: list[dict],
+    ) -> None:
+        self._outcomes = outcomes
+        self._requests = requests
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def request(self, method, url, *, headers=None, json=None):
+        self._requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json": json,
+            }
+        )
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, httpx.HTTPError):
+            raise outcome
+        return outcome
+
+
+def _client(
+    outcomes: list[httpx.Response | httpx.HTTPError],
+) -> tuple[GitHubAppAPIClient, list[dict]]:
+    requests: list[dict] = []
+    http_client = _HTTPClient(outcomes, requests)
+    return (
+        GitHubAppAPIClient(transport_factory=lambda **_kwargs: http_client),
+        requests,
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_owns_request_construction_headers_and_response_decoding():
+    client, requests = _client(
+        [
+            httpx.Response(200, json={"id": "007"}),
+            httpx.Response(200, json={"account": {"login": " Illospace "}}),
+            httpx.Response(
+                201,
+                json={
+                    "token": " minted-token ",
+                    "expires_at": "2026-07-08T13:00:00Z",
+                },
+            ),
+        ]
+    )
+
+    installation_id = await client.find_repository_installation(
+        owner="illospace",
+        repository="illospace",
+        app_jwt="signed-app-jwt",
+    )
+    owner = await client.get_installation_owner(
+        installation_id="7",
+        app_jwt="signed-app-jwt",
+    )
+    token = await client.create_installation_token(
+        installation_id="7",
+        repositories=["illospace"],
+        permissions={"contents": "read"},
+        app_jwt="signed-app-jwt",
+    )
+
+    assert installation_id == "7"
+    assert owner == "Illospace"
+    assert token == ("minted-token", EXPIRES_AT)
+    assert [(request["method"], request["url"]) for request in requests] == [
+        ("GET", f"{GITHUB_API_BASE}/repos/illospace/illospace/installation"),
+        ("GET", f"{GITHUB_API_BASE}/app/installations/7"),
+        ("POST", f"{GITHUB_API_BASE}/app/installations/7/access_tokens"),
+    ]
+    for request in requests:
+        assert request["headers"] == {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "illo-brain-project-context",
+            "Authorization": "Bearer signed-app-jwt",
+        }
+    assert requests[2]["json"] == {
+        "repositories": ["illospace"],
+        "permissions": {"contents": "read"},
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403, 404, 422])
+async def test_token_exchange_errors_are_sanitized(status_code):
+    forbidden = "minted-token-that-must-not-leak"
+    client, requests = _client(
+        [httpx.Response(status_code, json={"message": forbidden})]
+    )
+
+    with pytest.raises(GitHubConnectorError) as exc_info:
+        await client.create_installation_token(
+            installation_id="456",
+            repositories=["uwear-backend"],
+            permissions={"issues": "write"},
+            app_jwt="signed-app-jwt-secret",
+        )
+
+    assert exc_info.value.status_code == status_code
+    assert forbidden not in exc_info.value.message
+    assert "signed-app-jwt-secret" not in exc_info.value.message
+    assert requests
+
+
+@pytest.mark.asyncio
+async def test_discovery_error_is_sanitized():
+    client, _requests = _client(
+        [httpx.Response(404, json={"message": "private repository name"})]
+    )
+
+    with pytest.raises(
+        GitHubConnectorError,
+        match="installation was not found for the repository",
+    ) as exc_info:
+        await client.find_repository_installation(
+            owner="illospace",
+            repository="private-repository",
+            app_jwt="signed-app-jwt",
+        )
+
+    assert exc_info.value.status_code == 404
+    assert "private repository name" not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        (
+            "discovery",
+            "Could not reach GitHub while finding the repository installation.",
+        ),
+        ("exchange", "Could not reach GitHub."),
+    ],
+)
+async def test_transport_errors_are_sanitized(operation, message):
+    client, _requests = _client([httpx.ConnectError("secret network details")])
+
+    with pytest.raises(GitHubConnectorError) as exc_info:
+        if operation == "discovery":
+            await client.find_repository_installation(
+                owner="illospace",
+                repository="illospace",
+                app_jwt="signed-app-jwt",
+            )
+        else:
+            await client.create_installation_token(
+                installation_id="456",
+                repositories=["illospace"],
+                permissions={"contents": "read"},
+                app_jwt="signed-app-jwt",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.message == message
+    assert "secret network details" not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"expires_at": "2026-07-08T13:00:00Z"}, "missing token"),
+        ({"token": "minted-token"}, "missing expires_at"),
+        (
+            {"token": "minted-token", "expires_at": "not-a-date"},
+            "invalid expires_at",
+        ),
+    ],
+)
+async def test_token_response_fields_fail_closed(payload, message):
+    client, _requests = _client([httpx.Response(201, json=payload)])
+
+    with pytest.raises(GitHubConnectorError, match=message) as exc_info:
+        await client.create_installation_token(
+            installation_id="456",
+            repositories=["illospace"],
+            permissions={"contents": "read"},
+            app_jwt="signed-app-jwt",
+        )
+
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_fails_closed():
+    client, _requests = _client(
+        [httpx.Response(201, content=b"not-json")]
+    )
+
+    with pytest.raises(GitHubConnectorError, match="not valid JSON") as exc_info:
+        await client.create_installation_token(
+            installation_id="456",
+            repositories=["illospace"],
+            permissions={"contents": "read"},
+            app_jwt="signed-app-jwt",
+        )
+
+    assert exc_info.value.status_code == 502

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -19,7 +19,6 @@ from brain.systems.vault.github_app_mint import (
     GitHubAppCredential,
     MintedInstallationToken,
     _build_app_jwt,
-    _exchange_installation_token,
     async_mint_installation_token,
 )
 from brain.systems.vault.installation_resolver import (
@@ -215,37 +214,6 @@ def test_build_app_jwt_uses_app_id_when_client_id_absent(rsa_keypair):
 
 
 @pytest.mark.asyncio
-async def test_exchange_returns_only_token_and_expiry(monkeypatch):
-    api_client = _FakeAPIClient([("minted-token", NOW + timedelta(hours=1))])
-    monkeypatch.setattr(mint, "github_app_api_client", api_client)
-
-    minted = await _exchange_installation_token(
-        installation_id="456",
-        repositories=["uwear-backend"],
-        permissions={"issues": "write"},
-        app_jwt="signed-app-jwt",
-        now=NOW,
-    )
-
-    assert [field.name for field in fields(MintedInstallationToken)] == [
-        "token",
-        "expires_at",
-    ]
-    assert minted == MintedInstallationToken(
-        token="minted-token",
-        expires_at=NOW + timedelta(hours=1),
-    )
-    assert api_client.calls == [
-        {
-            "installation_id": "456",
-            "repositories": ["uwear-backend"],
-            "permissions": {"issues": "write"},
-            "app_jwt": "signed-app-jwt",
-        }
-    ]
-
-
-@pytest.mark.asyncio
 async def test_mint_discovers_full_slug_then_exchanges_bare_name(
     monkeypatch,
     rsa_keypair,
@@ -356,7 +324,7 @@ async def test_mint_cache_reuses_until_expiry_window_then_remints(
 ):
     private_pem, _public_pem = rsa_keypair
     current = {"now": NOW}
-    _resolver, api_client = _install_fakes(
+    resolver, api_client = _install_fakes(
         monkeypatch,
         resolved=[_resolved("uwear-ai/uwear-backend")],
         outcomes=[
@@ -366,14 +334,30 @@ async def test_mint_cache_reuses_until_expiry_window_then_remints(
         clock=lambda: current["now"],
     )
     blob = _blob(private_pem)
+    permissions = {"issues": "write"}
+
+    assert [field.name for field in fields(MintedInstallationToken)] == [
+        "token",
+        "expires_at",
+    ]
 
     assert await async_mint_installation_token(
         blob,
         repositories=["uwear-ai/uwear-backend"],
+        permissions=permissions,
     ) == "token-1"
+    assert api_client.calls == [
+        {
+            "installation_id": "456",
+            "repositories": ["uwear-backend"],
+            "permissions": permissions,
+            "app_jwt": resolver.calls[0]["app_jwt"],
+        }
+    ]
     assert await async_mint_installation_token(
         blob,
         repositories=["uwear-ai/uwear-backend"],
+        permissions=permissions,
     ) == "token-1"
     assert len(api_client.calls) == 1
 
@@ -381,6 +365,7 @@ async def test_mint_cache_reuses_until_expiry_window_then_remints(
     assert await async_mint_installation_token(
         blob,
         repositories=["uwear-ai/uwear-backend"],
+        permissions=permissions,
     ) == "token-2"
     assert len(api_client.calls) == 2
 

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from dataclasses import fields
 from datetime import datetime, timedelta, timezone
 
 import httpx
@@ -11,14 +12,19 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jose import jwt
 
-from brain.systems.cortex.project_context.github import GITHUB_API_BASE, GitHubConnectorError
+from brain.contracts.github import GitHubConnectorError
+from brain.platform.integrations.github_app import GITHUB_API_BASE, GitHubAppAPIClient
 from brain.systems.vault import github_app_mint as mint
-from brain.systems.vault import installation_resolver
 from brain.systems.vault.github_app_mint import (
     GitHubAppCredential,
+    MintedInstallationToken,
     _build_app_jwt,
     _exchange_installation_token,
     async_mint_installation_token,
+)
+from brain.systems.vault.installation_resolver import (
+    RepositoryInstallationResolver,
+    ResolvedRepositoryInstallation,
 )
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
@@ -28,10 +34,8 @@ NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
 @pytest.fixture(autouse=True)
 def clear_mint_cache():
     mint.reset_cache()
-    installation_resolver.repository_installation_resolver.reset()
     yield
     mint.reset_cache()
-    installation_resolver.repository_installation_resolver.reset()
 
 
 @pytest.fixture
@@ -49,11 +53,68 @@ def rsa_keypair():
     return private_pem, public_pem
 
 
+class _FakeResolver:
+    def __init__(
+        self,
+        results: list[ResolvedRepositoryInstallation],
+    ) -> None:
+        self.results = results
+        self.calls: list[dict] = []
+
+    async def resolve_many(self, resolver_input, *, repositories, app_jwt):
+        self.calls.append(
+            {
+                "resolver_input": resolver_input,
+                "repositories": list(repositories),
+                "app_jwt": app_jwt,
+            }
+        )
+        return list(self.results)
+
+
+class _FakeAPIClient:
+    def __init__(
+        self,
+        outcomes: list[tuple[str, datetime] | GitHubConnectorError],
+        *,
+        delay: float = 0,
+    ) -> None:
+        self.outcomes = outcomes
+        self.delay = delay
+        self.calls: list[dict] = []
+
+    async def create_installation_token(
+        self,
+        *,
+        installation_id,
+        repositories,
+        permissions,
+        app_jwt,
+    ):
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        self.calls.append(
+            {
+                "installation_id": installation_id,
+                "repositories": list(repositories),
+                "permissions": dict(permissions),
+                "app_jwt": app_jwt,
+            }
+        )
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, GitHubConnectorError):
+            raise outcome
+        return outcome
+
+
 class _HTTPClient:
-    def __init__(self, responses: list[httpx.Response], requests: list[dict], *, delay: float = 0) -> None:
+    def __init__(
+        self,
+        responses: list[httpx.Response],
+        requests: list[dict],
+    ) -> None:
         self._responses = responses
         self._requests = requests
-        self._delay = delay
 
     async def __aenter__(self):
         return self
@@ -61,59 +122,62 @@ class _HTTPClient:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def request(self, method, url, *, headers=None, json=None, params=None):
-        if self._delay:
-            await asyncio.sleep(self._delay)
-        self._requests.append({
-            "method": method,
-            "url": url,
-            "headers": dict(headers or {}),
-            "json": json,
-            "params": params,
-        })
+    async def request(self, method, url, *, headers=None, json=None):
+        self._requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json": json,
+            }
+        )
         return self._responses.pop(0)
 
 
-def _blob(private_key_pem: str, *, app_id=123, installation_id=456, client_id="Iv23.client") -> str:
-    payload = {
-        "app_id": app_id,
-        "client_id": client_id,
-        "installation_id": installation_id,
-        "private_key_pem": private_key_pem,
-    }
-    return json.dumps(payload)
-
-
-def _token_response(token: str, expires_at: datetime) -> httpx.Response:
-    return httpx.Response(
-        201,
-        json={"token": token, "expires_at": expires_at.isoformat().replace("+00:00", "Z")},
+def _blob(
+    private_key_pem: str,
+    *,
+    app_id=123,
+    installation_id=456,
+    client_id="Iv23.client",
+) -> str:
+    return json.dumps(
+        {
+            "app_id": app_id,
+            "client_id": client_id,
+            "installation_id": installation_id,
+            "private_key_pem": private_key_pem,
+        }
     )
 
 
-def _installation_response(installation_id: int) -> httpx.Response:
-    return httpx.Response(200, json={"id": installation_id})
-
-
-def _installation_owner_response(owner: str) -> httpx.Response:
-    return httpx.Response(200, json={"account": {"login": owner}})
-
-
-def _patch_http(monkeypatch, responses: list[httpx.Response], *, delay: float = 0) -> list[dict]:
-    requests: list[dict] = []
-    client = _HTTPClient(responses, requests, delay=delay)
-    monkeypatch.setattr(mint, "async_http_client", lambda **_kwargs: client)
-    monkeypatch.setattr(
-        installation_resolver,
-        "async_http_client",
-        lambda **_kwargs: client,
+def _resolved(
+    repository_slug: str,
+    *,
+    installation_id: str = "456",
+) -> ResolvedRepositoryInstallation:
+    _owner, repository_name = repository_slug.split("/", 1)
+    return ResolvedRepositoryInstallation(
+        installation_id=installation_id,
+        repository_name=repository_name,
+        repository_slug=repository_slug,
     )
-    return requests
 
 
-def _patch_now(monkeypatch, clock) -> None:
+def _install_fakes(
+    monkeypatch,
+    *,
+    resolved: list[ResolvedRepositoryInstallation],
+    outcomes: list[tuple[str, datetime] | GitHubConnectorError],
+    clock=lambda: NOW,
+    delay: float = 0,
+) -> tuple[_FakeResolver, _FakeAPIClient]:
+    resolver = _FakeResolver(resolved)
+    api_client = _FakeAPIClient(outcomes, delay=delay)
+    monkeypatch.setattr(mint, "repository_installation_resolver", resolver)
+    monkeypatch.setattr(mint, "github_app_api_client", api_client)
     monkeypatch.setattr(mint, "_now", clock)
-    monkeypatch.setattr(installation_resolver, "_now", clock)
+    return resolver, api_client
 
 
 def _decode(token: str, public_pem: str) -> dict:
@@ -151,50 +215,68 @@ def test_build_app_jwt_uses_app_id_when_client_id_absent(rsa_keypair):
 
 
 @pytest.mark.asyncio
-async def test_exchange_installation_token_request_shape(monkeypatch, rsa_keypair):
-    private_pem, public_pem = rsa_keypair
-    cred = GitHubAppCredential.from_blob(_blob(private_pem))
-    requests = _patch_http(
-        monkeypatch,
-        [_token_response("minted-token", NOW + timedelta(hours=1))],
-    )
+async def test_exchange_returns_only_token_and_expiry(monkeypatch):
+    api_client = _FakeAPIClient([("minted-token", NOW + timedelta(hours=1))])
+    monkeypatch.setattr(mint, "github_app_api_client", api_client)
 
     minted = await _exchange_installation_token(
-        cred,
+        installation_id="456",
         repositories=["uwear-backend"],
         permissions={"issues": "write"},
+        app_jwt="signed-app-jwt",
         now=NOW,
     )
 
-    assert minted.token == "minted-token"
-    assert len(requests) == 1
-    request = requests[0]
-    assert request["method"] == "POST"
-    assert request["url"] == f"{GITHUB_API_BASE}/app/installations/456/access_tokens"
-    assert request["headers"]["Accept"] == "application/vnd.github+json"
-    assert request["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
-    assert request["json"] == {
-        "repositories": ["uwear-backend"],
-        "permissions": {"issues": "write"},
-    }
-    app_jwt = request["headers"]["Authorization"].removeprefix("Bearer ")
-    assert _decode(app_jwt, public_pem)["iss"] == "Iv23.client"
+    assert [field.name for field in fields(MintedInstallationToken)] == [
+        "token",
+        "expires_at",
+    ]
+    assert minted == MintedInstallationToken(
+        token="minted-token",
+        expires_at=NOW + timedelta(hours=1),
+    )
+    assert api_client.calls == [
+        {
+            "installation_id": "456",
+            "repositories": ["uwear-backend"],
+            "permissions": {"issues": "write"},
+            "app_jwt": "signed-app-jwt",
+        }
+    ]
 
 
 @pytest.mark.asyncio
-async def test_mint_discovers_repository_installation_before_exchange(
+async def test_mint_discovers_full_slug_then_exchanges_bare_name(
     monkeypatch,
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
+    requests: list[dict] = []
+    http_client = _HTTPClient(
         [
-            _installation_response(789),
-            _token_response("illospace-token", NOW + timedelta(hours=1)),
+            httpx.Response(200, json={"id": 789}),
+            httpx.Response(
+                201,
+                json={
+                    "token": "illospace-token",
+                    "expires_at": (NOW + timedelta(hours=1))
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                },
+            ),
         ],
+        requests,
     )
+    api_client = GitHubAppAPIClient(
+        transport_factory=lambda **_kwargs: http_client
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=api_client,
+    )
+    monkeypatch.setattr(mint, "repository_installation_resolver", resolver)
+    monkeypatch.setattr(mint, "github_app_api_client", api_client)
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
 
     token = await async_mint_installation_token(
         _blob(private_pem),
@@ -219,31 +301,20 @@ async def test_mint_does_not_pass_private_key_pem_to_resolver(
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    _patch_http(
+    resolver, _api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(789),
-            _token_response("illospace-token", NOW + timedelta(hours=1)),
-        ],
+        resolved=[_resolved("illospace/illospace", installation_id="789")],
+        outcomes=[("illospace-token", NOW + timedelta(hours=1))],
     )
-    resolver = installation_resolver.repository_installation_resolver
-    real_resolve_many = resolver.resolve_many
-    received_inputs = []
-
-    async def inspect_resolver_input(resolver_input, **kwargs):
-        assert not hasattr(resolver_input, "private_key_pem")
-        received_inputs.append(resolver_input)
-        return await real_resolve_many(resolver_input, **kwargs)
-
-    monkeypatch.setattr(resolver, "resolve_many", inspect_resolver_input)
 
     await async_mint_installation_token(
         _blob(private_pem),
         repositories=["illospace/illospace"],
     )
 
-    assert vars(received_inputs[0]) == {
+    resolver_input = resolver.calls[0]["resolver_input"]
+    assert not hasattr(resolver_input, "private_key_pem")
+    assert vars(resolver_input) == {
         "app_id": "123",
         "client_id": "Iv23.client",
         "default_installation_id": "456",
@@ -254,113 +325,18 @@ async def test_mint_does_not_pass_private_key_pem_to_resolver(
 
 
 @pytest.mark.asyncio
-async def test_mint_requires_canonical_repository_slugs(monkeypatch, rsa_keypair):
-    private_pem, _public_pem = rsa_keypair
-    requests = _patch_http(monkeypatch, [])
-
-    with pytest.raises(RuntimeSecretUnavailable, match="owner/repository"):
-        await async_mint_installation_token(
-            _blob(private_pem),
-            repositories=["uwear-backend"],
-        )
-
-    assert requests == []
-
-
-@pytest.mark.asyncio
-async def test_mint_falls_back_to_stored_installation_and_caches_the_resolution(
-    monkeypatch,
-    rsa_keypair,
-):
-    private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
-        [
-            httpx.Response(404, json={"message": "Not Found"}),
-            _installation_owner_response("uwear-ai"),
-            _token_response("fallback-token", NOW + timedelta(hours=1)),
-            _token_response("fallback-write-token", NOW + timedelta(hours=1)),
-        ],
-    )
-
-    token = await async_mint_installation_token(
-        _blob(private_pem),
-        repositories=["uwear-ai/uwear-backend"],
-        permissions={"contents": "read"},
-    )
-
-    assert token == "fallback-token"
-    assert await async_mint_installation_token(
-        _blob(private_pem),
-        repositories=["uwear-ai/uwear-backend"],
-        permissions={"contents": "write"},
-    ) == "fallback-write-token"
-    assert [(request["method"], request["url"]) for request in requests] == [
-        (
-            "GET",
-            f"{GITHUB_API_BASE}/repos/uwear-ai/uwear-backend/installation",
-        ),
-        ("GET", f"{GITHUB_API_BASE}/app/installations/456"),
-        (
-            "POST",
-            f"{GITHUB_API_BASE}/app/installations/456/access_tokens",
-        ),
-        (
-            "POST",
-            f"{GITHUB_API_BASE}/app/installations/456/access_tokens",
-        ),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_mint_does_not_fallback_to_stored_installation_for_another_owner(
-    monkeypatch,
-    rsa_keypair,
-):
-    private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
-        [
-            httpx.Response(404, json={"message": "Not Found"}),
-            _installation_owner_response("uwear-ai"),
-        ],
-    )
-
-    with pytest.raises(
-        GitHubConnectorError,
-        match="installation was not found for the repository",
-    ) as exc_info:
-        await async_mint_installation_token(
-            _blob(private_pem),
-            repositories=["illospace/illospace"],
-            permissions={"contents": "write"},
-        )
-
-    assert exc_info.value.status_code == 404
-    assert [(request["method"], request["url"]) for request in requests] == [
-        ("GET", f"{GITHUB_API_BASE}/repos/illospace/illospace/installation"),
-        ("GET", f"{GITHUB_API_BASE}/app/installations/456"),
-    ]
-    assert not any(
-        request["url"].endswith("/access_tokens") for request in requests
-    )
-
-
-@pytest.mark.asyncio
 async def test_mint_rejects_repositories_across_installations_before_exchange(
     monkeypatch,
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
+    _resolver, api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(111),
-            _installation_response(222),
+        resolved=[
+            _resolved("first-org/backend", installation_id="111"),
+            _resolved("second-org/frontend", installation_id="222"),
         ],
+        outcomes=[],
     )
 
     with pytest.raises(GitHubConnectorError, match="span multiple installations"):
@@ -370,99 +346,24 @@ async def test_mint_rejects_repositories_across_installations_before_exchange(
             permissions={"contents": "read"},
         )
 
-    exchanges = [request for request in requests if request["method"] == "POST"]
-    assert exchanges == []
+    assert api_client.calls == []
 
 
 @pytest.mark.asyncio
-async def test_repository_installation_discovery_is_cached_across_token_scopes(
+async def test_mint_cache_reuses_until_expiry_window_then_remints(
     monkeypatch,
     rsa_keypair,
 ):
-    private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
-        [
-            _installation_response(789),
-            _token_response("read-token", NOW + timedelta(hours=1)),
-            _token_response("write-token", NOW + timedelta(hours=1)),
-        ],
-    )
-    blob = _blob(private_pem)
-
-    assert await async_mint_installation_token(
-        blob,
-        repositories=["illospace/illospace"],
-        permissions={"contents": "read"},
-    ) == "read-token"
-    assert await async_mint_installation_token(
-        blob,
-        repositories=["illospace/illospace"],
-        permissions={"contents": "write"},
-    ) == "write-token"
-
-    assert [request["method"] for request in requests] == ["GET", "POST", "POST"]
-
-
-@pytest.mark.asyncio
-async def test_repository_installation_cache_misses_after_pem_rotation(
-    monkeypatch,
-    rsa_keypair,
-):
-    first_private_pem, _public_pem = rsa_keypair
-    second_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    second_private_pem = second_key.private_bytes(
-        serialization.Encoding.PEM,
-        serialization.PrivateFormat.TraditionalOpenSSL,
-        serialization.NoEncryption(),
-    ).decode("ascii")
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
-        [
-            _installation_response(789),
-            _token_response("first-token", NOW + timedelta(hours=1)),
-            _installation_response(987),
-            _token_response("rotated-token", NOW + timedelta(hours=1)),
-        ],
-    )
-
-    assert await async_mint_installation_token(
-        _blob(first_private_pem),
-        repositories=["illospace/illospace"],
-        permissions={"contents": "read"},
-    ) == "first-token"
-    assert await async_mint_installation_token(
-        _blob(second_private_pem),
-        repositories=["illospace/illospace"],
-        permissions={"contents": "read"},
-    ) == "rotated-token"
-
-    assert [request["method"] for request in requests] == [
-        "GET",
-        "POST",
-        "GET",
-        "POST",
-    ]
-    assert requests[3]["url"] == (
-        f"{GITHUB_API_BASE}/app/installations/987/access_tokens"
-    )
-
-
-@pytest.mark.asyncio
-async def test_mint_cache_reuses_until_expiry_window_then_remints(monkeypatch, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
     current = {"now": NOW}
-    _patch_now(monkeypatch, lambda: current["now"])
-    requests = _patch_http(
+    _resolver, api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(456),
-            _token_response("token-1", NOW + timedelta(hours=1)),
-            _installation_response(456),
-            _token_response("token-2", NOW + timedelta(hours=2)),
+        resolved=[_resolved("uwear-ai/uwear-backend")],
+        outcomes=[
+            ("token-1", NOW + timedelta(hours=1)),
+            ("token-2", NOW + timedelta(hours=2)),
         ],
+        clock=lambda: current["now"],
     )
     blob = _blob(private_pem)
 
@@ -474,30 +375,45 @@ async def test_mint_cache_reuses_until_expiry_window_then_remints(monkeypatch, r
         blob,
         repositories=["uwear-ai/uwear-backend"],
     ) == "token-1"
-    assert len(requests) == 2
+    assert len(api_client.calls) == 1
 
     current["now"] = NOW + timedelta(minutes=56)
     assert await async_mint_installation_token(
         blob,
         repositories=["uwear-ai/uwear-backend"],
     ) == "token-2"
-    assert len(requests) == 4
+    assert len(api_client.calls) == 2
 
 
 @pytest.mark.asyncio
-async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rsa_keypair):
+async def test_mint_cache_separates_repositories_and_permissions(
+    monkeypatch,
+    rsa_keypair,
+):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
+    resolver = _FakeResolver([])
+
+    async def resolve_many(resolver_input, *, repositories, app_jwt):
+        resolver.calls.append(
+            {
+                "resolver_input": resolver_input,
+                "repositories": list(repositories),
+                "app_jwt": app_jwt,
+            }
+        )
+        return [_resolved(repository) for repository in repositories]
+
+    resolver.resolve_many = resolve_many
+    api_client = _FakeAPIClient(
         [
-            _installation_response(456),
-            _token_response("issues-token", NOW + timedelta(hours=1)),
-            _installation_response(456),
-            _token_response("other-repo-token", NOW + timedelta(hours=1)),
-            _token_response("metadata-token", NOW + timedelta(hours=1)),
-        ],
+            ("issues-token", NOW + timedelta(hours=1)),
+            ("other-repo-token", NOW + timedelta(hours=1)),
+            ("metadata-token", NOW + timedelta(hours=1)),
+        ]
     )
+    monkeypatch.setattr(mint, "repository_installation_resolver", resolver)
+    monkeypatch.setattr(mint, "github_app_api_client", api_client)
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
     blob = _blob(private_pem)
 
     assert await async_mint_installation_token(
@@ -514,11 +430,10 @@ async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rs
         permissions={"metadata": "read"},
     ) == "metadata-token"
 
-    default_scope = {"issues": "write", "contents": "read", "pull_requests": "write", "checks": "read"}
-    assert [request["json"] for request in requests if request["method"] == "POST"] == [
-        {"repositories": ["uwear-backend"], "permissions": default_scope},
-        {"repositories": ["uwear-mobile"], "permissions": default_scope},
-        {"repositories": ["uwear-backend"], "permissions": {"metadata": "read"}},
+    assert [call["repositories"] for call in api_client.calls] == [
+        ["uwear-backend"],
+        ["uwear-mobile"],
+        ["uwear-backend"],
     ]
 
 
@@ -528,58 +443,57 @@ async def test_mint_falls_back_to_read_only_pull_requests_for_older_installation
     rsa_keypair,
 ):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
+    _resolver, api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(456),
-            httpx.Response(422, json={"message": "Validation Failed"}),
-            _token_response("read-only-pr-token", NOW + timedelta(hours=1)),
+        resolved=[_resolved("uwear-ai/uwear-backend")],
+        outcomes=[
+            GitHubConnectorError(
+                status_code=422,
+                message="GitHub could not mint an installation token.",
+            ),
+            ("read-only-pr-token", NOW + timedelta(hours=1)),
         ],
     )
-    blob = _blob(private_pem)
 
     token = await async_mint_installation_token(
-        blob,
+        _blob(private_pem),
         repositories=["uwear-ai/uwear-backend"],
     )
 
     assert token == "read-only-pr-token"
-    exchanges = [request for request in requests if request["method"] == "POST"]
-    assert [request["json"]["permissions"]["pull_requests"] for request in exchanges] == [
+    assert [call["permissions"]["pull_requests"] for call in api_client.calls] == [
         "write",
         "read",
     ]
 
 
 @pytest.mark.asyncio
-async def test_concurrent_mint_calls_share_one_http_exchange(monkeypatch, rsa_keypair):
+async def test_concurrent_mint_calls_share_one_exchange(monkeypatch, rsa_keypair):
     private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
+    _resolver, api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(456),
-            _token_response("shared-token", NOW + timedelta(hours=1)),
-        ],
+        resolved=[_resolved("uwear-ai/uwear-backend")],
+        outcomes=[("shared-token", NOW + timedelta(hours=1))],
         delay=0.01,
     )
     blob = _blob(private_pem)
 
-    tokens = await asyncio.gather(*[
-        async_mint_installation_token(
-            blob,
-            repositories=["uwear-ai/uwear-backend"],
-        )
-        for _ in range(8)
-    ])
+    tokens = await asyncio.gather(
+        *[
+            async_mint_installation_token(
+                blob,
+                repositories=["uwear-ai/uwear-backend"],
+            )
+            for _ in range(8)
+        ]
+    )
 
     assert tokens == ["shared-token"] * 8
-    assert len(requests) == 2
+    assert len(api_client.calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_pem_rotation_misses_cache(monkeypatch, rsa_keypair):
+async def test_pem_rotation_misses_mint_cache(monkeypatch, rsa_keypair):
     first_private_pem, _public_pem = rsa_keypair
     second_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     second_private_pem = second_key.private_bytes(
@@ -587,14 +501,12 @@ async def test_pem_rotation_misses_cache(monkeypatch, rsa_keypair):
         serialization.PrivateFormat.TraditionalOpenSSL,
         serialization.NoEncryption(),
     ).decode("ascii")
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
+    _resolver, api_client = _install_fakes(
         monkeypatch,
-        [
-            _installation_response(456),
-            _token_response("token-before-rotation", NOW + timedelta(hours=1)),
-            _installation_response(456),
-            _token_response("token-after-rotation", NOW + timedelta(hours=1)),
+        resolved=[_resolved("uwear-ai/uwear-backend")],
+        outcomes=[
+            ("token-before-rotation", NOW + timedelta(hours=1)),
+            ("token-after-rotation", NOW + timedelta(hours=1)),
         ],
     )
 
@@ -606,25 +518,35 @@ async def test_pem_rotation_misses_cache(monkeypatch, rsa_keypair):
         _blob(second_private_pem),
         repositories=["uwear-ai/uwear-backend"],
     ) == "token-after-rotation"
-    assert len(requests) == 4
+    assert len(api_client.calls) == 2
 
 
 def test_from_blob_fails_closed_without_echoing_bad_secret_values():
-    non_pem_blob = json.dumps({
-        "app_id": "123",
-        "installation_id": "456",
-        "private_key_pem": "not-a-pem-secret-value",
-    })
-    wrong_key_type = json.dumps({
-        "app_id": "123",
-        "installation_id": "456",
-        "private_key_pem": "-----BEGIN CERTIFICATE-----\nsecret-cert\n-----END CERTIFICATE-----",
-    })
-    public_key = json.dumps({
-        "app_id": "123",
-        "installation_id": "456",
-        "private_key_pem": "-----BEGIN PUBLIC KEY-----\nsecret-public\n-----END PUBLIC KEY-----",
-    })
+    non_pem_blob = json.dumps(
+        {
+            "app_id": "123",
+            "installation_id": "456",
+            "private_key_pem": "not-a-pem-secret-value",
+        }
+    )
+    wrong_key_type = json.dumps(
+        {
+            "app_id": "123",
+            "installation_id": "456",
+            "private_key_pem": (
+                "-----BEGIN CERTIFICATE-----\nsecret-cert\n-----END CERTIFICATE-----"
+            ),
+        }
+    )
+    public_key = json.dumps(
+        {
+            "app_id": "123",
+            "installation_id": "456",
+            "private_key_pem": (
+                "-----BEGIN PUBLIC KEY-----\nsecret-public\n-----END PUBLIC KEY-----"
+            ),
+        }
+    )
 
     for blob, forbidden in [
         (non_pem_blob, "not-a-pem-secret-value"),
@@ -640,40 +562,16 @@ def test_from_blob_fails_closed_without_echoing_bad_secret_values():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status_code", [401, 403, 404, 422])
-async def test_exchange_errors_are_sanitized(monkeypatch, rsa_keypair, status_code):
+async def test_mint_does_not_log_pem_jwt_or_minted_token(
+    monkeypatch,
+    caplog,
+    rsa_keypair,
+):
     private_pem, _public_pem = rsa_keypair
-    cred = GitHubAppCredential.from_blob(_blob(private_pem))
-    forbidden_token = "minted-token-that-must-not-leak"
-    requests = _patch_http(
+    resolver, api_client = _install_fakes(
         monkeypatch,
-        [httpx.Response(status_code, json={"message": forbidden_token})],
-    )
-
-    with pytest.raises(GitHubConnectorError) as exc:
-        await _exchange_installation_token(
-            cred,
-            repositories=["uwear-backend"],
-            permissions={"issues": "write"},
-            now=NOW,
-        )
-
-    assert exc.value.status_code == status_code
-    assert forbidden_token not in exc.value.message
-    assert private_pem not in exc.value.message
-    assert requests
-
-
-@pytest.mark.asyncio
-async def test_mint_does_not_log_pem_jwt_or_minted_token(monkeypatch, caplog, rsa_keypair):
-    private_pem, _public_pem = rsa_keypair
-    _patch_now(monkeypatch, lambda: NOW)
-    requests = _patch_http(
-        monkeypatch,
-        [
-            _installation_response(456),
-            _token_response("minted-token-secret", NOW + timedelta(hours=1)),
-        ],
+        resolved=[_resolved("uwear-ai/uwear-backend")],
+        outcomes=[("minted-token-secret", NOW + timedelta(hours=1))],
     )
 
     with caplog.at_level("DEBUG"):
@@ -682,8 +580,9 @@ async def test_mint_does_not_log_pem_jwt_or_minted_token(monkeypatch, caplog, rs
             repositories=["uwear-ai/uwear-backend"],
         )
 
-    app_jwt = requests[0]["headers"]["Authorization"].removeprefix("Bearer ")
+    app_jwt = resolver.calls[0]["app_jwt"]
     assert token == "minted-token-secret"
+    assert api_client.calls
     assert private_pem not in caplog.text
     assert app_jwt not in caplog.text
     assert "minted-token-secret" not in caplog.text

--- a/tests/test_installation_resolver.py
+++ b/tests/test_installation_resolver.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brain.contracts.github import GitHubConnectorError
+from brain.systems.vault.installation_resolver import (
+    RepositoryInstallationResolver,
+    RepositoryInstallationResolverInput,
+    ResolvedRepositoryInstallation,
+)
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
+
+NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+
+
+class _FakeTransport:
+    def __init__(
+        self,
+        *,
+        installations: dict[str, list[str | GitHubConnectorError]],
+        owners: dict[str, list[str | GitHubConnectorError]] | None = None,
+        delay: float = 0,
+    ) -> None:
+        self.installations = installations
+        self.owners = owners or {}
+        self.delay = delay
+        self.installation_calls: list[dict] = []
+        self.owner_calls: list[dict] = []
+
+    async def find_repository_installation(
+        self,
+        *,
+        owner: str,
+        repository: str,
+        app_jwt: str,
+    ) -> str:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        self.installation_calls.append(
+            {
+                "owner": owner,
+                "repository": repository,
+                "app_jwt": app_jwt,
+            }
+        )
+        outcome = self.installations[f"{owner}/{repository}"].pop(0)
+        if isinstance(outcome, GitHubConnectorError):
+            raise outcome
+        return outcome
+
+    async def get_installation_owner(
+        self,
+        *,
+        installation_id: str,
+        app_jwt: str,
+    ) -> str:
+        self.owner_calls.append(
+            {
+                "installation_id": installation_id,
+                "app_jwt": app_jwt,
+            }
+        )
+        outcome = self.owners[installation_id].pop(0)
+        if isinstance(outcome, GitHubConnectorError):
+            raise outcome
+        return outcome
+
+
+def _resolver_input(
+    *,
+    private_key_sha256: str = "pem-sha-1",
+) -> RepositoryInstallationResolverInput:
+    return RepositoryInstallationResolverInput(
+        app_id="123",
+        client_id="Iv23.client",
+        default_installation_id="456",
+        private_key_sha256=private_key_sha256,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_many_normalizes_full_slugs_and_deduplicates_case():
+    transport = _FakeTransport(
+        installations={"Illospace/Repo.Name": ["789"]}
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    resolved = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=[" Illospace/Repo.Name ", "illospace/repo.name"],
+        app_jwt="signed-app-jwt",
+    )
+
+    assert resolved == [
+        ResolvedRepositoryInstallation(
+            installation_id="789",
+            repository_name="Repo.Name",
+            repository_slug="Illospace/Repo.Name",
+        )
+    ]
+    assert transport.installation_calls == [
+        {
+            "owner": "Illospace",
+            "repository": "Repo.Name",
+            "app_jwt": "signed-app-jwt",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "repositories",
+    [
+        ["uwear-backend"],
+        ["owner/repository/extra"],
+        ["bad owner/repository"],
+        [""],
+    ],
+)
+async def test_resolve_many_requires_canonical_repository_slugs(repositories):
+    transport = _FakeTransport(installations={})
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    with pytest.raises(RuntimeSecretUnavailable, match="owner/repository|required"):
+        await resolver.resolve_many(
+            _resolver_input(),
+            repositories=repositories,
+            app_jwt="signed-app-jwt",
+        )
+
+    assert transport.installation_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolution_cache_uses_injected_clock_and_refreshes_near_expiry():
+    current = {"now": NOW}
+    transport = _FakeTransport(
+        installations={"illospace/illospace": ["789", "987"]}
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: current["now"],
+        transport=transport,
+    )
+
+    first = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=["illospace/illospace"],
+        app_jwt="signed-app-jwt",
+    )
+    cached = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=["illospace/illospace"],
+        app_jwt="signed-app-jwt",
+    )
+
+    assert first[0].installation_id == "789"
+    assert cached[0].installation_id == "789"
+    assert len(transport.installation_calls) == 1
+
+    current["now"] = NOW + timedelta(minutes=56)
+    refreshed = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=["illospace/illospace"],
+        app_jwt="signed-app-jwt",
+    )
+
+    assert refreshed[0].installation_id == "987"
+    assert len(transport.installation_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_resolution_cache_misses_after_private_key_rotation():
+    transport = _FakeTransport(
+        installations={"illospace/illospace": ["789", "987"]}
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    first = await resolver.resolve_many(
+        _resolver_input(private_key_sha256="first-pem-sha"),
+        repositories=["illospace/illospace"],
+        app_jwt="first-app-jwt",
+    )
+    rotated = await resolver.resolve_many(
+        _resolver_input(private_key_sha256="second-pem-sha"),
+        repositories=["illospace/illospace"],
+        app_jwt="second-app-jwt",
+    )
+
+    assert first[0].installation_id == "789"
+    assert rotated[0].installation_id == "987"
+    assert [call["app_jwt"] for call in transport.installation_calls] == [
+        "first-app-jwt",
+        "second-app-jwt",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fallback_verifies_matching_owner_before_using_stored_installation():
+    discovery_error = GitHubConnectorError(
+        status_code=404,
+        message="GitHub App installation was not found for the repository.",
+    )
+    transport = _FakeTransport(
+        installations={"uwear-ai/uwear-backend": [discovery_error]},
+        owners={"456": ["UWEAR-AI"]},
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    first = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=["uwear-ai/uwear-backend"],
+        app_jwt="signed-app-jwt",
+    )
+    cached = await resolver.resolve_many(
+        _resolver_input(),
+        repositories=["uwear-ai/uwear-backend"],
+        app_jwt="signed-app-jwt",
+    )
+
+    assert first[0].installation_id == "456"
+    assert cached[0].installation_id == "456"
+    assert len(transport.installation_calls) == 1
+    assert transport.owner_calls == [
+        {
+            "installation_id": "456",
+            "app_jwt": "signed-app-jwt",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fallback_fails_closed_when_stored_installation_owner_differs():
+    discovery_error = GitHubConnectorError(
+        status_code=404,
+        message="GitHub App installation was not found for the repository.",
+    )
+    transport = _FakeTransport(
+        installations={"illospace/illospace": [discovery_error]},
+        owners={"456": ["uwear-ai"]},
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    with pytest.raises(GitHubConnectorError) as exc_info:
+        await resolver.resolve_many(
+            _resolver_input(),
+            repositories=["illospace/illospace"],
+            app_jwt="signed-app-jwt",
+        )
+
+    assert exc_info.value is discovery_error
+    assert transport.owner_calls
+
+
+@pytest.mark.asyncio
+async def test_fallback_preserves_discovery_error_when_owner_lookup_fails():
+    discovery_error = GitHubConnectorError(
+        status_code=404,
+        message="GitHub App installation was not found for the repository.",
+    )
+    owner_error = GitHubConnectorError(
+        status_code=502,
+        message="Could not reach GitHub while verifying the fallback installation.",
+    )
+    transport = _FakeTransport(
+        installations={"illospace/illospace": [discovery_error]},
+        owners={"456": [owner_error]},
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    with pytest.raises(GitHubConnectorError) as exc_info:
+        await resolver.resolve_many(
+            _resolver_input(),
+            repositories=["illospace/illospace"],
+            app_jwt="signed-app-jwt",
+        )
+
+    assert exc_info.value is discovery_error
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resolution_calls_share_one_transport_request():
+    transport = _FakeTransport(
+        installations={"illospace/illospace": ["789"]},
+        delay=0.01,
+    )
+    resolver = RepositoryInstallationResolver(
+        clock=lambda: NOW,
+        transport=transport,
+    )
+
+    results = await asyncio.gather(
+        *[
+            resolver.resolve_many(
+                _resolver_input(),
+                repositories=["illospace/illospace"],
+                app_jwt="signed-app-jwt",
+            )
+            for _ in range(8)
+        ]
+    )
+
+    assert [result[0].installation_id for result in results] == ["789"] * 8
+    assert len(transport.installation_calls) == 1

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -664,11 +664,7 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     )
     client = _MockGitHubClient()
     monkeypatch.setattr(
-        "brain.systems.vault.github_app_mint.async_http_client",
-        lambda **_kwargs: client,
-    )
-    monkeypatch.setattr(
-        "brain.systems.vault.installation_resolver.async_http_client",
+        "brain.platform.integrations.github_app.async_http_client",
         lambda **_kwargs: client,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
> *This was generated by AI during a routine run (R3), 2026-08-07.*

Closes #722

The three non-blocking findings left over from PR #721's maintainability review. **Structure only — no behaviour change and no known bug.**

## What changed

1. **GitHub App HTTP has one owner.** The resolver and the mint each built their own transport, and **both imported Cortex's private `_headers`**. Request construction, headers, decoding and sanitized transport errors now live in `brain/platform/integrations/github_app.py`. The resolver keeps resolution, fallback and caching; the mint keeps key handling. `brain/systems/vault/**` no longer imports anything private from Cortex.
2. **The dual-mode mint signature is gone.** `MintedInstallationToken` carries only `token` and `expires_at` — the unused `scope_key` and `installation_id` are removed, and the scope key is computed once.
3. **Mint tests no longer patch resolver internals.** The resolver has its own test module with an injected clock and transport; the mint tests use a fake resolver, with one end-to-end test still covering full-slug discovery followed by bare-name exchange.

`GitHubConnectorError` moved from Cortex into `brain/contracts/github.py` so both layers can depend on it without reaching into each other.

## The security invariants — I checked each one by hand

These are why this subsystem exists, so I verified them directly rather than trusting a green suite:

| invariant | how it is proven |
|---|---|
| The private key PEM never leaves the mint | `test_mint_does_not_pass_private_key_pem_to_resolver` asserts the resolver input's **exact** field set with `vars(...) == {...}` — a runtime check, not a `Protocol` annotation. #721 already learned that typing narrows only what a type checker sees. |
| Stored-installation fallback verifies the account owner | `test_fallback_verifies_matching_owner_before_using_stored_installation` plus a fails-closed twin for a differing owner |
| Repositories spanning two installations fail closed **before** any token exchange | `test_mint_rejects_repositories_across_installations_before_exchange` ends with `assert api_client.calls == []` — the guard is proven to fire before the network, not merely to fire |
| Discovery uses `owner/repository`, exchange uses the **bare** name | the end-to-end test; the mint passes `repository_name` and `repository_slug` separately at the call site |

## The review found one blocking issue; it is fixed

A Codex maintainability review held this PR on a real leftover: after the refactor `_exchange_installation_token` had become a **1:1 pass-through** that still took a `now` argument it never used, was listed in `__all__` despite being private, and was tested **directly** — which kept a test coupled to a path that skips the resolver, and skipping the resolver is exactly what the fail-closed checks prevent.

It is deleted in `867dd0c1`, its export removed, and the assertions it carried were merged into the public mint/cache test rather than dropped. `_build_app_jwt` stays in `__all__` — two tests import it, which the worker checked before leaving it.

## Acceptance checks

1. `git grep "_headers" brain/systems/vault/` returns nothing.
2. `MintedInstallationToken` has exactly two fields; one scope-key computation per mint.
3. `tests/test_installation_resolver.py` exists and injects its own clock and transport; mint tests patch no resolver internals.
4. Exactly one end-to-end test covers full-slug discovery plus bare-name exchange.

## Verification

Fast suite **4758 passed, 11 skipped** — up from the 4751 baseline (+8 new tests, −1 merged away when the directly-tested wrapper was deleted). 6 tests excluded: the sandbox blocks a localhost socket bind. The diff touches `brain/**` and `tests/**`, so CI selects both the backend-fast and Postgres DB lanes; no migration is added, so `alembic heads` is unchanged. No frontend files, so no frontend lane.

## Follow-up filed, not fixed here

The resolver still imports the **public** `parse_github_repo_slug` from Cortex. That is a layering tidy rather than a boundary violation, and moving it would widen this diff past the ticket, so it is filed as #725 — sequenced after this merges, since it edits the same files.