### PR TITLE
refactor(events): delete the unwired durable run-event scope (#731)

### DIFF
--- a/brain/platform/events.py
+++ b/brain/platform/events.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import asyncio
-from collections.abc import Awaitable, Mapping
-from contextlib import contextmanager
-from contextvars import ContextVar
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from sqlalchemy import false, or_, select
@@ -23,53 +21,11 @@ _publisher: Callable[[str, dict[str, Any]], None] | None = None
 _idea_org_cache: dict[str, str | None] = {}
 _run_org_cache: dict[int, str | None] = {}
 
-_run_event_scope: ContextVar[dict[str, Any] | None] = ContextVar(
-    "run_event_scope",
-    default=None,
-)
-
-_LIVE_AFTER_DURABLE_EVENT_TYPES = {
-    "browser_session_state",
-    "browser_session_frame",
-    "browser_session_delta",
-    "browser_session_error",
-    "browser_session_closed",
-    "vault_secret_prompt",
-    "vault_agent_grant_prompt",
-}
-
 
 def set_publisher(fn: Callable[[str, dict[str, Any]], None]) -> None:
     """Register the websocket publisher (called once by the web layer)."""
     global _publisher
     _publisher = fn
-
-
-@contextmanager
-def run_event_scope(
-    run_id: int | None,
-    *,
-    idea_id: str | None = None,
-    producer: str = "cortex",
-    consumer_runtime: str | None = None,
-    session: Any | None = None,
-    recorder: Callable[..., Awaitable[Any]] | None = None,
-):
-    """Scope publish() calls so they can also be durably recorded."""
-    token = _run_event_scope.set(
-        {
-            "run_id": run_id,
-            "idea_id": idea_id,
-            "producer": producer,
-            "consumer_runtime": consumer_runtime,
-            "session": session,
-            "recorder": recorder,
-        }
-    )
-    try:
-        yield
-    finally:
-        _run_event_scope.reset(token)
 
 
 def _normalize_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -325,15 +281,12 @@ def _active_async_loop() -> asyncio.AbstractEventLoop | None:
 def _log_async_event_write_failure(
     event_type: str,
     task: asyncio.Task,
-    *,
-    log_name: str = "cortex_event_write_failed",
 ) -> None:
     try:
         task.result()
     except Exception as exc:
         logger.warning(
-            "%s event_type=%s error=%s",
-            log_name,
+            "cortex_event_write_failed event_type=%s error=%s",
             event_type,
             exc,
         )
@@ -409,49 +362,8 @@ async def list_cortex_events_after_for_principal_async(
 
 
 def publish(event_type: str, data: dict[str, Any]) -> None:
-    """Publish an event and, when scoped, persist it durably first."""
-    scope = _run_event_scope.get()
-    recorded_durable = False
-    if scope and scope.get("run_id") is not None:
-        recorder = scope.get("recorder")
-        if recorder is not None:
-            try:
-                write = recorder(
-                    int(scope["run_id"]),
-                    event_type,
-                    data,
-                    idea_id=scope.get("idea_id") or data.get("idea_id"),
-                    producer=scope.get("producer") or "cortex",
-                    consumer_runtime=scope.get("consumer_runtime"),
-                    session=scope.get("session"),
-                )
-                loop = _active_async_loop()
-                if loop is not None:
-                    task = loop.create_task(write)
-                    task.add_done_callback(
-                        lambda done_task, event_type=event_type: _log_async_event_write_failure(
-                            event_type,
-                            done_task,
-                            log_name="run_event_write_failed",
-                        )
-                    )
-                else:
-                    asyncio.run(write)
-            except Exception as exc:
-                logger.warning(
-                    "run_event_write_failed event_type=%s error=%s",
-                    event_type,
-                    exc,
-                )
-            else:
-                recorded_durable = True
-
-    if recorded_durable and event_type not in _LIVE_AFTER_DURABLE_EVENT_TYPES:
-        # Durable run-scoped events are replayed by the API consumer.
-        # Skip the live publisher here to avoid double fanout.
-        return
-
-    if not recorded_durable and _infer_idea_id(data) is not None:
+    """Record an idea-scoped event for replay, then fan it out live."""
+    if _infer_idea_id(data) is not None:
         loop = _active_async_loop()
         if loop is not None:
             task = loop.create_task(record_cortex_event_async(event_type, data))

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -23,7 +23,6 @@ from brain.systems.runs.events import (
 from brain.systems.runs.tool_event_read_model import (
     parse_persisted_tool_side_effect,
 )
-from brain.platform.events import run_event_scope
 from brain.platform.db.models.run import RunEvent
 
 
@@ -480,81 +479,6 @@ async def test_publish_records_cortex_event_async_inside_running_loop(monkeypatc
 
     async_record.assert_awaited_once_with("status_change", payload)
     publisher.assert_called_once_with("status_change", payload)
-
-
-@pytest.mark.asyncio
-async def test_browser_run_events_live_publish_after_durable_record(monkeypatch):
-    import brain.platform.events as cortex_events
-
-    durable_records = []
-    live_events = []
-
-    async def _record(*args, **kwargs):
-        durable_records.append((args, kwargs))
-
-    monkeypatch.setattr(
-        cortex_events,
-        "_publisher",
-        lambda event_type, payload: live_events.append((event_type, payload)),
-    )
-
-    payload = {
-        "idea_id": "idea-1",
-        "session_id": "session-1",
-        "state": {"id": "session-1", "run_id": 42},
-    }
-    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=_record):
-        cortex_events.publish("browser_session_state", payload)
-    await asyncio.sleep(0)
-
-    assert durable_records
-    assert durable_records[0][0][:3] == (42, "browser_session_state", payload)
-    assert live_events == [("browser_session_state", payload)]
-
-
-@pytest.mark.asyncio
-async def test_non_browser_run_events_skip_live_publish_after_durable_record(monkeypatch):
-    import brain.platform.events as cortex_events
-
-    async_record = AsyncMock()
-    publisher = MagicMock()
-    monkeypatch.setattr(cortex_events, "_publisher", publisher)
-
-    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=async_record):
-        cortex_events.publish("run.activity", {"idea_id": "idea-1", "activity": "Working"})
-    await asyncio.sleep(0)
-
-    async_record.assert_awaited_once()
-    publisher.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_vault_secret_prompt_publishes_live_after_durable_record(monkeypatch):
-    import brain.platform.events as cortex_events
-
-    durable_records = []
-    live_events = []
-
-    async def _record(*args, **kwargs):
-        durable_records.append((args, kwargs))
-
-    monkeypatch.setattr(
-        cortex_events,
-        "_publisher",
-        lambda event_type, payload: live_events.append((event_type, payload)),
-    )
-
-    payload = {
-        "idea_id": "idea-1",
-        "run_id": 42,
-        "prompt": {"id": "prompt-1", "idea_id": "idea-1", "key_name": "GITHUB_TOKEN"},
-    }
-    with run_event_scope(42, idea_id="idea-1", session=object(), recorder=_record):
-        cortex_events.publish("vault_secret_prompt", payload)
-    await asyncio.sleep(0)
-
-    assert durable_records
-    assert live_events == [("vault_secret_prompt", payload)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #731

The durable run-event scope in `brain/platform/events.py` had no production caller. This deletes it. Behaviour is unchanged, because the code it removes could never run.

## The history question #731 asked, answered

- `git log -S "run_event_scope(" --all` in this repo returns two commits: `5af4eb1f` (the initial Illospace import — the code arrived already unwired) and `3083b1eb` (2026-05-13, which only *added* `"vault_secret_prompt"` to `_LIVE_AFTER_DURABLE_EVENT_TYPES`). Neither added a caller.
- A GitHub code search on the private upstream `uwear-ai/illo-brain` returns the same two files — `brain/systems/cortex/events.py` and `tests/test_run_events.py` — and nothing else. So no caller existed there either.
- **It was never wired, in either repo.** This is not a path that worked and then stopped.

## Why deleting beats wiring

Durable run-event persistence is wanted, and it already exists with an owner and live callers: `brain/systems/runs/events.run_event` and `brain/systems/runs/event_log.py`, used across `brain/systems/runs/**`. The scope was a second, unwired copy of the same idea. Wiring it would have created a duplicate owner for one concern.

## Why the deletion cannot change behaviour

In `publish()`, `recorded_durable` was only ever set inside `if scope and scope.get("run_id") is not None:`. With no scope open it stayed `False`, so:

- the `if recorded_durable and event_type not in _LIVE_AFTER_DURABLE_EVENT_TYPES: return` early return was unreachable, and `_LIVE_AFTER_DURABLE_EVENT_TYPES` was inert — including the `vault_secret_prompt` entry added in 2026-05;
- `publish()` always took the live path (`record_cortex_event_async` when an idea id is inferable, then `_publisher`).

That live path is untouched. `publish()` also regains a one-line docstring, since the old one described the deleted behaviour.

## What was removed

`run_event_scope`, the `_run_event_scope` ContextVar, the scoped branch in `publish()`, the early return, `_LIVE_AFTER_DURABLE_EVENT_TYPES`, the now-unused `log_name` parameter on `_log_async_event_write_failure`, and the three scope-only tests in `tests/test_run_events.py`. No shim, no deprecation alias, no re-export — the mistake #729 had to clean up.

`git grep -nE "run_event_scope|_LIVE_AFTER_DURABLE_EVENT_TYPES|recorded_durable"` returns nothing across the repo, including `frontend/`.

## Verification

- Backend lane, the repo's own CI command, run on the host (not in the worker sandbox): **4763 passed, 11 skipped, 87 deselected in 78s**, load average 5.4. `main` is 4766; the difference is exactly the three scope-only tests removed. Zero failures.
- Lane selection per `brain-ci.yml`: the diff touches `brain/**` and `tests/**`, so backend and db are selected, frontend is not. The db lane needs Postgres and was not run locally — the diff touches no model, no migration and no query, and every removed line was unreachable at runtime.

## Acceptance checks for the reviewer

1. `publish()` still records a Cortex event and still fans out live for an event with an inferable idea id — covered by `tests/test_run_events.py::test_publish_records_cortex_event_async_inside_running_loop`.
2. Browser-session and vault-prompt events still reach the websocket publisher; nothing about them was special-cased outside the deleted branch.
3. `brain/systems/runs/event_log.py` remains the only owner of AgentRun event persistence.
4. Nothing anywhere imports `run_event_scope`.

*Implemented by a Codex worker, reviewed and verified by Routine R3. Draft — not for merge until you say so.*
