### PR TITLE
feat(routing): add free local Ollama lane (qwen3.6-27b)

### DIFF
--- a/brain/app/api/routers/costs.py
+++ b/brain/app/api/routers/costs.py
@@ -40,7 +40,7 @@ def _provider_model_key(raw_model: Any) -> tuple[str, str, str]:
             prefix, model = value.split(separator, 1)
             provider = prefix.strip().lower()
             model = model.strip()
-            if provider in {"anthropic", "openai", "google", "local"} and model:
+            if provider in {"anthropic", "openai", "ollama", "google", "local"} and model:
                 return provider, model, f"{provider}/{model}"
 
     if lowered.startswith("claude-"):

--- a/brain/app/api/routers/system.py
+++ b/brain/app/api/routers/system.py
@@ -598,7 +598,14 @@ def _normalize_llm_model_value(value: Any) -> Any:
     if not isinstance(value, str):
         return value
     trimmed = value.strip()
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if trimmed.startswith(prefix):
             return trimmed[len(prefix):]
     return trimmed

--- a/brain/platform/effort.py
+++ b/brain/platform/effort.py
@@ -33,6 +33,13 @@ PROVIDER_EFFORT_RENDERINGS: dict[str, dict[str, str | None]] = {
         # it so callers can ask for the ceiling without provider vocabulary.
         "xhigh": "max",
     },
+    "ollama": {
+        "none": None,
+        "low": None,
+        "medium": None,
+        "high": None,
+        "xhigh": None,
+    },
 }
 
 

--- a/brain/platform/integrations/completions.py
+++ b/brain/platform/integrations/completions.py
@@ -25,7 +25,14 @@ DEFAULT_SIMPLE_COMPLETION_SYSTEM_PROMPT = (
 
 
 def _strip_provider_prefix(model: str) -> str:
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if model.startswith(prefix):
             return model[len(prefix):]
     return model

--- a/brain/platform/integrations/llm.py
+++ b/brain/platform/integrations/llm.py
@@ -237,6 +237,29 @@ def _build_openai_client(token: str, source: str = "") -> LLMClient:
     )
 
 
+def _build_ollama_client() -> LLMClient:
+    """Build an OpenAI-compatible client for the local Ollama runtime."""
+    openai = _import_openai_sdk()
+    base_url = (
+        os.environ.get("ILLO_OLLAMA_BASE_URL", "").strip()
+        or "http://172.17.0.1:11434/v1"
+    )
+    client = openai.OpenAI(
+        base_url=base_url,
+        api_key="ollama",
+        timeout=_llm_timeout_seconds(),
+    )
+    _wrap_openai_request_kwargs(client)
+    return LLMClient(
+        client=client,
+        provider="ollama",
+        source="ollama_local",
+        auth_mode=None,
+        is_oauth=False,
+        extra_headers={},
+    )
+
+
 def _wrap_openai_request_kwargs(client: Any) -> Any:
     """Normalize OpenAI request kwargs on raw SDK calls that bypass our provider layer."""
 
@@ -578,8 +601,11 @@ def resolve_llm_client(
 
     provider = normalize_default_provider(provider) if provider_from_default else normalize_runtime_provider(provider)
 
-    if provider not in ("anthropic", "openai"):
+    if provider not in ("anthropic", "ollama", "openai"):
         raise NotImplementedError(f"Provider '{provider}' not yet supported. Add it here.")
+
+    if provider == "ollama":
+        return _build_ollama_client()
 
     if provider == "openai":
         resolved_auth = _resolve_openai_local_auth(auth_mode=auth_mode)
@@ -659,8 +685,11 @@ async def async_resolve_llm_client(
             else normalize_runtime_provider(resolved_provider)
         )
 
-        if normalized_provider not in ("anthropic", "openai"):
+        if normalized_provider not in ("anthropic", "ollama", "openai"):
             raise NotImplementedError(f"Provider '{normalized_provider}' not yet supported. Add it here.")
+
+        if normalized_provider == "ollama":
+            return _build_ollama_client()
 
         if normalized_provider == "openai":
             resolved_auth = await _async_resolve_openai_auth(

--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -410,6 +410,8 @@ def _is_complete_openai_reasoning_summary_event(event_type: str) -> bool:
 class OpenAIProvider(LLMProvider):
     """OpenAI provider using the native Responses API."""
 
+    provider_name = "openai"
+
     def __init__(self, client):
         self._client = client
         self.transport = OpenAIResponsesTransport()
@@ -464,7 +466,7 @@ class OpenAIProvider(LLMProvider):
             recorded = True
             record_provider_success(
                 operation_type=request.operation_type,
-                provider="openai",
+                provider=self.provider_name,
                 model=request.normalized_model,
                 latency_ms=_latency_ms(),
             )
@@ -476,7 +478,7 @@ class OpenAIProvider(LLMProvider):
             recorded = True
             record_provider_failure(
                 operation_type=request.operation_type,
-                provider="openai",
+                provider=self.provider_name,
                 model=request.normalized_model,
                 exc=exc,
                 latency_ms=_latency_ms(),
@@ -612,10 +614,24 @@ class OpenAIProvider(LLMProvider):
         return exc.__class__.__module__.startswith("openai") or isinstance(exc, OpenAICodexError)
 
 
+class OllamaProvider(OpenAIProvider):
+    """Ollama provider using its OpenAI-compatible Responses API."""
+
+    provider_name = "ollama"
+
+    def _translate_request(self, request: LLMRequest) -> dict[str, Any]:
+        kwargs = super()._translate_request(request)
+        kwargs.pop("store", None)
+        if kwargs["model"] == "qwen3.6-27b":
+            kwargs["model"] = "qwen3.6:27b"
+        return kwargs
+
+
 # ── Provider Registry ─────────────────────────────────────────────
 
 _PROVIDERS: dict[str, type[LLMProvider]] = {
     "anthropic": AnthropicProvider,
+    "ollama": OllamaProvider,
     "openai": OpenAIProvider,
 }
 
@@ -624,8 +640,8 @@ def get_provider(name: str, client: Any) -> LLMProvider:
     """Create a provider instance wrapping the given client.
 
     Args:
-        name: Provider name ("anthropic" or "openai")
-        client: The SDK client (anthropic.Anthropic or openai.OpenAI)
+        name: Provider name ("anthropic", "ollama", or "openai")
+        client: The provider SDK client
 
     Returns:
         LLMProvider instance

--- a/brain/platform/integrations/transports/base.py
+++ b/brain/platform/integrations/transports/base.py
@@ -80,7 +80,14 @@ class LLMRequest:
     @property
     def normalized_model(self) -> str:
         """Strip provider prefixes for SDK calls."""
-        for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        for prefix in (
+            "anthropic/",
+            "ollama/",
+            "openai/",
+            "anthropic:",
+            "ollama:",
+            "openai:",
+        ):
             if self.model.startswith(prefix):
                 return self.model[len(prefix):]
         return self.model

--- a/brain/platform/model_catalog.py
+++ b/brain/platform/model_catalog.py
@@ -123,6 +123,23 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
         input_price_per_million=1.0,
         output_price_per_million=5.0,
     ),
+    ModelCatalogEntry(
+        id="ollama/qwen3.6-27b",
+        label="Qwen3.6 27B (local)",
+        provider="ollama",
+        description=(
+            "Free local lane on illo-dev's RTX 5090; zero marginal cost and unlimited "
+            "volume. Quality is well below Luna; use only for high-volume, low-stakes "
+            "single-shot work such as heartbeat-class probes, classification, and "
+            "summarization. Never use it for judgment, review, or long context."
+        ),
+        supported_effort_tiers=_NO_NATIVE_EFFORT,
+        availability_fallback="openai/gpt-5.6-luna",
+        context_window_tokens=32_768,
+        input_price_per_million=0.0,
+        output_price_per_million=0.0,
+        provider_default=True,
+    ),
 )
 
 MODEL_CATALOG_BY_ID = {entry.id: entry for entry in MODEL_CATALOG}

--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -321,10 +321,14 @@ def infer_provider_from_model(model: str | None, default: str | None = None) -> 
             return "anthropic"
         if value.startswith("openai:"):
             return "openai"
+        if value.startswith("ollama:"):
+            return "ollama"
         if value.startswith("anthropic/"):
             return "anthropic"
         if value.startswith("openai/"):
             return "openai"
+        if value.startswith("ollama/"):
+            return "ollama"
         if lowered.startswith("claude-"):
             return "anthropic"
         if lowered.startswith(("gpt-", "o1", "o3", "o4")):
@@ -484,7 +488,7 @@ def normalize_model_name(model: str | None) -> str:
     if catalog_id:
         return catalog_id
     explicitly_prefixed = value.replace(":", "/", 1)
-    if explicitly_prefixed.startswith(("anthropic/", "openai/")):
+    if explicitly_prefixed.startswith(("anthropic/", "ollama/", "openai/")):
         return explicitly_prefixed
 
     if lower.startswith("claude-"):

--- a/brain/systems/context/budget.py
+++ b/brain/systems/context/budget.py
@@ -77,7 +77,14 @@ def _env_int(name: str, default: int) -> int:
 
 def _strip_provider_prefix(model: str | None) -> str:
     value = str(model or "").strip()
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if value.startswith(prefix):
             return value[len(prefix):]
     return value

--- a/brain/systems/cortex/title_generation.py
+++ b/brain/systems/cortex/title_generation.py
@@ -69,7 +69,14 @@ def normalize_generated_title(title: str | None) -> str | None:
 
 def _strip_provider_prefix(model: str | None) -> str:
     value = (model or "").strip()
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if value.startswith(prefix):
             return value[len(prefix):]
     return value
@@ -88,12 +95,14 @@ def is_local_title_model(model: str | None) -> bool:
 
 def _provider_model_spec(provider: str, model: str) -> str:
     value = (model or "").strip()
-    if value.startswith(("anthropic/", "openai/")):
+    if value.startswith(("anthropic/", "ollama/", "openai/")):
         return value
     if value.startswith("anthropic:"):
         return f"anthropic/{value[len('anthropic:'):]}"
     if value.startswith("openai:"):
         return f"openai/{value[len('openai:'):]}"
+    if value.startswith("ollama:"):
+        return f"ollama/{value[len('ollama:'):]}"
     return f"{provider}/{value}"
 
 

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -204,7 +204,14 @@ from brain.systems.sessions.harvest import (  # noqa: F401
 
 def _normalize_model(model: str) -> str:
     """Strip provider prefix before passing a model name to the provider SDK."""
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if model.startswith(prefix):
             return model[len(prefix):]
     return model
@@ -1748,11 +1755,22 @@ async def run_agent_async(
                     if (
                         not model_fallback_used
                         and fallback
-                        and is_model_unavailable_error(exc)
+                        and is_model_unavailable_error(exc, model=model)
                     ):
                         preferred_model = model
+                        preferred_provider = infer_provider_from_model(preferred_model)
+                        fallback_provider = infer_provider_from_model(fallback)
                         model = _normalize_model(fallback)
                         model_fallback_used = True
+                        if preferred_provider != fallback_provider:
+                            llm, state.provider, _runtime_extra_headers = await _init_llm_async(
+                                effective_user_id,
+                                session_id,
+                                model,
+                                org_id=effective_org_id,
+                                resolved_llm=None,
+                            )
+                            state.provider_name = llm.provider
                         effective_routing = effective_routing_snapshot(
                             model,
                             thinking,

--- a/brain/systems/runs/direct_loop/model_fallback.py
+++ b/brain/systems/runs/direct_loop/model_fallback.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from brain.platform.model_catalog import availability_fallback_for
+from brain.platform.model_catalog import (
+    availability_fallback_for,
+    canonical_catalog_model_id,
+)
+from brain.platform.providers.model_policy import infer_provider_from_model
 
 _UNAVAILABLE_TERMS = (
     "model_not_found",
@@ -18,10 +22,19 @@ _UNAVAILABLE_TERMS = (
     "not available on this account",
     "do not have access to the model",
 )
+_CONNECTION_ERROR_CLASS_NAMES = frozenset({"APIConnectionError", "ConnectError"})
+_CONNECTION_ERROR_TERMS = (
+    "connection refused",
+    "connection error",
+    "timed out",
+)
 
 
 def _canonical_model(model: str | None) -> str:
     value = str(model or "").strip().lower().replace(":", "/", 1)
+    catalog_id = canonical_catalog_model_id(value)
+    if catalog_id:
+        return catalog_id
     return value if "/" in value else f"openai/{value}"
 
 
@@ -59,12 +72,34 @@ def _status_code(exc: Any) -> int | None:
         return None
 
 
-def is_model_unavailable_error(exc: Any) -> bool:
-    """Classify entitlement/model-catalog failures without hiding auth errors."""
-    if _status_code(exc) not in {400, 403, 404}:
-        return False
+def _is_connection_level_error(exc: Any) -> bool:
+    current = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if current.__class__.__name__ in _CONNECTION_ERROR_CLASS_NAMES:
+            return True
+        current = getattr(current, "__cause__", None) or getattr(
+            current,
+            "__context__",
+            None,
+        )
     text = _error_text(exc)
-    return any(term in text for term in _UNAVAILABLE_TERMS)
+    return any(term in text for term in _CONNECTION_ERROR_TERMS)
+
+
+def is_model_unavailable_error(exc: Any, *, model: str | None = None) -> bool:
+    """Classify model failures and Ollama-only connection unavailability."""
+    status_code = _status_code(exc)
+    if status_code in {400, 403, 404}:
+        text = _error_text(exc)
+        return any(term in text for term in _UNAVAILABLE_TERMS)
+    if status_code is not None or not model:
+        return False
+    return (
+        infer_provider_from_model(model) == "ollama"
+        and _is_connection_level_error(exc)
+    )
 
 
 def is_missing_required_model_auth(exc: Any) -> bool:

--- a/brain/systems/runs/direct_loop/request.py
+++ b/brain/systems/runs/direct_loop/request.py
@@ -18,7 +18,14 @@ _PROMPT_CACHE_KEY_PREFIX = "illo"
 def strip_provider_prefix(model: str) -> str:
     """Strip provider prefixes before passing model names to provider SDKs."""
 
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if model.startswith(prefix):
             return model[len(prefix):]
     return model

--- a/brain/systems/runs/routing_metadata.py
+++ b/brain/systems/runs/routing_metadata.py
@@ -26,7 +26,14 @@ def effective_routing_snapshot(
         provider or infer_provider_from_model(model)
     ).strip().lower()
     model_name = str(model or "").strip()
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+    for prefix in (
+        "anthropic/",
+        "ollama/",
+        "openai/",
+        "anthropic:",
+        "ollama:",
+        "openai:",
+    ):
         if model_name.startswith(prefix):
             model_name = model_name[len(prefix):]
             break

--- a/brain/systems/runs/tool_catalog/definitions/workers.py
+++ b/brain/systems/runs/tool_catalog/definitions/workers.py
@@ -19,7 +19,10 @@ WORKER_SPAWN_TOOLS = [
             "(xhigh judgment, high standard). Bulk/mechanical/single-shot/small-context execution: "
             "openai/gpt-5.6-luna at xhigh. Luna caveats: quality collapses above ~200K context; "
             "xhigh pays a long first-token pause per turn — never use Luna xhigh for many-short-turn "
-            "loops. Reserve non-OpenAI models for a cross-provider verifier."
+            "loops. Reserve non-OpenAI models for a cross-provider verifier. Free local lane: "
+            "`ollama/qwen3.6-27b` — zero cost, unlimited volume, ≤32k context, quality well below "
+            "Luna; use for heartbeat-class, high-volume, low-stakes single-shot work; never for "
+            "judgment or anything user-facing."
         ),
         "input_schema": {
             "type": "object",

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -38,7 +38,7 @@ from brain.systems.runs.status_questions import (
 )
 from brain.systems.runs.store import AsyncAgentRunStore
 
-_VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
+_VALID_MODEL_PROVIDERS = {"anthropic", "ollama", "openai"}
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
 THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -35,7 +35,7 @@ class RuntimeModelDefaultProvenance(BaseModel):
 class RuntimeModelCatalogEntry(BaseModel):
     id: str
     label: str
-    provider: Literal["openai", "anthropic"]
+    provider: Literal["openai", "anthropic", "ollama"]
     description: str
     supported_effort_tiers: list[Literal["none", "low", "medium", "high", "xhigh"]]
     auth_requirement: Literal["chatgpt", "api_key"]

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -269,7 +269,10 @@ or resources as another active slice.
   `openai/gpt-5.6-luna` at `xhigh`. Luna caveats: quality collapses above ~200K
   context; `xhigh` pays a long first-token pause per turn — never use Luna
   `xhigh` for many-short-turn loops. Reserve non-OpenAI models for a
-  cross-provider verifier.
+  cross-provider verifier. Free local lane: `ollama/qwen3.6-27b` — zero cost,
+  unlimited volume, ≤32k context, quality well below Luna; use for
+  heartbeat-class, high-volume, low-stakes single-shot work; never for judgment
+  or anything user-facing.
 - Set `headless=true` when the child needs no user input or visible thread
   updates. Headless children use a hidden thread and have visible reply tools
   disabled.

--- a/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
@@ -62,7 +62,10 @@ or resources as another active slice.
   `openai/gpt-5.6-luna` at `xhigh`. Luna caveats: quality collapses above ~200K
   context; `xhigh` pays a long first-token pause per turn — never use Luna
   `xhigh` for many-short-turn loops. Reserve non-OpenAI models for a
-  cross-provider verifier.
+  cross-provider verifier. Free local lane: `ollama/qwen3.6-27b` — zero cost,
+  unlimited volume, ≤32k context, quality well below Luna; use for
+  heartbeat-class, high-volume, low-stakes single-shot work; never for judgment
+  or anything user-facing.
 - Set `headless=true` when the child needs no user input or visible thread
   updates. Headless children use a hidden thread and have visible reply tools
   disabled.

--- a/frontend/src/lib/types/runtimeSettings.ts
+++ b/frontend/src/lib/types/runtimeSettings.ts
@@ -15,7 +15,7 @@ export interface RuntimeOption {
 export interface RuntimeModelCatalogEntry {
   id: string;
   label: string;
-  provider: 'openai' | 'anthropic';
+  provider: 'openai' | 'anthropic' | 'ollama';
   description: string;
   supported_effort_tiers: RuntimeThinking[];
   auth_requirement: 'chatgpt' | 'api_key';

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -70,6 +70,11 @@ class TestModelNormalization:
         from brain.systems.runs.direct_agent import _normalize_model
         assert _normalize_model("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
 
+    def test_strips_ollama_prefix(self):
+        from brain.systems.runs.direct_agent import _normalize_model
+
+        assert _normalize_model("ollama/qwen3.6-27b") == "qwen3.6-27b"
+
 
 class TestProviderInference:
     def test_direct_agent_requires_chatgpt_auth_for_subscription_models(self):
@@ -97,10 +102,54 @@ class TestProviderInference:
 
         assert fallback_model_for("openai/gpt-5.6-sol") == "openai/gpt-5.5"
         assert fallback_model_for("openai/gpt-5.6") == "openai/gpt-5.5"
+        assert fallback_model_for("qwen3.6-27b") == "openai/gpt-5.6-luna"
         assert fallback_model_for("gpt-5.5") is None
         assert is_model_unavailable_error(unsupported) is True
         assert is_model_unavailable_error(missing) is True
         assert is_model_unavailable_error(expired) is False
+
+    def test_ollama_connection_error_is_model_unavailable(self):
+        import httpx
+
+        from brain.systems.runs.direct_loop.model_fallback import (
+            is_model_unavailable_error,
+        )
+
+        error = httpx.ConnectError("Connection refused")
+
+        assert is_model_unavailable_error(
+            error,
+            model="ollama/qwen3.6-27b",
+        ) is True
+
+    def test_openai_connection_error_is_not_model_unavailable(self):
+        import httpx
+
+        from brain.systems.runs.direct_loop.model_fallback import (
+            is_model_unavailable_error,
+        )
+
+        error = httpx.ConnectError("Connection refused")
+
+        assert is_model_unavailable_error(
+            error,
+            model="openai/gpt-5.6-sol",
+        ) is False
+
+    def test_ollama_model_not_found_is_model_unavailable(self):
+        from brain.systems.runs.direct_loop.model_fallback import (
+            is_model_unavailable_error,
+        )
+
+        error = SimpleNamespace(
+            status_code=404,
+            body={"error": {"code": "model_not_found"}},
+        )
+
+        assert is_model_unavailable_error(
+            error,
+            model="ollama/qwen3.6-27b",
+        ) is True
 
     @patch("brain.systems.runs.direct_loop.final_reply_checker.get_provider")
     @patch("brain.systems.runs.direct_loop.final_reply_checker.resolve_llm_client")
@@ -231,6 +280,117 @@ async def test_agent_retries_gpt_5_6_on_gpt_5_5_when_account_lacks_entitlement(m
     assert result.effective_routing == {
         "model": "openai/gpt-5.5",
         "effort": "xhigh",
+        "provider": "openai",
+        "auth_mode": "chatgpt",
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_reresolves_client_for_ollama_to_luna_fallback(monkeypatch):
+    import httpx
+
+    from brain.platform.integrations.providers import LLMResponse, TextContentBlock, Usage
+    from brain.systems.runs.direct_agent import run_agent_async
+
+    ollama_llm = _mock_llm_client(MagicMock(), provider="ollama")
+    ollama_llm.auth_mode = None
+    luna_llm = _mock_llm_client(MagicMock(), provider="openai")
+    luna_llm.auth_mode = "chatgpt"
+    luna_llm.is_oauth = True
+    ollama_provider = MagicMock(name="ollama_provider")
+    openai_provider = MagicMock(name="openai_provider")
+    init_llm = AsyncMock(
+        side_effect=[
+            (ollama_llm, ollama_provider, {}),
+            (luna_llm, openai_provider, {"session_id": "luna-session"}),
+        ]
+    )
+    checkpoint_compactor = MagicMock(side_effect=[MagicMock(), MagicMock()])
+    thread_handoff_compactor = MagicMock(side_effect=[MagicMock(), MagicMock()])
+    calls = []
+
+    async def fake_api_call(provider, request, active_llm, *_args, **_kwargs):
+        calls.append((provider, request, active_llm))
+        if len(calls) == 1:
+            raise httpx.ConnectError("Connection refused")
+        return LLMResponse(
+            content=[TextContentBlock("Luna fallback succeeded")],
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=3, output_tokens=2),
+            model="gpt-5.6-luna",
+        )
+
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._init_llm_async",
+        init_llm,
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._api_call_with_retry_async",
+        fake_api_call,
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._llm_context_checkpoint_compactor",
+        checkpoint_compactor,
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._llm_thread_handoff_compactor",
+        thread_handoff_compactor,
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._async_record_api_call",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
+        AsyncMock(),
+    )
+
+    result = await run_agent_async(
+        "Test local provider fallback",
+        session_id="ollama-fallback-session",
+        model="ollama/qwen3.6-27b",
+        thinking="none",
+        tools=[],
+        tool_handlers={},
+        persist_session=False,
+        skip_harvest=True,
+        user_id="user-1",
+        org_id="org-1",
+    )
+
+    assert result.success is True
+    assert result.output == "Luna fallback succeeded"
+    assert [request.model for _, request, _ in calls] == [
+        "qwen3.6-27b",
+        "gpt-5.6-luna",
+    ]
+    assert calls[0][0] is ollama_provider
+    assert calls[0][2] is ollama_llm
+    assert calls[1][0] is openai_provider
+    assert calls[1][2] is luna_llm
+    assert calls[1][1].extra_headers == {"session_id": "luna-session"}
+    assert init_llm.await_count == 2
+    assert init_llm.await_args_list[1].args[:3] == (
+        "user-1",
+        "ollama-fallback-session",
+        "gpt-5.6-luna",
+    )
+    assert init_llm.await_args_list[1].kwargs == {
+        "org_id": "org-1",
+        "resolved_llm": None,
+    }
+    for factory in (checkpoint_compactor, thread_handoff_compactor):
+        assert factory.call_count == 2
+        assert factory.call_args_list[1].kwargs == {
+            "provider": openai_provider,
+            "llm": luna_llm,
+            "model": "gpt-5.6-luna",
+            "provider_name": "openai",
+            "session_id": "ollama-fallback-session",
+        }
+    assert result.effective_routing == {
+        "model": "openai/gpt-5.6-luna",
+        "effort": "none",
         "provider": "openai",
         "auth_mode": "chatgpt",
     }

--- a/tests/test_agent_auth_fallback.py
+++ b/tests/test_agent_auth_fallback.py
@@ -109,6 +109,73 @@ def test_resolve_llm_client_raises_when_no_key():
             resolve_llm_client(user_id="user-1", provider="anthropic")
 
 
+def test_resolve_ollama_client_uses_safe_default_without_provider_auth(monkeypatch):
+    from brain.platform.integrations.llm import resolve_llm_client
+
+    mock_openai = MagicMock()
+    mock_openai.OpenAI.return_value = MagicMock()
+    monkeypatch.delenv("ILLO_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("ILLO_LLM_TIMEOUT_SECONDS", raising=False)
+
+    with patch(
+        "brain.platform.integrations.llm._import_openai_sdk",
+        return_value=mock_openai,
+    ):
+        result = resolve_llm_client(user_id="user-1", provider="ollama")
+
+    assert result.provider == "ollama"
+    assert result.source == "ollama_local"
+    assert result.auth_mode is None
+    assert mock_openai.OpenAI.call_args.kwargs == {
+        "base_url": "http://172.17.0.1:11434/v1",
+        "api_key": "ollama",
+        "timeout": 240.0,
+    }
+
+
+def test_resolve_ollama_client_treats_empty_base_url_as_unset(monkeypatch):
+    from brain.platform.integrations.llm import resolve_llm_client
+
+    mock_openai = MagicMock()
+    mock_openai.OpenAI.return_value = MagicMock()
+    monkeypatch.setenv("ILLO_OLLAMA_BASE_URL", "  ")
+
+    with patch(
+        "brain.platform.integrations.llm._import_openai_sdk",
+        return_value=mock_openai,
+    ):
+        resolve_llm_client(provider="ollama")
+
+    assert mock_openai.OpenAI.call_args.kwargs["base_url"] == (
+        "http://172.17.0.1:11434/v1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_ollama_client_uses_configured_base_url(monkeypatch):
+    from brain.platform.integrations.llm import async_resolve_llm_client
+
+    mock_openai = MagicMock()
+    mock_openai.OpenAI.return_value = MagicMock()
+    monkeypatch.setenv("ILLO_OLLAMA_BASE_URL", "http://ollama.test:11434/v1")
+
+    with patch(
+        "brain.platform.integrations.llm._import_openai_sdk",
+        return_value=mock_openai,
+    ):
+        result = await async_resolve_llm_client(
+            user_id="user-1",
+            provider="ollama",
+            session=object(),
+        )
+
+    assert result.provider == "ollama"
+    assert mock_openai.OpenAI.call_args.kwargs["base_url"] == (
+        "http://ollama.test:11434/v1"
+    )
+    assert mock_openai.OpenAI.call_args.kwargs["api_key"] == "ollama"
+
+
 def test_resolve_llm_client_detects_oauth_token():
     """Setup tokens (sk-ant-oat*) are detected and get OAuth headers."""
     from brain.platform.integrations.llm import resolve_llm_client

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1919,6 +1919,69 @@ async def test_spawn_worker_coerces_inherited_api_key_model(monkeypatch):
     assert payload["routing"]["auth_mode"] == "chatgpt"
 
 
+async def test_spawn_worker_admits_ollama_model_without_coercion(monkeypatch):
+    payload, captured, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "high",
+        },
+        model="ollama/qwen3.6-27b",
+        effort="none",
+    )
+
+    assert captured["model_policy"] == {
+        "model": "ollama/qwen3.6-27b",
+        "thinking": "none",
+    }
+    assert captured["preflight"]["model"] == "ollama/qwen3.6-27b"
+    assert captured["metadata"]["routing"]["requested"]["model"] == {
+        "value": "ollama/qwen3.6-27b",
+        "source": "spawn_worker.model",
+    }
+    assert payload["model"] == "ollama/qwen3.6-27b"
+    assert payload["routing"] == {
+        "model": "ollama/qwen3.6-27b",
+        "effort": "none",
+        "provider": "ollama",
+        "auth_mode": None,
+    }
+
+
+async def test_spawn_worker_ollama_auth_preflight_is_skipped(monkeypatch):
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthSkippedPreflightResult,
+    )
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    async def unexpected_probe(*_args, **_kwargs):
+        raise AssertionError("Ollama must not enter stored-credential auth probing")
+
+    monkeypatch.setattr(
+        worker_handlers,
+        "async_probe_provider_auth",
+        unexpected_probe,
+    )
+
+    result = await worker_handlers._preflight_spawn_worker_auth(
+        object(),
+        user_id="user-1",
+        org_id="org-1",
+        model="ollama/qwen3.6-27b",
+    )
+
+    assert isinstance(result, ProviderAuthSkippedPreflightResult)
+    assert result.to_dict() == {
+        "status": "skipped",
+        "provider": "ollama",
+        "model": "ollama/qwen3.6-27b",
+        "credential": None,
+        "error_code": None,
+        "repair_action": None,
+        "visible_message": None,
+    }
+
+
 async def test_spawn_worker_without_overrides_materializes_parent_effective_defaults(monkeypatch):
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
@@ -2233,6 +2296,10 @@ async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatc
         (
             {"model": "anthropic/not-a-real-model"},
             "model for provider 'anthropic' must be one of",
+        ),
+        (
+            {"model": "ollama/not-a-real-model"},
+            "model for provider 'ollama' must be one of",
         ),
         (
             {"model": "openai/gpt-4.1"},

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -139,6 +139,22 @@ class TestGetCosts:
         assert models["openai/gpt-5.6-sol"]["runs"] == 3
 
     @patch("brain.app.api.routers.costs.async_summarize_recent_run_usage")
+    def test_by_model_preserves_ollama_provider(self, mock_usage, client):
+        mock_usage.return_value = [
+            _fake_run(
+                id=1,
+                model_used="ollama/qwen3.6-27b",
+                estimated_cost=0.0,
+            ),
+        ]
+
+        result = client.get("/api/costs/")
+        models = {item["model"]: item for item in result.json()["by_model"]}
+
+        assert models["ollama/qwen3.6-27b"]["provider"] == "ollama"
+        assert models["ollama/qwen3.6-27b"]["normalized_model"] == "qwen3.6-27b"
+
+    @patch("brain.app.api.routers.costs.async_summarize_recent_run_usage")
     def test_by_skill_groups(self, mock_usage, client):
         runs = [
             _fake_run(id=1, skill_used="develop", estimated_cost=0.10),

--- a/tests/test_effort_rendering.py
+++ b/tests/test_effort_rendering.py
@@ -24,6 +24,14 @@ def test_anthropic_ceiling_renders_to_max():
     assert render_reasoning_effort("anthropic", "high") == "high"
 
 
+def test_ollama_omits_native_effort_for_every_tier():
+    assert set(PROVIDER_EFFORT_RENDERINGS["ollama"]) == EFFORT_TIER_SET
+    assert all(
+        value is None
+        for value in PROVIDER_EFFORT_RENDERINGS["ollama"].values()
+    )
+
+
 @pytest.mark.parametrize("provider", ["openai", "anthropic", "unknown-provider"])
 @pytest.mark.parametrize("tier", ["none", "", None, "  NONE  "])
 def test_none_and_empty_always_omit_reasoning(provider, tier):

--- a/tests/test_effort_vocabulary.py
+++ b/tests/test_effort_vocabulary.py
@@ -46,3 +46,11 @@ def test_spawn_worker_description_teaches_routing_patterns():
     assert "~200k context" in description
     assert "many-short-turn loops" in description
     assert "cross-provider verifier" in description
+    assert "ollama/qwen3.6-27b" in description
+    assert "zero cost" in description
+    assert "unlimited volume" in description
+    assert "≤32k context" in description
+    assert "quality well below luna" in description
+    assert "heartbeat-class" in description
+    assert "never for judgment" in description
+    assert "anything user-facing" in description

--- a/tests/test_model_catalog_contract.py
+++ b/tests/test_model_catalog_contract.py
@@ -42,10 +42,12 @@ def test_composer_consumes_runtime_catalog_instead_of_owning_model_options():
     source = Path(
         "frontend/src/lib/features/composer/domain/runSettings.ts"
     ).read_text()
+    runtime_types = Path("frontend/src/lib/types/runtimeSettings.ts").read_text()
 
     assert "MODEL_OPTIONS" not in source
     assert "modelCatalog" in source
     assert "RuntimeModelCatalogEntry" in source
+    assert "'openai' | 'anthropic' | 'ollama'" in runtime_types
 
 
 def test_gpt_5_6_sol_uses_provider_context_contract(monkeypatch):
@@ -89,3 +91,24 @@ def test_gpt_5_6_luna_uses_subscription_catalog_contract():
     assert entry.input_price_per_million == 0.20
     assert entry.output_price_per_million == 1.20
     assert required_openai_auth_mode(entry.id) == "chatgpt"
+
+
+def test_ollama_qwen_uses_free_local_catalog_contract():
+    from brain.platform.model_catalog import get_model_catalog_entry
+    from brain.platform.providers.model_policy import get_model_catalog_contract
+    from brain.systems.runtime_settings.schemas import RuntimeModelCatalogEntry
+
+    entry = get_model_catalog_entry("ollama/qwen3.6-27b")
+    contract = {
+        item["id"]: item
+        for item in get_model_catalog_contract()
+    }["ollama/qwen3.6-27b"]
+
+    assert entry is not None
+    assert entry.input_price_per_million == 0.0
+    assert entry.output_price_per_million == 0.0
+    assert entry.availability_fallback == "openai/gpt-5.6-luna"
+    assert entry.context_window_tokens == 32_768
+    assert entry.supported_effort_tiers == ("none",)
+    assert contract["auth_requirement"] == "api_key"
+    assert RuntimeModelCatalogEntry.model_validate(contract).provider == "ollama"

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -94,6 +94,13 @@ class TestModelPolicy:
         assert infer_provider_from_model("openai:gpt-5.6-luna") == "openai"
         assert infer_provider_from_model("gpt-5.5") == "openai"
 
+    def test_infer_provider_recognizes_ollama_model(self):
+        from brain.platform.providers.model_policy import infer_provider_from_model
+
+        assert infer_provider_from_model("ollama/qwen3.6-27b") == "ollama"
+        assert infer_provider_from_model("ollama:qwen3.6-27b") == "ollama"
+        assert infer_provider_from_model("qwen3.6-27b") == "ollama"
+
     def test_infer_provider_recognizes_claude_family_names(self):
         from brain.platform.providers.model_policy import infer_provider_from_model
 
@@ -108,6 +115,17 @@ class TestModelPolicy:
         assert normalize_model_name("gpt-5.6-luna") == "openai/gpt-5.6-luna"
         assert normalize_model_name("gpt-5.6") == "openai/gpt-5.6-sol"
         assert normalize_model_name("gpt-5.5") == "openai/gpt-5.5"
+
+    def test_ollama_normalization_preserves_catalog_and_unknown_ids(self):
+        from brain.platform.providers.model_policy import normalize_model_name
+
+        assert normalize_model_name("ollama/qwen3.6-27b") == "ollama/qwen3.6-27b"
+        assert normalize_model_name("ollama/not-a-real-model") == "ollama/not-a-real-model"
+
+    def test_ollama_is_not_an_implicit_default_provider(self):
+        from brain.platform.providers.model_policy import normalize_default_provider
+
+        assert normalize_default_provider("ollama") == "openai"
 
     def test_cost_uses_native_pricing_for_default_openai_models(self):
         from brain.platform.providers.model_policy import calculate_model_cost
@@ -202,6 +220,10 @@ class TestModelPolicy:
         assert catalogs["openai"]["default"] == "gpt-5.6-sol"
         assert "gpt-5.5" in catalogs["openai"]["options"]
         assert catalogs["anthropic"]["default"] == "claude-sonnet-5"
+        assert catalogs["ollama"] == {
+            "default": "qwen3.6-27b",
+            "options": ["qwen3.6-27b"],
+        }
 
     def test_model_catalog_contract_is_provider_aware_and_pruned(self):
         from brain.platform.providers.model_policy import get_model_catalog_contract
@@ -232,6 +254,8 @@ class TestModelPolicy:
         assert by_id["anthropic/claude-haiku-4-5"]["supported_effort_tiers"] == [
             "none"
         ]
+        assert by_id["ollama/qwen3.6-27b"]["auth_requirement"] == "api_key"
+        assert by_id["ollama/qwen3.6-27b"]["supported_effort_tiers"] == ["none"]
         assert not {
             "openai/o3-mini",
             "openai/gpt-4o",

--- a/tests/test_openai_auth_mode.py
+++ b/tests/test_openai_auth_mode.py
@@ -23,7 +23,14 @@ def test_subscription_only_models_require_chatgpt_auth(model):
 
 @pytest.mark.parametrize(
     "model",
-    ["gpt-4.1", "openai/gpt-4.1-mini", "anthropic/claude-sonnet-4-6", "", None],
+    [
+        "gpt-4.1",
+        "openai/gpt-4.1-mini",
+        "anthropic/claude-sonnet-4-6",
+        "ollama/qwen3.6-27b",
+        "",
+        None,
+    ],
 )
 def test_other_models_do_not_pin_an_auth_mode(model):
     assert required_openai_auth_mode(model) is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from brain.platform.integrations.openai_codex_client import OpenAICodexError, OpenAICodexRetryableError
 from brain.platform.integrations.providers import (
     AnthropicProvider,
+    OllamaProvider,
     OpenAIProvider,
     ContentBlock,
     LLMRequest,
@@ -252,6 +253,23 @@ class TestProviderRegistry:
         client = MagicMock()
         p = get_provider("openai", client)
         assert isinstance(p, OpenAIProvider)
+
+    def test_get_ollama_provider_maps_catalog_id_to_runtime_tag(self):
+        client = MagicMock()
+        provider = get_provider("ollama", client)
+        request = LLMRequest(
+            model="ollama/qwen3.6-27b",
+            messages=[{"role": "user", "content": "classify this"}],
+            reasoning_effort="xhigh",
+        )
+
+        kwargs = provider._translate_request(request)
+
+        assert isinstance(provider, OllamaProvider)
+        assert kwargs["model"] == "qwen3.6:27b"
+        assert "store" not in kwargs
+        assert "reasoning" not in kwargs
+        assert "include" not in kwargs
 
     def test_unknown_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider"):

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -490,6 +490,22 @@ def test_invalid_high_priority_metadata_warns_before_valid_fallback(caplog):
     ) in caplog.messages
 
 
+def test_model_policy_metadata_accepts_explicit_ollama_route():
+    from brain.systems.runs.work_intake import model_policy_from_metadata
+
+    assert model_policy_from_metadata(
+        {
+            "model": "ollama/qwen3.6-27b",
+            "provider": "ollama",
+            "effort": "none",
+        }
+    ) == {
+        "model": "ollama/qwen3.6-27b",
+        "provider": "ollama",
+        "thinking": "none",
+    }
+
+
 def test_deep_profile_metadata_is_coerced_to_fast_with_structured_source_log(caplog):
     from brain.systems.runs.domain import RunProfile
     from brain.systems.runs.work_intake import profile_from_metadata


### PR DESCRIPTION
## What

Adds a third routing lane next to the Sol reasoning lane and the Luna bulk lane: **`ollama/qwen3.6-27b`**, served by Ollama on the illo-dev host's RTX 5090.

The lane costs nothing to run, so it suits high-volume, low-stakes, single-shot work — heartbeat-class probes, classification, summarization. Its quality sits well below Luna, so the doctrine forbids it for judgment, review, and long context.

## Where it sits

| lane | model | intelligence | marginal cost |
|---|---|---|---|
| judgment | `openai/gpt-5.6-sol` | 59 | Codex subscription window |
| bulk | `openai/gpt-5.6-luna` | 51 | Codex subscription window |
| **free local** | **`ollama/qwen3.6-27b`** | **~38** | **$0, unlimited** |

Intelligence numbers come from Artificial Analysis. Sol and Luna use index v4.0 and Qwen uses v4.1, so the values are not directly comparable, but the ordering holds.

## How it works

- The catalog entry carries $0.00 per million tokens, a 32k context window, no native effort tiers, and an availability fallback to `openai/gpt-5.6-luna`.
- A thin `OllamaProvider` reuses the OpenAI Responses transport, drops the `store` field, and maps the catalog id to Ollama's runtime tag `qwen3.6:27b`.
- The client reads `ILLO_OLLAMA_BASE_URL` and defaults to `http://172.17.0.1:11434/v1`. No deploy or compose change is needed.
- The admission guard is untouched. It already ignores non-OpenAI providers, and a test pins that `ollama/qwen3.6-27b` passes `spawn_worker` admission without coercion. Unknown `ollama/*` ids still fail catalog membership like any other model.

Which work uses the lane stays runtime policy, not code: a cycle sets `model_override`, so Illo can route its own heartbeat-class work here without a deploy.

## Two fallback defects found in review and fixed here

1. **A dead host never fell back.** Ollama being down raises a connection-level error with no HTTP status, which the unavailability classifier never matched, so the run failed instead of falling back to Luna. The classifier now treats connection errors as unavailability **for Ollama models only**; OpenAI and Anthropic keep their existing retry behaviour.
2. **The fallback reused the wrong client.** The in-loop fallback swapped the model name but kept the same client, so Luna requests would have gone to the Ollama URL with no Codex auth. The loop now re-resolves the client whenever the fallback crosses providers.

## Verification

- Full test suite: **4826 passed, 98 skipped**.
- New tests cover the catalog contract, effort rendering across every tier, provider tag mapping, client base-url resolution, `spawn_worker` admission, the connection-error classifier in both directions, and the cross-provider client re-resolve.
- The runtime host is live and reachable from the worker containers: Ollama 0.17.5, `qwen3.6:27b` at ~60 tok/s fully on GPU.

One cosmetic note: the runtime settings contract reports `auth_requirement: "api_key"` for this entry because the schema has no "none" value. Ollama ignores the key. The field is display-only and does not affect routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)