### PR TITLE
fix(nightly): normalize retrieval timestamps

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -220,6 +220,9 @@ def _command_summary(proc: Any) -> dict[str, Any]:
     )
     if exception:
         summary["exception"] = exception
+    scheduler_step_result = _scheduler_step_result(getattr(proc, "stdout", None))
+    if scheduler_step_result is not None:
+        summary["scheduler_step_result"] = scheduler_step_result
     return summary
 
 
@@ -233,6 +236,14 @@ def _json_objects(text_value: str | None) -> list[dict[str, Any]]:
         if isinstance(value, dict):
             objects.append(value)
     return objects
+
+
+def _scheduler_step_result(stdout: str | None) -> dict[str, Any] | None:
+    for payload in _json_objects(stdout):
+        result = payload.get("scheduler_step_result")
+        if isinstance(result, dict):
+            return result
+    return None
 
 
 def _configuration_skips_from_command(

--- a/brain/jobs/pipelines/nightly_reflect.py
+++ b/brain/jobs/pipelines/nightly_reflect.py
@@ -79,6 +79,11 @@ async def gather_context(target_date: date, org_id: str | None = None) -> dict:
         except Exception as e:
             print(f"[reflect] Warning: retrieval feedback analysis failed: {e}")
             context["consistently_missed_memories"] = []
+            context.setdefault("scheduler_step_warnings", []).append({
+                "kind": "retrieval_feedback_analysis_failed",
+                "error_type": type(e).__name__,
+                "message": str(e)[:500],
+            })
 
         # 6. Today's task-like prompts, now sourced from agent_runs.input_message.
         result = await uow.session.execute(text("""
@@ -157,6 +162,22 @@ async def gather_context(target_date: date, org_id: str | None = None) -> dict:
             context["daily_log"] = (await read_text_async(daily_file))[:5000]
 
     return context
+
+
+def _emit_scheduler_step_result(context: dict) -> None:
+    """Emit one JSON line that the scheduler records in the step result."""
+    warnings = context.get("scheduler_step_warnings", [])
+    print(
+        json.dumps(
+            {
+                "scheduler_step_result": {
+                    "status": "completed_with_warnings" if warnings else "completed",
+                    "warnings": warnings,
+                }
+            },
+            default=str,
+        )
+    )
 
 
 def _format_failures_by_category(runs: list) -> str:
@@ -509,6 +530,7 @@ async def run_reflection(target_date: date):
 
     if total_data == 0:
         print("[reflect] No data to reflect on today. Skipping.")
+        _emit_scheduler_step_result(context)
         return
 
     print(f"[reflect] Data: {len(context['skill_executions'])} skill execs, "
@@ -563,6 +585,7 @@ async def run_reflection(target_date: date):
             print("[reflect] Main agent will process this on next wake-up.")
         else:
             print("[reflect] Pending reflection could not be persisted; nightly work will continue.")
+        _emit_scheduler_step_result(context)
         return
 
     # 5.5 Meta-skill analysis
@@ -601,6 +624,8 @@ async def run_reflection(target_date: date):
     except Exception as e:
         print(f"\n[quality] Sweep failed: {e}")
         reflection["quality_sweep_error"] = str(e)
+
+    _emit_scheduler_step_result(context)
 
 
 def main():

--- a/brain/platform/db/alembic/versions/0057_retrieval_log_timestamptz.py
+++ b/brain/platform/db/alembic/versions/0057_retrieval_log_timestamptz.py
@@ -1,0 +1,57 @@
+"""Normalize retrieval-log timestamps to timezone-aware UTC.
+
+Revision ID: 0057_retrieval_log_timestamptz
+Revises: 0056_scheduler_self_heal_attempts
+Create Date: 2026-08-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0057_retrieval_log_timestamptz"
+down_revision = "0056_scheduler_self_heal_attempts"
+branch_labels = None
+depends_on = None
+
+_TABLE = "retrieval_log"
+_COLUMN = "timestamp"
+
+
+def _column_data_type() -> str | None:
+    return op.get_bind().execute(
+        sa.text(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = :table_name
+              AND column_name = :column_name
+            """
+        ),
+        {"table_name": _TABLE, "column_name": _COLUMN},
+    ).scalar_one_or_none()
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    if _column_data_type() == "timestamp without time zone":
+        op.execute(
+            'ALTER TABLE "retrieval_log" '
+            'ALTER COLUMN "timestamp" TYPE TIMESTAMP WITH TIME ZONE '
+            'USING "timestamp" AT TIME ZONE \'UTC\''
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    if _column_data_type() == "timestamp with time zone":
+        op.execute(
+            'ALTER TABLE "retrieval_log" '
+            'ALTER COLUMN "timestamp" TYPE TIMESTAMP WITHOUT TIME ZONE '
+            'USING "timestamp" AT TIME ZONE \'UTC\''
+        )

--- a/tests/test_nightly_pipeline.py
+++ b/tests/test_nightly_pipeline.py
@@ -173,12 +173,27 @@ class TestPhaseReflection:
         """When all context sections are empty, reflection should skip."""
         with patch("brain.jobs.pipelines.nightly_reflect.UnitOfWork", return_value=mock_nightly_uow), \
              patch("brain.jobs.pipelines.nightly_reflect.WORKSPACE", "/nonexistent"), \
-            patch("brain.jobs.pipelines.nightly_reflect.config.JOURNAL_DIR", Path("/nonexistent/journal")):
+             patch("brain.jobs.pipelines.nightly_reflect.config.JOURNAL_DIR", Path("/nonexistent/journal")), \
+             patch(
+                 "brain.systems.memory.retrieval_feedback.analyze_missed_memories",
+                 new=AsyncMock(return_value=[]),
+             ):
             from brain.jobs.pipelines.nightly_reflect import run_reflection
             await run_reflection(target_date)
 
         captured = capsys.readouterr()
         assert "No data to reflect on" in captured.out or "Skipping" in captured.out
+        structured_lines = [
+            json.loads(line)
+            for line in captured.out.splitlines()
+            if line.startswith('{"scheduler_step_result"')
+        ]
+        assert structured_lines == [{
+            "scheduler_step_result": {
+                "status": "completed",
+                "warnings": [],
+            }
+        }]
 
     async def test_reflection_continues_when_artifact_path_is_unwritable(
         self,

--- a/tests/test_nightly_reflect.py
+++ b/tests/test_nightly_reflect.py
@@ -110,6 +110,27 @@ class TestGatherContextRegressions:
         assert "INTERVAL" not in str(statement)
         assert params == {"metrics_cutoff": date(2026, 7, 17)}
 
+    async def test_retrieval_feedback_failure_records_scheduler_warning(
+        self,
+        patch_reflect_uow,
+    ):
+        target = date(2026, 7, 24)
+
+        with patch("brain.kernel.config.JOURNAL_DIR", "/nonexistent/journal"), patch(
+            "brain.systems.memory.retrieval_feedback.analyze_missed_memories",
+            new=AsyncMock(side_effect=TypeError("naive/aware mismatch")),
+        ):
+            from brain.jobs.pipelines.nightly_reflect import gather_context
+
+            context = await gather_context(target)
+
+        assert context["consistently_missed_memories"] == []
+        assert context["scheduler_step_warnings"] == [{
+            "kind": "retrieval_feedback_analysis_failed",
+            "error_type": "TypeError",
+            "message": "naive/aware mismatch",
+        }]
+
     def test_connection_uses_context_manager(self):
         """Regression: must use a UnitOfWork/db connection context manager."""
         import inspect

--- a/tests/test_retrieval_feedback.py
+++ b/tests/test_retrieval_feedback.py
@@ -150,6 +150,17 @@ class TestApplyRetrievalFeedback:
 
 @pytest.mark.requires_db
 class TestAnalyzeMissedMemories:
+    async def test_timestamp_column_is_timezone_aware(self, db_session):
+        data_type = await db_session.scalar(text("""
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'retrieval_log'
+              AND column_name = 'timestamp'
+        """))
+
+        assert data_type == "timestamp with time zone"
+
     async def test_identifies_consistently_missed(self, db_session, scoped_principal, unit_of_work_for_session):
         mid = await _ensure_test_memory(db_session, "always missed", salience=5.0)
         for _ in range(4):
@@ -199,6 +210,7 @@ class TestAnalyzeMissedMemoriesQuery:
             "cutoff": now - timedelta(days=30),
             "min_misses": 3,
         }
+        assert params["cutoff"].tzinfo is timezone.utc
 
 
 class TestAttentionUsefulnessAttribution:

--- a/tests/test_retrieval_log_timestamp_migration.py
+++ b/tests/test_retrieval_log_timestamp_migration.py
@@ -1,0 +1,60 @@
+"""Regression coverage for retrieval-log timestamp normalization."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _migration_with_type(monkeypatch, data_type: str):
+    migration = importlib.import_module(
+        "brain.platform.db.alembic.versions.0057_retrieval_log_timestamptz"
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = data_type
+    bind = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql"),
+        execute=MagicMock(return_value=result),
+    )
+    operation = MagicMock()
+    operation.get_bind.return_value = bind
+    monkeypatch.setattr(migration, "op", operation)
+    return migration, operation
+
+
+def test_upgrade_interprets_legacy_naive_values_as_utc(monkeypatch):
+    migration, operation = _migration_with_type(
+        monkeypatch,
+        "timestamp without time zone",
+    )
+
+    migration.upgrade()
+
+    statement = operation.execute.call_args.args[0]
+    assert "TYPE TIMESTAMP WITH TIME ZONE" in statement
+    assert "USING \"timestamp\" AT TIME ZONE 'UTC'" in statement
+
+
+def test_upgrade_is_noop_when_column_is_already_timezone_aware(monkeypatch):
+    migration, operation = _migration_with_type(
+        monkeypatch,
+        "timestamp with time zone",
+    )
+
+    migration.upgrade()
+
+    operation.execute.assert_not_called()
+
+
+def test_downgrade_preserves_absolute_time_as_utc_naive(monkeypatch):
+    migration, operation = _migration_with_type(
+        monkeypatch,
+        "timestamp with time zone",
+    )
+
+    migration.downgrade()
+
+    statement = operation.execute.call_args.args[0]
+    assert "TYPE TIMESTAMP WITHOUT TIME ZONE" in statement
+    assert "USING \"timestamp\" AT TIME ZONE 'UTC'" in statement

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -135,6 +135,37 @@ async def test_command_failure_prefers_structured_exception_over_log_tail():
     assert "HTTP/1.1 201 Created" in summary["stderr_tail"]
 
 
+async def test_command_summary_records_structured_scheduler_step_result():
+    proc = SimpleNamespace(
+        returncode=0,
+        stdout="\n".join([
+            "[reflect] Warning: retrieval feedback analysis failed",
+            json.dumps({
+                "scheduler_step_result": {
+                    "status": "completed_with_warnings",
+                    "warnings": [{
+                        "kind": "retrieval_feedback_analysis_failed",
+                        "error_type": "TypeError",
+                        "message": "naive/aware mismatch",
+                    }],
+                }
+            }),
+        ]),
+        stderr="",
+    )
+
+    summary = scheduler_executor._command_summary(proc)
+
+    assert summary["scheduler_step_result"] == {
+        "status": "completed_with_warnings",
+        "warnings": [{
+            "kind": "retrieval_feedback_analysis_failed",
+            "error_type": "TypeError",
+            "message": "naive/aware mismatch",
+        }],
+    }
+
+
 async def test_configuration_skip_json_precedes_exit_one_and_names_all_gaps(
     session,
     monkeypatch,


### PR DESCRIPTION
Summary

- Migrate legacy retrieval_log timestamps from UTC-naive values to timestamptz without shifting stored instants.
- Keep the 30-day retrieval cutoff timezone-aware.
- Record non-fatal retrieval analysis failures as structured scheduler step warnings.
- Preserve later nightly steps when retrieval analysis warns.

Review

Independent review found one P2 schema split. The fix now normalizes the schema end to end, and re-review is clean.

Tests

- Focused fast suite: 98 passed, 10 skipped.
- PostgreSQL retrieval suite in review: 10 passed.
- Migration upgrade, downgrade, idempotency, schema type, and single-head checks passed.

Closes #734.