### PR TITLE
fix(routing): floor the Ollama output budget so thinking cannot starve the answer

### DIFF
--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -97,6 +97,9 @@ _TRANSIENT_TRANSPORT_DISCONNECT_TERMS = (
     "incomplete chunked read",
     "peer closed connection",
 )
+# Ollama reasoning consumes 185-506 output tokens before the message, and
+# thinking cannot be disabled on its Responses API.
+_OLLAMA_MIN_OUTPUT_TOKENS = 2048
 
 
 def _openai_stream_error_message(error: Any) -> str:
@@ -622,6 +625,8 @@ class OllamaProvider(OpenAIProvider):
     def _translate_request(self, request: LLMRequest) -> dict[str, Any]:
         kwargs = super()._translate_request(request)
         kwargs.pop("store", None)
+        if (kwargs.get("max_output_tokens") or 0) < _OLLAMA_MIN_OUTPUT_TOKENS:
+            kwargs["max_output_tokens"] = _OLLAMA_MIN_OUTPUT_TOKENS
         if kwargs["model"] == "qwen3.6-27b":
             kwargs["model"] = "qwen3.6:27b"
         return kwargs

--- a/brain/platform/model_catalog.py
+++ b/brain/platform/model_catalog.py
@@ -131,7 +131,8 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
             "Free local lane on illo-dev's RTX 5090; zero marginal cost and unlimited "
             "volume. Quality is well below Luna; use only for high-volume, low-stakes "
             "single-shot work such as heartbeat-class probes, classification, and "
-            "summarization. Never use it for judgment, review, or long context."
+            "summarization. Never use it for judgment, review, or long context. The model "
+            "always emits a reasoning block, so short output budgets are raised automatically."
         ),
         supported_effort_tiers=_NO_NATIVE_EFFORT,
         availability_fallback="openai/gpt-5.6-luna",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -268,8 +268,42 @@ class TestProviderRegistry:
         assert isinstance(provider, OllamaProvider)
         assert kwargs["model"] == "qwen3.6:27b"
         assert "store" not in kwargs
+        assert kwargs["max_output_tokens"] == 2048
         assert "reasoning" not in kwargs
         assert "include" not in kwargs
+
+    def test_ollama_raises_small_output_budget_to_reasoning_floor(self):
+        provider = OllamaProvider(MagicMock())
+
+        kwargs = provider._translate_request(LLMRequest(
+            model="ollama/qwen3.6-27b",
+            messages=[{"role": "user", "content": "classify this"}],
+            max_output_tokens=512,
+        ))
+
+        assert kwargs["max_output_tokens"] == 2048
+
+    def test_ollama_preserves_output_budget_above_reasoning_floor(self):
+        provider = OllamaProvider(MagicMock())
+
+        kwargs = provider._translate_request(LLMRequest(
+            model="ollama/qwen3.6-27b",
+            messages=[{"role": "user", "content": "summarize this"}],
+            max_output_tokens=4096,
+        ))
+
+        assert kwargs["max_output_tokens"] == 4096
+
+    def test_openai_does_not_apply_ollama_output_budget_floor(self):
+        provider = OpenAIProvider(MagicMock())
+
+        kwargs = provider._translate_request(LLMRequest(
+            model="openai/gpt-5.6-luna",
+            messages=[{"role": "user", "content": "classify this"}],
+            max_output_tokens=512,
+        ))
+
+        assert kwargs["max_output_tokens"] == 512
 
     def test_unknown_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider"):


### PR DESCRIPTION
Follow-up to #759, found while verifying that lane on the live host.

## The defect

`qwen3.6:27b` is a reasoning model. It always emits a reasoning block before any message, and on a *trivial* prompt that block consumes **185–506 output tokens**. When the caller's budget runs out inside the reasoning block, the response carries no message item at all, so `_extract_openai_text_blocks` finds nothing, `_openai_response_to_unified` logs `OpenAI response parsed to empty content`, and the caller silently receives nothing.

Measured live with the prompt `Answer with one word only: what colour is grass?`:

| budget | output shape | result |
|---|---|---|
| 300 | `['reasoning']` | empty content |
| 2000 | `['reasoning', 'message']` | `Green` |

This is load-bearing rather than theoretical. `brain/platform/integrations/completions.py` defaults to `max_tokens: int = 512`, and that simple-completion path serves exactly the classification and summarization work the free local lane exists for.

## Why not just turn thinking off

Verified against Ollama 0.17.5 that its OpenAI-compatible Responses API silently ignores every documented switch — `think: false`, `reasoning: {effort: "none"}`, and `chat_template_kwargs: {enable_thinking: false}` all still return `['reasoning', 'message']`. A Modelfile rejects the parameter outright with `unknown parameter 'think'`. Only the native `/api/chat` endpoint honours it (2 output tokens instead of ~200), and moving the provider to that endpoint would cost us the Responses-shaped parsing the provider is built on.

## The fix

`OllamaProvider` raises any output budget below 2048 tokens to that floor, and never lowers one. Raising a ceiling costs close to nothing because generation still stops at `end_turn` — the earlier 2000-token call spent 197.

The catalog description gains one sentence so the behaviour is discoverable from the model list.

## Verification

Full suite: **4829 passed, 98 skipped**. New tests cover a budget below the floor being raised, a budget above it passing through unchanged, an absent budget, and no regression for `OpenAIProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)