### PR TITLE
fix(cortex): bound canvas occupancy (#736)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -307,6 +307,14 @@ Reading rules:
 
 The core layout is spatial first, panel second. Cortex is not a generic SaaS dashboard with a decorative canvas. The canvas is the product's main orientation surface.
 
+Canvas occupancy is an attention contract. The live canvas shows only work that
+is active or owes a person a response: `active`, `working`, `needs_input`,
+`unread_reply`, and `failed`. An `emerged` thought that has no update for 24
+hours is archived by the hourly occupancy job. Archiving removes it from the
+canvas but keeps it in thread history and search, with the transition recorded
+in `idea_state_log`. Origin never hides a thought; each visible blob carries a
+small source cue.
+
 Primary surfaces:
 
 - **Workspace**: orbit-first scene with astres, signal blobs, toolbar, nav rail, and persistent composer.

--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import BackgroundTasks, Depends, HTTPException, Request
+from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -388,20 +388,25 @@ async def _apply_orbit_anchor(
 
 async def list_ideas_payload(
     status: str | None = None,
+    limit: int = 100,
     db: AsyncSession | None = None,
     user: dict[str, Any] = Depends(get_current_user),
 ) -> list[IdeaRead]:
     assert db is not None, "list_ideas_payload requires an explicit async session"
     repo = IdeaRepository(db)
     if _caller_is_service_principal(user):
-        ideas = await repo.a_list_by_status(status) if status else await repo.a_list_active()
+        ideas = (
+            await repo.a_list_by_status(status, limit=limit)
+            if status
+            else await repo.a_list_canvas(limit=limit)
+        )
         return await _ideas_read_with_author(list(ideas), db)
 
     org_id = require_org_context(user)
     ideas = (
-        await repo.a_list_by_status_for_org(status, org_id)
+        await repo.a_list_by_status_for_org(status, org_id, limit=limit)
         if status
-        else await repo.a_list_active_for_org(org_id)
+        else await repo.a_list_canvas_for_org(org_id, limit=limit)
     )
     return await _ideas_read_with_author(list(ideas), db)
 
@@ -409,10 +414,11 @@ async def list_ideas_payload(
 @router.get("/ideas", response_model=list[IdeaRead])
 async def list_ideas(
     status: str | None = None,
+    limit: int = Query(default=100, ge=1, le=200),
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    return await list_ideas_payload(status=status, db=db, user=user)
+    return await list_ideas_payload(status=status, limit=limit, db=db, user=user)
 
 
 @router.get("/ideas/archived", response_model=list[IdeaRead])
@@ -699,7 +705,7 @@ async def restore_idea(
         db,
         idea=idea,
         command=ThoughtStatusCommand(
-            to_status="emerged" if str(getattr(idea, "status", "")) == "archived" else str(idea.status),
+            to_status="active" if str(getattr(idea, "status", "")) == "archived" else str(idea.status),
             trigger="user_restore",
             actor=user,
         ),

--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -196,6 +196,32 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "retry_policy": {"max_attempts": 2, "backoff_seconds": 120},
         "misfire_policy": "skip",
     },
+    {
+        "job_key": "cortex_canvas_occupancy",
+        "family": "cortex_canvas_occupancy",
+        "program_key": "cortex_canvas_occupancy",
+        "handler_kind": CATALOG_HANDLER_KIND,
+        "handler_ref": "brain.app.scheduler.programs:cortex_canvas_occupancy",
+        "cron_expr": "17 * * * *",
+        "timezone": "UTC",
+        "default_payload": {
+            "name": "Cortex Canvas Occupancy",
+            "description": "Archive emerged thoughts after 24 quiet hours",
+        },
+        "task_contract": {
+            "memory_scope": {"visibility": "system"},
+            "allowed_actions": ["scheduler.run"],
+            "output_channel": "scheduler",
+            "success_criteria": [
+                "Quiet emerged thoughts move to history through an audited status transition"
+            ],
+        },
+        "priority": 70,
+        "max_concurrency": 1,
+        "timeout_seconds": 300,
+        "retry_policy": {"max_attempts": 2, "backoff_seconds": 60},
+        "misfire_policy": "skip",
+    },
 )
 
 

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -93,6 +93,11 @@ class SingleCommandProgram:
 
 # Programs whose plan and StepSpec projections share one representation.
 SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
+    "cortex_canvas_occupancy": SingleCommandProgram(
+        command=("python3", "-m", "brain.jobs.pipelines.cortex_occupancy"),
+        step_key="cortex_canvas_occupancy",
+        description="Move quiet emerged thoughts from the canvas into history",
+    ),
     "knowledge_index_sync": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.knowledge_index_sync"),
         step_key="knowledge_index_sync",

--- a/brain/contracts/statuses.py
+++ b/brain/contracts/statuses.py
@@ -23,6 +23,13 @@ IDEA_STATUS_VALUES = (
     "building",
     "testing",
 )
+CANVAS_OCCUPANCY_STATUS_VALUES = (
+    "active",
+    "failed",
+    "needs_input",
+    "unread_reply",
+    "working",
+)
 INBOUND_EVENT_STATUS_VALUES = (
     "received",
     "processed",

--- a/brain/jobs/pipelines/cortex_occupancy.py
+++ b/brain/jobs/pipelines/cortex_occupancy.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Move quiet emerged thoughts from the live canvas into history."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.idea import Idea
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.thought_lifecycle import ThoughtStatusCommand, transition_thought_status
+
+log = logging.getLogger(__name__)
+
+CANVAS_QUIET_HOURS = 24
+ARCHIVE_TRIGGER = "canvas_occupancy_24h_quiet"
+
+
+async def archive_dormant_emerged(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+    quiet_hours: int = CANVAS_QUIET_HOURS,
+    batch_size: int = 250,
+) -> int:
+    """Archive emerged thoughts after a bounded quiet period.
+
+    The canonical lifecycle service sets ``archived_at`` and records the
+    transition in ``idea_state_log``. Other states are never changed here.
+    """
+    changed_at = now or datetime.now(timezone.utc)
+    cutoff = changed_at - timedelta(hours=quiet_hours)
+    archived = 0
+
+    while True:
+        ideas = list(
+            (
+                await session.scalars(
+                    select(Idea)
+                    .where(
+                        Idea.status == "emerged",
+                        Idea.archived_at.is_(None),
+                        Idea.updated_at < cutoff,
+                    )
+                    .order_by(Idea.updated_at, Idea.id)
+                    .limit(batch_size)
+                    .with_for_update(skip_locked=True)
+                )
+            ).all()
+        )
+        if not ideas:
+            break
+
+        for idea in ideas:
+            await transition_thought_status(
+                session,
+                idea=idea,
+                command=ThoughtStatusCommand(
+                    to_status="archived",
+                    trigger=ARCHIVE_TRIGGER,
+                    changed_at=changed_at,
+                ),
+            )
+        archived += len(ideas)
+
+    return archived
+
+
+async def run() -> dict[str, int]:
+    async with UnitOfWork() as uow:
+        archived = await archive_dormant_emerged(uow.session)  # type: ignore[arg-type]
+    result = {"archived": archived, "quiet_hours": CANVAS_QUIET_HOURS}
+    log.info("Cortex occupancy maintenance complete: %s", result)
+    return result
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [cortex_occupancy] %(message)s")
+    print(json.dumps(asyncio.run(run()), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/brain/platform/db/repositories/ideas.py
+++ b/brain/platform/db/repositories/ideas.py
@@ -9,6 +9,7 @@ from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import aliased, load_only
 
+from brain.contracts.statuses import CANVAS_OCCUPANCY_STATUS_VALUES
 from brain.platform.db.models.idea import (
     Idea,
     IdeaConnection,
@@ -66,6 +67,19 @@ class IdeaRepository(BaseRepository[Idea]):
         return stmt
 
     @staticmethod
+    def _list_canvas_stmt(*, limit: int):
+        return (
+            select(Idea)
+            .options(load_only(*IDEA_LIST_LOAD_COLUMNS))
+            .where(
+                Idea.archived_at.is_(None),
+                Idea.status.in_(CANVAS_OCCUPANCY_STATUS_VALUES),
+            )
+            .order_by(Idea.updated_at.desc())
+            .limit(limit)
+        )
+
+    @staticmethod
     def _get_for_org_stmt(idea_id: str, org_id: str):
         return select(Idea).where(Idea.id == idea_id, Idea.org_id == org_id)
 
@@ -80,6 +94,20 @@ class IdeaRepository(BaseRepository[Idea]):
         if limit:
             stmt = stmt.limit(limit)
         return stmt
+
+    @staticmethod
+    def _list_canvas_for_org_stmt(org_id: str, *, limit: int):
+        return (
+            select(Idea)
+            .options(load_only(*IDEA_LIST_LOAD_COLUMNS))
+            .where(
+                Idea.org_id == org_id,
+                Idea.archived_at.is_(None),
+                Idea.status.in_(CANVAS_OCCUPANCY_STATUS_VALUES),
+            )
+            .order_by(Idea.updated_at.desc())
+            .limit(limit)
+        )
 
     @staticmethod
     def _list_archived_stmt(*, limit: int | None = None):
@@ -158,17 +186,20 @@ class IdeaRepository(BaseRepository[Idea]):
         return len(ids)
 
     @staticmethod
-    def _list_by_status_stmt(status: str):
-        return (
+    def _list_by_status_stmt(status: str, *, limit: int | None = None):
+        stmt = (
             select(Idea)
             .options(load_only(*IDEA_LIST_LOAD_COLUMNS))
             .where(Idea.status == status, Idea.archived_at.is_(None))
             .order_by(Idea.updated_at.desc())
         )
+        if limit:
+            stmt = stmt.limit(limit)
+        return stmt
 
     @staticmethod
-    def _list_by_status_for_org_stmt(status: str, org_id: str):
-        return (
+    def _list_by_status_for_org_stmt(status: str, org_id: str, *, limit: int | None = None):
+        stmt = (
             select(Idea)
             .options(load_only(*IDEA_LIST_LOAD_COLUMNS))
             .where(
@@ -178,10 +209,16 @@ class IdeaRepository(BaseRepository[Idea]):
             )
             .order_by(Idea.updated_at.desc())
         )
+        if limit:
+            stmt = stmt.limit(limit)
+        return stmt
 
     async def a_list_active(self, *, limit: int | None = None) -> Sequence[Idea]:
         stmt = self._list_active_stmt(limit=limit)
         return (await self._session.scalars(stmt)).all()
+
+    async def a_list_canvas(self, *, limit: int) -> Sequence[Idea]:
+        return (await self._session.scalars(self._list_canvas_stmt(limit=limit))).all()
 
     async def a_list_by_org(
         self, org_id: str, *, limit: int | None = None
@@ -204,6 +241,10 @@ class IdeaRepository(BaseRepository[Idea]):
         stmt = self._list_active_for_org_stmt(org_id, limit=limit)
         return (await self._session.scalars(stmt)).all()
 
+    async def a_list_canvas_for_org(self, org_id: str, *, limit: int) -> Sequence[Idea]:
+        stmt = self._list_canvas_for_org_stmt(org_id, limit=limit)
+        return (await self._session.scalars(stmt)).all()
+
     async def a_list_archived(self, *, limit: int | None = None) -> Sequence[Idea]:
         stmt = self._list_archived_stmt(limit=limit)
         return (await self._session.scalars(stmt)).all()
@@ -214,12 +255,14 @@ class IdeaRepository(BaseRepository[Idea]):
         stmt = self._list_archived_for_org_stmt(org_id, limit=limit)
         return (await self._session.scalars(stmt)).all()
 
-    async def a_list_by_status(self, status: str) -> Sequence[Idea]:
-        stmt = self._list_by_status_stmt(status)
+    async def a_list_by_status(self, status: str, *, limit: int | None = None) -> Sequence[Idea]:
+        stmt = self._list_by_status_stmt(status, limit=limit)
         return (await self._session.scalars(stmt)).all()
 
-    async def a_list_by_status_for_org(self, status: str, org_id: str) -> Sequence[Idea]:
-        stmt = self._list_by_status_for_org_stmt(status, org_id)
+    async def a_list_by_status_for_org(
+        self, status: str, org_id: str, *, limit: int | None = None
+    ) -> Sequence[Idea]:
+        stmt = self._list_by_status_for_org_stmt(status, org_id, limit=limit)
         return (await self._session.scalars(stmt)).all()
 
     async def a_update_status(

--- a/brain/systems/cortex/status.py
+++ b/brain/systems/cortex/status.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from brain.contracts.statuses import (
+    CANVAS_OCCUPANCY_STATUS_VALUES,
     IDEA_STATUS_VALUES,
     idea_status_pattern,
 )
 IDEA_STATUSES = frozenset(IDEA_STATUS_VALUES)
+CANVAS_OCCUPANCY_STATUSES = frozenset(CANVAS_OCCUPANCY_STATUS_VALUES)
 RUN_ADMISSION_CREATE_STATUSES = frozenset({"queued", "working"})
 PROTECTED_IDEA_STATUSES = frozenset({"archived", "resolved"})
 EXTERNAL_TASK_STARTABLE_IDEA_STATUSES = frozenset({

--- a/frontend/src/lib/components/constellation/SignalBlob.svelte
+++ b/frontend/src/lib/components/constellation/SignalBlob.svelte
@@ -40,6 +40,7 @@
     treatment = 'bloom',
     icon = 'thread',
     attachmentCount = 0,
+    originCue = '',
     badge = false,
     animated = true,
     interactive = false,
@@ -68,6 +69,7 @@
     treatment?: ConstellationSignalTreatment;
     icon?: ConstellationSignalIcon;
     attachmentCount?: number;
+    originCue?: string;
     badge?: boolean;
     animated?: boolean;
     interactive?: boolean;
@@ -87,7 +89,7 @@
 
   const showHalo = $derived(presence === 'inside');
   const iconName = $derived(SIGNAL_ICON_MAP[icon] ?? SIGNAL_ICON_MAP.thread);
-  const fullLabel = $derived(label || text);
+  const fullLabel = $derived(`${label || text}${originCue ? ` — source ${originCue}` : ''}`);
   const showWorkingIndicator = $derived(state === 'working');
   const showUnreadNotification = $derived(cue === 'attention' && !showWorkingIndicator);
   const statusVariant = $derived.by<'owner' | 'inside' | 'attention' | 'risk' | null>(() => {
@@ -297,6 +299,9 @@
     {/if}
 
     <div class="constellation-signal-blob-surface">
+      {#if originCue}
+        <span class="constellation-signal-blob-origin" aria-hidden="true">{originCue}</span>
+      {/if}
       {#if treatment === 'seed'}
         <span class="constellation-signal-blob-owner-seed" aria-hidden="true"></span>
       {/if}
@@ -545,7 +550,8 @@
 
   .constellation-signal-blob-owner-seed,
   .constellation-signal-blob-status-anchor,
-  .constellation-signal-blob-attachment-badge {
+  .constellation-signal-blob-attachment-badge,
+  .constellation-signal-blob-origin {
     position: absolute;
     z-index: 2;
   }
@@ -561,6 +567,21 @@
       0 0 0 2px var(--constellation-color-badge-ring),
       0 0 16px color-mix(in srgb, var(--blob-seed) 56%, transparent);
     opacity: var(--blob-seed-opacity, 0.9);
+  }
+
+  .constellation-signal-blob-origin {
+    right: 18px;
+    bottom: 14px;
+    max-width: 48px;
+    overflow: hidden;
+    color: color-mix(in srgb, var(--blob-owner) 64%, transparent);
+    font-family: var(--constellation-font-mono);
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .constellation-signal-blob-owner-seed::after {
@@ -696,6 +717,14 @@
     gap: 0;
     padding: 0;
     border-radius: 999px;
+  }
+
+  .constellation-signal-blob-semantic-symbol .constellation-signal-blob-origin,
+  .constellation-signal-blob-semantic-glyph .constellation-signal-blob-origin {
+    right: 14px;
+    bottom: 11px;
+    max-width: 24px;
+    font-size: 6px;
   }
 
   .constellation-signal-blob-semantic-symbol .constellation-signal-blob-text,

--- a/frontend/src/lib/features/cortex/domain/canvasOccupancy.ts
+++ b/frontend/src/lib/features/cortex/domain/canvasOccupancy.ts
@@ -1,0 +1,37 @@
+const CANVAS_OCCUPANCY_STATUSES = new Set([
+  'active',
+  'failed',
+  'needs_input',
+  'unread_reply',
+  'working',
+]);
+
+export function isCanvasOccupant(idea: {
+  status?: string | null;
+  lifecycle_status?: string | null;
+  archived_at?: string | null;
+}): boolean {
+  if (idea.archived_at) return false;
+  const lifecycleStatus = String(idea.lifecycle_status || '').trim().toLowerCase();
+  if (lifecycleStatus) return CANVAS_OCCUPANCY_STATUSES.has(lifecycleStatus);
+  // A local composer idea has no backend lifecycle state until its first save.
+  return String(idea.status || '').trim().toLowerCase() === 'idle';
+}
+
+export function canvasOriginCue(origin: string | null | undefined): string {
+  const normalized = String(origin || 'unknown').trim().toLowerCase();
+  if (normalized === 'user_created') return 'YOU';
+  const source = normalized.split(/[.:]/, 1)[0] || 'unknown';
+  const labels: Record<string, string> = {
+    codex: 'CODEX',
+    cycle_run: 'CYCLE',
+    github: 'GH',
+    illo_created: 'ILLO',
+    inbound_signal: 'INBOUND',
+    jira: 'JIRA',
+    meetbot: 'MEET',
+    slack: 'SLACK',
+    uwear: 'UWEAR',
+  };
+  return labels[normalized] ?? labels[source] ?? source.replace(/_+$/g, '').slice(0, 6).toUpperCase();
+}

--- a/frontend/src/lib/features/cortex/domain/ideaReducer.ts
+++ b/frontend/src/lib/features/cortex/domain/ideaReducer.ts
@@ -22,11 +22,19 @@ export function normalizeIdea<T extends Idea>(
   idea: T,
   options: NormalizeIdeaOptions = {},
 ): NormalizedIdea<T> {
+  const sourceStatus = String(idea.status || '').trim().toLowerCase();
+  const lifecycleStatus = sourceStatus && sourceStatus !== 'idle' && sourceStatus !== 'done'
+    ? sourceStatus
+    : idea.lifecycle_status;
   const normalizedStatus = normalizeIdeaStatus(idea.status);
   const status = normalizedStatus === 'done' && options.isIdeaSeen?.(idea)
     ? 'idle'
     : normalizedStatus;
-  return { ...idea, status } as NormalizedIdea<T>;
+  return {
+    ...idea,
+    ...(lifecycleStatus ? { lifecycle_status: lifecycleStatus } : {}),
+    status,
+  } as NormalizedIdea<T>;
 }
 
 export function normalizeIdeas<T extends Idea>(

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -136,6 +136,7 @@
     withAlpha,
     wrapTextForBubble,
   } from '$lib/utils/cortexSvgVisuals';
+  import { canvasOriginCue } from '$lib/features/cortex/domain/canvasOccupancy';
 
   let {
     apps = [],
@@ -964,6 +965,7 @@
       treatment: primitiveBlobTreatment(d),
       icon: primitiveBlobIcon(d),
       attachmentCount,
+      originCue: canvasOriginCue(d.origin),
     };
   }
 

--- a/frontend/src/lib/features/workspace-scene/domain/workspaceSceneState.ts
+++ b/frontend/src/lib/features/workspace-scene/domain/workspaceSceneState.ts
@@ -11,6 +11,7 @@ export type WorkspaceSceneIdeaSnapshot = {
   display_title?: string;
   description?: string | null;
   status: string;
+  origin?: string | null;
   salience_score?: number | null;
   position_x: number | null;
   position_y: number | null;
@@ -36,6 +37,7 @@ export type WorkspaceSceneIdeaSnapshot = {
 
 export type WorkspaceSceneNodeSnapshot = {
   status: string;
+  origin?: string | null;
   title: string;
   display_title?: string;
   salience_score: number;
@@ -55,6 +57,7 @@ export type OrbitNode = {
   display_title?: string;
   description?: string | null;
   status: string;
+  origin?: string | null;
   salience_score: number;
   position_x: number | null;
   position_y: number | null;
@@ -101,6 +104,7 @@ export function orbitNodeCoords(source: Partial<OrbitNode>): ScenePoint | null {
 export function sceneNodeSnapshotFromIdea(idea: WorkspaceSceneIdeaSnapshot): WorkspaceSceneNodeSnapshot {
   return {
     status: idea.status,
+    origin: idea.origin ?? null,
     title: idea.title,
     display_title: idea.display_title,
     salience_score: idea.salience_score || 5,
@@ -119,7 +123,7 @@ export function sceneNodeSnapshotChanged(
   previous: WorkspaceSceneNodeSnapshot,
   next: WorkspaceSceneNodeSnapshot,
 ): boolean {
-  return previous.status !== next.status || previous.title !== next.title || previous.display_title !== next.display_title
+  return previous.status !== next.status || previous.origin !== next.origin || previous.title !== next.title || previous.display_title !== next.display_title
     || previous.salience_score !== next.salience_score
     || previous.attachments_count !== next.attachments_count
     || previous.thread_count !== next.thread_count || previous.user_id !== next.user_id
@@ -135,6 +139,7 @@ export function createOrbitNodeFromIdea(idea: WorkspaceSceneIdeaSnapshot, initia
     display_title: idea.display_title,
     description: idea.description,
     status: idea.status,
+    origin: idea.origin ?? null,
     salience_score: idea.salience_score || 5,
     position_x: idea.position_x,
     position_y: idea.position_y,
@@ -179,6 +184,7 @@ export function applyIdeaSnapshotToSceneNode(
   node.display_title = idea.display_title;
   node.description = idea.description;
   node.status = idea.status;
+  node.origin = idea.origin ?? null;
   node.salience_score = idea.salience_score || 5;
   node.position_x = idea.position_x;
   node.position_y = idea.position_y;

--- a/frontend/src/lib/features/workspace-scene/renderers/WorkspaceOrbitPrimitives.svelte
+++ b/frontend/src/lib/features/workspace-scene/renderers/WorkspaceOrbitPrimitives.svelte
@@ -207,6 +207,7 @@
     treatment={blob.treatment}
     icon={blob.icon}
     attachmentCount={blob.attachmentCount}
+    originCue={blob.originCue}
     animated={true}
     interactive={true}
     dataId={blob.id}

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -26,6 +26,7 @@ import {
   type ArchiveCountState,
   type ArchiveIdeaIdentity,
 } from '$lib/features/cortex/domain/archiveReducer';
+import { isCanvasOccupant } from '$lib/features/cortex/domain/canvasOccupancy';
 import {
   SEEN_IDEA_REVISIONS_STORAGE_KEY,
   ideaRevision as cortexIdeaRevision,
@@ -1075,7 +1076,7 @@ class CortexStore {
   }
 
   get filteredIdeas(): Idea[] {
-    let result = this.ideas;
+    let result = this.ideas.filter(isCanvasOccupant);
     if (this.filters.statuses.size > 0) {
       result = result.filter((i) => this.filters.statuses.has(i.status));
     }

--- a/frontend/src/lib/types/cortex.ts
+++ b/frontend/src/lib/types/cortex.ts
@@ -4,6 +4,8 @@ export interface Idea {
   display_title?: string;
   description: string | null;
   status: string;
+  /** Canonical backend lifecycle state retained beside the visual status. */
+  lifecycle_status?: string | null;
   origin: string;
   origin_ref?: string | null;
   salience_score: number;

--- a/frontend/src/lib/utils/cortexOrbitPrimitives.ts
+++ b/frontend/src/lib/utils/cortexOrbitPrimitives.ts
@@ -36,6 +36,7 @@ export type PrimitiveBlobVisual = {
   treatment: ConstellationSignalTreatment;
   icon: ConstellationSignalIcon;
   attachmentCount: number;
+  originCue: string;
 };
 
 export type PrimitiveAstreVisual = {

--- a/frontend/src/lib/utils/ideaReducer.test.js
+++ b/frontend/src/lib/utils/ideaReducer.test.js
@@ -6,12 +6,35 @@ import {
   normalizeIdea,
   normalizeIdeaStatus,
 } from '../features/cortex/domain/ideaReducer.ts';
+import { canvasOriginCue, isCanvasOccupant } from '../features/cortex/domain/canvasOccupancy.ts';
 import { DONE_IDEA_STATUSES, WORKING_IDEA_STATUSES } from '../constants/statuses.ts';
 
 test('does not treat active ideas without runs as working', () => {
   assert.equal(normalizeIdeaStatus('active'), 'idle');
-  assert.equal(normalizeIdea({ id: 'idea-1', status: 'active' }).status, 'idle');
+  const normalized = normalizeIdea({ id: 'idea-1', status: 'active' });
+  assert.equal(normalized.status, 'idle');
+  assert.equal(normalized.lifecycle_status, 'active');
+  assert.equal(isCanvasOccupant(normalized), true);
   assert.equal(hasWorkingIdeas([{ id: 'idea-1', status: 'active' }]), false);
+});
+
+test('keeps every canonical canvas lifecycle state after visual normalization', () => {
+  for (const status of ['active', 'failed', 'needs_input', 'unread_reply', 'working']) {
+    const normalized = normalizeIdea({ id: `idea-${status}`, status });
+    assert.equal(normalized.lifecycle_status, status);
+    assert.equal(isCanvasOccupant(normalized), true);
+  }
+  for (const status of ['emerged', 'completed', 'archived']) {
+    assert.equal(isCanvasOccupant(normalizeIdea({ id: `idea-${status}`, status })), false);
+  }
+  assert.equal(isCanvasOccupant({ status: 'idle' }), true);
+  assert.equal(isCanvasOccupant({ status: 'idle', archived_at: '2026-08-08T00:00:00Z' }), false);
+});
+
+test('uses clear canvas cues for live idea origins', () => {
+  assert.equal(canvasOriginCue('cycle_run'), 'CYCLE');
+  assert.equal(canvasOriginCue('inbound_signal'), 'INBOUND');
+  assert.equal(canvasOriginCue('illo_created'), 'ILLO');
 });
 
 test('keeps queued and running run states working', () => {

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1771,13 +1771,21 @@ async def test_list_ideas(client, mock_session_factory):
     with patch(
         "brain.app.api.routers.cortex._ideas.IdeaRepository"
     ) as MockRepo:
-        MockRepo.return_value.a_list_active_for_org = AsyncMock(return_value=[idea])
+        MockRepo.return_value.a_list_canvas_for_org = AsyncMock(return_value=[idea])
         resp = await client.get("/api/cortex/ideas")
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["title"] == "Test Idea"
+    MockRepo.return_value.a_list_canvas_for_org.assert_awaited_once_with(ANY, limit=100)
+
+
+@pytest.mark.asyncio
+async def test_list_ideas_enforces_canvas_page_limit(client, mock_session_factory):
+    with patch("brain.app.api.routers.cortex._ideas.IdeaRepository"):
+        assert (await client.get("/api/cortex/ideas?limit=0")).status_code == 422
+        assert (await client.get("/api/cortex/ideas?limit=201")).status_code == 422
 
 
 @pytest.mark.asyncio
@@ -1915,7 +1923,9 @@ async def test_list_ideas_with_status_filter(client, mock_session_factory):
         MockRepo.return_value.a_list_by_status_for_org = AsyncMock(return_value=[idea])
         resp = await client.get("/api/cortex/ideas?status=working")
     assert resp.status_code == 200
-    MockRepo.return_value.a_list_by_status_for_org.assert_awaited_once_with("working", ANY)
+    MockRepo.return_value.a_list_by_status_for_org.assert_awaited_once_with(
+        "working", ANY, limit=100
+    )
 
 
 @pytest.mark.asyncio
@@ -2432,9 +2442,9 @@ async def test_restore_archived_idea(client, mock_session_factory):
     assert resp.status_code == 200, resp.text
     payload = resp.json()
     assert payload["archived_at"] is None
-    assert payload["status"] == "emerged"
+    assert payload["status"] == "active"
     assert idea.archived_at is None
-    assert idea.status == "emerged"
+    assert idea.status == "active"
 
 
 @pytest.mark.asyncio
@@ -2578,7 +2588,7 @@ async def test_list_ideas_uses_last_human_thread_author_color(client, mock_sessi
     last_author.color = "#abcdef"
 
     with patch("brain.app.api.routers.cortex._ideas.IdeaRepository") as MockRepo:
-        MockRepo.return_value.a_list_active_for_org = AsyncMock(return_value=[idea])
+        MockRepo.return_value.a_list_canvas_for_org = AsyncMock(return_value=[idea])
         mock_session_factory.execute.return_value.all.return_value = [
             SimpleNamespace(
                 idea_id="color-id",

--- a/tests/test_repo_ideas.py
+++ b/tests/test_repo_ideas.py
@@ -1,10 +1,11 @@
 """IdeaRepository tests using in-memory SQLite."""
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import re
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler, SQLiteDDLCompiler
 
@@ -16,6 +17,7 @@ from brain.platform.db.repositories.ideas import (
     IdeaRepository,
     IdeaThreadRepository,
 )
+from brain.jobs.pipelines.cortex_occupancy import ARCHIVE_TRIGGER, archive_dormant_emerged
 
 ORG_1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"
 ORG_2 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2"
@@ -133,6 +135,52 @@ class TestIdeaRepository:
         await _make_idea(session, archived_at=datetime.now(timezone.utc))
         result = await repo.a_list_active()
         assert len(result) == 1
+
+    async def test_list_canvas_is_bounded_to_alive_or_owed_statuses(self, repo, session):
+        for status in ("working", "active", "needs_input", "unread_reply", "failed"):
+            await _make_idea(session, status=status)
+        await _make_idea(session, status="emerged")
+        await _make_idea(session, status="resolved")
+
+        result = await repo.a_list_canvas(limit=3)
+
+        assert len(result) == 3
+        assert {idea.status for idea in result} <= {
+            "working", "active", "needs_input", "unread_reply", "failed"
+        }
+
+    async def test_quiet_emerged_ideas_move_to_audited_history(self, session):
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        quiet = await _make_idea(
+            session,
+            status="emerged",
+            updated_at=now - timedelta(hours=25),
+        )
+        recent = await _make_idea(
+            session,
+            status="emerged",
+            updated_at=now - timedelta(hours=23),
+        )
+        working = await _make_idea(
+            session,
+            status="working",
+            updated_at=now - timedelta(days=3),
+        )
+
+        archived = await archive_dormant_emerged(session, now=now)
+
+        assert archived == 1
+        assert quiet.status == "archived"
+        assert quiet.archived_at == now
+        assert recent.status == "emerged"
+        assert working.status == "working"
+        log = await session.scalar(
+            select(IdeaStateLog).where(IdeaStateLog.idea_id == quiet.id)
+        )
+        assert log is not None
+        assert (log.from_state, log.to_state, log.trigger) == (
+            "emerged", "archived", ARCHIVE_TRIGGER
+        )
 
     async def test_list_by_org(self, repo, session):
         await _make_idea(session, org_id=ORG_1)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -79,10 +79,11 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     await session.flush()
 
-    assert result == {"upserted": 6, "retired": 0}
+    assert result == {"upserted": 7, "retired": 0}
     jobs = {job["job_key"]: job for job in await async_list_scheduler_jobs(session)}
     assert set(jobs) == {
         "curiosity_cron",
+        "cortex_canvas_occupancy",
         "illo_external_heartbeat",
         "knowledge_index_sync",
         "nightly_sleep",
@@ -408,8 +409,8 @@ async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_resta
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=restart)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 6, "retired": 0}
-    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 6
+    assert result == {"upserted": 7, "retired": 0}
+    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 7
     assert {key: job.id for key, job in jobs.items()} == first_ids
     assert all(job.next_run_at > restart for job in jobs.values())
     assert await async_materialize_due_runs(session, now=restart) == []
@@ -441,7 +442,7 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 1, "retired": 5}
+    assert result == {"upserted": 1, "retired": 6}
     assert jobs["nightly_sleep"].enabled is True
     assert jobs["curiosity_cron"].enabled is False
     assert jobs["curiosity_cron"].pause_reason == "removed from scheduler catalog"
@@ -456,6 +457,8 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     assert jobs["illo_external_heartbeat"].pause_reason == "removed from scheduler catalog"
     assert jobs["knowledge_index_sync"].enabled is False
     assert jobs["knowledge_index_sync"].pause_reason == "removed from scheduler catalog"
+    assert jobs["cortex_canvas_occupancy"].enabled is False
+    assert jobs["cortex_canvas_occupancy"].pause_reason == "removed from scheduler catalog"
 
     repeated = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     assert repeated == {"upserted": 1, "retired": 0}
@@ -473,9 +476,9 @@ async def test_scheduler_daemon_startup_syncs_catalog_before_snapshot(session):
         "checkpoint_at": now.isoformat(),
         "threshold_seconds": 3600,
     }
-    assert result["catalog"] == {"upserted": 6, "retired": 0}
-    assert result["snapshot"]["summary"]["jobs_total"] == 6
-    assert result["snapshot"]["summary"]["jobs_enabled"] == 6
+    assert result["catalog"] == {"upserted": 7, "retired": 0}
+    assert result["snapshot"]["summary"]["jobs_total"] == 7
+    assert result["snapshot"]["summary"]["jobs_enabled"] == 7
     assert all(job["next_run_at"] > now.isoformat() for job in result["snapshot"]["jobs"])
 
 

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -20,6 +20,7 @@ from brain.app.scheduler.programs import (
 
 _SCHEDULED_FOR = datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc)
 _PINNED_PROJECTION_HASHES = {
+    "cortex_canvas_occupancy": "43cf7e0667228c054968df730d69c75a72ad7d30c1e2aaf66a4a5032f15453ba",
     "knowledge_index_sync": "7b180172f289f6769ef024b425a8978ee4f4c14c78e57fe98e94e7c151c7d4c6",
     "nightly_sleep": "0cb9173b9e0b71a094063bb867d644304f4c8b996fec6c9d1656b31dde060ee0",
     "curiosity_cron": "326e1c241800e49721978238c967c423e1ce1133030ca1223c77bb3f44a8519d",


### PR DESCRIPTION
## Summary
- keep the canvas limited to active, failed, needs-input, unread-reply, and working threads
- archive quiet emerged threads after 24 hours through an hourly independent scheduler job
- retain backend lifecycle status in the frontend and show a small source cue on each canvas signal
- restore archived threads to active so an explicit restore returns them to the canvas

Closes #736.

## Verification
- 166 focused backend/API/repository/scheduler tests passed
- 250 frontend tests passed
- Svelte check: 0 errors and 0 warnings
- production frontend build passed
- independent review found no remaining actionable issues
