### PR TITLE
refactor(events): give the event bus one owner outside Cortex (#728)

### DIFF
--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -144,7 +144,7 @@ def _schedule_on_main_loop(coro, done_callback=None) -> bool:
 async def _publish_product_event(event_type, data):
     """Resolve product scope and broadcast a live event without sync DB access."""
     from brain.app.api.routers.ws import ws_manager
-    from brain.systems.cortex.events import resolve_event_org_id_async
+    from brain.platform.events import resolve_event_org_id_async
 
     payload = dict(data)
     org_id = str(payload.get("org_id") or "").strip()
@@ -201,7 +201,7 @@ async def lifespan(app):
     _main_loop = asyncio.get_running_loop()
     inline_runner_started = False
 
-    from brain.systems.cortex.events import set_publisher
+    from brain.platform.events import set_publisher
     set_publisher(_schedule_product_event_publish)
     scheduler_overdue_monitor = SchedulerOverdueMonitor()
     _scheduler_overdue_monitor_task = _main_loop.create_task(

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -528,7 +528,7 @@ async def add_thread_message_raw(idea_id: str, request: Request, user: dict[str,
         raise HTTPException(status_code=400, detail="Content is required")
     if role not in ("user", "assistant", "illo"):
         raise HTTPException(status_code=400, detail="Role must be 'user', 'assistant', or 'illo'")
-    from brain.systems.cortex.events import publish
+    from brain.platform.events import publish
 
     attachments_data = data.get("attachments", [])
     if not isinstance(attachments_data, list):
@@ -658,7 +658,7 @@ async def update_presence(request: Request, user: dict[str, Any] = Depends(get_c
         _presence_leave(idea_id, user_id)
 
     viewers = _presence_get(idea_id)
-    from brain.systems.cortex.events import publish
+    from brain.platform.events import publish
     publish("presence", {"idea_id": idea_id, "viewers": viewers, "status": "online"})
     return {"viewers": viewers}
 

--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -141,7 +141,7 @@ async def _store_generated_display_title(
 
 
 def _publish_generated_display_title(idea_id: str, title: str, *, org_id: str | None) -> None:
-    from brain.systems.cortex.events import publish
+    from brain.platform.events import publish
 
     payload: dict[str, str] = {"idea_id": str(idea_id), "title": title}
     if org_id:
@@ -393,7 +393,7 @@ async def split_idea(idea_id: str, request: Request, user: dict[str, Any] = Depe
     data = await request.json()
     branches = data.get("branches", [])
 
-    from brain.systems.cortex.events import publish
+    from brain.platform.events import publish
 
     async with UnitOfWork() as uow:
         parent = await _a_require_idea_for_user(uow.session, idea_id, user)

--- a/brain/app/api/routers/ws.py
+++ b/brain/app/api/routers/ws.py
@@ -14,7 +14,7 @@ from brain.systems.runs.event_log import (
     run_event_to_message,
     list_run_events_after_for_principal_async,
 )
-from brain.systems.cortex.events import (
+from brain.platform.events import (
     cortex_event_to_message,
     list_cortex_events_after_for_principal_async,
 )

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1317,7 +1317,7 @@ async def tool_vault_secret_prompt(
     requested_by: str = "agent",
 ) -> dict:
     """Open a guided Vault form for a user-supplied secret value."""
-    from brain.systems.cortex.events import publish_safe
+    from brain.platform.events import publish_safe
     from brain.systems.vault import record_missing_request
 
     if not user_id:

--- a/brain/platform/browser/service.py
+++ b/brain/platform/browser/service.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 from brain.kernel.common.time import utcnow as _shared_utcnow
 
-from brain.systems.cortex.events import publish_safe
+from brain.platform.events import publish_safe
 from brain.systems.cortex.resources.telemetry import build_browser_resource_summary
 from brain.systems.cortex.upload_preview import public_static_upload_url, static_upload_url_for
 from brain.platform.async_io import async_http_client, copy_file, ensure_dir, glob_paths, iter_dir, path_exists, path_is_file, path_stat

--- a/brain/platform/events.py
+++ b/brain/platform/events.py
@@ -1,13 +1,10 @@
-"""Event bus for cortex run.
-
-Compatibility shim for websocket fanout plus durable run-event storage.
-"""
+"""Event bus for websocket fanout plus durable event storage."""
 from __future__ import annotations
 
 import json
 import logging
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable
@@ -56,6 +53,7 @@ def run_event_scope(
     producer: str = "cortex",
     consumer_runtime: str | None = None,
     session: Any | None = None,
+    recorder: Callable[..., Awaitable[Any]] | None = None,
 ):
     """Scope publish() calls so they can also be durably recorded."""
     token = _run_event_scope.set(
@@ -65,6 +63,7 @@ def run_event_scope(
             "producer": producer,
             "consumer_runtime": consumer_runtime,
             "session": session,
+            "recorder": recorder,
         }
     )
     try:
@@ -414,38 +413,38 @@ def publish(event_type: str, data: dict[str, Any]) -> None:
     scope = _run_event_scope.get()
     recorded_durable = False
     if scope and scope.get("run_id") is not None:
-        try:
-            from brain.systems.runs.event_log import async_record_run_event
-
-            write = async_record_run_event(
-                int(scope["run_id"]),
-                event_type,
-                data,
-                idea_id=scope.get("idea_id") or data.get("idea_id"),
-                producer=scope.get("producer") or "cortex",
-                consumer_runtime=scope.get("consumer_runtime"),
-                session=scope.get("session"),
-            )
-            loop = _active_async_loop()
-            if loop is not None:
-                task = loop.create_task(write)
-                task.add_done_callback(
-                    lambda done_task, event_type=event_type: _log_async_event_write_failure(
-                        event_type,
-                        done_task,
-                        log_name="run_event_write_failed",
+        recorder = scope.get("recorder")
+        if recorder is not None:
+            try:
+                write = recorder(
+                    int(scope["run_id"]),
+                    event_type,
+                    data,
+                    idea_id=scope.get("idea_id") or data.get("idea_id"),
+                    producer=scope.get("producer") or "cortex",
+                    consumer_runtime=scope.get("consumer_runtime"),
+                    session=scope.get("session"),
+                )
+                loop = _active_async_loop()
+                if loop is not None:
+                    task = loop.create_task(write)
+                    task.add_done_callback(
+                        lambda done_task, event_type=event_type: _log_async_event_write_failure(
+                            event_type,
+                            done_task,
+                            log_name="run_event_write_failed",
+                        )
                     )
+                else:
+                    asyncio.run(write)
+            except Exception as exc:
+                logger.warning(
+                    "run_event_write_failed event_type=%s error=%s",
+                    event_type,
+                    exc,
                 )
             else:
-                asyncio.run(write)
-        except Exception as exc:
-            logger.warning(
-                "run_event_write_failed event_type=%s error=%s",
-                event_type,
-                exc,
-            )
-        else:
-            recorded_durable = True
+                recorded_durable = True
 
     if recorded_durable and event_type not in _LIVE_AFTER_DURABLE_EVENT_TYPES:
         # Durable run-scoped events are replayed by the API consumer.

--- a/brain/systems/cortex/resources/leases.py
+++ b/brain/systems/cortex/resources/leases.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 
 from brain.kernel.common.time import utcnow as _shared_utcnow
 
-from brain.systems.cortex.events import publish_safe
+from brain.platform.events import publish_safe
 from brain.platform.db.models.resource_pool import ResourceLease
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 

--- a/brain/systems/cortex/resources/telemetry.py
+++ b/brain/systems/cortex/resources/telemetry.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from brain.kernel.common.time import utcnow as _shared_utcnow
 
-from brain.systems.cortex.events import publish_safe
+from brain.platform.events import publish_safe
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 

--- a/brain/systems/cortex/thread_read_model.py
+++ b/brain/systems/cortex/thread_read_model.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.cortex.events import publish_safe
+from brain.platform.events import publish_safe
 from brain.systems.cortex.thread_links import thread_link_payload
 
 THREAD_OBJECT_TYPE = "thread"

--- a/brain/systems/cortex/title_generation.py
+++ b/brain/systems/cortex/title_generation.py
@@ -344,7 +344,7 @@ def _publish_generated_display_title(
     *,
     org_id: str | None,
 ) -> None:
-    from brain.systems.cortex.events import publish
+    from brain.platform.events import publish
 
     payload: dict[str, str] = {"idea_id": str(idea_id), "title": title}
     if org_id:

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -27,7 +27,7 @@ def publish_cycle_change(
         payload["target_idea_id"] = str(target_idea_id)
 
     try:
-        from brain.systems.cortex.events import publish_safe
+        from brain.platform.events import publish_safe
 
         publish_safe("cycles_changed", payload)
     except Exception:

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -13,7 +13,7 @@ from brain.kernel.common.time import assume_utc_optional
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthBlockedPreflightResult,
 )
-from brain.systems.cortex.events import publish
+from brain.platform.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
 from brain.systems.cycles.admission import (

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -58,7 +58,7 @@ from brain.systems.runs.cortex.queue_health import (
     runner_concurrency as _shared_runner_concurrency,
 )
 from brain.systems.runs.ui_events import run_event_to_ui_message
-from brain.systems.cortex.events import publish_live_safe, publish_safe
+from brain.platform.events import publish_live_safe, publish_safe
 from brain.systems.cortex.project_context.materializer import (
     materialize_project_context_workspaces,
     project_context_has_materializable_resources,

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -278,7 +278,7 @@ async def _handle_post_thread_discussion_reply(
     """Post an Illo-authored reply to a Thread's Discussion surface."""
     from brain.platform.db.models.idea import Idea, ThreadDiscussionComment
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
-    from brain.systems.cortex.events import publish_safe
+    from brain.platform.events import publish_safe
 
     text = str(body or "").strip()
     if not text:
@@ -359,7 +359,7 @@ async def _handle_post_ai_timeline_message(
     """Post an Illo-authored message to a Thread's AI Timeline surface."""
     from brain.platform.db.models.idea import Idea
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
-    from brain.systems.cortex.events import publish_safe
+    from brain.platform.events import publish_safe
     from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 
     text = str(body or "").strip()

--- a/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
+++ b/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
@@ -152,7 +152,7 @@ async def _handle_cortex_visual_reply(content_type: str, title: str, content: st
     display_mode = display or "inline"
 
     try:
-        from brain.systems.cortex.events import publish_safe as _ws_publish
+        from brain.platform.events import publish_safe as _ws_publish
         from brain.platform.db.repositories.unit_of_work import UnitOfWork
         from brain.platform.db.models.idea import VisualBlock
         from sqlalchemy import text as sa_text

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -596,7 +596,7 @@ async def _handle_manage_idea(
     if normalized_action in {"help", "schema"}:
         return _manage_tool_guide("manage_idea", operation)
 
-    from brain.systems.cortex.events import publish_safe
+    from brain.platform.events import publish_safe
     from brain.platform.db.models.idea import Idea
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 

--- a/brain/systems/vault/agent_access.py
+++ b/brain/systems/vault/agent_access.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from brain.platform.events import publish_safe
+
 
 def _json_safe(value: Any) -> Any:
     if isinstance(value, datetime):
@@ -38,8 +40,6 @@ def _grant_prompt_response(
     normalized_idea_id = (str(idea_id).strip() if idea_id else "") or None
     prompt = None
     if normalized_idea_id:
-        from brain.systems.cortex.events import publish_safe
-
         prompt = {
             "id": f"vault-grant-{grant.get('id') or run_id or 'thread'}",
             "idea_id": normalized_idea_id,

--- a/brain/systems/workspace_apps/events.py
+++ b/brain/systems/workspace_apps/events.py
@@ -31,7 +31,7 @@ def publish_workspace_app_change(
             payload["key"] = str(key)
 
     try:
-        from brain.systems.cortex.events import publish_safe
+        from brain.platform.events import publish_safe
 
         publish_safe("workspace_apps_changed", payload)
     except Exception:
@@ -60,7 +60,7 @@ def publish_workspace_app_collaboration_event(
         payload["events"] = [dict(event) for event in events]
 
     try:
-        from brain.systems.cortex.events import publish_safe
+        from brain.platform.events import publish_safe
 
         publish_safe("workspace_app_collaboration_changed", payload)
     except Exception:

--- a/docs/personal-agent-connections-mvp.md
+++ b/docs/personal-agent-connections-mvp.md
@@ -82,7 +82,7 @@ Illo already has most of the local collaboration machinery:
 - Cortex idea/thread persistence in `brain/platform/db/models/idea.py`.
 - Native chat persistence in `brain/platform/db/models/chat.py`.
 - AgentRun queue/events/artifacts in `brain/platform/db/models/agent_run.py` and `brain/systems/runs/store.py`.
-- Cortex websocket fanout and durable replay in `brain/systems/cortex/events.py` and `brain/app/api/routers/ws.py`.
+- Cortex websocket fanout and durable replay in `brain/platform/events.py` and `brain/app/api/routers/ws.py`.
 - Team chat service and agent-authored replies in `brain/app/api/services/chat.py`.
 - Workspace notifications and mentions in `brain/app/api/routers/cortex/_idea_ops.py`.
 - Vault secrets and task-scoped agent grants in `brain/platform/db/models/vault.py`.

--- a/ops/validate-cortex.sh
+++ b/ops/validate-cortex.sh
@@ -28,7 +28,7 @@ PY_TARGETS=(
     brain/app/api/routers/cortex_intel.py
     brain/app/api/main.py
     brain/systems/runs/cortex
-    brain/systems/cortex/events.py
+    brain/platform/events.py
     brain/systems/cortex/encode.py
     brain/systems/cortex/intelligence.py
     brain/systems/cortex/worker.py

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -74,16 +74,6 @@
     },
     {
       "source": "brain/platform/browser/service.py",
-      "import": "brain.systems.cortex.events",
-      "source_layer": "brain.platform",
-      "target_layer": "brain.systems",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
-    },
-    {
-      "source": "brain/platform/browser/service.py",
       "import": "brain.systems.cortex.resources.telemetry",
       "source_layer": "brain.platform",
       "target_layer": "brain.systems",

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -639,7 +639,7 @@ async def test_manage_idea_archive_defaults_to_current_thread(monkeypatch):
 
     monkeypatch.setattr(idea_tools, "_serialize_idea", serialize_idea)
     monkeypatch.setattr(
-        "brain.systems.cortex.events.publish_safe",
+        "brain.platform.events.publish_safe",
         lambda event_type, data: published.append((event_type, data)),
     )
 
@@ -706,7 +706,7 @@ async def test_manage_idea_create_seeds_new_thread_message(monkeypatch):
 
     monkeypatch.setattr(idea_tools, "_serialize_idea", serialize_idea)
     monkeypatch.setattr(
-        "brain.systems.cortex.events.publish_safe",
+        "brain.platform.events.publish_safe",
         lambda event_type, data: published.append((event_type, data)),
     )
 
@@ -778,7 +778,7 @@ async def test_manage_idea_create_can_handoff_owner(monkeypatch):
     session.execute = AsyncMock(return_value=SimpleNamespace(one_or_none=lambda: None))
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", FakeUnitOfWork)
     monkeypatch.setattr(idea_tools, "_require_idea_for_actor", AsyncMock(return_value=SimpleNamespace(id=parent_id)))
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", lambda *_: None)
+    monkeypatch.setattr("brain.platform.events.publish_safe", lambda *_: None)
 
     async def serialize_idea(idea_arg, session_arg):
         return {"id": str(idea_arg.id), "user_id": idea_arg.user_id}
@@ -852,7 +852,7 @@ async def test_manage_idea_create_queued_admits_run_instead_of_empty_queue(monke
     session.flush = AsyncMock(side_effect=flush)
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", FakeUnitOfWork)
     monkeypatch.setattr(idea_tools, "_require_idea_for_actor", AsyncMock(return_value=SimpleNamespace(id=parent_id)))
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", lambda *_: None)
+    monkeypatch.setattr("brain.platform.events.publish_safe", lambda *_: None)
     monkeypatch.setattr(idea_tools, "_admit_created_idea_run", admit)
 
     async def serialize_idea(idea_arg, session_arg):
@@ -2161,7 +2161,7 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
 
     published = Mock()
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
+    monkeypatch.setattr("brain.platform.events.publish_safe", published)
 
     with bind_agent_context(
         {
@@ -2268,7 +2268,7 @@ async def test_post_thread_discussion_reply_tool_infers_upload_attachments(monke
 
     published = Mock()
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
+    monkeypatch.setattr("brain.platform.events.publish_safe", published)
 
     with bind_agent_context(
         {
@@ -2344,7 +2344,7 @@ async def test_post_ai_timeline_message_tool_writes_linked_thread_message(monkey
 
     published = Mock()
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
+    monkeypatch.setattr("brain.platform.events.publish_safe", published)
 
     with bind_agent_context(
         {

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -105,7 +105,7 @@ async def test_product_event_publish_drops_unscoped_product_event(monkeypatch):
     monkeypatch.setattr(api_main, "_main_loop", loop)
 
     with patch("brain.app.api.routers.ws.ws_manager", ws_manager), patch(
-        "brain.systems.cortex.events.resolve_event_org_id_async",
+        "brain.platform.events.resolve_event_org_id_async",
         AsyncMock(return_value=None),
     ):
         api_main._schedule_product_event_publish("browser_session_frame", {"session_id": "session-1"})
@@ -132,7 +132,7 @@ async def test_product_event_publish_resolves_org_scope_before_fanout(monkeypatc
     monkeypatch.setattr(api_main, "_main_loop", loop)
 
     with patch("brain.app.api.routers.ws.ws_manager", ws_manager), patch(
-        "brain.systems.cortex.events.resolve_event_org_id_async",
+        "brain.platform.events.resolve_event_org_id_async",
         resolve_org,
     ):
         api_main._schedule_product_event_publish("browser_session_frame", {"idea_id": "idea-1"})
@@ -162,7 +162,7 @@ async def test_ensure_starting_skill_bundle_awaits_async_catalog():
 @pytest.mark.asyncio
 async def test_lifespan_skips_inline_runner_by_default():
     with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
-        with patch("brain.systems.cortex.events.set_publisher") as mock_set_publisher:
+        with patch("brain.platform.events.set_publisher") as mock_set_publisher:
             with patch("brain.systems.runs.cortex.start_runner") as mock_start_runner:
                 async with api_main.lifespan(app):
                     pass
@@ -174,7 +174,7 @@ async def test_lifespan_skips_inline_runner_by_default():
 @pytest.mark.asyncio
 async def test_lifespan_ensures_starting_skill_bundle():
     with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
-        with patch("brain.systems.cortex.events.set_publisher"):
+        with patch("brain.platform.events.set_publisher"):
             with patch("brain.app.api.main._ensure_starting_skill_bundle", new=AsyncMock()) as ensure_bundle:
                 async with api_main.lifespan(app):
                     pass
@@ -196,7 +196,7 @@ async def test_lifespan_hosts_scheduler_overdue_monitor_outside_daemon():
 
     with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
         with patch("brain.app.api.main._should_start_run_event_consumer", return_value=False):
-            with patch("brain.systems.cortex.events.set_publisher"):
+            with patch("brain.platform.events.set_publisher"):
                 with patch(
                     "brain.app.api.main._ensure_starting_skill_bundle",
                     new=AsyncMock(),
@@ -231,7 +231,7 @@ async def test_lifespan_hosts_stale_run_reaper_outside_daemon():
 
     with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
         with patch("brain.app.api.main._should_start_run_event_consumer", return_value=False):
-            with patch("brain.systems.cortex.events.set_publisher"):
+            with patch("brain.platform.events.set_publisher"):
                 with patch(
                     "brain.app.api.main._ensure_starting_skill_bundle",
                     new=AsyncMock(),
@@ -271,7 +271,7 @@ async def test_lifespan_can_start_inline_runner_when_enabled():
     from brain.systems.runs.cortex import DrainResult
 
     with patch("brain.app.api.main._should_start_inline_runner", return_value=True):
-        with patch("brain.systems.cortex.events.set_publisher") as mock_set_publisher:
+        with patch("brain.platform.events.set_publisher") as mock_set_publisher:
             with patch("brain.systems.runs.cortex.start_runner") as mock_start_runner:
                 with patch("brain.systems.cycles.start_cycle_scheduler"), patch(
                     "brain.systems.cycles.stop_cycle_scheduler",
@@ -303,7 +303,7 @@ async def test_lifespan_recovers_inline_runs_that_time_out_during_drain():
     )
     recover = AsyncMock(return_value=recovered)
     with patch("brain.app.api.main._should_start_inline_runner", return_value=True):
-        with patch("brain.systems.cortex.events.set_publisher"):
+        with patch("brain.platform.events.set_publisher"):
             with patch("brain.systems.runs.cortex.start_runner"):
                 with patch("brain.systems.cycles.start_cycle_scheduler"), patch(
                     "brain.systems.cycles.stop_cycle_scheduler",

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -107,7 +107,7 @@ def test_ws_replay_cursor_parser_reports_invalid_cursor():
 
 
 async def test_cortex_replay_query_scopes_human_principal_to_authenticated_org():
-    from brain.systems.cortex.events import list_cortex_events_after_for_principal_async
+    from brain.platform.events import list_cortex_events_after_for_principal_async
 
     session = MagicMock()
     session.scalars = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=[])))

--- a/tests/test_cortex_misc_failure_projection.py
+++ b/tests/test_cortex_misc_failure_projection.py
@@ -139,7 +139,7 @@ async def test_split_projects_legacy_failed_message_before_copying_it():
             "async_cancel_open_runs_for_thread",
             cancel_open_runs,
         ),
-        patch("brain.systems.cortex.events.publish"),
+        patch("brain.platform.events.publish"),
     ):
         result = await _misc.split_idea(
             "idea-1",

--- a/tests/test_cortex_visual_reply.py
+++ b/tests/test_cortex_visual_reply.py
@@ -76,7 +76,7 @@ async def test_cortex_visual_reply_persists_and_broadcasts_visual_block(monkeypa
 
     fake_events = SimpleNamespace(publish_safe=lambda event, payload: published.append((event, payload)))
     fake_uow_mod = SimpleNamespace(UnitOfWork=FakeUnitOfWork, open_unit_of_work=lambda factory: factory())
-    monkeypatch.setitem(sys.modules, "brain.systems.cortex.events", fake_events)
+    monkeypatch.setitem(sys.modules, "brain.platform.events", fake_events)
     monkeypatch.setitem(sys.modules, "brain.platform.db.repositories.unit_of_work", fake_uow_mod)
     monkeypatch.setattr(idea_models, "VisualBlock", FakeVisualBlock)
 

--- a/tests/test_manage_idea.py
+++ b/tests/test_manage_idea.py
@@ -62,7 +62,7 @@ async def test_manage_idea_create_normalizes_emptyish_parent_id_to_null(
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
 
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", lambda *_: None)
+    monkeypatch.setattr("brain.platform.events.publish_safe", lambda *_: None)
     monkeypatch.setattr(idea_tools, "_seed_created_idea_thread", AsyncMock(return_value=None))
     monkeypatch.setattr(
         idea_tools,
@@ -127,7 +127,7 @@ async def test_manage_idea_create_persists_emptyish_parent_as_null(
         return {"id": str(idea.id), "parent_id": idea.parent_id}
 
     install_unit_of_work(session, flush_on_exit=True)
-    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", lambda *_: None)
+    monkeypatch.setattr("brain.platform.events.publish_safe", lambda *_: None)
     monkeypatch.setattr(idea_tools, "_seed_created_idea_thread", AsyncMock(return_value=None))
     monkeypatch.setattr(idea_tools, "_serialize_idea", serialize_idea)
 

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -23,7 +23,7 @@ from brain.systems.runs.events import (
 from brain.systems.runs.tool_event_read_model import (
     parse_persisted_tool_side_effect,
 )
-from brain.systems.cortex.events import run_event_scope
+from brain.platform.events import run_event_scope
 from brain.platform.db.models.run import RunEvent
 
 
@@ -453,7 +453,7 @@ def test_public_tool_projection_keeps_legacy_read_non_write():
 
 
 def test_publish_live_fans_out_without_durable_storage(monkeypatch):
-    from brain.systems.cortex import events
+    from brain.platform import events
 
     published = []
 
@@ -466,7 +466,7 @@ def test_publish_live_fans_out_without_durable_storage(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_publish_records_cortex_event_async_inside_running_loop(monkeypatch):
-    from brain.systems.cortex import events
+    from brain.platform import events
 
     async_record = AsyncMock()
     publisher = MagicMock()
@@ -484,7 +484,7 @@ async def test_publish_records_cortex_event_async_inside_running_loop(monkeypatc
 
 @pytest.mark.asyncio
 async def test_browser_run_events_live_publish_after_durable_record(monkeypatch):
-    import brain.systems.cortex.events as cortex_events
+    import brain.platform.events as cortex_events
 
     durable_records = []
     live_events = []
@@ -492,7 +492,6 @@ async def test_browser_run_events_live_publish_after_durable_record(monkeypatch)
     async def _record(*args, **kwargs):
         durable_records.append((args, kwargs))
 
-    monkeypatch.setattr("brain.systems.runs.event_log.async_record_run_event", _record)
     monkeypatch.setattr(
         cortex_events,
         "_publisher",
@@ -504,7 +503,7 @@ async def test_browser_run_events_live_publish_after_durable_record(monkeypatch)
         "session_id": "session-1",
         "state": {"id": "session-1", "run_id": 42},
     }
-    with run_event_scope(42, idea_id="idea-1", session=object()):
+    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=_record):
         cortex_events.publish("browser_session_state", payload)
     await asyncio.sleep(0)
 
@@ -515,14 +514,13 @@ async def test_browser_run_events_live_publish_after_durable_record(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_non_browser_run_events_skip_live_publish_after_durable_record(monkeypatch):
-    import brain.systems.cortex.events as cortex_events
+    import brain.platform.events as cortex_events
 
     async_record = AsyncMock()
-    monkeypatch.setattr("brain.systems.runs.event_log.async_record_run_event", async_record)
     publisher = MagicMock()
     monkeypatch.setattr(cortex_events, "_publisher", publisher)
 
-    with run_event_scope(42, idea_id="idea-1", session=object()):
+    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=async_record):
         cortex_events.publish("run.activity", {"idea_id": "idea-1", "activity": "Working"})
     await asyncio.sleep(0)
 
@@ -532,7 +530,7 @@ async def test_non_browser_run_events_skip_live_publish_after_durable_record(mon
 
 @pytest.mark.asyncio
 async def test_vault_secret_prompt_publishes_live_after_durable_record(monkeypatch):
-    import brain.systems.cortex.events as cortex_events
+    import brain.platform.events as cortex_events
 
     durable_records = []
     live_events = []
@@ -540,7 +538,6 @@ async def test_vault_secret_prompt_publishes_live_after_durable_record(monkeypat
     async def _record(*args, **kwargs):
         durable_records.append((args, kwargs))
 
-    monkeypatch.setattr("brain.systems.runs.event_log.async_record_run_event", _record)
     monkeypatch.setattr(
         cortex_events,
         "_publisher",
@@ -552,7 +549,7 @@ async def test_vault_secret_prompt_publishes_live_after_durable_record(monkeypat
         "run_id": 42,
         "prompt": {"id": "prompt-1", "idea_id": "idea-1", "key_name": "GITHUB_TOKEN"},
     }
-    with run_event_scope(42, idea_id="idea-1", session=object()):
+    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=_record):
         cortex_events.publish("vault_secret_prompt", payload)
     await asyncio.sleep(0)
 

--- a/tests/test_vault_hardening.py
+++ b/tests/test_vault_hardening.py
@@ -239,7 +239,7 @@ async def test_vault_secret_prompt_records_missing_and_broadcasts_thread_event()
     published = []
 
     with patch("brain.systems.vault.record_missing_request", new=AsyncMock()) as record_missing, \
-         patch("brain.systems.cortex.events.publish_safe", side_effect=lambda event, payload: published.append((event, payload))):
+         patch("brain.platform.events.publish_safe", side_effect=lambda event, payload: published.append((event, payload))):
         result = await tool_vault_secret_prompt(
             "example_api_key",
             description="Example API access for generated product workflows.",
@@ -483,7 +483,7 @@ async def test_brain_vault_publishes_grant_prompt_for_thread_approval():
         "grant": grant,
     })), \
          patch("brain.systems.vault.get_secret", new=AsyncMock()) as get_secret, \
-         patch("brain.systems.cortex.events.publish_safe") as publish:
+         patch("brain.systems.vault.agent_access.publish_safe") as publish:
         result = await tool_brain_vault(
             "GITHUB_TOKEN",
             reason="Need GitHub access for this run",


### PR DESCRIPTION
> *This was generated by AI. Implemented by a Codex worker, reviewed and verified by Routine R3.*

Closes #728.

## What this does

`publish_safe` lived in `brain/systems/cortex/events.py`, so the vault reached into Cortex through a function-local import to publish one grant-prompt event. That module was never a Cortex concern — its only module-level `brain` imports are `brain.platform.db.*`. It is a websocket-fanout plus durable-event bus.

- **Move** `brain/systems/cortex/events.py` → `brain/platform/events.py`. **No shim**: the old module is deleted and all 27 importers point at the new path. (#725 shipped a re-export shim by accident and had to fix it; this PR has none — the review confirmed it.)
- **Remove the module's one `brain/systems/**` edge.** `publish()` used a lazy `from brain.systems.runs.event_log import async_record_run_event`, which is illegal once the module sits in `brain.platform`. The caller now passes the recorder in: `run_event_scope(..., recorder=...)`.
- **Vault** imports `publish_safe` at module level. The deferral only existed to dodge the cortex cycle, which no longer exists.
- **Pays down existing debt:** the architecture-boundary allowlist entry for `brain/platform/browser/service.py` → `brain.systems.cortex.events` is deleted — that import is now platform → platform.

## Why not a module-global registry

The obvious alternative was `set_run_event_recorder(...)` mirroring the existing `set_publisher(...)`. Rejected: `set_publisher` is registered in exactly one place (`brain/app/api/main.py:204`) and the deployment runs **four** processes — `api`, `worker`, `scheduler`, `slack-connector` (`deploy/compose/docker-compose.yml`). A registry would have been silently unset in three of them. The code review agreed with this call.

## Verification (this repo is out of CI minutes, so these ran locally on the host)

- `pytest tests/ -m "not requires_db and not requires_browser and not live_provider"` → **4766 passed, 11 skipped, 87 deselected in 79s**, load average 3.75. Same 4766 as `main`: this change adds and removes no tests.
- `pytest tests/test_architecture_boundaries.py` → **2 passed** (it fails on *stale* allowlist entries too, so the deleted entry is proven gone).
- `git grep -n "brain.systems.cortex" -- brain/systems/vault/` → empty.
- `git grep -n "brain.systems.cortex.events"` → empty repo-wide.
- Backend lane only. Zero `frontend/**` files, so no `svelte-check` lane applies.

The worker reported 1 failure + 5 errors; all six bind `127.0.0.1` and are blocked by its sandbox. 4760 + 1 + 5 = 4766 accounts for every test, and the host run above is green.

## Acceptance checks

1. Vault grant prompt still reaches the UI: request an agent secret that needs a grant, inside a thread — the `vault_agent_grant_prompt` event still fans out over the websocket.
2. `brain/systems/vault/**` imports nothing from `brain/systems/cortex/**`, module-level or function-local.
3. `brain/systems/cortex/events.py` does not exist and nothing re-exports it under the old name.
4. `tests/test_architecture_boundaries.py` passes with **one fewer** allowlist entry, not one more.

## One review finding NOT folded in — for @redawear to route

The code-quality review raised one **blocking** structural finding, and I deliberately left it out of this PR:

> `run_event_scope` has no production callers. Injecting a recorder into it preserves dead complexity. Delete the scope machinery instead.

The finding is factually right — `git grep -n "run_event_scope" origin/main` returns only the module itself and `tests/test_run_events.py`. But deleting a subsystem is a different decision from #728, whose scope is "structure only; no known bug", and I have evidence that the path is *unused*, not evidence of *why* it exists or whether someone is about to wire it. So this PR keeps behavior identical and I filed the question separately rather than widening a scoped refactor into a deletion.

Everything else in the review came back clean: `brain.platform` is the right altitude, the registry rejection was correct, no shim remains, and the vault test seam is right.
