### PR TITLE
fix(auth): preserve subscription policy on model fallback

### DIFF
--- a/brain/platform/integrations/llm.py
+++ b/brain/platform/integrations/llm.py
@@ -584,6 +584,10 @@ def resolve_llm_client(
     if provider == "openai":
         resolved_auth = _resolve_openai_local_auth(auth_mode=auth_mode)
         if not resolved_auth:
+            if auth_mode == "chatgpt":
+                raise RuntimeError(
+                    "No user Codex subscription is connected. Connect one in Illo."
+                )
             shared_hint = (
                 "user Codex subscription credentials require async_resolve_llm_client."
                 if os.environ.get("ILLO_ENV", "development") == "production"
@@ -666,6 +670,10 @@ async def async_resolve_llm_client(
                 auth_mode=auth_mode,
             )
             if not resolved_auth:
+                if auth_mode == "chatgpt":
+                    raise RuntimeError(
+                        "No user Codex subscription is connected. Connect one in Illo."
+                    )
                 shared_hint = (
                     "Connect a Codex subscription or add an org OpenAI key in Illo."
                     if os.environ.get("ILLO_ENV", "development") == "production"

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -221,9 +221,6 @@ def _publish_effective_routing(
     _agent_context.execution_metadata = execution_metadata
 
 
-_AUTO_OPENAI_AUTH_MODE = object()
-
-
 # ── Constants ──────────────────────────────────────────────────
 
 _MAX_PERSISTED_MESSAGES = 40
@@ -444,16 +441,11 @@ async def _init_llm_async(
     *,
     org_id: str | None = None,
     resolved_llm=None,
-    auth_mode_override: str | None | object = _AUTO_OPENAI_AUTH_MODE,
 ):
     """Resolve LLM client from async runtime code without sync DB access."""
     if resolved_llm is None:
         requested_provider = infer_provider_from_model(model)
-        auth_mode = (
-            required_openai_auth_mode(model)
-            if auth_mode_override is _AUTO_OPENAI_AUTH_MODE
-            else auth_mode_override
-        )
+        auth_mode = required_openai_auth_mode(model)
         llm = await async_resolve_llm_client(
             user_id=user_id,
             org_id=org_id,
@@ -1496,7 +1488,6 @@ async def run_agent_async(
                 model,
                 org_id=effective_org_id,
                 resolved_llm=resolved_llm,
-                auth_mode_override=None,
             )
             model_fallback_used = True
             fallback_activity = f"{preferred_model} requires a personal Codex connection; using {model}"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -330,39 +330,23 @@ async def test_cortex_reply_checker_reuses_run_client_with_model_after_fallback(
 
 
 @pytest.mark.asyncio
-async def test_agent_uses_shared_key_fallback_when_personal_codex_connection_is_missing(monkeypatch):
-    from brain.platform.integrations.providers import LLMResponse, TextContentBlock, Usage
+async def test_agent_does_not_use_shared_key_for_subscription_only_fallback(monkeypatch):
     from brain.systems.runs.direct_agent import run_agent_async
 
-    llm = _mock_llm_client(MagicMock(), provider="openai")
     resolve = AsyncMock(
         side_effect=[
-            RuntimeError("No OpenAI auth found. Connect a Codex subscription or add an org OpenAI key in Illo."),
-            llm,
+            RuntimeError(
+                "No OpenAI auth found. Connect a Codex subscription or add an "
+                "org OpenAI key in Illo."
+            ),
+            RuntimeError("No user Codex subscription is connected."),
         ]
     )
-    seen_models = []
-
-    async def fake_api_call(_provider, request, *_args, **_kwargs):
-        seen_models.append(request.model)
-        return LLMResponse(
-            content=[TextContentBlock("Shared fallback succeeded")],
-            stop_reason="end_turn",
-            usage=Usage(input_tokens=3, output_tokens=2),
-            model="gpt-5.5",
-        )
 
     monkeypatch.setattr("brain.systems.runs.direct_agent.async_resolve_llm_client", resolve)
-    monkeypatch.setattr("brain.systems.runs.direct_agent.get_provider", lambda *_args: MagicMock())
-    monkeypatch.setattr("brain.systems.runs.direct_agent._api_call_with_retry_async", fake_api_call)
-    monkeypatch.setattr("brain.systems.runs.direct_agent._async_record_api_call", AsyncMock())
-    monkeypatch.setattr(
-        "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
-        AsyncMock(),
-    )
 
     result = await run_agent_async(
-        "Test shared fallback",
+        "Test subscription fallback",
         model="openai/gpt-5.6-sol",
         thinking="xhigh",
         tools=[],
@@ -373,15 +357,12 @@ async def test_agent_uses_shared_key_fallback_when_personal_codex_connection_is_
         org_id="org-1",
     )
 
-    assert result.success is True
-    assert seen_models == ["gpt-5.5"]
-    assert [call.kwargs["auth_mode"] for call in resolve.await_args_list] == ["chatgpt", None]
-    assert result.effective_routing == {
-        "model": "openai/gpt-5.5",
-        "effort": "xhigh",
-        "provider": "openai",
-        "auth_mode": "api_key",
-    }
+    assert result.success is False
+    assert result.error == "No user Codex subscription is connected."
+    assert [call.kwargs["auth_mode"] for call in resolve.await_args_list] == [
+        "chatgpt",
+        "chatgpt",
+    ]
 
 class TestLiveGuidance:
     async def test_append_live_guidance_adds_user_message(self):

--- a/tests/test_agent_auth_fallback.py
+++ b/tests/test_agent_auth_fallback.py
@@ -52,6 +52,37 @@ async def test_async_resolve_llm_client_rejects_anthropic_without_any_key():
     mock_build.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_async_resolve_subscription_only_openai_rejects_stored_org_api_key():
+    """ChatGPT-only models must not silently use an available org API key."""
+    from brain.platform.integrations.llm import async_resolve_llm_client
+
+    resolve_key = AsyncMock(return_value=("sk-org-openai-key", "org_openai"))
+    with patch(
+        "brain.platform.integrations.llm._async_resolve_key_from_db",
+        resolve_key,
+    ), patch(
+        "brain.platform.integrations.llm._allow_local_codex_auth_fallback",
+        return_value=False,
+    ), patch(
+        "brain.platform.integrations.llm._build_openai_client",
+    ) as build_api_key_client:
+        with pytest.raises(
+            RuntimeError,
+            match="No user Codex subscription is connected",
+        ):
+            await async_resolve_llm_client(
+                user_id="user-1",
+                org_id="org-1",
+                provider="openai",
+                auth_mode="chatgpt",
+                session=object(),
+            )
+
+    assert resolve_key.await_args.kwargs["auth_mode"] == "chatgpt"
+    build_api_key_client.assert_not_called()
+
+
 def test_resolve_llm_client_falls_back_to_env():
     """The sync resolver only uses local/env fallback auth."""
     from brain.platform.integrations.llm import resolve_llm_client


### PR DESCRIPTION
Summary

- Keep ChatGPT subscription auth mandatory when gpt-5.6-sol falls back to gpt-5.5.
- Prevent an organization OpenAI API key from bypassing the model auth policy.
- Return a clear subscription-specific error for ChatGPT-only resolution.
- Add an org-key-present resolver regression test.

Review

Independent review is clean after one accepted P2 test and error-message gap was fixed.

Tests

- Auth and agent review suite: 198 passed.
- Focused policy suite: 44 passed.
- git diff --check passed.

Closes #636.