### PR TITLE
fix(meetbot): ship active service on normal deploys (#658)

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -19,6 +19,7 @@ on:
       - "pyproject.toml"
       - "alembic.ini"
       - "ops/install-browser-runtime.sh"
+      - "meetbot/**"
       - ".github/workflows/container-images.yml"
   workflow_dispatch:
 
@@ -39,6 +40,7 @@ jobs:
       api: ${{ steps.selected.outputs.api }}
       web: ${{ steps.selected.outputs.web }}
       updater: ${{ steps.selected.outputs.updater }}
+      meetbot: ${{ steps.selected.outputs.meetbot }}
 
     steps:
       - name: Check out repository
@@ -72,6 +74,12 @@ jobs:
               - "deploy/scripts/self-update-daemon.sh"
               - "deploy/scripts/self-update-healthcheck.sh"
               - ".github/workflows/container-images.yml"
+            meetbot:
+              - ".dockerignore"
+              - "meetbot/**"
+              - "deploy/docker/meetbot.Dockerfile"
+              - "deploy/docker/meetbot-entrypoint.sh"
+              - ".github/workflows/container-images.yml"
 
       - name: Select images
         id: selected
@@ -80,10 +88,12 @@ jobs:
             echo "api=${{ steps.filter.outputs.api }}" >> "$GITHUB_OUTPUT"
             echo "web=${{ steps.filter.outputs.web }}" >> "$GITHUB_OUTPUT"
             echo "updater=${{ steps.filter.outputs.updater }}" >> "$GITHUB_OUTPUT"
+            echo "meetbot=${{ steps.filter.outputs.meetbot }}" >> "$GITHUB_OUTPUT"
           else
             echo "api=true" >> "$GITHUB_OUTPUT"
             echo "web=true" >> "$GITHUB_OUTPUT"
             echo "updater=true" >> "$GITHUB_OUTPUT"
+            echo "meetbot=true" >> "$GITHUB_OUTPUT"
           fi
 
   build-api:
@@ -227,5 +237,55 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
+
+  build-meetbot:
+    name: Build meetbot image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.meetbot == 'true'
+    env:
+      IMAGE_NAME: meetbot
+      DOCKERFILE: deploy/docker/meetbot.Dockerfile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/illospace/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ILLO_BUILD_COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
           cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}

--- a/deploy/compose/.env.production.example
+++ b/deploy/compose/.env.production.example
@@ -11,6 +11,10 @@ COMPOSE_PROJECT_NAME=illospace
 # available, run `./illo deploy up --build --no-pull` to build locally.
 ILLO_API_IMAGE=ghcr.io/illospace/api:latest
 ILLO_WEB_IMAGE=ghcr.io/illospace/web:latest
+ILLO_MEETBOT_IMAGE=ghcr.io/illospace/meetbot:latest
+# Keep empty while meetbot is dormant. Set to meetbot to make normal deploy and
+# update commands start and refresh the optional service.
+COMPOSE_PROFILES=
 
 # Browser-facing app URL. The default is for SSH-tunnel access from a
 # workstation. Set this to your private network or reverse-proxy URL only when

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -208,6 +208,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/meetbot.Dockerfile
+      args:
+        ILLO_BUILD_COMMIT: ${ILLO_BUILD_COMMIT:-unknown}
     profiles: ["meetbot"]
     restart: unless-stopped
     environment:

--- a/deploy/docker/meetbot.Dockerfile
+++ b/deploy/docker/meetbot.Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.12-slim-bookworm
 
+ARG ILLO_BUILD_COMMIT=unknown
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PYTHONPATH=/app \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+ENV ILLO_BUILD_COMMIT=${ILLO_BUILD_COMMIT}
+
+LABEL org.opencontainers.image.revision=${ILLO_BUILD_COMMIT}
 
 WORKDIR /app
 

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -11,7 +11,50 @@ source "$COMPOSE_RUNTIME_LIB_DIR/worker-swap-lib.sh"
 source "$COMPOSE_RUNTIME_LIB_DIR/worker-lifecycle-lib.sh"
 
 compose() {
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+  local build_commit
+  build_commit="${ILLO_BUILD_COMMIT:-$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+  ILLO_BUILD_COMMIT="$build_commit" \
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+compose_env_value() {
+  local key="$1"
+  python3 - "$ENV_FILE" "$key" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+if not path.exists():
+    raise SystemExit(0)
+pattern = re.compile(rf"^{re.escape(key)}=(.*)$")
+for line in path.read_text(encoding="utf-8").splitlines():
+    match = pattern.match(line.strip())
+    if not match:
+        continue
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    print(value)
+    break
+PY
+}
+
+compose_profile_enabled() {
+  local profile="$1" profiles
+  profiles="$(compose_env_value COMPOSE_PROFILES)"
+  profiles=",${profiles// /,},"
+  case "$profiles" in
+    *",$profile,"*) return 0 ;;
+  esac
+  return 1
+}
+
+compose_service_enabled() {
+  local service="$1" profile="${2:-$1}"
+  compose_profile_enabled "$profile" && return 0
+  [ -n "$(compose ps -q "$service" 2>/dev/null || true)" ]
 }
 
 worker_swap_snapshot_acquire() {

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -43,9 +43,14 @@ PY
 
 compose_profile_enabled() {
   local profile="$1" profiles
-  profiles="$(compose_env_value COMPOSE_PROFILES)"
+  if [ "${COMPOSE_PROFILES+x}" = "x" ]; then
+    profiles="$COMPOSE_PROFILES"
+  else
+    profiles="$(compose_env_value COMPOSE_PROFILES)"
+  fi
   profiles=",${profiles// /,},"
   case "$profiles" in
+    *,\*,*) return 0 ;;
     *",$profile,"*) return 0 ;;
   esac
   return 1
@@ -54,7 +59,7 @@ compose_profile_enabled() {
 compose_service_enabled() {
   local service="$1" profile="${2:-$1}"
   compose_profile_enabled "$profile" && return 0
-  [ -n "$(compose ps -q "$service" 2>/dev/null || true)" ]
+  [ -n "$(compose_service_container_id "$service")" ]
 }
 
 worker_swap_snapshot_acquire() {
@@ -131,6 +136,17 @@ container_is_oneoff() {
     True|true|TRUE) return 0 ;;
   esac
   return 1
+}
+
+compose_service_container_id() {
+  local service="$1" id
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    container_is_oneoff "$id" && continue
+    printf '%s\n' "$id"
+    return 0
+  done < <(compose ps --all -q "$service" 2>/dev/null || true)
+  return 0
 }
 
 # `compose ps -q worker` lists the temporary `compose run` handoff workers next

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -22,6 +22,13 @@ runtime_checks=1
 tmp_running=""
 strict_credentials=0
 check_app_url=0
+compose_profiles_was_set=0
+compose_profiles_override=""
+
+if [ "${COMPOSE_PROFILES+x}" = "x" ]; then
+  compose_profiles_was_set=1
+  compose_profiles_override="$COMPOSE_PROFILES"
+fi
 
 usage() {
   cat <<'EOF'
@@ -101,6 +108,11 @@ else
   # shellcheck disable=SC1090
   . "$ENV_FILE"
   set +a
+  if [ "$compose_profiles_was_set" = "1" ]; then
+    export COMPOSE_PROFILES="$compose_profiles_override"
+  else
+    unset COMPOSE_PROFILES
+  fi
   [ "$check_app_url" = "0" ] || export ILLO_CHECK_APP_URL=1
 fi
 
@@ -235,12 +247,22 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
       fi
     fi
 
+    meetbot_expected=0
+    if compose_service_enabled meetbot; then
+      meetbot_expected=1
+    fi
+
     services_to_check="$DOCTOR_REQUIRED_SERVICES"
-    if printf '%s\n' "$running" | grep -qx meetbot; then
+    if [ "$meetbot_expected" = "1" ]; then
       services_to_check="$services_to_check meetbot"
     fi
     for service in $services_to_check; do
-      printf '%s\n' "$running" | grep -qx "$service" || continue
+      if ! printf '%s\n' "$running" | grep -qx "$service"; then
+        if [ "$service" = "meetbot" ]; then
+          fail "configured meetbot is not running"
+        fi
+        continue
+      fi
       health="$(container_health "$service" || true)"
       case "$health" in
         healthy|running)
@@ -255,7 +277,7 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
       esac
     done
 
-    if printf '%s\n' "$running" | grep -qx meetbot; then
+    if [ "$meetbot_expected" = "1" ] && printf '%s\n' "$running" | grep -qx meetbot; then
       meetbot_commit="$(
         compose exec -T meetbot python3 -c \
           'import os; print(os.environ.get("ILLO_BUILD_COMMIT", "unknown"))' \

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -235,7 +235,11 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
       fi
     fi
 
-    for service in $DOCTOR_REQUIRED_SERVICES; do
+    services_to_check="$DOCTOR_REQUIRED_SERVICES"
+    if printf '%s\n' "$running" | grep -qx meetbot; then
+      services_to_check="$services_to_check meetbot"
+    fi
+    for service in $services_to_check; do
       printf '%s\n' "$running" | grep -qx "$service" || continue
       health="$(container_health "$service" || true)"
       case "$health" in
@@ -250,6 +254,22 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
           ;;
       esac
     done
+
+    if printf '%s\n' "$running" | grep -qx meetbot; then
+      meetbot_commit="$(
+        compose exec -T meetbot python3 -c \
+          'import os; print(os.environ.get("ILLO_BUILD_COMMIT", "unknown"))' \
+          2>/dev/null || true
+      )"
+      expected_commit="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+      if [ -z "$meetbot_commit" ] || [ "$meetbot_commit" = "unknown" ]; then
+        fail "meetbot build commit is unknown"
+      elif [ "$meetbot_commit" != "$expected_commit" ]; then
+        fail "meetbot is stale: running commit $meetbot_commit, checkout commit $expected_commit"
+      else
+        pass "meetbot build commit matches the checkout: $meetbot_commit"
+      fi
+    fi
 
     queue_health_output=""
     queue_health_status=0

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -57,11 +57,18 @@ COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS="${ILLO_COMPOSE_WORKER_DRAIN_TIMEOU
 
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
 
+MEETBOT_ENABLED=0
+if compose_service_enabled meetbot; then
+  MEETBOT_ENABLED=1
+fi
+
 non_worker_services() {
+  printf '%s\n' api scheduler web
+  [ "$MEETBOT_ENABLED" = "0" ] || printf '%s\n' meetbot
   if [ "$SKIP_UPDATER_RESTART" = "1" ]; then
-    printf '%s\n' api scheduler web
+    return 0
   else
-    printf '%s\n' api scheduler web updater
+    printf '%s\n' updater
   fi
 }
 
@@ -84,17 +91,21 @@ schedule_updater_refresh_after_self_update() {
 }
 
 if [ "$PULL" = "1" ]; then
-  compose pull postgres api web updater || {
+  pull_services=(postgres api web updater)
+  [ "$MEETBOT_ENABLED" = "0" ] || pull_services+=(meetbot)
+  compose pull "${pull_services[@]}" || {
     echo "Image pull failed. If release images are not published yet, rerun with --build." >&2
     exit 1
   }
 fi
 
 if [ "$BUILD" = "1" ]; then
+  build_services=(api web updater)
+  [ "$MEETBOT_ENABLED" = "0" ] || build_services+=(meetbot)
   if [ "$BUILD_NO_CACHE" = "1" ]; then
-    compose build --no-cache api web updater
+    compose build --no-cache "${build_services[@]}"
   else
-    compose build api web updater
+    compose build "${build_services[@]}"
   fi
 fi
 

--- a/illo
+++ b/illo
@@ -2391,12 +2391,34 @@ deploy_require_env_file() {
 
 deploy_meetbot_enabled() {
   local profiles
-  profiles="$(deploy_env_value COMPOSE_PROFILES)"
+  if [ "${COMPOSE_PROFILES+x}" = "x" ]; then
+    profiles="$COMPOSE_PROFILES"
+  else
+    profiles="$(deploy_env_value COMPOSE_PROFILES)"
+  fi
   profiles=",${profiles// /,},"
   case "$profiles" in
+    *,\*,*) return 0 ;;
     *",meetbot,"*) return 0 ;;
   esac
-  [ -n "$(deploy_compose ps -q meetbot 2>/dev/null || true)" ]
+  [ -n "$(deploy_service_container_id meetbot)" ]
+}
+
+deploy_service_container_id() {
+  local service="$1" id oneoff
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    oneoff="$(
+      docker inspect --format '{{index .Config.Labels "com.docker.compose.oneoff"}}' \
+        "$id" 2>/dev/null || true
+    )"
+    case "$oneoff" in
+      True|true|TRUE) continue ;;
+    esac
+    printf '%s\n' "$id"
+    return 0
+  done < <(deploy_compose ps --all -q "$service" 2>/dev/null || true)
+  return 0
 }
 
 deploy_ensure_env_file() {

--- a/illo
+++ b/illo
@@ -2345,7 +2345,10 @@ deploy_ensure_docker() {
 }
 
 deploy_compose() {
-  docker compose --env-file "$(deploy_compose_env_file)" -f "$(deploy_compose_file)" "$@"
+  local build_commit
+  build_commit="${ILLO_BUILD_COMMIT:-$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+  ILLO_BUILD_COMMIT="$build_commit" \
+    docker compose --env-file "$(deploy_compose_env_file)" -f "$(deploy_compose_file)" "$@"
 }
 
 deploy_env_value() {
@@ -2386,6 +2389,16 @@ deploy_require_env_file() {
   fi
 }
 
+deploy_meetbot_enabled() {
+  local profiles
+  profiles="$(deploy_env_value COMPOSE_PROFILES)"
+  profiles=",${profiles// /,},"
+  case "$profiles" in
+    *",meetbot,"*) return 0 ;;
+  esac
+  [ -n "$(deploy_compose ps -q meetbot 2>/dev/null || true)" ]
+}
+
 deploy_ensure_env_file() {
   if [ -f "$(deploy_compose_env_file)" ]; then
     return 0
@@ -2417,6 +2430,7 @@ deploy_up() {
   local build=0
   local pull=1
   local doctor=1
+  local meetbot_enabled=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -2445,17 +2459,30 @@ deploy_up() {
 
   deploy_ensure_env_file || return 1
   deploy_ensure_docker || return 1
+  if deploy_meetbot_enabled; then
+    meetbot_enabled=1
+  fi
 
   if [ "$pull" = "1" ]; then
-    if ! deploy_compose pull; then
-      warn "Image pull failed; building API and web images locally instead."
+    local pull_status=0
+    deploy_compose pull || pull_status=$?
+    if [ "$meetbot_enabled" = "1" ]; then
+      deploy_compose pull meetbot || pull_status=$?
+    fi
+    if [ "$pull_status" -ne 0 ]; then
+      warn "Image pull failed; building selected images locally instead."
       build=1
     fi
   fi
   if [ "$build" = "1" ]; then
-    deploy_compose build api web updater || return 1
+    local build_services=(api web updater)
+    [ "$meetbot_enabled" = "0" ] || build_services+=(meetbot)
+    deploy_compose build "${build_services[@]}" || return 1
   fi
   deploy_compose up -d || return 1
+  if [ "$meetbot_enabled" = "1" ]; then
+    deploy_compose up -d --no-deps meetbot || return 1
+  fi
   if [ "$doctor" = "1" ]; then
     "$ROOT/deploy/scripts/doctor.sh"
   fi

--- a/meetbot/app.py
+++ b/meetbot/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import secrets
 from contextlib import asynccontextmanager
@@ -97,6 +98,7 @@ class ActionResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     status: Literal["ok"] = "ok"
+    commit: str
 
 
 def create_app(
@@ -108,6 +110,7 @@ def create_app(
     """Create an app with injectable browser and webhook boundaries."""
 
     resolved_config = config or MeetbotConfig.from_env()
+    build_commit = os.getenv("ILLO_BUILD_COMMIT", "unknown").strip() or "unknown"
     resolved_engine = engine or PlaywrightMeetEngine(resolved_config)
     resolved_sender = webhook_sender or MeetingWebhookCallback(resolved_config)
     manager = SessionManager(resolved_config, resolved_engine, resolved_sender)
@@ -141,7 +144,7 @@ def create_app(
 
     @application.get("/healthz", response_model=HealthResponse)
     async def healthz() -> HealthResponse:
-        return HealthResponse()
+        return HealthResponse(commit=build_commit)
 
     @application.post(
         "/join",

--- a/meetbot/tests/test_api.py
+++ b/meetbot/tests/test_api.py
@@ -128,14 +128,21 @@ def _wait_for_status(
     raise AssertionError(f"Session {session_id} did not reach {expected}")
 
 
-def test_health_is_public_but_session_routes_require_token(tmp_path: Path) -> None:
+def test_health_is_public_but_session_routes_require_token(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("ILLO_BUILD_COMMIT", "abc123")
     app = create_app(
         config=_config(tmp_path),
         engine=FakeEngine(),
         webhook_sender=FakeMeetingWebhookSender(),
     )
     with TestClient(app) as client:
-        assert client.get("/healthz").json() == {"status": "ok"}
+        assert client.get("/healthz").json() == {
+            "status": "ok",
+            "commit": "abc123",
+        }
         assert _join(client, token=False).status_code == 401
         assert client.get("/sessions/missing").status_code == 401
 

--- a/specs/meetbot/README.md
+++ b/specs/meetbot/README.md
@@ -162,6 +162,20 @@ The UI locale and caption language are independent. Meet's controls stay in Engl
 the text-based DOM selectors remain deterministic, while captions use the meeting's
 spoken language (French by default) to prevent translation, garbage, or empty output.
 
+### Deployment path
+
+Changes under `meetbot/**` build and test `ghcr.io/illospace/meetbot` in the container
+image workflow. A merge to `main` publishes both the commit tag and `latest`.
+
+To enable the optional service, set `COMPOSE_PROFILES=meetbot` in
+`deploy/compose/.env`, configure the meetbot variables above, and run
+`./illo deploy up`. Normal `./illo update --mode compose` and
+`./illo deploy upgrade` calls then include meetbot whenever its profile is enabled or
+its container is already running. Local build paths pass the current Git commit into
+the image. `./illo deploy doctor` reports that commit and fails when the running
+meetbot does not match the checkout. The public `/healthz` response exposes the same
+commit without requiring the meetbot token.
+
 ## Slices
 
 - **S-A (meetbot service)**: everything under "Component 1" + Dockerfile + compose

--- a/tests/test_deploy_doctor.py
+++ b/tests/test_deploy_doctor.py
@@ -105,3 +105,72 @@ def test_strict_credentials_uses_current_db_tables_without_legacy_user_keys(tmp_
     assert result.returncode == 0, result.stdout + result.stderr
     assert "DB-backed provider credentials are configured (2 key record(s))" in result.stdout
     assert "user_api_keys" not in docker_log.read_text()
+
+
+def test_profile_enabled_meetbot_must_be_running(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ILLO_PUBLIC_URL=http://illospace.local",
+                "SECRET_KEY=secret-key",
+                "VAULT_MASTER_KEY=MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+                "DB_NAME=illospace",
+                "DB_USER=illo",
+                "DB_PASSWORD=db-password",
+                "COMPOSE_PROFILES=meetbot",
+            ]
+        )
+        + "\n"
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [ "${1:-}" = "info" ]; then exit 0; fi
+            if [ "${1:-}" = "inspect" ]; then echo healthy; exit 0; fi
+            if [ "${1:-}" = "compose" ]; then
+              args="$*"
+              case "$args" in
+                *" config"*) exit 0 ;;
+                *" ps --services --status running"*)
+                  printf '%s\n' postgres api web worker scheduler updater
+                  exit 0
+                  ;;
+                *" ps --all -q meetbot"*) echo stopped-meetbot; exit 0 ;;
+                *" ps -q "*) echo container-id; exit 0 ;;
+                *"pg_extension"*) echo vector; exit 0 ;;
+                *"brain.app.cli.agent_run_queue_health"*)
+                  echo "AgentRun queue healthy: no stale queued backlog."
+                  exit 0
+                  ;;
+              esac
+            fi
+            exit 0
+            """
+        )
+    )
+    docker.chmod(0o755)
+    curl = bin_dir / "curl"
+    curl.write_text("#!/usr/bin/env bash\nexit 0\n")
+    curl.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("COMPOSE_PROFILES", None)
+    env["ILLO_COMPOSE_ENV_FILE"] = str(env_file)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    result = subprocess.run(
+        [str(ROOT / "deploy" / "scripts" / "doctor.sh")],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "configured meetbot is not running" in result.stderr

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -469,7 +469,14 @@ def test_meetbot_changes_build_publish_update_and_report_the_running_commit():
     assert "pull_services+=(meetbot)" in upgrade
     assert "build_services+=(meetbot)" in upgrade
     assert "compose_profile_enabled" in runtime_lib
+    assert '${COMPOSE_PROFILES+x}' in runtime_lib
+    assert '*,\\*,*)' in runtime_lib
+    assert "ps --all -q" in runtime_lib
+    assert '${COMPOSE_PROFILES+x}' in launcher
+    assert 'com.docker.compose.oneoff' in runtime_lib
+    assert 'com.docker.compose.oneoff' in launcher
     assert "ILLO_BUILD_COMMIT" in runtime_lib
+    assert 'fail "configured meetbot is not running"' in doctor
     assert "meetbot build commit matches the checkout" in doctor
     assert "meetbot is stale" in doctor
     assert "ARG ILLO_BUILD_COMMIT=unknown" in dockerfile
@@ -477,6 +484,102 @@ def test_meetbot_changes_build_publish_update_and_report_the_running_commit():
     assert "ILLO_BUILD_COMMIT: ${ILLO_BUILD_COMMIT:-unknown}" in compose
     assert "COMPOSE_PROFILES=meetbot" in spec
     assert "./illo update --mode compose" in spec
+
+
+def test_meetbot_profile_detection_honors_shell_precedence_wildcard_and_stopped_container(tmp_path):
+    runtime_lib = (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "scripts"
+        / "compose-runtime-lib.sh"
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("COMPOSE_PROFILES=slack\n")
+
+    shell_override = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{runtime_lib}"; compose_profile_enabled meetbot',
+        ],
+        env={**os.environ, "ENV_FILE": str(env_file), "COMPOSE_PROFILES": "meetbot"},
+        capture_output=True,
+        text=True,
+    )
+    assert shell_override.returncode == 0
+
+    env_file.write_text("COMPOSE_PROFILES=*\n")
+    wildcard = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'unset COMPOSE_PROFILES; source "{runtime_lib}"; compose_profile_enabled meetbot',
+        ],
+        env={key: value for key, value in os.environ.items() if key != "COMPOSE_PROFILES"}
+        | {"ENV_FILE": str(env_file)},
+        capture_output=True,
+        text=True,
+    )
+    assert wildcard.returncode == 0
+
+    env_file.write_text("COMPOSE_PROFILES=slack\n")
+    stopped_container = subprocess.run(
+        [
+            "bash",
+            "-c",
+            (
+                f'unset COMPOSE_PROFILES; source "{runtime_lib}"; '
+                'compose() { [ "$*" = "ps --all -q meetbot" ] && printf "stopped-id\\n"; }; '
+                "compose_service_enabled meetbot"
+            ),
+        ],
+        env={key: value for key, value in os.environ.items() if key != "COMPOSE_PROFILES"}
+        | {"ENV_FILE": str(env_file)},
+        capture_output=True,
+        text=True,
+    )
+    assert stopped_container.returncode == 0
+
+    oneoff_only = subprocess.run(
+        [
+            "bash",
+            "-c",
+            (
+                f'unset COMPOSE_PROFILES; source "{runtime_lib}"; '
+                'compose() { [ "$*" = "ps --all -q meetbot" ] && printf "oneoff-id\\n"; }; '
+                'docker() { [ "$1" = "inspect" ] && printf "true\\n"; }; '
+                "! compose_service_enabled meetbot"
+            ),
+        ],
+        env={key: value for key, value in os.environ.items() if key != "COMPOSE_PROFILES"}
+        | {"ENV_FILE": str(env_file)},
+        capture_output=True,
+        text=True,
+    )
+    assert oneoff_only.returncode == 0
+
+    launcher = (Path(__file__).resolve().parents[1] / "illo").read_text()
+    launcher_functions = []
+    for name in ("deploy_meetbot_enabled", "deploy_service_container_id"):
+        match = re.search(rf"^{name}\(\) \{{\n.*?^\}}$", launcher, re.MULTILINE | re.DOTALL)
+        assert match is not None
+        launcher_functions.append(match.group(0))
+    launcher_oneoff_only = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "\n".join(launcher_functions)
+            + "\n"
+            + 'deploy_env_value() { printf "slack\\n"; }\n'
+            + 'deploy_compose() { printf "oneoff-id\\n"; }\n'
+            + 'docker() { printf "true\\n"; }\n'
+            + "unset COMPOSE_PROFILES\n"
+            + "! deploy_meetbot_enabled\n",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert launcher_oneoff_only.returncode == 0
 
 
 def test_compose_worker_restart_asserts_exactly_one_running_worker():

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -276,7 +276,8 @@ def test_illo_exposes_native_default_dev_mode_and_compose_deploy():
     assert "deploy" in content
     assert 'deploy_command "${@:2}"' in content
     assert 'update_command "${@:2}"' in content
-    assert "deploy_compose build api web updater" in content
+    assert "local build_services=(api web updater)" in content
+    assert "build_services+=(meetbot)" in content
     assert "--no-next" in content
     assert "worker-status" not in content
     assert "worker-drain" not in content
@@ -417,7 +418,8 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert 'source "$COMPOSE_RUNTIME_LIB_DIR/worker-swap-lib.sh"' in runtime_lib
     assert "worker_swap_snapshot_acquire" in runtime_lib
     assert "non_worker_services" in upgrade
-    assert "api scheduler web updater" in upgrade
+    assert "printf '%s\\n' api scheduler web" in upgrade
+    assert 'printf \'%s\\n\' updater' in upgrade
     assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
     assert "schedule_updater_refresh_after_self_update" in upgrade
     assert "ILLO_COMPOSE_UPDATER_SELF_REFRESH_DELAY_SECONDS" in upgrade
@@ -442,6 +444,39 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "assert_single_running_worker" in upgrade
     assert "ILLO_COMPOSE_BUILD_NO_CACHE" in upgrade
     assert "ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE" in upgrade
+
+
+def test_meetbot_changes_build_publish_update_and_report_the_running_commit():
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github" / "workflows" / "container-images.yml").read_text()
+    launcher = (root / "illo").read_text()
+    runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
+    upgrade = (root / "deploy" / "scripts" / "upgrade.sh").read_text()
+    doctor = (root / "deploy" / "scripts" / "doctor.sh").read_text()
+    dockerfile = (root / "deploy" / "docker" / "meetbot.Dockerfile").read_text()
+    compose = (root / "deploy" / "compose" / "docker-compose.yml").read_text()
+    spec = (root / "specs" / "meetbot" / "README.md").read_text()
+
+    assert '      meetbot: ${{ steps.selected.outputs.meetbot }}' in workflow
+    assert '              - "meetbot/**"' in workflow
+    assert "  build-meetbot:" in workflow
+    assert "IMAGE_NAME: meetbot" in workflow
+    assert "ILLO_BUILD_COMMIT=${{ github.sha }}" in workflow
+    assert "deploy_meetbot_enabled" in launcher
+    assert "build_services+=(meetbot)" in launcher
+    assert "up -d --no-deps meetbot" in launcher
+    assert "compose_service_enabled meetbot" in upgrade
+    assert "pull_services+=(meetbot)" in upgrade
+    assert "build_services+=(meetbot)" in upgrade
+    assert "compose_profile_enabled" in runtime_lib
+    assert "ILLO_BUILD_COMMIT" in runtime_lib
+    assert "meetbot build commit matches the checkout" in doctor
+    assert "meetbot is stale" in doctor
+    assert "ARG ILLO_BUILD_COMMIT=unknown" in dockerfile
+    assert "org.opencontainers.image.revision" in dockerfile
+    assert "ILLO_BUILD_COMMIT: ${ILLO_BUILD_COMMIT:-unknown}" in compose
+    assert "COMPOSE_PROFILES=meetbot" in spec
+    assert "./illo update --mode compose" in spec
 
 
 def test_compose_worker_restart_asserts_exactly_one_running_worker():


### PR DESCRIPTION
## Summary
- build and publish the meetbot image with the rest of the Illo release
- include meetbot in normal upgrade, updater, and doctor flows when its effective Compose profile or managed service enables it
- expose build commit data and verify health and release parity without mistaking Compose one-off containers for the service

Closes #658.

## Verification
- 100 focused deploy, doctor, and meetbot tests passed
- Bash syntax passed
- workflow YAML parsed
- independent review found no actionable issues
