### PR TITLE
fix(routing): give the local lane a 64k context window

### DIFF
--- a/brain/platform/model_catalog.py
+++ b/brain/platform/model_catalog.py
@@ -139,7 +139,7 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
         ),
         supported_effort_tiers=_NO_NATIVE_EFFORT,
         availability_fallback="openai/gpt-5.6-luna",
-        context_window_tokens=32_768,
+        context_window_tokens=65_536,
         input_price_per_million=0.0,
         output_price_per_million=0.0,
         provider_default=True,

--- a/brain/systems/runs/tool_catalog/definitions/workers.py
+++ b/brain/systems/runs/tool_catalog/definitions/workers.py
@@ -20,7 +20,7 @@ WORKER_SPAWN_TOOLS = [
             "openai/gpt-5.6-luna at xhigh. Luna caveats: quality collapses above ~200K context; "
             "xhigh pays a long first-token pause per turn — never use Luna xhigh for many-short-turn "
             "loops. Reserve non-OpenAI models for a cross-provider verifier. Free local lane: "
-            "`ollama/qwen3.6-27b` — zero cost, unlimited volume, ≤32k context, quality well below "
+            "`ollama/qwen3.6-27b` — zero cost, unlimited volume, ≤64k context, quality well below "
             "Luna; use for heartbeat-class, high-volume, low-stakes single-shot work; never for "
             "judgment or anything user-facing."
         ),

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -270,7 +270,7 @@ or resources as another active slice.
   context; `xhigh` pays a long first-token pause per turn — never use Luna
   `xhigh` for many-short-turn loops. Reserve non-OpenAI models for a
   cross-provider verifier. Free local lane: `ollama/qwen3.6-27b` — zero cost,
-  unlimited volume, ≤32k context, quality well below Luna; use for
+  unlimited volume, ≤64k context, quality well below Luna; use for
   heartbeat-class, high-volume, low-stakes single-shot work; never for judgment
   or anything user-facing.
 - Set `headless=true` when the child needs no user input or visible thread

--- a/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
@@ -63,7 +63,7 @@ or resources as another active slice.
   context; `xhigh` pays a long first-token pause per turn — never use Luna
   `xhigh` for many-short-turn loops. Reserve non-OpenAI models for a
   cross-provider verifier. Free local lane: `ollama/qwen3.6-27b` — zero cost,
-  unlimited volume, ≤32k context, quality well below Luna; use for
+  unlimited volume, ≤64k context, quality well below Luna; use for
   heartbeat-class, high-volume, low-stakes single-shot work; never for judgment
   or anything user-facing.
 - Set `headless=true` when the child needs no user input or visible thread

--- a/tests/test_effort_vocabulary.py
+++ b/tests/test_effort_vocabulary.py
@@ -49,7 +49,7 @@ def test_spawn_worker_description_teaches_routing_patterns():
     assert "ollama/qwen3.6-27b" in description
     assert "zero cost" in description
     assert "unlimited volume" in description
-    assert "≤32k context" in description
+    assert "≤64k context" in description
     assert "quality well below luna" in description
     assert "heartbeat-class" in description
     assert "never for judgment" in description

--- a/tests/test_model_catalog_contract.py
+++ b/tests/test_model_catalog_contract.py
@@ -108,7 +108,7 @@ def test_ollama_qwen_uses_free_local_catalog_contract():
     assert entry.input_price_per_million == 0.0
     assert entry.output_price_per_million == 0.0
     assert entry.availability_fallback == "openai/gpt-5.6-luna"
-    assert entry.context_window_tokens == 32_768
+    assert entry.context_window_tokens == 65_536
     assert entry.supported_effort_tiers == ("none",)
     assert contract["auth_requirement"] == "none"
     assert RuntimeModelCatalogEntry.model_validate(contract).provider == "ollama"


### PR DESCRIPTION
Found by asking Illo to actually use the lane. A spawned worker on `ollama/qwen3.6-27b` could not start at all:

```
context_floor_exceeds_budget: floor=27363 ceiling=7372 tools=79
```

## What that means

Illo's agent harness needs roughly **27k tokens before any conversation happens** — the system prompt plus 79 tool definitions have to fit first. A 32k window cannot hold that once the reservations for output, reasoning, tools and safety margin come out of it, so every agent run on this lane failed on admission. Routing itself was fine: the run recorded `provider: ollama`, `auth_mode: null`, the correct model.

## The change

The 5090 has room for more. Measured on the host, 64k context loads fully on GPU at **27.0 GB of 32.6 GB**, and the model natively supports far more. Ollama now serves 65536 by default (persisted in its systemd override), so the catalog is updated to match what the server actually provides — the two must agree, or Illo would send more than the server accepts and get silent truncation.

Budget at 64k, same 79 tools:

| effort | input budget | vs 27363 floor |
|---|---|---|
| high | 33056 | fits |
| none | 49440 | fits comfortably |

The doctrine text moves from `≤32k` to `≤64k` in all three mirrored copies.

## Known separate issue, deliberately not in this PR

At `effort: high` the budget still reserves **16384 tokens for reasoning** even though this model declares no native effort tiers and the transport never sends a reasoning request. Removing that would raise the budget from 33056 to 49440. It is not Ollama-specific — `claude-haiku-4-5` also declares no native effort and is over-reserved the same way — so it deserves its own change rather than riding along here.

Full suite: **4830 passed, 98 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)