### PR TITLE
feat(runs): reclaim orphaned headless-worker workspaces (#750)

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -197,6 +197,32 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "misfire_policy": "skip",
     },
     {
+        "job_key": "workspace_gc",
+        "family": "workspace_gc",
+        "program_key": "workspace_gc",
+        "handler_kind": CATALOG_HANDLER_KIND,
+        "handler_ref": "brain.app.scheduler.programs:workspace_gc",
+        "cron_expr": "47 * * * *",
+        "timezone": "UTC",
+        "default_payload": {
+            "name": "Workspace GC",
+            "description": "Reclaim old workspaces left by finished headless workers",
+        },
+        "task_contract": {
+            "memory_scope": {"visibility": "system"},
+            "allowed_actions": ["scheduler.run"],
+            "output_channel": "scheduler",
+            "success_criteria": [
+                "Old headless-worker workspaces are reclaimed only after parent runs finish"
+            ],
+        },
+        "priority": 70,
+        "max_concurrency": 1,
+        "timeout_seconds": 3600,
+        "retry_policy": {"max_attempts": 2, "backoff_seconds": 300},
+        "misfire_policy": "skip",
+    },
+    {
         "job_key": "cortex_canvas_occupancy",
         "family": "cortex_canvas_occupancy",
         "program_key": "cortex_canvas_occupancy",

--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -213,7 +213,8 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
             "allowed_actions": ["scheduler.run"],
             "output_channel": "scheduler",
             "success_criteria": [
-                "Old headless-worker workspaces are reclaimed only after parent runs finish"
+                "Headless-worker workspaces older than 48 hours are reclaimed only when "
+                "the parent run is terminal or absent from the database"
             ],
         },
         "priority": 70,

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -96,7 +96,10 @@ SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
     "workspace_gc": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.workspace_gc"),
         step_key="workspace_gc",
-        description="Reclaim old headless-worker workspaces after parent runs finish",
+        description=(
+            "Reclaim headless-worker workspaces older than 48 hours when parent runs are "
+            "terminal or absent from the database"
+        ),
     ),
     "cortex_canvas_occupancy": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.cortex_occupancy"),

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -93,6 +93,11 @@ class SingleCommandProgram:
 
 # Programs whose plan and StepSpec projections share one representation.
 SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
+    "workspace_gc": SingleCommandProgram(
+        command=("python3", "-m", "brain.jobs.pipelines.workspace_gc"),
+        step_key="workspace_gc",
+        description="Reclaim old headless-worker workspaces after parent runs finish",
+    ),
     "cortex_canvas_occupancy": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.cortex_occupancy"),
         step_key="cortex_canvas_occupancy",

--- a/brain/jobs/pipelines/workspace_gc.py
+++ b/brain/jobs/pipelines/workspace_gc.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal, NamedTuple, TypedDict
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,7 +31,17 @@ HEADLESS_WORKER_PREFIX = "headless-worker-"
 HEADLESS_WORKER_WORKSPACE_RETENTION = timedelta(hours=48)
 
 
-def _empty_result() -> dict[str, int]:
+class WorkspaceGCResult(TypedDict):
+    directories_scanned: int
+    directories_reclaimed: int
+    bytes_reclaimed: int
+    directories_recent: int
+    directories_non_terminal: int
+    directories_refused: int
+    errors: int
+
+
+def _empty_result() -> WorkspaceGCResult:
     return {
         "directories_scanned": 0,
         "directories_reclaimed": 0,
@@ -54,12 +65,26 @@ def _parent_run_id(path: Path) -> int | None:
     return parsed if parsed > 0 else None
 
 
-def _path_is_safe_headless_worker_workspace(
+_ValidationCounter = Literal[
+    "directories_recent",
+    "directories_refused",
+    "errors",
+]
+
+
+class _WorkspaceValidation(NamedTuple):
+    parent_run_id: int | None
+    counter: _ValidationCounter | None
+    error: OSError | None = None
+
+
+def _validate_headless_worker_workspace(
     path: Path,
     *,
     workspace_root: Path,
-) -> bool:
-    """Accept only a real, direct child of the configured ideas directory."""
+    cutoff: datetime,
+) -> _WorkspaceValidation:
+    """Validate that a candidate is a safe, parseable, old workspace now."""
 
     try:
         root = workspace_root.expanduser().resolve(strict=True)
@@ -67,18 +92,31 @@ def _path_is_safe_headless_worker_workspace(
         if path.is_symlink() or not stat.S_ISDIR(
             path.stat(follow_symlinks=False).st_mode
         ):
-            return False
+            return _WorkspaceValidation(None, "directories_refused")
         resolved = path.resolve(strict=True)
-        return (
+        parent_run_id = _parent_run_id(path)
+        if not (
             ideas.is_relative_to(root)
             and ideas != root
             and path.parent.resolve(strict=True) == ideas
             and resolved.parent == ideas
             and resolved.is_relative_to(ideas)
-            and _parent_run_id(path) is not None
-        )
+            and parent_run_id is not None
+        ):
+            return _WorkspaceValidation(None, "directories_refused")
     except (OSError, RuntimeError):
-        return False
+        return _WorkspaceValidation(None, "directories_refused")
+
+    try:
+        modified_at = datetime.fromtimestamp(
+            path.stat(follow_symlinks=False).st_mtime,
+            tz=timezone.utc,
+        )
+    except OSError as exc:
+        return _WorkspaceValidation(None, "errors", exc)
+    if modified_at > cutoff:
+        return _WorkspaceValidation(parent_run_id, "directories_recent")
+    return _WorkspaceValidation(parent_run_id, None)
 
 
 def _directory_size_bytes(path: Path) -> int:
@@ -120,7 +158,7 @@ async def reclaim_headless_worker_workspaces(
     workspace_root: Path,
     now: datetime | None = None,
     retention: timedelta = HEADLESS_WORKER_WORKSPACE_RETENTION,
-) -> dict[str, int]:
+) -> WorkspaceGCResult:
     """Delete old worker workspaces whose parent run is terminal or absent."""
 
     result = _empty_result()
@@ -155,26 +193,20 @@ async def reclaim_headless_worker_workspaces(
         if not path.name.startswith(HEADLESS_WORKER_PREFIX):
             continue
         result["directories_scanned"] += 1
-        parent_run_id = _parent_run_id(path)
-        if parent_run_id is None or not _path_is_safe_headless_worker_workspace(
+        validation = _validate_headless_worker_workspace(
             path,
             workspace_root=workspace_root,
-        ):
-            result["directories_refused"] += 1
-            log.warning("Workspace GC refused unsafe candidate: %s", path)
+            cutoff=cutoff,
+        )
+        if validation.counter is not None:
+            result[validation.counter] += 1
+            if validation.counter == "directories_refused":
+                log.warning("Workspace GC refused unsafe candidate: %s", path)
+            elif validation.counter == "errors":
+                log.warning("Workspace GC could not stat %s: %s", path, validation.error)
             continue
-        try:
-            modified_at = datetime.fromtimestamp(
-                path.stat(follow_symlinks=False).st_mtime,
-                tz=timezone.utc,
-            )
-        except OSError as exc:
-            result["errors"] += 1
-            log.warning("Workspace GC could not stat %s: %s", path, exc)
-            continue
-        if modified_at > cutoff:
-            result["directories_recent"] += 1
-            continue
+        parent_run_id = validation.parent_run_id
+        assert parent_run_id is not None
         candidates.append((path, parent_run_id))
 
     statuses = await _parent_run_statuses(
@@ -190,19 +222,21 @@ async def reclaim_headless_worker_workspaces(
             continue
 
         try:
-            if not _path_is_safe_headless_worker_workspace(
+            validation = _validate_headless_worker_workspace(
                 path,
                 workspace_root=workspace_root,
-            ):
-                result["directories_refused"] += 1
-                log.warning("Workspace GC refused candidate before deletion: %s", path)
-                continue
-            modified_at = datetime.fromtimestamp(
-                path.stat(follow_symlinks=False).st_mtime,
-                tz=timezone.utc,
+                cutoff=cutoff,
             )
-            if modified_at > cutoff:
-                result["directories_recent"] += 1
+            if validation.counter is not None:
+                result[validation.counter] += 1
+                if validation.counter == "directories_refused":
+                    log.warning(
+                        "Workspace GC refused candidate before deletion: %s", path
+                    )
+                elif validation.counter == "errors":
+                    log.warning(
+                        "Workspace GC could not delete %s: %s", path, validation.error
+                    )
                 continue
             size = _directory_size_bytes(path)
             shutil.rmtree(path)
@@ -218,7 +252,7 @@ async def reclaim_headless_worker_workspaces(
     return result
 
 
-async def run() -> dict[str, int]:
+async def run() -> WorkspaceGCResult:
     async with UnitOfWork() as uow:
         return await reclaim_headless_worker_workspaces(
             uow.session,  # type: ignore[arg-type]

--- a/brain/jobs/pipelines/workspace_gc.py
+++ b/brain/jobs/pipelines/workspace_gc.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Reclaim retained headless-worker workspaces after their parent runs finish."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel import config as brain_config
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.status import (
+    TERMINAL_RUN_STATUSES,
+    coerce_run_status,
+    project_run_status_value,
+)
+
+log = logging.getLogger(__name__)
+
+HEADLESS_WORKER_PREFIX = "headless-worker-"
+HEADLESS_WORKER_WORKSPACE_RETENTION = timedelta(hours=48)
+
+
+def _empty_result() -> dict[str, int]:
+    return {
+        "directories_scanned": 0,
+        "directories_reclaimed": 0,
+        "bytes_reclaimed": 0,
+        "directories_recent": 0,
+        "directories_non_terminal": 0,
+        "directories_refused": 0,
+        "errors": 0,
+    }
+
+
+def _parent_run_id(path: Path) -> int | None:
+    if not path.name.startswith(HEADLESS_WORKER_PREFIX):
+        return None
+    parent_run_id, separator, digest = path.name.removeprefix(
+        HEADLESS_WORKER_PREFIX
+    ).partition("-")
+    if not separator or not parent_run_id.isdigit() or not digest:
+        return None
+    parsed = int(parent_run_id)
+    return parsed if parsed > 0 else None
+
+
+def _path_is_safe_headless_worker_workspace(
+    path: Path,
+    *,
+    workspace_root: Path,
+) -> bool:
+    """Accept only a real, direct child of the configured ideas directory."""
+
+    try:
+        root = workspace_root.expanduser().resolve(strict=True)
+        ideas = (workspace_root.expanduser() / "ideas").resolve(strict=True)
+        if path.is_symlink() or not stat.S_ISDIR(
+            path.stat(follow_symlinks=False).st_mode
+        ):
+            return False
+        resolved = path.resolve(strict=True)
+        return (
+            ideas.is_relative_to(root)
+            and ideas != root
+            and path.parent.resolve(strict=True) == ideas
+            and resolved.parent == ideas
+            and resolved.is_relative_to(ideas)
+            and _parent_run_id(path) is not None
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
+def _directory_size_bytes(path: Path) -> int:
+    """Return regular-file bytes without following links inside the workspace."""
+
+    total = 0
+    pending = [path]
+    while pending:
+        current = pending.pop()
+        with os.scandir(current) as entries:
+            for entry in entries:
+                entry_stat = entry.stat(follow_symlinks=False)
+                if stat.S_ISREG(entry_stat.st_mode):
+                    total += entry_stat.st_size
+                elif stat.S_ISDIR(entry_stat.st_mode):
+                    pending.append(Path(entry.path))
+    return total
+
+
+async def _parent_run_statuses(
+    session: AsyncSession,
+    parent_run_ids: set[int],
+) -> dict[int, str]:
+    if not parent_run_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(AgentRunRow.id, AgentRunRow.status).where(
+                AgentRunRow.id.in_(sorted(parent_run_ids))
+            )
+        )
+    ).all()
+    return {int(run_id): str(status) for run_id, status in rows}
+
+
+async def reclaim_headless_worker_workspaces(
+    session: AsyncSession,
+    *,
+    workspace_root: Path,
+    now: datetime | None = None,
+    retention: timedelta = HEADLESS_WORKER_WORKSPACE_RETENTION,
+) -> dict[str, int]:
+    """Delete old worker workspaces whose parent run is terminal or absent."""
+
+    result = _empty_result()
+    cutoff = now or datetime.now(timezone.utc)
+    cutoff = cutoff.astimezone(timezone.utc) - retention
+    ideas = workspace_root.expanduser() / "ideas"
+    if not ideas.exists():
+        log.info("Workspace GC complete: %s", result)
+        return result
+
+    try:
+        root = workspace_root.expanduser().resolve(strict=True)
+        resolved_ideas = ideas.resolve(strict=True)
+        if not resolved_ideas.is_relative_to(root) or resolved_ideas == root:
+            result["directories_refused"] += 1
+            log.error(
+                "Workspace GC refused unsafe ideas directory: root=%s ideas=%s",
+                root,
+                resolved_ideas,
+            )
+            log.info("Workspace GC complete: %s", result)
+            return result
+        entries = sorted(ideas.iterdir(), key=lambda entry: entry.name)
+    except (OSError, RuntimeError) as exc:
+        result["errors"] += 1
+        log.exception("Workspace GC could not inspect %s: %s", ideas, exc)
+        log.info("Workspace GC complete: %s", result)
+        return result
+
+    candidates: list[tuple[Path, int]] = []
+    for path in entries:
+        if not path.name.startswith(HEADLESS_WORKER_PREFIX):
+            continue
+        result["directories_scanned"] += 1
+        parent_run_id = _parent_run_id(path)
+        if parent_run_id is None or not _path_is_safe_headless_worker_workspace(
+            path,
+            workspace_root=workspace_root,
+        ):
+            result["directories_refused"] += 1
+            log.warning("Workspace GC refused unsafe candidate: %s", path)
+            continue
+        try:
+            modified_at = datetime.fromtimestamp(
+                path.stat(follow_symlinks=False).st_mtime,
+                tz=timezone.utc,
+            )
+        except OSError as exc:
+            result["errors"] += 1
+            log.warning("Workspace GC could not stat %s: %s", path, exc)
+            continue
+        if modified_at > cutoff:
+            result["directories_recent"] += 1
+            continue
+        candidates.append((path, parent_run_id))
+
+    statuses = await _parent_run_statuses(
+        session,
+        {parent_run_id for _, parent_run_id in candidates},
+    )
+    for path, parent_run_id in candidates:
+        status = statuses.get(parent_run_id)
+        if status is not None and coerce_run_status(
+            project_run_status_value(status)
+        ) not in TERMINAL_RUN_STATUSES:
+            result["directories_non_terminal"] += 1
+            continue
+
+        try:
+            if not _path_is_safe_headless_worker_workspace(
+                path,
+                workspace_root=workspace_root,
+            ):
+                result["directories_refused"] += 1
+                log.warning("Workspace GC refused candidate before deletion: %s", path)
+                continue
+            modified_at = datetime.fromtimestamp(
+                path.stat(follow_symlinks=False).st_mtime,
+                tz=timezone.utc,
+            )
+            if modified_at > cutoff:
+                result["directories_recent"] += 1
+                continue
+            size = _directory_size_bytes(path)
+            shutil.rmtree(path)
+        except OSError as exc:
+            result["errors"] += 1
+            log.warning("Workspace GC could not delete %s: %s", path, exc)
+            continue
+
+        result["directories_reclaimed"] += 1
+        result["bytes_reclaimed"] += size
+
+    log.info("Workspace GC complete: %s", result)
+    return result
+
+
+async def run() -> dict[str, int]:
+    async with UnitOfWork() as uow:
+        return await reclaim_headless_worker_workspaces(
+            uow.session,  # type: ignore[arg-type]
+            workspace_root=brain_config.resolve_workspace_root(),
+        )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [workspace_gc] %(message)s",
+    )
+    print(json.dumps(asyncio.run(run()), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -353,6 +353,10 @@ async def test_workspace_gc_catalog_config(session):
     assert job.timeout_seconds == 3600
     assert job.max_concurrency == 1
     assert job.retry_policy == {"max_attempts": 2, "backoff_seconds": 300}
+    assert job.task_contract["success_criteria"] == [
+        "Headless-worker workspaces older than 48 hours are reclaimed only when "
+        "the parent run is terminal or absent from the database"
+    ]
     assert build_scheduler_step_plan(job) == [
         {
             "step_key": "workspace_gc",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -79,7 +79,7 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     await session.flush()
 
-    assert result == {"upserted": 7, "retired": 0}
+    assert result == {"upserted": 8, "retired": 0}
     jobs = {job["job_key"]: job for job in await async_list_scheduler_jobs(session)}
     assert set(jobs) == {
         "curiosity_cron",
@@ -89,6 +89,7 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
         "nightly_sleep",
         "uwear_aws_health_scan",
         "uwear_staging_promotion_pr",
+        "workspace_gc",
     }
     assert jobs["nightly_sleep"]["owner_mode"] == "scheduler"
     assert jobs["nightly_sleep"]["handler_kind"] == "scheduler_builtin"
@@ -339,6 +340,31 @@ async def test_knowledge_index_sync_catalog_config(session):
     ]
 
 
+async def test_workspace_gc_catalog_config(session):
+    now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
+
+    await async_sync_scheduler_catalog(session, timezone_name="America/Toronto", now=now)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+    job = jobs["workspace_gc"]
+
+    assert job.cron_expr == "47 * * * *"
+    assert job.timezone == "UTC"
+    assert job.misfire_policy == "skip"
+    assert job.timeout_seconds == 3600
+    assert job.max_concurrency == 1
+    assert job.retry_policy == {"max_attempts": 2, "backoff_seconds": 300}
+    assert build_scheduler_step_plan(job) == [
+        {
+            "step_key": "workspace_gc",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": "brain.app.scheduler.programs:workspace_gc",
+            "payload": {"program": "workspace_gc"},
+            "command": ["python3", "-m", "brain.jobs.pipelines.workspace_gc"],
+        }
+    ]
+
+
 async def test_uwear_aws_health_scan_catalog_config(session):
     now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
 
@@ -440,8 +466,8 @@ async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_resta
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=restart)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 7, "retired": 0}
-    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 7
+    assert result == {"upserted": 8, "retired": 0}
+    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 8
     assert {key: job.id for key, job in jobs.items()} == first_ids
     assert all(job.next_run_at > restart for job in jobs.values())
     assert await async_materialize_due_runs(session, now=restart) == []
@@ -473,7 +499,7 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 1, "retired": 6}
+    assert result == {"upserted": 1, "retired": 7}
     assert jobs["nightly_sleep"].enabled is True
     assert jobs["curiosity_cron"].enabled is False
     assert jobs["curiosity_cron"].pause_reason == "removed from scheduler catalog"
@@ -490,6 +516,8 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     assert jobs["knowledge_index_sync"].pause_reason == "removed from scheduler catalog"
     assert jobs["cortex_canvas_occupancy"].enabled is False
     assert jobs["cortex_canvas_occupancy"].pause_reason == "removed from scheduler catalog"
+    assert jobs["workspace_gc"].enabled is False
+    assert jobs["workspace_gc"].pause_reason == "removed from scheduler catalog"
 
     repeated = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     assert repeated == {"upserted": 1, "retired": 0}
@@ -507,9 +535,9 @@ async def test_scheduler_daemon_startup_syncs_catalog_before_snapshot(session):
         "checkpoint_at": now.isoformat(),
         "threshold_seconds": 3600,
     }
-    assert result["catalog"] == {"upserted": 7, "retired": 0}
-    assert result["snapshot"]["summary"]["jobs_total"] == 7
-    assert result["snapshot"]["summary"]["jobs_enabled"] == 7
+    assert result["catalog"] == {"upserted": 8, "retired": 0}
+    assert result["snapshot"]["summary"]["jobs_total"] == 8
+    assert result["snapshot"]["summary"]["jobs_enabled"] == 8
     assert all(job["next_run_at"] > now.isoformat() for job in result["snapshot"]["jobs"])
 
 

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -20,6 +20,7 @@ from brain.app.scheduler.programs import (
 
 _SCHEDULED_FOR = datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc)
 _PINNED_PROJECTION_HASHES = {
+    "workspace_gc": "23fb152c7a24128aa116ace80eac5fbd0c7f1be38e028f0400ebf9735baf5b6b",
     "cortex_canvas_occupancy": "43cf7e0667228c054968df730d69c75a72ad7d30c1e2aaf66a4a5032f15453ba",
     "knowledge_index_sync": "7b180172f289f6769ef024b425a8978ee4f4c14c78e57fe98e94e7c151c7d4c6",
     "nightly_sleep": "0cb9173b9e0b71a094063bb867d644304f4c8b996fec6c9d1656b31dde060ee0",

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -20,7 +20,7 @@ from brain.app.scheduler.programs import (
 
 _SCHEDULED_FOR = datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc)
 _PINNED_PROJECTION_HASHES = {
-    "workspace_gc": "23fb152c7a24128aa116ace80eac5fbd0c7f1be38e028f0400ebf9735baf5b6b",
+    "workspace_gc": "eb924b58441b1c94b2390f7f97f70f60da5d80d8001c8a9f245b97897a328891",
     "cortex_canvas_occupancy": "43cf7e0667228c054968df730d69c75a72ad7d30c1e2aaf66a4a5032f15453ba",
     "knowledge_index_sync": "7b180172f289f6769ef024b425a8978ee4f4c14c78e57fe98e94e7c151c7d4c6",
     "nightly_sleep": "0cb9173b9e0b71a094063bb867d644304f4c8b996fec6c9d1656b31dde060ee0",
@@ -77,6 +77,13 @@ def test_aws_health_scan_declares_detached_agent_run_completion():
     assert (
         SINGLE_COMMAND_PROGRAM_REGISTRY["uwear_aws_health_scan"].completion_mode
         == "agent_run"
+    )
+
+
+def test_workspace_gc_description_states_complete_deletion_policy():
+    assert SINGLE_COMMAND_PROGRAM_REGISTRY["workspace_gc"].description == (
+        "Reclaim headless-worker workspaces older than 48 hours when parent runs are "
+        "terminal or absent from the database"
     )
 
 

--- a/tests/test_workspace_gc.py
+++ b/tests/test_workspace_gc.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from brain.jobs.pipelines.workspace_gc import reclaim_headless_worker_workspaces
+
+
+NOW = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+
+
+class _Rows:
+    def __init__(self, statuses: dict[int, str]) -> None:
+        self._statuses = statuses
+
+    def all(self) -> list[tuple[int, str]]:
+        return list(self._statuses.items())
+
+
+class _Session:
+    def __init__(self, statuses: dict[int, str]) -> None:
+        self._statuses = statuses
+
+    async def execute(self, _statement) -> _Rows:
+        return _Rows(self._statuses)
+
+
+def _worker_workspace(
+    workspace_root: Path,
+    parent_run_id: int,
+    *,
+    age: timedelta,
+    payload: bytes = b"workspace data",
+) -> Path:
+    path = workspace_root / "ideas" / f"headless-worker-{parent_run_id}-abcdef1234567890"
+    path.mkdir(parents=True)
+    (path / "payload.bin").write_bytes(payload)
+    timestamp = (NOW - age).timestamp()
+    os.utime(path, (timestamp, timestamp))
+    return path
+
+
+async def test_terminal_workspace_past_retention_is_deleted_and_reports_bytes(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    payload = b"old worker bytes"
+    workspace = _worker_workspace(
+        workspace_root,
+        101,
+        age=timedelta(hours=49),
+        payload=payload,
+    )
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({101: "completed"}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert not workspace.exists()
+    assert result["directories_reclaimed"] == 1
+    assert result["bytes_reclaimed"] == len(payload)
+
+
+async def test_terminal_workspace_inside_retention_is_kept(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    workspace = _worker_workspace(workspace_root, 102, age=timedelta(hours=47))
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({102: "completed"}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert workspace.is_dir()
+    assert result["directories_recent"] == 1
+    assert result["directories_reclaimed"] == 0
+
+
+async def test_non_terminal_workspace_is_kept_past_retention(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    workspace = _worker_workspace(workspace_root, 103, age=timedelta(days=7))
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({103: "running"}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert workspace.is_dir()
+    assert result["directories_non_terminal"] == 1
+    assert result["directories_reclaimed"] == 0
+
+
+async def test_missing_parent_run_is_treated_as_terminal_past_retention(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    workspace = _worker_workspace(workspace_root, 104, age=timedelta(days=7))
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert not workspace.exists()
+    assert result["directories_reclaimed"] == 1
+
+
+async def test_uuid_named_idea_workspace_is_kept(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    idea_workspace = workspace_root / "ideas" / "55e655bf-664a-4b67-82c8-43ca688c9084"
+    idea_workspace.mkdir(parents=True)
+    (idea_workspace / "draft.md").write_text("keep", encoding="utf-8")
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert idea_workspace.is_dir()
+    assert result["directories_scanned"] == 0
+    assert result["directories_reclaimed"] == 0
+
+
+async def test_headless_worker_symlink_outside_root_is_refused(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    ideas = workspace_root / "ideas"
+    ideas.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    link = ideas / "headless-worker-105-abcdef1234567890"
+    link.symlink_to(outside, target_is_directory=True)
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert link.is_symlink()
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert result["directories_refused"] == 1
+    assert result["directories_reclaimed"] == 0
+
+
+async def test_project_roots_and_siblings_of_ideas_are_untouched(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    ideas = workspace_root / "ideas"
+    ideas.mkdir(parents=True)
+    project_root = (
+        workspace_root / "project-roots" / "headless-worker-106-abcdef1234567890"
+    )
+    sibling = workspace_root / "other" / "headless-worker-107-abcdef1234567890"
+    project_root.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({106: "completed", 107: "completed"}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert project_root.is_dir()
+    assert sibling.is_dir()
+    assert result["directories_scanned"] == 0
+    assert result["directories_reclaimed"] == 0


### PR DESCRIPTION
Closes #750

## What was wrong

Nothing ever deleted `headless-worker-*` workspaces. They accumulated to 851
orphaned clone sets holding 579GB and growing ~38GB/day on illo-dev.

**The backlog is already gone** — those directories were removed by hand, and
the volume is back to ~28GB. This PR is the part that stops it happening again:
without it, nothing in the code prevents regrowth, and 25 fresh directories
already exist.

## The fix

A new hourly scheduler job, `workspace_gc`, wired the same way as
`cortex_canvas_occupancy` (same catalog shape, same `SingleCommandProgram`
registry, same handler kind). It deletes a workspace only when **all** of these
hold:

1. the name starts with `headless-worker-` and parses to a positive integer run id
2. it is a real directory (not a symlink) and a **direct child** of `<workspace_root>/ideas`
3. its mtime is older than the 48h retention window
4. its parent `AgentRun` is in a terminal status, **or absent from the DB entirely**

It logs `directories_scanned`, `directories_reclaimed`, `bytes_reclaimed`, plus
the reasons it skipped things (`directories_recent`, `directories_non_terminal`,
`directories_refused`, `errors`).

## Read this part carefully — it is deletion code

The safety check runs **twice**: once when building the candidate list, and
again immediately before `shutil.rmtree`, along with a second mtime check. That
second pass is what closes the window between deciding and deleting.

Two behaviors worth your explicit sign-off:

- **An absent parent run means delete.** That is the definition of "orphaned"
  and it is what reclaims the 851, but it does mean a `AgentRunRow` row lost for
  any other reason takes its workspace with it.
- **Retention is 48h**, a module constant (`HEADLESS_WORKER_WORKSPACE_RETENTION`),
  overridable per call.

UUID-named idea-thread workspaces and `/workspaces/project-roots` are never
candidates — they fail the prefix check and the "direct child of `ideas`" check
respectively.

## How to check it

```
venv/bin/python -m pytest tests/test_workspace_gc.py tests/test_scheduler.py tests/test_scheduler_programs.py -q
```

The job is also runnable by hand and prints a JSON summary without touching
anything it should not:

```
python3 -m brain.jobs.pipelines.workspace_gc
```

## Acceptance

- [x] A scheduled job removes orphaned `headless-worker-*` workspaces on a defined retention window, logging directories and bytes reclaimed
- [x] Workspaces belonging to non-terminal runs are never deleted
- [x] UUID-named idea-thread workspaces and `/workspaces/project-roots` are never deleted
- [ ] `illospace_illo_workspaces` returns to single-digit GB and stays bounded across a week — operational, observable only after this runs on illo-dev

## Code-quality review

A Codex review pass returned BLOCKING. Two findings were folded into this branch
(second commit):

- The eligibility rules were written twice — once building the candidate list,
  once again before `rmtree`. Both **passes** stay (that is the TOCTOU defense);
  the duplicated **logic** is gone, replaced by one
  `_validate_headless_worker_workspace` helper that both passes call. One place
  now knows what makes a directory eligible.
- The scheduler catalog and program description said only "after parent runs
  finish", which understated what the job deletes. They now state the full
  policy: older than 48h **and** parent run terminal or absent.
- Counters are a `TypedDict` rather than a bare `dict[str, int]`.

One finding was deliberately deferred and filed as issue #754 — the
`headless-worker` name is built, transformed and parsed in three places. It is a
drift risk, not a live defect: the parser was checked against the real
directories on illo-dev and handles them correctly. Fixing it properly means
touching the producer, which does not belong in this PR.

## Assumptions

- No migration, no schema change; it only reads `AgentRunRow.id` and `.status`.
- Hourly at `:47` with `max_concurrency: 1` and a 3600s timeout, matching the
  neighbouring catalog entries.
- Issue #754 stays open after this merges.
