### PR TITLE
fix(deploy): bound the idle worker drain wait (#749)

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -169,7 +169,11 @@ Two worker settings interact with shutdown and must stay consistent:
 - `ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS` (default `infinity`) bounds the
   *deploy-time* drain, not shutdown. The graceful handoff signals with `docker
   kill -s TERM`, which ignores `stop_grace_period` entirely, and enforces its own
-  bound via `COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS`.
+  bound via `COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS`. When two consecutive
+  canonical snapshots confirm zero active AgentRuns,
+  `COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS` (default `120`) bounds the
+  remaining idle exit wait. Any later active AgentRun abandons that shorter
+  deadline until two consecutive zero-active snapshots re-arm it.
 
 ## Operations
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -145,9 +145,13 @@ services:
     # This does not shorten the deploy-time drain. The graceful handoff in
     # deploy/scripts/compose-runtime-lib.sh signals with `docker kill -s TERM`,
     # which ignores stop_grace_period entirely, and bounds the drain itself via
-    # COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS. The grace period only ever
-    # applied to daemon shutdown and to a naive `compose down` / `compose up
-    # --force-recreate`, where 24h was a hang, not a safeguard.
+    # COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS. Once two consecutive
+    # canonical snapshots confirm zero active AgentRuns, the remaining wait is
+    # bounded by COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS (default 120s).
+    # A later active run abandons that shorter deadline until zero is confirmed
+    # twice again. The grace period only ever applied to daemon shutdown and to
+    # a naive `compose down` / `compose up --force-recreate`, where 24h was a
+    # hang, not a safeguard.
     stop_grace_period: ${ILLO_WORKER_STOP_GRACE_PERIOD:-10s}
     environment:
       <<: *illo-env

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -745,8 +745,8 @@ replace_idle_worker() {
   echo "Worker: no interactive AgentRuns; signaling a graceful replacement."
   suspend_worker_restart_policy "$worker_id"
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  # No handoff exists on this path, so there is no cover to watch: only the clock
-  # can end this wait.
+  # No handoff exists on this path, so there is no cover to monitor. Both the
+  # full drain deadline and the shorter confirmed-idle deadline apply.
   drain_status=0
   wait_for_worker_exit "$worker_id" "" || drain_status=$?
   if [ "$drain_status" -ne 0 ]; then

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -498,12 +498,15 @@ record_worker_drain_timeout() {
 #
 # So the wait now ends on either condition, and the caller escalates for both:
 #   1 = the drain deadline passed          2 = the cover is gone
+#   3 = the confirmed-idle exit deadline passed
 wait_for_worker_exit() {
   local id="$1"
   local handoff_id="${2:-}"
   local wait_seconds="${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
+  local idle_wait_seconds="${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}"
   local started_at="$SECONDS"
   local deadline=$((started_at + wait_seconds))
+  local idle_deadline=""
   local wait_iterations=0
   local consecutive_zero_checks=0
   local hint_printed=0
@@ -533,6 +536,18 @@ wait_for_worker_exit() {
         *) ;;
       esac
     fi
+    if [ -n "$idle_deadline" ] && [ "$SECONDS" -ge "$idle_deadline" ]; then
+      snapshot="$(worker_swap_snapshot)"
+      active_runs="$(worker_swap_snapshot_count "$snapshot")"
+      if [ "$active_runs" = "0" ]; then
+        echo "Worker: canonical snapshot still has 0 active AgentRuns at the idle exit deadline of ${idle_wait_seconds}s. Ending the wait so the existing safe replacement path can continue. No interactive AgentRuns are affected." >&2
+        return 3
+      fi
+      echo "Worker: active AgentRuns reappeared before the idle exit deadline; abandoning that deadline and continuing the ${wait_seconds}s drain." >&2
+      consecutive_zero_checks=0
+      idle_deadline=""
+      hint_printed=0
+    fi
     sleep 5
     wait_iterations=$((wait_iterations + 1))
     if [ $((wait_iterations % 6)) -eq 0 ] && container_running "$id"; then
@@ -543,11 +558,21 @@ wait_for_worker_exit() {
         if [ "$consecutive_zero_checks" -ge 2 ] && [ "$hint_printed" = "0" ]; then
           elapsed=$((SECONDS - started_at))
           echo "Hint: worker has 0 active AgentRuns but its process has not exited after ${elapsed}s." >&2
-          echo "Leave it alone: it is already draining and the swap completes on its own. At the ${wait_seconds}s deadline this deploy force-replaces it rather than keeping a worker that can no longer claim." >&2
+          if [ -z "$handoff_id" ]; then
+            idle_deadline=$((SECONDS + idle_wait_seconds))
+            echo "Worker: two consecutive canonical snapshots confirm it is idle. Waiting at most ${idle_wait_seconds}s more before safe replacement; the shorter deadline will be abandoned if an active AgentRun appears." >&2
+          else
+            echo "Leave it alone: it is already draining and the swap completes on its own. At the ${wait_seconds}s deadline this deploy force-replaces it rather than keeping a worker that can no longer claim." >&2
+          fi
           hint_printed=1
         fi
       else
+        if [ -n "$idle_deadline" ]; then
+          echo "Worker: active AgentRuns reappeared before the idle exit deadline; abandoning that deadline and continuing the ${wait_seconds}s drain." >&2
+        fi
         consecutive_zero_checks=0
+        idle_deadline=""
+        hint_printed=0
       fi
     fi
   done
@@ -695,7 +720,7 @@ remove_worker_handoff_bounded() {
 }
 
 replace_idle_worker() {
-  local action affected_ids run_details snapshot worker_id
+  local action affected_ids run_details snapshot worker_id drain_status
   worker_id="$(worker_container_id)"
 
   if [ -z "$worker_id" ]; then
@@ -722,12 +747,18 @@ replace_idle_worker() {
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
   # No handoff exists on this path, so there is no cover to watch: only the clock
   # can end this wait.
-  if ! wait_for_worker_exit "$worker_id" ""; then
+  drain_status=0
+  wait_for_worker_exit "$worker_id" "" || drain_status=$?
+  if [ "$drain_status" -ne 0 ]; then
     # Returning here would leave a container that is running, healthy-looking and
     # permanently unable to claim -- and this path has no handoff worker to cover
     # for it. There are no interactive runs to protect, so nothing weighs against
     # replacing it.
-    echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within ${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}s and will never claim another AgentRun; replacing it. No interactive AgentRuns are affected." >&2
+    if [ "$drain_status" = "3" ]; then
+      echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within the ${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}s idle exit deadline after consecutive zero-active checks; replacing it. No interactive AgentRuns are affected." >&2
+    else
+      echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within ${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}s and will never claim another AgentRun; replacing it. No interactive AgentRuns are affected." >&2
+    fi
     docker kill "$worker_id" >/dev/null 2>&1 || true
   fi
   # A failed recreate here IS the outage: the outgoing worker was already told to

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -432,6 +432,32 @@ def test_idle_deadline_is_abandoned_and_rearmed_when_active_runs_reappear(tmp_pa
     assert "did not drain within 300s" not in result.stderr
 
 
+def test_active_run_at_idle_deadline_requires_two_fresh_zero_snapshots(tmp_path):
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "worker_swap_snapshot_count() { "
+            'case "$(ticks)" in 19) printf \'1\\n\' ;; *) printf \'0\\n\' ;; esac; }\n'
+            'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
+            "SECONDS=$((SECONDS + $1)); return 0; }\n"
+            "wait_for_worker_exit worker-1 ''"
+        ),
+        stub_drain_wait=False,
+        drain_timeout_seconds=300,
+        idle_exit_timeout_seconds=35,
+    )
+    result = _run(script)
+
+    assert "STATUS=3" in result.stdout
+    # Zero at 30s and 60s arms a deadline at 95s. The active run at that
+    # deadline abandons it. Zero at 120s and 150s re-arms a fresh deadline.
+    assert (state / "ticks").read_text().strip() == "37"
+    assert result.stderr.count("active AgentRuns reappeared") == 1
+    assert "idle exit deadline of 35s" in result.stderr
+    assert "did not drain within 300s" not in result.stderr
+
+
 def test_an_unanswered_handoff_inspect_does_not_end_the_drain_wait(tmp_path):
     """dockerd here is a snap that restarts itself, taking every inspect with it.
 

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -29,6 +29,7 @@ def _simulator(
     handoff_dies_after_ticks: int | None = None,
     handoff_state_unknown: bool = False,
     drain_timeout_seconds: int = 1,
+    idle_exit_timeout_seconds: int = 120,
     claiming_timeout_seconds: int = 0,
 ) -> str:
     """Build a bash script whose `docker`/`compose` mutate simulated containers.
@@ -54,6 +55,7 @@ export HANDOFF_DIES_AFTER_TICKS={-1 if handoff_dies_after_ticks is None else han
 export HANDOFF_STATE_UNKNOWN={"1" if handoff_state_unknown else "0"}
 COMPOSE_RUNTIME_HANDOFF_REAP_TIMEOUT_SECONDS=0
 COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS={drain_timeout_seconds}
+COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS={idle_exit_timeout_seconds}
 COMPOSE_RUNTIME_WORKER_CLAIMING_TIMEOUT_SECONDS={claiming_timeout_seconds}
 source "{RUNTIME_LIB}"
 
@@ -372,6 +374,62 @@ def test_the_drain_wait_ends_when_the_handoff_worker_dies(tmp_path):
     assert "restart=no" in result.stderr
     # The worker it was draining is untouched by the wait itself.
     assert (state / "worker-1.running").exists()
+
+
+def test_idle_worker_that_ignores_sigterm_is_replaced_at_idle_deadline(tmp_path):
+    """Regression for the 2026-08-08 deploy that waited on an idle worker for 24h."""
+
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "worker_swap_snapshot_decision() { printf 'replace\\n'; }\n"
+            "worker_swap_snapshot_count() { printf '0\\n'; }\n"
+            'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
+            "SECONDS=$((SECONDS + $1)); return 0; }\n"
+            "replace_idle_worker"
+        ),
+        stub_drain_wait=False,
+        drain_timeout_seconds=86400,
+        idle_exit_timeout_seconds=10,
+    )
+    result = _run(script)
+
+    assert "STATUS=0" in result.stdout
+    assert result.stdout.split("RUNNING=")[1].strip() == "worker-2"
+    assert (state / "ticks").read_text().strip() == "14"
+    assert "idle exit deadline of 10s" in result.stderr
+    assert "86400s" not in result.stderr
+    assert "No interactive AgentRuns are affected" in result.stderr
+    calls = _calls(state)
+    assert "kill -s TERM worker-1" in calls
+    assert "kill worker-1" in calls
+
+
+def test_idle_deadline_is_abandoned_and_rearmed_when_active_runs_reappear(tmp_path):
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "worker_swap_snapshot_count() { "
+            'case "$(ticks)" in 18) printf \'1\\n\' ;; *) printf \'0\\n\' ;; esac; }\n'
+            'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
+            "SECONDS=$((SECONDS + $1)); return 0; }\n"
+            "wait_for_worker_exit worker-1 ''"
+        ),
+        stub_drain_wait=False,
+        drain_timeout_seconds=300,
+        idle_exit_timeout_seconds=40,
+    )
+    result = _run(script)
+
+    assert "STATUS=3" in result.stdout
+    # Zero at 30s and 60s arms a deadline at 100s. The active run at 90s
+    # abandons it. Zero at 120s and 150s re-arms a new deadline at 190s.
+    assert (state / "ticks").read_text().strip() == "38"
+    assert "active AgentRuns reappeared" in result.stderr
+    assert "idle exit deadline of 40s" in result.stderr
+    assert "did not drain within 300s" not in result.stderr
 
 
 def test_an_unanswered_handoff_inspect_does_not_end_the_drain_wait(tmp_path):


### PR DESCRIPTION
Closes #749

## What was wrong

When the outgoing worker confirmed it was idle but its process did not exit, the
deploy sat on the full `COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS` — 86400s,
24 hours — waiting for a worker that would never claim another run. The old code
printed a hint saying "leave it alone" and kept waiting.

## The fix

`wait_for_worker_exit` gains a third exit status, `3`, for "confirmed idle long
enough". Once two consecutive canonical snapshots report zero active AgentRuns,
it arms a short deadline — `COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS`,
default **120s**. At that deadline it re-samples the snapshot one more time, and
only returns `3` if the count is *still* zero. `replace_idle_worker` then takes
the existing safe replacement path it already used for the 24h case.

The shorter deadline is deliberately **not** armed on the handoff path (it only
arms when `handoff_id` is empty), so the graceful-handoff drain is unchanged.

If an active run reappears at any point, the idle deadline is abandoned and the
full drain resumes; two fresh consecutive zero-active snapshots are needed to
re-arm it.

## How to check it

```
venv/bin/python -m pytest tests/test_worker_swap_deploy.py -q
bash -n deploy/scripts/compose-runtime-lib.sh
```

The regression the ticket asked for is
`test_idle_deadline_is_abandoned_and_rearmed_when_active_runs_reappear`: the
worker ignores `SIGTERM`, active count stays zero, and replacement happens at the
idle deadline rather than at 86400s. It also covers the abandon-and-re-arm path
by making an active run reappear mid-wait.

## Acceptance

- [x] Idle exit wait is bounded to a short configurable limit (120s default), then the existing safe replacement path runs
- [x] The drain is never shortened while any active AgentRun is present — and a reappearing run abandons an already-armed deadline
- [x] Restart-policy restoration is untouched; the swap still ends with exactly one Compose-managed worker
- [x] Deploy output states plainly that no interactive AgentRuns are affected, on both the idle-deadline and 24h-deadline messages

## Code-quality review

A Codex review pass returned BLOCKING. What was folded in (second commit):

- A new test for an active run arriving **exactly at** the idle deadline — the
  existing tests only covered one arriving before it.
- A comment in `replace_idle_worker` that still claimed "only the clock can end
  this wait", which stopped being true with this change.

The review also asked to route both active-run transitions through one block. I
tried it and **reverted it**: in Bash that costs a two-iteration pseudo-loop with
the `sleep` buried inside one branch, which reads worse than the four duplicated
lines it removes. The new test passes against the un-restructured shell, which
is the evidence that the restructure bought nothing.

The real fix — splitting `wait_for_worker_exit` into a covered wait and an idle
wait, so one function stops carrying two policies and three exit statuses — is
filed as issue #755. It is deliberately not attempted here: this is
deploy-critical shell with no CI and no test against a real Docker daemon.

## Assumptions

- 120s is the ticket's own suggested value, exposed as
  `COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS` so it can be tuned without
  a code change.
- Both `deploy/compose/docker-compose.yml` and `deploy/compose/README.md` were
  updated so the two places that document the drain do not drift from it.
- This is shell in the deploy path. The tests drive it through the existing
  simulator harness in `tests/test_worker_swap_deploy.py`; nothing here was
  exercised against a real Docker daemon.
- Issue #755 stays open after this merges.
