### PR TITLE
fix(cycles): require off-slot delivery self-review

### DIFF
--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -16,6 +16,7 @@ from brain.platform.integrations.provider_error_sentinel import (
 )
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.systems.cycles.common import OFF_SLOT_MATERIAL_ALERT_RUN_KIND
 from brain.systems.cycles.contracts import (
     CLOSING_BLOCK_VERDICT_REQUIRED_OUTPUT,
     SELF_REVIEW_SUMMARY_MARKERS,
@@ -73,6 +74,11 @@ _SELF_REVIEW_SUMMARY_RES = tuple(
         re.IGNORECASE,
     )
     for marker in SELF_REVIEW_SUMMARY_MARKERS
+)
+_SLACK_DELIVERY_DECISION_RE = re.compile(
+    r"(?:\bslack\s+(?:was\s+)?(?:posted|skipped)\b|"
+    r"\b(?:posted|skipped)\s+(?:to\s+)?slack\b)",
+    re.IGNORECASE,
 )
 _NON_PRESERVABLE_OUTPUTS = frozenset(
     {
@@ -156,6 +162,16 @@ def extract_self_review_summary(candidate_answer: str | None) -> str | None:
     )
 
 
+def _off_slot_self_review_has_delivery_decision(summary: str | None) -> bool:
+    if not summary:
+        return False
+    match = _SLACK_DELIVERY_DECISION_RE.search(summary)
+    if match is None:
+        return False
+    reason = str(summary[match.end():]).strip(" \t:;,.—-–")
+    return bool(reason)
+
+
 def _satisfies_required_output(
     requirement: str,
     *,
@@ -205,6 +221,8 @@ def _satisfies_required_output(
     if requirement == "record_next_action_or_blocker":
         return _contains_any(normalized_candidate, ("next action", "next step", "blocker"))
     if requirement == "short_self_review_summary":
+        if result_contract.get("run_kind") == OFF_SLOT_MATERIAL_ALERT_RUN_KIND:
+            return _off_slot_self_review_has_delivery_decision(self_review_summary)
         return self_review_summary is not None
     if requirement == CLOSING_BLOCK_VERDICT_REQUIRED_OUTPUT:
         return closing_block_verdict is not None
@@ -497,6 +515,17 @@ def _repair_prompt(
         else "Candidate visible answer"
     )
     soul_section = soul_prompt_section()
+    off_slot_self_review_rule = (
+        "\n\nOff-slot self-review rule:\n"
+        "For `short_self_review_summary`, write one `Self-review summary:` line that "
+        "states the Slack decision (`Slack posted` or `Slack skipped`) and then gives "
+        "the reason. A generic contract-compliance statement is invalid."
+        if (
+            result_contract.get("run_kind") == OFF_SLOT_MATERIAL_ALERT_RUN_KIND
+            and "short_self_review_summary" in missing_outputs
+        )
+        else ""
+    )
     return [
         {
             "role": "system",
@@ -520,7 +549,8 @@ def _repair_prompt(
                 "Evidence packet:\n"
                 f"{json.dumps(evidence_packet, ensure_ascii=True, sort_keys=True, default=str)[:5000]}\n\n"
                 "Missing required outputs:\n"
-                f"{json.dumps(missing_outputs, ensure_ascii=True)}\n\n"
+                f"{json.dumps(missing_outputs, ensure_ascii=True)}"
+                f"{off_slot_self_review_rule}\n\n"
                 f"{candidate_label}:\n"
                 f"{candidate_answer[:4000]}"
             ),

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -54,6 +54,7 @@ CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND = {
         "answer_the_cycle_mission",
         "summarize_workspace_evidence_or_explicit_gaps",
         "report_evidence_health",
+        "short_self_review_summary",
     ),
 }
 VALID_CYCLE_RUN_KINDS = frozenset(CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND)

--- a/brain/systems/cycles/prompts.py
+++ b/brain/systems/cycles/prompts.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea
 from brain.systems.cycles.common import (
+    OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
     SCHEDULED_CYCLE_ORIGIN,
     SCHEDULED_DIGEST_RUN_KIND,
     cycle_run_launch_context,
@@ -146,14 +147,26 @@ def cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
     degradation_instruction = _degradation_instruction(envelope["degradation_tracking"])
     open_ask_instruction = _open_ask_instruction(envelope["open_ask_stragglers"])
     exception_ping_instruction = _exception_ping_instruction(cycle)
-    completion_instruction = (
-        "- End with a short self-review summary suitable for the Cycle ledger and visible outputs.\n"
-        if "short_self_review_summary" in json_list(result_contract.get("required_outputs"))
-        else (
+    requires_self_review = "short_self_review_summary" in json_list(
+        result_contract.get("required_outputs")
+    )
+    if (
+        requires_self_review
+        and result_contract.get("run_kind") == OFF_SLOT_MATERIAL_ALERT_RUN_KIND
+    ):
+        completion_instruction = (
+            "- End with a one-line self-review summary that states the Slack delivery decision "
+            "(posted or skipped) and the reason.\n"
+        )
+    elif requires_self_review:
+        completion_instruction = (
+            "- End with a short self-review summary suitable for the Cycle ledger and visible outputs.\n"
+        )
+    else:
+        completion_instruction = (
             "- Keep the visible answer in the mission's concise alert format; do not add a "
             "digest-only next-action or self-review footer.\n"
         )
-    )
     evidence_gap_destination = (
         "your self-review"
         if "short_self_review_summary" in json_list(result_contract.get("required_outputs"))
@@ -236,9 +249,14 @@ def _required_output_sections(result_contract: dict) -> str:
     if "record_next_action_or_blocker" in required_outputs:
         example_lines.append("Next action: name the single next action.")
     if "short_self_review_summary" in required_outputs:
-        example_lines.append(
-            "Self-review summary: mission sweep and delivery completed; contract fields checked."
-        )
+        if result_contract.get("run_kind") == OFF_SLOT_MATERIAL_ALERT_RUN_KIND:
+            example_lines.append(
+                "Self-review summary: Slack posted — material change verified and sent once."
+            )
+        else:
+            example_lines.append(
+                "Self-review summary: mission sweep and delivery completed; contract fields checked."
+            )
     example = "\n".join(example_lines)
     return (
         "## Required Output Sections\n"

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1703,6 +1703,7 @@ def test_scheduled_coordinator_prompt_preserves_both_open_ask_sections():
                 "answer_the_cycle_mission",
                 "summarize_workspace_evidence_or_explicit_gaps",
                 "report_evidence_health",
+                "short_self_review_summary",
             ],
         ),
     ],
@@ -1718,7 +1719,7 @@ def test_coordinator_run_kind_contracts_are_explicit(run_kind, expected_outputs)
     )
 
 
-def test_material_alert_contract_keeps_evidence_gate_without_digest_footer_fields():
+def test_material_alert_contract_requires_delivery_self_review_without_next_action():
     from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
 
     contract = cycle_result_contract(run_kind="off_slot_material_alert")
@@ -1728,6 +1729,7 @@ def test_material_alert_contract_keeps_evidence_gate_without_digest_footer_field
         "answer_the_cycle_mission",
         "summarize_workspace_evidence_or_explicit_gaps",
         "report_evidence_health",
+        "short_self_review_summary",
     ]
 
     alert = (
@@ -1735,26 +1737,53 @@ def test_material_alert_contract_keeps_evidence_gate_without_digest_footer_field
         "release per project. Evidence reviewed: workspace run receipts and the merged change. "
         "Evidence health: ok."
     )
-    reduced_review = evaluate_cycle_result_contract(
+    missing_review = evaluate_cycle_result_contract(
         candidate_answer=alert,
         result_contract=contract,
         mission="Post one concise material engineering change alert.",
     )
+    generic_review = evaluate_cycle_result_contract(
+        candidate_answer=f"{alert} Self-review summary: contract satisfied.",
+        result_contract=contract,
+        mission="Post one concise material engineering change alert.",
+    )
+    decision_without_reason = evaluate_cycle_result_contract(
+        candidate_answer=f"{alert} Self-review summary: Slack skipped.",
+        result_contract=contract,
+        mission="Post one concise material engineering change alert.",
+    )
+    reviewed_alert = (
+        f"{alert} Self-review summary: Slack posted — material change verified and sent once."
+    )
+    reduced_review = evaluate_cycle_result_contract(
+        candidate_answer=reviewed_alert,
+        result_contract=contract,
+        mission="Post one concise material engineering change alert.",
+    )
+    skipped_review = evaluate_cycle_result_contract(
+        candidate_answer=(
+            f"{alert} Self-review summary: Slack skipped — no material todo-list change."
+        ),
+        result_contract=contract,
+        mission="Post one concise material engineering change alert.",
+    )
     strict_review = evaluate_cycle_result_contract(
-        candidate_answer=alert,
+        candidate_answer=reviewed_alert,
         result_contract=cycle_result_contract(run_kind="scheduled_digest"),
         mission="Publish the coordinator digest.",
     )
 
+    assert missing_review["approved"] is False
+    assert missing_review["missing_outputs"] == ["short_self_review_summary"]
+    assert generic_review["missing_outputs"] == ["short_self_review_summary"]
+    assert decision_without_reason["missing_outputs"] == ["short_self_review_summary"]
     assert reduced_review["approved"] is True
+    assert skipped_review["approved"] is True
     assert strict_review["approved"] is False
-    assert strict_review["missing_outputs"] == [
-        "record_next_action_or_blocker",
-        "short_self_review_summary",
-    ]
+    assert strict_review["missing_outputs"] == ["record_next_action_or_blocker"]
 
 
-def test_material_alert_launch_prompt_does_not_request_digest_footer_fields():
+def test_material_alert_launch_prompt_requests_delivery_self_review_only():
     cycle = Cycle()
     cycle.id = 2
     cycle.name = "Uwear Ticket Coordinator Check-ins"
@@ -1790,10 +1819,11 @@ def test_material_alert_launch_prompt_does_not_request_digest_footer_fields():
     )[0]
 
     assert "`record_next_action_or_blocker`" not in output_section
-    assert "`short_self_review_summary`" not in output_section
+    assert "`short_self_review_summary`" in output_section
     assert "Next action:" not in output_section
-    assert "Self-review summary:" not in output_section
-    assert "End with a short self-review summary" not in message
+    assert "Self-review summary: Slack posted" in output_section
+    assert "one-line self-review summary" in message
+    assert "posted or skipped" in message
 
 
 @pytest.mark.asyncio
@@ -1878,7 +1908,7 @@ async def test_async_run_cycle_now_snapshots_off_slot_contract_after_admission(
     snapshot = created_runs[0].context_snapshot
     assert snapshot["launch_context"]["run_kind"] == "off_slot_material_alert"
     assert snapshot["result_contract"]["run_kind"] == "off_slot_material_alert"
-    assert "short_self_review_summary" not in snapshot["result_contract"]["required_outputs"]
+    assert "short_self_review_summary" in snapshot["result_contract"]["required_outputs"]
 
 
 @pytest.mark.asyncio
@@ -3748,19 +3778,20 @@ def test_promotion_unchanged_run_persists_skip_and_posting_verdict(monkeypatch):
             "Material engineering alert: deploy admission now preserves the active release "
             "when a duplicate trigger arrives. Evidence reviewed: merged change, deploy "
             "receipt, Slack post, and tracker update. Evidence health: ok. Next action: "
-            "monitor the next trigger.",
+            "monitor the next trigger. Self-review summary: Slack posted — material change "
+            "verified and sent once.",
         ),
         (
             1884,
             "Material engineering alert: chantier movement now records the newly blocked "
             "member and owner in the tracker. Evidence reviewed: current chantier, issue, "
             "Slack post, and tracker update. Evidence health: ok. Self-review summary: "
-            "single material change verified and posted once.",
+            "Slack posted — single material change verified and sent once.",
         ),
     ],
-    ids=["run-1857-no-self-review", "run-1884-no-next-action"],
+    ids=["run-1857-with-next-action", "run-1884-no-next-action"],
 )
-def test_off_slot_material_alert_settles_completed_without_digest_footer_fields(
+def test_off_slot_material_alert_settles_with_self_review_without_next_action(
     monkeypatch,
     run_id,
     answer,
@@ -4155,6 +4186,28 @@ def test_cycle_contract_repair_prompt_requests_only_missing_sections():
     assert "append only the missing section" in prompt.lower()
     assert "do not repeat or rewrite" in prompt.lower()
     assert candidate in prompt
+
+
+def test_off_slot_repair_prompt_requires_slack_decision_and_reason():
+    from brain.systems.cycles.contract_gate import _repair_prompt
+
+    messages = _repair_prompt(
+        mission="Post one concise material engineering change alert.",
+        result_contract={
+            "run_kind": "off_slot_material_alert",
+            "required_outputs": ["short_self_review_summary"],
+        },
+        evidence_packet={"side_effects_succeeded": True},
+        missing_outputs=["short_self_review_summary"],
+        candidate_answer="Evidence reviewed. Evidence health: ok.",
+        append_only=True,
+    )
+
+    prompt = "\n".join(message["content"] for message in messages)
+    assert "Slack posted" in prompt
+    assert "Slack skipped" in prompt
+    assert "then gives the reason" in prompt
+    assert "generic contract-compliance statement is invalid" in prompt
 
 
 def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):


### PR DESCRIPTION
Summary

- Require an off-slot coordinator self-review before the result contract can pass.
- Require that line to state Slack posted or Slack skipped and give the reason.
- Give the bounded repair pass the same semantic rule.
- Keep scheduled cycle self-review behavior unchanged.

Review

Independent review found one semantic enforcement gap. It is fixed, and re-review is clean.

Tests

- Cycle contract and degradation suites: 112 passed, 1 skipped.
- git diff --check passed.

Closes #735.