### PR TITLE
refactor(contracts): give parse_github_repo_slug one home outside Cortex (#725)

### DIFF
--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -14,12 +14,12 @@ from brain.app.api.authorization import require_org_context
 from brain.app.api.deps import get_db
 from brain.app.api.routers.cortex._helpers import UPLOAD_DIR, _caller_is_service_principal
 from brain.app.api.routers.cortex._router import router
+from brain.contracts.github import parse_github_repo_slug
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_connect_with_token,
     async_get_repo_by_slug,
     async_search_repos,
-    parse_github_repo_slug,
 )
 from brain.systems.cortex.project_context.browser import (
     project_file_blob,

--- a/brain/contracts/github.py
+++ b/brain/contracts/github.py
@@ -2,6 +2,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
+
+
+# The prefixes that mark a value as an explicit GitHub reference. Stated once: the
+# same list decides whether the origin is trusted AND what gets stripped, so the two
+# can never drift apart.
+_GITHUB_PREFIX_RE = re.compile(
+    r"^(?:git@github\.com:|https?://github\.com/|github://|github\.com/)",
+    flags=re.IGNORECASE,
+)
 
 
 @dataclass
@@ -13,4 +23,27 @@ class GitHubConnectorError(Exception):
         super().__init__(self.message)
 
 
-__all__ = ["GitHubConnectorError"]
+def parse_github_repo_slug(value: str) -> str | None:
+    slug = (value or "").strip()
+    if not slug:
+        return None
+    stripped = _GITHUB_PREFIX_RE.sub("", slug, count=1)
+    has_github_prefix = stripped != slug
+    slug = re.sub(r"[?#].*$", "", stripped)
+    if not has_github_prefix:
+        if slug.startswith("/") or len(slug.strip("/").split("/")) != 2:
+            return None
+    slug = slug.strip("/")
+    parts = [part for part in slug.split("/") if part]
+    if len(parts) < 2:
+        return None
+    owner = parts[0]
+    repo = re.sub(r"\.git$", "", parts[1], flags=re.IGNORECASE)
+    if not re.fullmatch(r"[A-Za-z0-9-]+", owner):
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", repo):
+        return None
+    return f"{owner}/{repo}"
+
+
+__all__ = ["GitHubConnectorError", "parse_github_repo_slug"]

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -14,7 +14,7 @@ from urllib.parse import quote
 
 import httpx
 
-from brain.contracts.github import GitHubConnectorError
+from brain.contracts.github import GitHubConnectorError, parse_github_repo_slug
 from brain.kernel.common.pagination import InvalidPageToken, decode_page_token, encode_page_token
 from brain.platform.async_io import async_http_client, sync_http_client
 
@@ -109,38 +109,6 @@ class GithubIssueClosure:
     closed_at: datetime | None
     closed_by: str | None
     fixing_pull_requests: tuple[GithubFixingPullRequest, ...]
-
-
-# The prefixes that mark a value as an explicit GitHub reference. Stated once: the
-# same list decides whether the origin is trusted AND what gets stripped, so the two
-# can never drift apart.
-_GITHUB_PREFIX_RE = re.compile(
-    r"^(?:git@github\.com:|https?://github\.com/|github://|github\.com/)",
-    flags=re.IGNORECASE,
-)
-
-
-def parse_github_repo_slug(value: str) -> str | None:
-    slug = (value or "").strip()
-    if not slug:
-        return None
-    stripped = _GITHUB_PREFIX_RE.sub("", slug, count=1)
-    has_github_prefix = stripped != slug
-    slug = re.sub(r"[?#].*$", "", stripped)
-    if not has_github_prefix:
-        if slug.startswith("/") or len(slug.strip("/").split("/")) != 2:
-            return None
-    slug = slug.strip("/")
-    parts = [part for part in slug.split("/") if part]
-    if len(parts) < 2:
-        return None
-    owner = parts[0]
-    repo = re.sub(r"\.git$", "", parts[1], flags=re.IGNORECASE)
-    if not re.fullmatch(r"[A-Za-z0-9-]+", owner):
-        return None
-    if not re.fullmatch(r"[A-Za-z0-9._-]+", repo):
-        return None
-    return f"{owner}/{repo}"
 
 
 def _headers(token: str | None = None) -> dict[str, str]:

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -14,7 +14,8 @@ from urllib.parse import quote
 
 import httpx
 
-from brain.contracts.github import GitHubConnectorError, parse_github_repo_slug
+from brain.contracts.github import GitHubConnectorError
+from brain.contracts.github import parse_github_repo_slug as _parse_github_repo_slug
 from brain.kernel.common.pagination import InvalidPageToken, decode_page_token, encode_page_token
 from brain.platform.async_io import async_http_client, sync_http_client
 
@@ -1636,7 +1637,7 @@ def _graphql_parent_reference(data: Any) -> tuple[str, int] | None:
     if parent is None:
         return None
     repository = parent.get("repository") if isinstance(parent, dict) else None
-    parent_slug = parse_github_repo_slug(
+    parent_slug = _parse_github_repo_slug(
         str(repository.get("nameWithOwner") or "") if isinstance(repository, dict) else ""
     )
     parent_number = parent.get("number") if isinstance(parent, dict) else None
@@ -1746,7 +1747,7 @@ def _sub_issue_repository_slug(issue: dict[str, Any]) -> str | None:
             value,
             flags=re.IGNORECASE,
         )
-        parsed = parse_github_repo_slug(api_slug)
+        parsed = _parse_github_repo_slug(api_slug)
         if parsed:
             return parsed
     return None
@@ -1904,7 +1905,7 @@ async def async_get_repo_issue_parent(
                 if exc.status_code != 404:
                     raise
             if isinstance(parent, dict):
-                parent_slug = parse_github_repo_slug(str(parent.get("html_url") or ""))
+                parent_slug = _parse_github_repo_slug(str(parent.get("html_url") or ""))
                 parent_payload = _issue_payload(parent)
                 parent_payload["repo"] = parent_slug
     return {
@@ -2627,7 +2628,7 @@ def search_repos(query: str, *, token: str | None = None) -> dict[str, Any]:
     if not trimmed:
         raise GitHubConnectorError(status_code=422, message="Search query is required.")
 
-    slug = parse_github_repo_slug(trimmed)
+    slug = _parse_github_repo_slug(trimmed)
     if slug:
         token_candidates = [token, None] if token else [None]
         first_error: GitHubConnectorError | None = None
@@ -2670,7 +2671,7 @@ async def async_search_repos(query: str, *, token: str | None = None) -> dict[st
     if not trimmed:
         raise GitHubConnectorError(status_code=422, message="Search query is required.")
 
-    slug = parse_github_repo_slug(trimmed)
+    slug = _parse_github_repo_slug(trimmed)
     if slug:
         token_candidates = [token, None] if token else [None]
         first_error: GitHubConnectorError | None = None

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -11,10 +11,10 @@ import subprocess
 import tempfile
 from typing import Any
 
+from brain.contracts.github import parse_github_repo_slug
 from brain.platform.async_io import check_output_sync, run_subprocess_sync
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.cortex.project_context.drafts import load_draft_metadata, sync_draft_from_root
 from brain.systems.cortex.project_context.identity import durable_project_id_from_context
 from brain.systems.cortex.project_context.permissions import derive_project_permission_scope

--- a/brain/systems/cortex/project_context/merge.py
+++ b/brain/systems/cortex/project_context/merge.py
@@ -5,7 +5,7 @@ import copy
 import json
 from typing import Any
 
-from brain.systems.cortex.project_context.github import parse_github_repo_slug
+from brain.contracts.github import parse_github_repo_slug
 
 
 def project_resource_identity(resource: dict[str, Any]) -> str:

--- a/brain/systems/deploy_state_github.py
+++ b/brain/systems/deploy_state_github.py
@@ -7,10 +7,8 @@ import logging
 import re
 from dataclasses import dataclass
 
-from brain.systems.cortex.project_context.github import (
-    async_compare_commits,
-    parse_github_repo_slug,
-)
+from brain.contracts.github import parse_github_repo_slug
+from brain.systems.cortex.project_context.github import async_compare_commits
 
 
 logger = logging.getLogger("illo.deploy_state.github")

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -12,6 +12,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.contracts.github import parse_github_repo_slug
 from brain.kernel.config import (
     KNOWLEDGE_CONNECTOR_BATCH_SIZE,
     KNOWLEDGE_GITHUB_REPOSITORIES,
@@ -23,7 +24,6 @@ from brain.systems.cortex.project_context.github import (
     GithubIssueClosure,
     async_get_issue_closure_info,
     async_list_repo_issues,
-    parse_github_repo_slug,
 )
 from brain.systems.github_read_failures import (
     GITHUB_READ_ACCESS_FORBIDDEN,

--- a/brain/systems/runs/project_execution_env.py
+++ b/brain/systems/runs/project_execution_env.py
@@ -145,7 +145,7 @@ def _canonical_project_token_slug(value: object, *, require_repo_like: bool = Fa
     if not raw:
         return None
     try:
-        from brain.systems.cortex.project_context.github import parse_github_repo_slug
+        from brain.contracts.github import parse_github_repo_slug
 
         github_slug = parse_github_repo_slug(raw)
     except Exception:

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -7,6 +7,7 @@ import json
 import re
 from typing import Any, Hashable, Mapping
 
+from brain.contracts.github import parse_github_repo_slug
 from brain.kernel.common.pagination import InvalidPageToken
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
@@ -29,7 +30,6 @@ from brain.systems.cortex.project_context.github import (
     async_list_repo_sub_issues,
     async_remove_repo_sub_issue,
     async_update_repo_issue,
-    parse_github_repo_slug,
 )
 from brain.systems.cortex.project_context.github_promotion import (
     PROMOTION_PULL_REQUEST_POLICY,

--- a/brain/systems/vault/installation_resolver.py
+++ b/brain/systems/vault/installation_resolver.py
@@ -8,9 +8,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Protocol
 
-from brain.contracts.github import GitHubConnectorError
+from brain.contracts.github import GitHubConnectorError, parse_github_repo_slug
 from brain.platform.integrations.github_app import github_app_api_client
-from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)

--- a/tests/test_contracts_github.py
+++ b/tests/test_contracts_github.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from brain.contracts.github import parse_github_repo_slug
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://github.com/owner/repo", "owner/repo"),
+        ("https://github.com/owner/repo/tree/main", "owner/repo"),
+        ("http://github.com/owner/repo/issues/1", "owner/repo"),
+        ("git@github.com:owner/repo.git", "owner/repo"),
+        ("github://owner/repo/tree/main", "owner/repo"),
+        ("github.com/owner/repo", "owner/repo"),
+        ("owner/repo", "owner/repo"),
+    ],
+)
+def test_parse_github_repo_slug_accepts_github_references(value: str, expected: str):
+    assert parse_github_repo_slug(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/static/uploads/whatever.pdf",
+        "static/uploads/whatever.pdf",
+        "https://gitlab.com/owner/repo",
+        "https://example.com/a/b",
+        "file:///a/b",
+    ],
+)
+def test_parse_github_repo_slug_rejects_non_github_references(value: str):
+    assert parse_github_repo_slug(value) is None
+
+
+def test_parser_is_not_reachable_through_its_old_cortex_home():
+    """The move is only real if the old public path stops resolving.
+
+    Cortex imports the parser under a private alias precisely so that
+    ``from brain.systems.cortex.project_context.github import parse_github_repo_slug``
+    fails. Without this test an unaliased import could silently reintroduce the
+    cross-layer path that #725 removed.
+    """
+    import brain.systems.cortex.project_context.github as cortex_github
+
+    assert not hasattr(cortex_github, "parse_github_repo_slug")

--- a/tests/test_project_context_github.py
+++ b/tests/test_project_context_github.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from brain.systems.cortex.project_context.github import parse_github_repo_slug
+from brain.contracts.github import parse_github_repo_slug
 from brain.systems.knowledge.connectors.github import _resource_repositories
 
 

--- a/tests/test_project_context_github.py
+++ b/tests/test_project_context_github.py
@@ -1,39 +1,6 @@
 from __future__ import annotations
 
-import pytest
-
-from brain.contracts.github import parse_github_repo_slug
 from brain.systems.knowledge.connectors.github import _resource_repositories
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("https://github.com/owner/repo", "owner/repo"),
-        ("https://github.com/owner/repo/tree/main", "owner/repo"),
-        ("http://github.com/owner/repo/issues/1", "owner/repo"),
-        ("git@github.com:owner/repo.git", "owner/repo"),
-        ("github://owner/repo/tree/main", "owner/repo"),
-        ("github.com/owner/repo", "owner/repo"),
-        ("owner/repo", "owner/repo"),
-    ],
-)
-def test_parse_github_repo_slug_accepts_github_references(value: str, expected: str):
-    assert parse_github_repo_slug(value) == expected
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "/static/uploads/whatever.pdf",
-        "static/uploads/whatever.pdf",
-        "https://gitlab.com/owner/repo",
-        "https://example.com/a/b",
-        "file:///a/b",
-    ],
-)
-def test_parse_github_repo_slug_rejects_non_github_references(value: str):
-    assert parse_github_repo_slug(value) is None
 
 
 def test_resource_repositories_ignores_uploaded_file_uri():


### PR DESCRIPTION
Closes #725.

`parse_github_repo_slug` lived in `brain/systems/cortex/project_context/github.py`, and
`brain/systems/vault/installation_resolver.py` reached across layers to import it. This
moves the parser to `brain/contracts/github.py` — which already owns `GitHubConnectorError`
and is import-safe from both layers — and repoints every caller.

Behaviour-preserving. No feature change.

## Why the parser matters

The vault's GitHub App mint does **installation discovery with `owner/repository`** but
**token exchange with a bare repository name**. That distinction is a fail-closed
invariant, so the parser body moved unchanged, along with its only dependency
(`_GITHUB_PREFIX_RE`). Return type, `None` handling, accepted URL forms, case handling and
`.git` stripping are all identical.

## What changed

One definition, no compatibility shim:

```
$ git grep -n "def parse_github_repo_slug"
brain/contracts/github.py:26:def parse_github_repo_slug(value: str) -> str | None:
```

Nine call sites repointed, across `cortex/project_context/{github,materializer,merge}.py`,
`knowledge/connectors/github.py`, `deploy_state_github.py`, `vault/installation_resolver.py`,
`app/api/routers/cortex/_project_context.py`, and — **not in the issue's list, found while
implementing** — `runs/project_execution_env.py` and `runs/tool_catalog/handlers/github.py`.

## The review caught an implicit shim — fixed before this PR opened

The first implementation moved the function correctly but imported it back into the old
Cortex module under its **public** name. That is a re-export shim by accident: the old
path kept resolving, so nothing stopped code drifting back to it.

```
# before the fix
>>> from brain.systems.cortex.project_context.github import parse_github_repo_slug
>>> parse_github_repo_slug.__module__
'brain.contracts.github'          # resolves — two public paths to one function
```

Cortex now imports it under a private alias (`as _parse_github_repo_slug`) and its five
local calls use that. The old path raises `ImportError`, which is the point of the ticket:

```
# after
>>> from brain.systems.cortex.project_context.github import parse_github_repo_slug
ImportError: cannot import name 'parse_github_repo_slug' from
'brain.systems.cortex.project_context.github'
```

`tests/test_contracts_github.py::test_parser_is_not_reachable_through_its_old_cortex_home`
locks that shut, so a future unaliased import fails the suite instead of silently
reopening the cross-layer path.

The parser's tests also moved out of `tests/test_project_context_github.py` into
`tests/test_contracts_github.py`, following the function to its new owner. No assertion
was weakened or dropped; that file keeps only its Knowledge-connector cases.

## One acceptance bullet is only partly met — read this before merging

The issue asks that `brain/systems/vault/**` import **nothing** from
`brain/systems/cortex/**`. After this change the **module-level** cross-layer import is
gone, but one remains:

```
brain/systems/vault/agent_access.py:41
    from brain.systems.cortex.events import publish_safe
```

It is a **function-local lazy import** of the event publisher, almost certainly deliberate
to break an import cycle, and it is a different concern from slug parsing — event
ownership, not GitHub contracts. Removing it means deciding who owns `publish_safe`, which
is a separate refactor. It was left alone rather than widened into this diff. Filed
separately as #728.

So: the import this ticket was written about is gone; the layer is not yet 100% clean.

## Verification

- Full fast suite on the host, on this branch after the review fixes:
  **4766 passed, 11 skipped, 87 deselected** (+1 = the new old-path regression test).
- Same command on clean `origin/main` for comparison: **4765 passed** — no test lost in
  the move.
- The Codex worker's own run reported 1 failure and 5 errors. Those are **sandbox
  artifacts**: six tests bind a local socket, which its sandbox blocks
  (`PermissionError: [Errno 1]`). The host runs above are green on both sides, and
  4759 + 1 + 5 = 4765 accounts for every one of them.
- The diff touches only `brain/**` and `tests/**`, so only the backend CI lane is selected.
  No `frontend/**` and no `.github/workflows/**` changes.

## Acceptance checks

- [x] `parse_github_repo_slug` has exactly one definition, in `brain/contracts/github.py`.
- [x] No compatibility re-export left in Cortex — the old public path now raises
      `ImportError`, and a test holds it that way.
- [x] `brain/contracts/github.py` imports nothing from `brain/systems/**` or `brain/app/**`
      — no dependency inversion, no cycle.
- [x] Full-slug discovery then bare-name exchange still proven end to end; a repository
      spanning two installations still fails closed **before any token exchange**
      (`assert api_client.calls == []` retained).
- [~] `brain/systems/vault/**` imports nothing from `brain/systems/cortex/**` — module-level
      yes, one lazy function-local import remains, tracked in #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
