### PR TITLE
fix(scheduler): derive the standing-failure count from run history (#758)

### DIFF
--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -13,11 +13,11 @@ from typing import (
     TypeAlias,
 )
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.contracts.scheduler_outcomes import SchedulerSkipKind
-from brain.kernel.common.time import ensure_utc
+from brain.kernel.common.time import assume_utc, ensure_utc
 from brain.platform.db.models.scheduler import (
     SchedulerFailureGuardLatch,
     SchedulerFailureGuardTriggerState,
@@ -163,14 +163,110 @@ class StandingFailuresTrigger:
             ),
         )
 
-    async def evaluate_with_state(
+    async def evaluate(
         self,
         context: SchedulerFailureGuardLifecycleContext,
-        *,
-        state: FailureGuardTriggerState,
     ) -> FailureGuardTriggerResult:
-        del context
-        count = int(state.get("count", 0))
+        return (await self.evaluate_many((context,)))[context.job.id]
+
+    async def evaluate_many(
+        self,
+        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+    ) -> Mapping[int, FailureGuardTriggerResult]:
+        """Project terminal failures since each job's last terminal success."""
+        if not contexts:
+            return {}
+        session = contexts[0].session
+        now = contexts[0].now
+        if any(
+            context.session is not session or context.now != now
+            for context in contexts
+        ):
+            raise ValueError(
+                "Bulk scheduler trigger contexts must share a session and time"
+            )
+        job_ids = [context.job.id for context in contexts]
+        last_successes = (
+            select(
+                SchedulerRun.job_id.label("job_id"),
+                func.max(SchedulerRun.created_at).label("last_success_at"),
+            )
+            .where(
+                SchedulerRun.job_id.in_(job_ids),
+                SchedulerRun.status == "settled_success",
+            )
+            .group_by(SchedulerRun.job_id)
+            .subquery()
+        )
+        result = await session.execute(
+            select(
+                SchedulerJob.id,
+                func.count(SchedulerRun.id),
+                func.min(SchedulerRun.created_at),
+                last_successes.c.last_success_at,
+            )
+            .select_from(SchedulerJob)
+            .outerjoin(
+                last_successes,
+                last_successes.c.job_id == SchedulerJob.id,
+            )
+            .outerjoin(
+                SchedulerRun,
+                and_(
+                    SchedulerRun.job_id == SchedulerJob.id,
+                    SchedulerRun.status == "settled_failure",
+                    or_(
+                        last_successes.c.last_success_at.is_(None),
+                        SchedulerRun.created_at
+                        > last_successes.c.last_success_at,
+                    ),
+                ),
+            )
+            .where(SchedulerJob.id.in_(job_ids))
+            .group_by(
+                SchedulerJob.id,
+                last_successes.c.last_success_at,
+            )
+        )
+        history_by_job = {
+            int(job_id): (
+                int(count),
+                first_failure_at,
+                last_success_at,
+            )
+            for job_id, count, first_failure_at, last_success_at in result.all()
+        }
+        return {
+            context.job.id: self._result(
+                *history_by_job.get(context.job.id, (0, None, None)),
+                now=now,
+            )
+            for context in contexts
+        }
+
+    def _result(
+        self,
+        count: int,
+        first_failure_at: datetime | None,
+        last_success_at: datetime | None,
+        *,
+        now: datetime,
+    ) -> FailureGuardTriggerResult:
+        failure_label = "failure" if count == 1 else "failures"
+        if last_success_at is not None:
+            alert_summary = (
+                f"{count} {failure_label} over "
+                f"{_standing_failure_elapsed_text(last_success_at, now)} "
+                "since last successful run"
+            )
+        elif first_failure_at is not None:
+            alert_summary = (
+                f"{count} {failure_label} over "
+                f"{_standing_failure_elapsed_text(first_failure_at, now)}; "
+                "job has never succeeded"
+            )
+        else:
+            alert_summary = "0 failures; job has never succeeded"
         return FailureGuardTriggerResult(
             kind=self.kind,
             active=count >= self.threshold,
@@ -180,20 +276,8 @@ class StandingFailuresTrigger:
                 "window_hours": None,
             },
             alert_title="Scheduler job standing failure",
-            alert_summary=f"Failures without a successful run: {count}",
+            alert_summary=alert_summary,
         )
-
-    async def transition_state(
-        self,
-        context: SchedulerFailureGuardLifecycleContext,
-        state: FailureGuardTriggerState,
-        *,
-        event: FailureGuardLifecycleEvent,
-    ) -> FailureGuardTriggerState | None:
-        del context
-        if event == "success":
-            return None
-        return {"count": int(state.get("count", 0)) + 1}
 
     async def should_reset(
         self,
@@ -203,6 +287,30 @@ class StandingFailuresTrigger:
     ) -> bool:
         del context
         return event == "success"
+
+
+def _standing_failure_elapsed_text(
+    started_at: datetime,
+    ended_at: datetime,
+) -> str:
+    elapsed_seconds = max(
+        0,
+        int(
+            (
+                assume_utc(ended_at) - assume_utc(started_at)
+            ).total_seconds()
+        ),
+    )
+    for unit, seconds in (
+        ("day", 24 * 60 * 60),
+        ("hour", 60 * 60),
+        ("minute", 60),
+    ):
+        amount = elapsed_seconds // seconds
+        if amount:
+            suffix = "" if amount == 1 else "s"
+            return f"{amount} {unit}{suffix}"
+    return "less than 1 minute"
 
 
 @dataclass(frozen=True)

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy import event, select
+from sqlalchemy import delete, event, func, select
 
 import brain.app.scheduler.executor as scheduler_executor
 import brain.app.scheduler.scheduler_failure_guard as scheduler_failure_guard
@@ -28,6 +28,9 @@ from brain.app.scheduler.scheduler_failure_guard import (
     ROLLING_WINDOW_TRIGGER_KIND,
     STANDING_FAILURE_TRIGGER_KIND,
     SchedulerFailureGuardResetEvent,
+    async_latch_scheduler_failure_alerts,
+    async_read_scheduler_failure_guard,
+    async_record_scheduler_job_failure,
     scheduler_failure_signature,
 )
 from brain.app.scheduler.planner import async_materialize_due_runs
@@ -164,7 +167,7 @@ async def test_health_projection_preserves_each_jobs_latches_and_trigger_output(
                 },
                 {
                     "kind": "standing_failure",
-                    "count": 0,
+                    "count": 1,
                     "threshold": 3,
                     "window_hours": None,
                     "alerted_at": None,
@@ -202,7 +205,7 @@ async def test_health_projection_preserves_each_jobs_latches_and_trigger_output(
                 },
                 {
                     "kind": "standing_failure",
-                    "count": 0,
+                    "count": 2,
                     "threshold": 3,
                     "window_hours": None,
                     "alerted_at": None,
@@ -313,7 +316,7 @@ async def test_catalog_projection_batches_failure_guard_queries_across_jobs(
         len(job["failure_guard"]["triggers"]) == 4
         for job in several_job_projection
     )
-    assert single_job_statements == several_job_statements == 4
+    assert single_job_statements == several_job_statements == 5
 
 
 async def test_registered_database_trigger_projects_once_across_jobs(
@@ -357,7 +360,7 @@ async def test_registered_database_trigger_projects_once_across_jobs(
         await _list_scheduler_jobs_with_statement_count(session, now=now)
     )
 
-    assert single_job_statements == several_job_statements == 5
+    assert single_job_statements == several_job_statements == 6
     assert database_trigger.projected_job_counts == [1, 4]
 
 
@@ -588,6 +591,7 @@ async def _apply_standing_failure(
         idempotency_key=f"standing-failure:{job.id}:{index}",
         started_at=observed_at,
         finished_at=observed_at,
+        created_at=observed_at,
     )
     session.add(run)
     await session.flush()
@@ -600,6 +604,212 @@ async def _apply_standing_failure(
         now=observed_at,
     )
     return run
+
+
+def _standing_edge(evaluation: FailureGuardEvaluation) -> FailureGuardEdge:
+    return next(
+        edge
+        for edge in evaluation.edges
+        if edge.kind == STANDING_FAILURE_TRIGGER_KIND
+    )
+
+
+async def test_standing_failure_uses_lifetime_history_and_survives_latch_reset(
+    session,
+    monkeypatch,
+):
+    monkeypatch.setenv("SCHEDULER_STANDING_FAILURE_ALERT_THRESHOLD", "3")
+    first_failure_at = datetime(2026, 7, 18, 3, 0, tzinfo=timezone.utc)
+    observed_at = first_failure_at + timedelta(days=23)
+    job = _make_scheduler_job(next_run_at=observed_at + timedelta(days=1))
+    session.add(job)
+    await session.flush()
+    for index in range(21):
+        failed_at = (
+            observed_at
+            if index == 20
+            else first_failure_at + timedelta(days=index)
+        )
+        session.add(
+            SchedulerRun(
+                job_id=job.id,
+                scheduled_for=failed_at,
+                window_start=failed_at,
+                window_end=failed_at + timedelta(hours=1),
+                status="settled_failure",
+                idempotency_key=f"lifetime-standing-failure:{index}",
+                started_at=failed_at,
+                finished_at=failed_at,
+                created_at=failed_at,
+            )
+        )
+    await session.flush()
+
+    evaluation = await async_record_scheduler_job_failure(
+        session,
+        job,
+        failure_identity="nightly_sleep:failure",
+        error_text="RuntimeError: nightly sleep failed",
+        now=observed_at,
+    )
+    standing_before_reset = _standing_edge(evaluation)
+    assert standing_before_reset.public_details["count"] == 21
+    assert standing_before_reset.alert_summary == (
+        "21 failures over 23 days; job has never succeeded"
+    )
+
+    await async_latch_scheduler_failure_alerts(
+        session,
+        job,
+        evaluation,
+        now=observed_at,
+    )
+    await session.execute(
+        delete(SchedulerFailureGuardLatch).where(
+            SchedulerFailureGuardLatch.job_id == job.id,
+            SchedulerFailureGuardLatch.trigger_kind == "standing_failure",
+        )
+    )
+    await session.execute(
+        delete(SchedulerFailureGuardTriggerState).where(
+            SchedulerFailureGuardTriggerState.job_id == job.id,
+            SchedulerFailureGuardTriggerState.trigger_kind == "standing_failure",
+        )
+    )
+    await session.flush()
+
+    reset_evaluation = await async_read_scheduler_failure_guard(
+        session,
+        job,
+        now=observed_at,
+    )
+    standing_after_reset = _standing_edge(reset_evaluation)
+    assert standing_after_reset.public_details["count"] == (
+        standing_before_reset.public_details["count"]
+    )
+
+    session.add(
+        SchedulerFailureGuardLatch(
+            job_id=job.id,
+            trigger_kind="standing_failure",
+            alerted_at=observed_at,
+        )
+    )
+    await session.flush()
+    recreated_evaluation = await async_read_scheduler_failure_guard(
+        session,
+        job,
+        now=observed_at,
+    )
+    assert _standing_edge(recreated_evaluation).public_details["count"] == 21
+
+
+async def test_standing_failure_counts_runs_since_last_success_and_reports_age(
+    session,
+    monkeypatch,
+):
+    monkeypatch.setenv("SCHEDULER_STANDING_FAILURE_ALERT_THRESHOLD", "3")
+    last_success_at = datetime(2026, 8, 5, 3, 0, tzinfo=timezone.utc)
+    observed_at = last_success_at + timedelta(days=5)
+    job = _make_scheduler_job(next_run_at=observed_at + timedelta(days=1))
+    session.add(job)
+    await session.flush()
+    run_specs = (
+        ("settled_failure", last_success_at - timedelta(days=1)),
+        ("settled_success", last_success_at),
+        ("settled_failure", last_success_at + timedelta(days=1)),
+        ("settled_failure", last_success_at + timedelta(days=3)),
+        ("settled_failure", observed_at),
+    )
+    for index, (status, created_at) in enumerate(run_specs):
+        session.add(
+            SchedulerRun(
+                job_id=job.id,
+                scheduled_for=created_at,
+                window_start=created_at,
+                window_end=created_at + timedelta(hours=1),
+                status=status,
+                idempotency_key=f"success-bounded-standing-failure:{index}",
+                started_at=created_at,
+                finished_at=created_at,
+                created_at=created_at,
+            )
+        )
+    await session.flush()
+
+    expected_count = await session.scalar(
+        select(func.count())
+        .select_from(SchedulerRun)
+        .where(
+            SchedulerRun.job_id == job.id,
+            SchedulerRun.status == "settled_failure",
+            SchedulerRun.created_at > last_success_at,
+        )
+    )
+    evaluation = await async_record_scheduler_job_failure(
+        session,
+        job,
+        failure_identity="nightly_sleep:failure",
+        error_text="RuntimeError: nightly sleep failed",
+        now=observed_at,
+    )
+    standing = _standing_edge(evaluation)
+
+    assert standing.public_details["count"] == expected_count == 3
+    assert standing.alert_summary == (
+        "3 failures over 5 days since last successful run"
+    )
+
+
+async def test_standing_failure_counts_retried_attempts_as_one_scheduled_run(
+    session,
+    monkeypatch,
+):
+    monkeypatch.setenv("SCHEDULER_STANDING_FAILURE_ALERT_THRESHOLD", "1")
+    observed_at = datetime(2026, 8, 10, 3, 0, tzinfo=timezone.utc)
+    job = _make_scheduler_job(
+        retry_policy={"max_attempts": 3, "backoff_seconds": 0},
+        next_run_at=observed_at + timedelta(days=1),
+    )
+    session.add(job)
+    await session.flush()
+    run = SchedulerRun(
+        job_id=job.id,
+        scheduled_for=observed_at,
+        window_start=observed_at,
+        window_end=observed_at + timedelta(hours=1),
+        status="retryable",
+        attempt=1,
+        idempotency_key="standing-failure-retried-run",
+        started_at=observed_at,
+        finished_at=observed_at,
+        created_at=observed_at,
+    )
+    session.add(run)
+    await session.flush()
+
+    for attempt in (1, 2):
+        run.attempt = attempt
+        retry_evaluation = await async_record_scheduler_job_failure(
+            session,
+            job,
+            failure_identity="nightly_sleep:failure",
+            error_text="RuntimeError: nightly sleep failed",
+            now=observed_at + timedelta(minutes=attempt),
+        )
+        assert _standing_edge(retry_evaluation).public_details["count"] == 0
+
+    run.attempt = 3
+    run.status = "settled_failure"
+    await session.flush()
+    settled_evaluation = await async_record_scheduler_job_failure(
+        session,
+        job,
+        failure_identity="nightly_sleep:failure",
+        error_text="RuntimeError: nightly sleep failed",
+        now=observed_at + timedelta(minutes=3),
+    )
+    assert _standing_edge(settled_evaluation).public_details["count"] == 1
 
 
 async def test_standing_failure_alerts_after_eighteen_on_schedule_failures(


### PR DESCRIPTION
> Draft PR opened by Routine R3. Reda merges; I never mark ready.

Closes #758

## What was broken

The standing-failure alert reported a **21-failure, 23-day** outage as:

```
Scheduler job standing failure
Job key: nightly_sleep
Failures without a successful run: 3
```

The label states a lifetime quantity and the number was not that quantity. A reader who
trusts the label sees a three-day blip and correctly deprioritizes it — which is what a
dead nightly self-improvement lane has looked like in Slack for three weeks. This is the
alarm that hid #757.

## Why the number was wrong — two drifts, same direction

The count came from a persisted JSON latch counter, and it was wrong twice over:

1. **It seeded from its own row's creation**, not from the job's last success, so it
   forgot every failure that predated the trigger-state row.
2. **It advanced per attempt, not per scheduled run.** The executor updates the guard on
   `retryable` failures as well as settled ones, and `retry_policy.max_attempts` is 2 —
   which is why the count moved 3 → 6 across two nightly slots.

Both errors push the same way: the alert always looks newer and smaller than the outage.

> **Correction to the ticket:** #758 attributes the latch row to migration
> `0055_scheduler_alert_escalation` (PR #715, 2026-08-07). It does not come from there —
> the generic trigger-state table came from migration `0048`. The Codex worker followed
> the code rather than the ticket and caught this.

## The fix

Delete the counter. Derive the number from `scheduler_runs` instead — terminal
`settled_failure` rows after the job's latest `settled_success`, or the whole history
when there has never been one. A query cannot drift, and it survives migrations and
latch resets.

The message now carries the age too, because the count alone was never the sentence that
would have moved this job up the queue:

```
21 failures over 23 days; job has never succeeded
3 failures over 5 days since last successful run
```

`StandingFailuresTrigger` no longer persists state, so it stops satisfying the
`FailureGuardStatefulTrigger` protocol and is dispatched through the stateless
`evaluate` path. **No migration is required.**

## Acceptance checks — all five covered by tests

| # | check | test |
|---|---|---|
| 1 | count equals N since last success | `..._counts_runs_since_last_success_and_reports_age` — asserts against a direct `select(func.count())`, not a hardcoded number |
| 2 | never-succeeded job reports lifetime count and says so | `..._uses_lifetime_history_and_survives_latch_reset` — the real 21-failure/23-day shape |
| 3 | text includes elapsed time | asserted verbatim in both tests above |
| 4 | latch reset does not change the number | same test — deletes the latch, re-reads, asserts equal to before, then recreates and asserts 21 again |
| 5 | retried attempts count as one run | `..._counts_retried_attempts_as_one_scheduled_run` — 0 while `retryable`, 1 at `settled_failure` |

## Gates — run serially on an idle machine

- Backend fast suite (the repo's CI command): **4873 passed**, 11 skipped, 0 failed, 88s, at load 2.3 with no Codex workers running.
- Targeted scheduler lane: **115 passed**.
- Frontend lane not selected (no `frontend/**` in the diff). No migration, so `alembic heads` still prints one head.

## Code-quality review findings (Codex, cross-family) — NOT fixed here

Two were marked blocking. Neither is fixed in this PR, and you should see them:

1. **Trigger mode is implicit.** Dispatch depends on runtime structural `Protocol`
   membership in `brain/systems/failure_guard/core.py:182`, so removing
   `transition_state` silently changes evaluation *and* persistence behavior. The
   reviewer wants each trigger registered with an explicit `stateless`/`stateful` tag.
   That is a refactor of the shared framework used by the Cycle triggers too —
   genuinely out of scope for this fix. Filed separately.

2. **Old `standing_failure` rows in `scheduler_failure_guard_trigger_states` become
   dead data** — nothing reads, transitions or deletes them now, but the state preload
   still loads them. The fix is a one-statement Alembic migration deleting those rows.
   **I could not write it: my tool permissions refuse a migration that deletes rows.**
   Filed separately so it does not get lost.

Non-blocking: `evaluate_many`'s signature accepts a shape it then rejects at runtime
(shared `session`/`now` repeated per context), and the standing-failure tests would sit
better in their own file. Both named in the follow-up ticket.
