### PR TITLE
fix(worker): cancel returned shutdown watchdog

### DIFF
--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -370,7 +370,16 @@ def main() -> None:
             _publish_worker_lifecycle_phase(WorkerLifecyclePhase.STOPPED)
             logger.info("agent-run worker stopped")
             logging.shutdown()
-            _terminate_process(exit_code)
+            try:
+                _terminate_process(exit_code)
+            finally:
+                # Production uses ``os._exit`` and never reaches this cleanup.
+                # Tests and embedded callers replace the terminator with a
+                # returning function; do not leave a daemon timer behind that
+                # can terminate the surrounding process later.
+                if _shutdown_watchdog is not None:
+                    _shutdown_watchdog.cancel()
+                    _shutdown_watchdog = None
 
 
 if __name__ == "__main__":

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -476,6 +476,28 @@ def test_health_exit_drains_with_a_floor_even_when_deploy_drain_is_infinite(monk
     assert terminate_calls == [1]
 
 
+def test_returning_terminator_cancels_the_shutdown_watchdog(monkeypatch):
+    """A test double must not leave a timer that later kills pytest."""
+    from brain.systems.cortex import worker
+
+    worker_module = _run_main_until_queue_stall(
+        monkeypatch,
+        stop_runner=lambda **_kwargs: worker.DrainResult(),
+    )
+    terminate_calls = []
+    monkeypatch.setattr(worker_module, "_SELF_RESTART_SHUTDOWN_GRACE_SECONDS", 0.05)
+    monkeypatch.setenv("ILLO_AGENT_RUNNER_SELF_RESTART_DRAIN_TIMEOUT_SECONDS", "0")
+    monkeypatch.setattr(worker_module, "_terminate_process", terminate_calls.append)
+
+    with pytest.raises(SystemExit):
+        worker_module.main()
+
+    threading.Event().wait(0.1)
+
+    assert terminate_calls == [1]
+    assert worker_module._shutdown_watchdog is None
+
+
 def test_deploy_sigterm_keeps_the_unbounded_drain(monkeypatch):
     """The handoff worker is already claiming, so long runs may finish."""
     from brain.systems.cortex import worker


### PR DESCRIPTION
Summary

- Cancel the shutdown watchdog when an injected process terminator returns or raises.
- Keep the watchdog armed for the production os._exit path.
- Prevent delayed test timers from terminating later test processes.

Review

Independent review found no merge-blocking issues. The production hard-exit invariant remains intact.

Tests

- tests/test_cortex_worker.py: 30 passed.
- Worker regression set: 109 passed, 8 skipped.
- git diff --check passed.

Follow-up to #740 and #739.