### PR TITLE
fix(scheduler): pin the dream query's date parameter so nightly_sleep can run (#757)

### DIFF
--- a/brain/jobs/pipelines/nightly_dream.py
+++ b/brain/jobs/pipelines/nightly_dream.py
@@ -60,7 +60,7 @@ async def gather_random_old_memories(target_date: date, limit: int = 10, org_id:
                    ARRAY_REMOVE(ARRAY[node_kind, content_kind], NULL) AS tags,
                    created_at::date as created_date
             FROM memory_nodes
-            WHERE created_at::date < :target_date - INTERVAL '7 days'
+            WHERE created_at::date < CAST(:target_date AS date) - INTERVAL '7 days'
               AND archived_at IS NULL
               AND confidence >= 0.4 {_org_filter}
             ORDER BY RANDOM()

--- a/tests/test_nightly_dream.py
+++ b/tests/test_nightly_dream.py
@@ -8,7 +8,39 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
-from brain.jobs.pipelines.nightly_dream import build_dream_prompt, store_dream_memories
+from brain.jobs.pipelines.nightly_dream import (
+    build_dream_prompt,
+    gather_random_old_memories,
+    store_dream_memories,
+)
+
+
+@pytest.mark.requires_db
+async def test_random_old_memories_accepts_date_bound_parameter(
+    unit_of_work_for_session,
+    monkeypatch,
+):
+    """The dream query must resolve against real PostgreSQL with a `date` bind.
+
+    The parameter is sent untyped, so Postgres infers its type from the
+    expression it appears in. Before the fix the query read
+    `created_at::date < :target_date - INTERVAL '7 days'`, which inferred
+    `:target_date` as `interval` and failed with
+    `operator does not exist: date < interval` — every night for 23 days.
+
+    `:target_date - 7` fails the same way one type over
+    (`date < integer`), so only an explicit `CAST(... AS date)` is correct.
+    SQLite accepts all three spellings, which is why this test must run
+    against PostgreSQL to mean anything.
+    """
+    monkeypatch.setattr(
+        "brain.jobs.pipelines.nightly_dream.UnitOfWork",
+        unit_of_work_for_session,
+    )
+
+    memories = await gather_random_old_memories(date(2026, 8, 10))
+
+    assert isinstance(memories, list)
 
 
 class TestBuildDreamPrompt:


### PR DESCRIPTION
> Draft PR opened by Routine R3. Reda merges; I never mark ready.

Closes #757

## What was broken

`nightly_sleep` has run **21 times, failed 21 times, and never once succeeded** since
2026-07-18. Steps 10–16 — `dream`, `wake_up_index`, `file_sync`, `self_improvement`,
`daily_blog` — have never executed. The lane has been dark for 23 days.

Step 10 died on this, every night:

```
asyncpg.exceptions.UndefinedFunctionError: operator does not exist: date < interval
```

## The ticket's diagnosis was wrong, and so was its suggested fix

I checked both against a real PostgreSQL 16 before accepting any fix. Full probe:
`state/evidence/757-date-interval-groundtruth-20260810.md`.

**The ticket says Postgres has no `date - interval` operator.** It has one:

```
 oprname | oprleft | oprright |          oprresult
---------+---------+----------+-----------------------------
 -       | date    | interval | timestamp without time zone
 -       | date    | integer  | date
```

The real mechanism is **type inference**. SQLAlchemy sends `:target_date` untyped, so
Postgres infers it from the expression it sits in. The only known operand in
`:target_date - INTERVAL '7 days'` is an interval, so it resolved the parameter to
`interval`, and the comparison became `date < interval`.

**The ticket then offers `:target_date - 7` as a valid fix. It is not** — inference
resolves the parameter to `integer` there, and the query fails identically one type over:

```
PREPARE r AS SELECT 'x' WHERE current_date < $1 - 7;
ERROR:  operator does not exist: date < integer
```

That would have been the **seventh** failure signature in this job's life, and with a
SQLite- or fake-backed test it would have shipped green. The Codex worker did pick that
form; its sandbox denied the database socket, so it reported `0 passed` on its own DB
test rather than claiming success. I corrected the fix and produced the proof.

## The fix

Pin the parameter with an explicit cast — the pattern this repo already uses at
`brain/jobs/pipelines/nightly_guardian.py:58`:

```sql
WHERE created_at::date < CAST(:target_date AS date) - INTERVAL '7 days'
```

`pg_prepared_statements.parameter_types` then reads `{date}`, and the query executes.

## Evidence

The regression test is `requires_db` and runs against real PostgreSQL. It must:
**SQLite accepts all three spellings**, including both broken ones, so a fake-backed
test here proves nothing. I verified it has teeth by reverting the fix to each broken
form in turn:

| query form | result against real Postgres |
|---|---|
| `:target_date - INTERVAL '7 days'` (shipped, broken) | `operator does not exist: date < interval` — reproduces production exactly |
| `:target_date - 7` (the ticket's suggestion) | `operator does not exist: date < integer` |
| `CAST(:target_date AS date) - INTERVAL '7 days'` (this PR) | **1 passed** |

Run it:

```
cd <worktree> && export DB_HOST=127.0.0.1 DB_PORT=5433 DB_NAME=illo_test \
  DB_USER=illo_test DB_PASSWORD=illo_test CI_BRAIN_DB=1 \
  TEST_DB_URL=postgresql://illo_test:illo_test@127.0.0.1:5433/illo_test
venv/bin/python -m alembic upgrade head
venv/bin/python -m pytest tests/test_nightly_dream.py -m requires_db -q
```

## Sweep of the rest of the lane

The ticket asked for it — this class has now bitten twice (#734). Every bound-date
`INTERVAL` expression under `brain/jobs/pipelines/`:

| file | verdict | why |
|---|---|---|
| `nightly_dream.py` | **fixed** | untyped bound `date` in interval arithmetic |
| `nightly_guardian.py` | safe | already uses `CAST(:target AS date)` |
| `cortex_encode_digest.py` | safe | `days` is an int multiplier, not a date operand |
| `cortex_optimize.py` | safe | intervals are relative to `NOW()`, no bound date |
| `cortex_emerge.py` | safe | same |

## What this PR does NOT prove

The ticket's acceptance checks 2 and 3 require a full `nightly_sleep` run reaching
`settled_success` against the live database. **I cannot trigger that from here, and this
PR does not claim it.** This fixes the step-10 blocker; steps 11–16 have never run, so
the next failure may simply be one step later. That is the pattern this job has
repeated five times — worth one manual trigger after deploy rather than waiting for
03:00.

**After deploy, please run once:**
`python3 -m brain.jobs.pipelines.nightly_dream --date <today>` and then trigger
`nightly_sleep` manually.
