### PR TITLE
feat(runs): make the API maintenance loop prove it is alive (#756)

### DIFF
--- a/brain/app/ops/runtime_status.py
+++ b/brain/app/ops/runtime_status.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.scheduler.cold_start import scheduler_liveness_checkpoint
 from brain.app.scheduler.daemon import async_scheduler_health_snapshot
+from brain.app.scheduler.stale_run_reaper import agent_run_maintenance_snapshot
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.cycle import Cycle
 from brain.systems.runs.cortex.queue_health import (
@@ -168,7 +169,7 @@ async def async_runtime_status_snapshot(
     *,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return six compact health rows backed by durable runtime facts."""
+    """Return compact health rows backed by durable or process-local facts."""
 
     captured_at = _utc(now or datetime.now(timezone.utc))
     if captured_at is None:
@@ -233,6 +234,7 @@ async def async_runtime_status_snapshot(
         tick_age_seconds=tick_age,
         lag_seconds=lag_seconds,
     )
+    maintenance = agent_run_maintenance_snapshot(now=captured_at)
 
     enabled_cycle_count = int(
         await session.scalar(
@@ -322,6 +324,7 @@ async def async_runtime_status_snapshot(
             "max_lag_seconds": lag_seconds,
             "reason": scheduler_reason,
         },
+        "maintenance": maintenance,
         "runs": {
             "state": runs_state,
             "queued": queued,

--- a/brain/app/scheduler/stale_run_reaper.py
+++ b/brain/app/scheduler/stale_run_reaper.py
@@ -11,8 +11,10 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import json
 import logging
 import os
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -43,6 +45,7 @@ from brain.systems.slack.client import slack_web_client_from_runtime
 AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX = "agent_run_deadline_overdue"
 _DEADLINE_ALERT_AFTER = timedelta(hours=1)
 _MAINTENANCE_LIMIT = 25
+_OPERATION_TIMEOUT_SECONDS = 10.0
 
 CandidateProvider = Callable[..., Awaitable[tuple["OverdueAgentRun", ...]]]
 ReapRuns = Callable[..., Awaitable[int]]
@@ -54,6 +57,18 @@ AlertClaim = Callable[..., Awaitable[bool]]
 AlertRelease = Callable[..., Awaitable[None]]
 
 logger = logging.getLogger(__name__)
+_latest_reaper_check: _StaleRunReaperCheck | None = None
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    """Write compact runtime evidence to the container's stdout stream."""
+    print(json.dumps(payload, separators=(",", ":"), default=str), flush=True)
+
+
+def _error_text(exc: BaseException) -> str:
+    detail = str(exc).strip()
+    label = type(exc).__name__
+    return f"{label}: {detail}" if detail else label
 
 
 def _duration_label(seconds: float) -> str:
@@ -103,11 +118,64 @@ class OverdueAgentRun:
 
 @dataclass(frozen=True, slots=True)
 class _StaleRunReaperCheck:
+    checked_at: datetime
     reaped: int
     closeout_requested: int
     expired: int
     overdue_run_ids: tuple[int, ...]
     alert_sent: bool
+    errors: tuple[str, ...] = ()
+
+
+def agent_run_maintenance_snapshot(
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return process-local evidence from the latest maintenance interval."""
+    reference_time = assume_utc(now or datetime.now(timezone.utc))
+    check = _latest_reaper_check
+    if check is None:
+        return {
+            "state": "stalled",
+            "last_interval_at": None,
+            "interval_age_seconds": None,
+            "reaped": 0,
+            "closeout_requested": 0,
+            "expired": 0,
+            "overdue_run_ids": [],
+            "alert_sent": False,
+            "errors": [],
+            "reason": "No agent-run maintenance interval has been recorded.",
+        }
+
+    age_seconds = max(
+        0,
+        int((reference_time - assume_utc(check.checked_at)).total_seconds()),
+    )
+    if check.errors:
+        state = "stalled"
+        reason = "The latest agent-run maintenance interval had an error."
+    elif age_seconds > int(StaleRunReaper.check_interval_seconds * 5):
+        state = "stalled"
+        reason = "Agent-run maintenance has not reported for five intervals."
+    elif age_seconds > int(StaleRunReaper.check_interval_seconds * 2):
+        state = "late"
+        reason = "The latest agent-run maintenance interval is late."
+    else:
+        state = "good"
+        reason = "Agent-run maintenance is reporting on time."
+    return {
+        "state": state,
+        "last_interval_at": assume_utc(check.checked_at).isoformat(),
+        "interval_age_seconds": age_seconds,
+        "reaped": check.reaped,
+        "closeout_requested": check.closeout_requested,
+        "expired": check.expired,
+        "overdue_run_ids": list(check.overdue_run_ids),
+        "alert_sent": check.alert_sent,
+        "errors": list(check.errors),
+        "reason": reason,
+    }
 
 
 async def async_overdue_agent_runs(
@@ -194,6 +262,7 @@ class StaleRunReaper:
     reap_limit = _MAINTENANCE_LIMIT
     deadline_sweep_limit = _MAINTENANCE_LIMIT
     deadline_alert_after = _DEADLINE_ALERT_AFTER
+    operation_timeout_seconds = _OPERATION_TIMEOUT_SECONDS
 
     def __init__(
         self,
@@ -219,13 +288,34 @@ class StaleRunReaper:
     async def run(self) -> None:
         """Run maintenance on the API event loop at a fixed cadence."""
         while True:
-            await asyncio.sleep(self.check_interval_seconds)
+            interval_started_at = asyncio.get_running_loop().time()
             try:
                 await self._run_once()
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001 - the next interval retries
+            except Exception as exc:  # noqa: BLE001 - the next interval retries
                 logger.exception("Agent-run stale reaper failed safely")
+                self._record_interval(
+                    _StaleRunReaperCheck(
+                        checked_at=datetime.now(timezone.utc),
+                        reaped=0,
+                        closeout_requested=0,
+                        expired=0,
+                        overdue_run_ids=(),
+                        alert_sent=False,
+                        errors=(_error_text(exc),),
+                    )
+                )
+                _emit(
+                    {
+                        "event": "stale_run_reaper_interval_failed",
+                        "host": "api",
+                        "ok": False,
+                        "error": _error_text(exc),
+                    }
+                )
+            elapsed = asyncio.get_running_loop().time() - interval_started_at
+            await asyncio.sleep(max(0.0, self.check_interval_seconds - elapsed))
 
     async def _run_once(
         self,
@@ -233,50 +323,121 @@ class StaleRunReaper:
         now: datetime | None = None,
     ) -> _StaleRunReaperCheck:
         reference_time = self._reference_time(now)
+        errors: list[str] = []
         candidates: tuple[OverdueAgentRun, ...] | None = None
         try:
-            candidates = await self._overdue_candidates(now=reference_time)
-        except Exception:  # noqa: BLE001 - maintenance must still run
+            candidates = await self._bounded(
+                self._overdue_candidates(now=reference_time)
+            )
+        except Exception as exc:  # noqa: BLE001 - maintenance must still run
             logger.exception("agent_run_deadline_overdue_observation_failed")
+            errors.append(f"overdue_observation={_error_text(exc)}")
+            self._emit_failure(
+                "agent_run_deadline_overdue_observation_failed",
+                exc,
+                checked_at=reference_time,
+            )
 
         deadline_result = DeadlineSweepResult()
         try:
-            deadline_result = await self._enforce_deadlines(now=reference_time)
-        except Exception:  # noqa: BLE001 - stale reaping must still run
+            deadline_result = await self._bounded(
+                self._enforce_deadlines(now=reference_time)
+            )
+        except Exception as exc:  # noqa: BLE001 - stale reaping must still run
             logger.exception("agent_run_deadline_sweep_failed")
-        else:
-            logger.info(
-                "agent_run_deadline_sweep",
-                extra={
-                    "host": "api",
-                    "closeout_requested": deadline_result.closeout_requested,
-                    "expired": deadline_result.expired,
-                },
+            errors.append(f"deadline_sweep={_error_text(exc)}")
+            self._emit_failure(
+                "agent_run_deadline_sweep_failed",
+                exc,
+                checked_at=reference_time,
             )
 
         reaped = 0
         try:
-            reaped = await self._reap_runs(
-                now=reference_time,
-                limit=self.reap_limit,
+            reaped = await self._bounded(
+                self._reap_runs(
+                    now=reference_time,
+                    limit=self.reap_limit,
+                )
             )
-        except Exception:  # noqa: BLE001 - the next interval retries
+        except Exception as exc:  # noqa: BLE001 - the next interval retries
             logger.exception("agent_run_stale_reap_failed")
-        else:
-            logger.info(
-                "agent_run_stale_reap",
-                extra={"host": "api", "reaped": reaped},
+            errors.append(f"stale_reap={_error_text(exc)}")
+            self._emit_failure(
+                "agent_run_stale_reap_failed",
+                exc,
+                checked_at=reference_time,
+                reaped=0,
             )
 
         alert_sent = False
         if candidates is not None:
-            alert_sent = await self._evaluate_alert(candidates, now=reference_time)
-        return _StaleRunReaperCheck(
+            try:
+                alert_sent = await self._bounded(
+                    self._evaluate_alert(candidates, now=reference_time)
+                )
+            except Exception as exc:  # noqa: BLE001 - the next interval retries
+                logger.exception("agent_run_deadline_overdue_alert_failed")
+                errors.append(f"overdue_alert={_error_text(exc)}")
+                self._emit_failure(
+                    "agent_run_deadline_overdue_alert_failed",
+                    exc,
+                    checked_at=reference_time,
+                )
+        check = _StaleRunReaperCheck(
+            checked_at=reference_time,
             reaped=reaped,
             closeout_requested=deadline_result.closeout_requested,
             expired=deadline_result.expired,
             overdue_run_ids=tuple(candidate.run_id for candidate in candidates or ()),
             alert_sent=alert_sent,
+            errors=tuple(errors),
+        )
+        self._record_interval(check)
+        return check
+
+    async def _bounded(self, operation: Awaitable[Any]) -> Any:
+        return await asyncio.wait_for(
+            operation,
+            timeout=max(0.01, float(self.operation_timeout_seconds)),
+        )
+
+    @staticmethod
+    def _emit_failure(
+        event: str,
+        exc: BaseException,
+        *,
+        checked_at: datetime,
+        **counters: Any,
+    ) -> None:
+        _emit(
+            {
+                "event": event,
+                "host": "api",
+                "ok": False,
+                "checked_at": assume_utc(checked_at).isoformat(),
+                **counters,
+                "error": _error_text(exc),
+            }
+        )
+
+    @staticmethod
+    def _record_interval(check: _StaleRunReaperCheck) -> None:
+        global _latest_reaper_check
+        _latest_reaper_check = check
+        _emit(
+            {
+                "event": "agent_run_stale_reap",
+                "host": "api",
+                "ok": not check.errors,
+                "checked_at": assume_utc(check.checked_at).isoformat(),
+                "reaped": check.reaped,
+                "expired": check.expired,
+                "closeout_requested": check.closeout_requested,
+                "overdue_run_ids": list(check.overdue_run_ids),
+                "alert_sent": check.alert_sent,
+                "errors": list(check.errors),
+            }
         )
 
     async def _overdue_candidates(
@@ -378,5 +539,6 @@ __all__ = [
     "AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX",
     "OverdueAgentRun",
     "StaleRunReaper",
+    "agent_run_maintenance_snapshot",
     "async_overdue_agent_runs",
 ]

--- a/frontend/src/lib/types/runtimeStatus.ts
+++ b/frontend/src/lib/types/runtimeStatus.ts
@@ -21,6 +21,18 @@ export interface RuntimeStatusSnapshot {
     max_lag_seconds: number;
     reason: string;
   };
+  maintenance: {
+    state: RuntimeHealthState;
+    last_interval_at: string | null;
+    interval_age_seconds: number | null;
+    reaped: number;
+    closeout_requested: number;
+    expired: number;
+    overdue_run_ids: number[];
+    alert_sent: boolean;
+    errors: string[];
+    reason: string;
+  };
   runs: {
     state: RuntimeHealthState;
     queued: number;

--- a/frontend/src/routes/system/RuntimeStatusPanel.svelte
+++ b/frontend/src/routes/system/RuntimeStatusPanel.svelte
@@ -75,7 +75,7 @@
           </span>
         {/if}
       </div>
-      <p>Six signals from the running system. Container state is not used as health proof.</p>
+      <p>Seven signals from the running system. Container state is not used as health proof.</p>
     </div>
     <ConstellationButton variant="secondary" size="sm" onclick={onrefresh} {loading} loadingLabel="Refreshing">
       Refresh
@@ -129,6 +129,24 @@
           <span>oldest queue {duration(status.runs.oldest_queued_age_seconds)} · oldest active {duration(status.runs.oldest_running_age_seconds)}</span>
         </div>
         <p>{status.runs.reason}</p>
+      </article>
+
+      <article class="runtime-status-row">
+        <div class="runtime-status-name">
+          <span>Run maintenance</span>
+          <span class="runtime-row-state" data-state={status.maintenance.state}>{stateLabel[status.maintenance.state]}</span>
+        </div>
+        <div class="runtime-status-evidence">
+          <strong>Last interval {duration(status.maintenance.interval_age_seconds)} ago</strong>
+          <span>{status.maintenance.reaped} reaped · {status.maintenance.expired} expired · {status.maintenance.closeout_requested} close-outs</span>
+        </div>
+        <p>{status.maintenance.reason}</p>
+        <p>
+          Overdue runs:
+          {status.maintenance.overdue_run_ids.length
+            ? status.maintenance.overdue_run_ids.join(', ')
+            : 'none'}
+        </p>
       </article>
 
       <article class="runtime-status-row">

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -71,7 +71,7 @@ def test_deploy_evidence_requires_a_real_build_sha(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_runtime_snapshot_contains_all_six_evidence_rows(monkeypatch):
+async def test_runtime_snapshot_contains_all_seven_evidence_rows(monkeypatch):
     now = datetime(2026, 8, 8, 20, 0, tzinfo=timezone.utc)
     session = MagicMock()
     session.scalar = AsyncMock(
@@ -135,6 +135,21 @@ async def test_runtime_snapshot_contains_all_six_evidence_rows(monkeypatch):
             AsyncMock(return_value=now - timedelta(seconds=30)),
         ),
         patch(
+            "brain.app.ops.runtime_status.agent_run_maintenance_snapshot",
+            return_value={
+                "state": "good",
+                "last_interval_at": (now - timedelta(seconds=10)).isoformat(),
+                "interval_age_seconds": 10,
+                "reaped": 1,
+                "closeout_requested": 2,
+                "expired": 3,
+                "overdue_run_ids": [15926],
+                "alert_sent": True,
+                "errors": [],
+                "reason": "Agent-run maintenance is reporting on time.",
+            },
+        ),
+        patch(
             "brain.app.ops.runtime_status.async_summarize_token_totals",
             usage_summary,
         ),
@@ -146,6 +161,7 @@ async def test_runtime_snapshot_contains_all_six_evidence_rows(monkeypatch):
         "overall",
         "worker",
         "scheduler",
+        "maintenance",
         "runs",
         "cycles",
         "spend",
@@ -154,6 +170,9 @@ async def test_runtime_snapshot_contains_all_six_evidence_rows(monkeypatch):
     assert snapshot["worker"]["state"] == "good"
     assert snapshot["worker"]["heartbeat_age_seconds"] == 20
     assert snapshot["scheduler"]["state"] == "late"
+    assert snapshot["maintenance"]["reaped"] == 1
+    assert snapshot["maintenance"]["expired"] == 3
+    assert snapshot["maintenance"]["overdue_run_ids"] == [15926]
     assert snapshot["runs"]["queued"] == 1
     assert snapshot["runs"]["running"] == 2
     assert snapshot["cycles"]["overdue"] == 1
@@ -205,3 +224,7 @@ def test_runtime_panel_keeps_stale_and_detailed_evidence_visible():
     assert "Showing the 20 most overdue cycles." in panel
     assert "status.deploy.built_at" in panel
     assert "status.deploy.process_started_at" in panel
+    assert "status.maintenance.reaped" in panel
+    assert "status.maintenance.expired" in panel
+    assert "status.maintenance.closeout_requested" in panel
+    assert "status.maintenance.overdue_run_ids" in panel

--- a/tests/test_stale_run_reaper.py
+++ b/tests/test_stale_run_reaper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+import json
 from unittest.mock import patch
 
 import pytest
@@ -11,14 +12,17 @@ from brain.app.scheduler.stale_run_reaper import (
     AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX,
     OverdueAgentRun,
     StaleRunReaper,
+    agent_run_maintenance_snapshot,
     async_overdue_agent_runs,
 )
+from brain.app.scheduler.overdue_alert_state import try_claim_scheduler_alert
 from brain.platform.db.models.agent_run import (
     AgentRunArtifactRow,
     AgentRunEventRow,
     AgentRunRow,
 )
-from brain.systems.runs.deadlines import DeadlineSweepResult
+from brain.platform.db.models.scheduler import SchedulerAlertLatch
+from brain.systems.runs.deadlines import DeadlineSweepResult, sweep_agent_run_deadlines
 from brain.systems.runs.domain import AgentRunRequest
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -69,6 +73,7 @@ async def agent_run_session(
             AgentRunRow.__table__,
             AgentRunEventRow.__table__,
             AgentRunArtifactRow.__table__,
+            SchedulerAlertLatch.__table__,
         ]
     )
 
@@ -105,6 +110,66 @@ def _reaper(**overrides) -> StaleRunReaper:
     return StaleRunReaper(**dependencies)
 
 
+async def _create_15926_shaped_child(
+    session,
+    *,
+    closeout_expires_at: datetime | None = None,
+    deadline_at: datetime | None = None,
+    last_activity_at: datetime | None = None,
+    last_event_at: datetime | None = None,
+):
+    deadline_at = deadline_at or NOW - timedelta(hours=2)
+    last_activity_at = last_activity_at or NOW - timedelta(minutes=10)
+    last_event_at = last_event_at or last_activity_at
+    store = AsyncAgentRunStore(session)
+    root = await store.create_run(
+        AgentRunRequest(
+            org_id="org-1",
+            thread_id="root-15925",
+            message="completed root",
+        )
+    )
+    await store.set_status(root.id, RunStatus.STARTING)
+    await store.set_status(root.id, RunStatus.RUNNING)
+    await store.set_status(root.id, RunStatus.COMPLETED)
+    child = await store.create_run(
+        AgentRunRequest(
+            org_id="org-1",
+            thread_id="child-15926",
+            message="stale overdue child",
+            parent_run_id=root.id,
+            root_run_id=root.id,
+            deadline_at=deadline_at,
+        ),
+        parent_step_key_hash="15926-shape",
+    )
+    await store.set_status(child.id, RunStatus.STARTING)
+    await store.set_status(child.id, RunStatus.RUNNING)
+    row = await session.get(AgentRunRow, child.id)
+    assert row is not None
+    row.created_at = last_activity_at
+    row.started_at = last_activity_at
+    row.updated_at = last_activity_at
+    row.deadline_at = deadline_at
+    row.closeout_expires_at = closeout_expires_at
+    row.execution_token = "frozen-worker"
+    row.metadata_ = {
+        "runner_heartbeat": {
+            "at": last_activity_at.isoformat(),
+            "reason": "runner_running",
+        }
+    }
+    events = (
+        await session.scalars(
+            select(AgentRunEventRow).where(AgentRunEventRow.run_id == child.id)
+        )
+    ).all()
+    for event in events:
+        event.created_at = last_event_at
+    await session.commit()
+    return root, child, row
+
+
 def test_reaper_checks_well_inside_stale_run_window():
     assert StaleRunReaper.check_interval_seconds <= 5 * 60
     assert StaleRunReaper.reap_limit == 25
@@ -132,8 +197,67 @@ async def test_reaper_keeps_its_cadence_after_a_failed_tick(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await reaper.run()
 
-    assert sleeps == [60.0, 60.0]
+    assert len(sleeps) == 1
+    assert sleeps[0] == pytest.approx(60.0, abs=0.1)
     assert checks == 2
+
+
+async def test_quiet_interval_emits_zero_work_liveness(capsys):
+    result = await _reaper()._run_once(now=NOW)
+
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    snapshot = agent_run_maintenance_snapshot(now=NOW + timedelta(seconds=10))
+    assert result.reaped == 0
+    assert payload == {
+        "event": "agent_run_stale_reap",
+        "host": "api",
+        "ok": True,
+        "checked_at": NOW.isoformat(),
+        "reaped": 0,
+        "expired": 0,
+        "closeout_requested": 0,
+        "overdue_run_ids": [],
+        "alert_sent": False,
+        "errors": [],
+    }
+    assert snapshot["state"] == "good"
+    assert snapshot["interval_age_seconds"] == 10
+    assert snapshot["reaped"] == 0
+    assert snapshot["expired"] == 0
+    assert snapshot["closeout_requested"] == 0
+    assert snapshot["overdue_run_ids"] == []
+
+
+async def test_blocked_owner_times_out_without_stopping_later_maintenance(capsys):
+    calls = []
+
+    async def blocked_deadline_sweep(_session, **_kwargs):
+        calls.append("deadlines")
+        await asyncio.Event().wait()
+
+    async def reap_runs(**_kwargs):
+        calls.append("reap")
+        return 1
+
+    reaper = _reaper(
+        deadline_sweep=blocked_deadline_sweep,
+        reap_runs=reap_runs,
+    )
+    reaper.operation_timeout_seconds = 0.01
+
+    result = await reaper._run_once(now=NOW)
+
+    payloads = [
+        json.loads(line) for line in capsys.readouterr().out.strip().splitlines()
+    ]
+    assert calls == ["deadlines", "reap"]
+    assert result.reaped == 1
+    assert result.errors == ("deadline_sweep=TimeoutError",)
+    assert payloads[0]["event"] == "agent_run_deadline_sweep_failed"
+    assert payloads[0]["error"] == "TimeoutError"
+    assert payloads[-1]["event"] == "agent_run_stale_reap"
+    assert payloads[-1]["reaped"] == 1
+    assert payloads[-1]["ok"] is False
 
 
 async def test_one_maintenance_failure_does_not_block_the_other_owners():
@@ -223,6 +347,131 @@ async def test_api_reaper_requeues_stale_run_without_scheduler_daemon(
     assert result.reaped == 1
     assert row.status == RunStatus.QUEUED.value
     assert row.execution_token is None
+
+
+async def test_15926_shape_is_selected_by_alert_deadline_and_stale_reap_paths(
+    agent_run_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import runner
+
+    root, child, row = await _create_15926_shaped_child(
+        agent_run_session,
+        closeout_expires_at=NOW - timedelta(hours=36),
+        deadline_at=NOW - timedelta(hours=36, minutes=2),
+        last_activity_at=NOW - timedelta(hours=36),
+        last_event_at=NOW - timedelta(hours=36, minutes=2),
+    )
+
+    candidates = await async_overdue_agent_runs(
+        agent_run_session,
+        now=NOW,
+        overdue_after=timedelta(hours=1),
+        limit=25,
+    )
+    assert [candidate.run_id for candidate in candidates] == [child.id]
+
+    with patch(
+        "brain.systems.runs.chantier_continuation.queue_chantier_continuation_for_terminal_run",
+        return_value=None,
+    ):
+        deadline_result = await sweep_agent_run_deadlines(
+            agent_run_session,
+            now=NOW,
+            limit=25,
+        )
+    assert deadline_result.expired_run_ids == (child.id,)
+
+    await agent_run_session.refresh(row)
+    old = NOW - timedelta(minutes=10)
+    row.status = RunStatus.RUNNING.value
+    row.expired_at = None
+    row.completed_at = None
+    row.updated_at = old
+    row.execution_token = "frozen-worker"
+    events = (
+        await agent_run_session.scalars(
+            select(AgentRunEventRow).where(AgentRunEventRow.run_id == child.id)
+        )
+    ).all()
+    for event in events:
+        event.created_at = old
+    await agent_run_session.commit()
+
+    monkeypatch.setattr(
+        runner,
+        "UnitOfWork",
+        lambda: _SessionUnitOfWork(agent_run_session),
+    )
+    with (
+        patch("brain.systems.runs.cortex.runner.publish_safe"),
+        patch(
+            "brain.systems.runs.cortex.runner._settle_idea_for_terminal_root_run_async",
+            return_value=None,
+        ),
+        patch(
+            "brain.systems.runs.cortex.runner.notify_run_interruption",
+            return_value=None,
+        ),
+    ):
+        reaped = await runner.reap_stale_active_runs(now=NOW, limit=25)
+
+    await agent_run_session.refresh(row)
+    root_row = await agent_run_session.get(AgentRunRow, root.id)
+    assert reaped == 1
+    assert row.status == RunStatus.QUEUED.value
+    assert root_row is not None
+    assert root_row.status == RunStatus.COMPLETED.value
+
+
+async def test_overdue_stale_run_expires_within_two_api_intervals(
+    agent_run_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import runner
+
+    _root, child, row = await _create_15926_shaped_child(agent_run_session)
+
+    def unit_of_work():
+        return _SessionUnitOfWork(agent_run_session)
+
+    monkeypatch.setattr(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        unit_of_work,
+    )
+    monkeypatch.setattr(runner, "UnitOfWork", unit_of_work)
+
+    async def do_not_claim_alert(**_kwargs):
+        return False
+
+    async def no_settlement(*_args, **_kwargs):
+        return None
+
+    reaper = StaleRunReaper(
+        claim_alert=do_not_claim_alert,
+        settle_run=no_settlement,
+        finalize_run=no_settlement,
+    )
+    with (
+        patch(
+            "brain.systems.runs.chantier_continuation.queue_chantier_continuation_for_terminal_run",
+            return_value=None,
+        ),
+        patch("brain.systems.runs.cortex.runner.publish_safe"),
+        patch(
+            "brain.systems.runs.cortex.runner.notify_run_interruption",
+            return_value=None,
+        ),
+    ):
+        first = await reaper._run_once(now=NOW)
+        second = await reaper._run_once(now=NOW + timedelta(minutes=2))
+
+    await agent_run_session.refresh(row)
+    assert first.closeout_requested == 1
+    assert second.expired == 1
+    assert row.status == RunStatus.EXPIRED.value
+    assert row.expired_at is not None
+    assert row.expired_at.replace(tzinfo=timezone.utc) == NOW + timedelta(minutes=2)
 
 
 async def test_scheduler_daemon_ticks_do_not_mutate_stale_overdue_agent_runs(
@@ -400,6 +649,47 @@ async def test_two_api_replicas_share_one_durable_alert_claim():
     assert [result.alert_sent for result in results].count(True) == 1
     assert len(deliveries) == 1
     assert AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX != "scheduler_overdue_freeze"
+
+
+async def test_overdue_run_alert_latch_delivers_exactly_once(
+    agent_run_session,
+    monkeypatch,
+):
+    _root, child, _row = await _create_15926_shaped_child(agent_run_session)
+    monkeypatch.setattr(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        lambda: _SessionUnitOfWork(agent_run_session),
+    )
+    deliveries = []
+
+    async def claim_alert(*, run_id, alerted_at):
+        return await try_claim_scheduler_alert(
+            agent_run_session,
+            alert_key=f"{AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX}:{run_id}",
+            alerted_at=alerted_at,
+        )
+
+    async def deliver_alert(**kwargs):
+        deliveries.append(kwargs)
+
+    reaper = _reaper(
+        candidate_provider=async_overdue_agent_runs,
+        claim_alert=claim_alert,
+        deliver_alert=deliver_alert,
+    )
+    first = await reaper._run_once(now=NOW)
+    second = await reaper._run_once(now=NOW + timedelta(minutes=1))
+
+    latches = (
+        await agent_run_session.scalars(select(SchedulerAlertLatch))
+    ).all()
+    assert first.alert_sent is True
+    assert second.alert_sent is False
+    assert len(deliveries) == 1
+    assert len(latches) == 1
+    assert latches[0].alert_key == (
+        f"{AGENT_RUN_DEADLINE_OVERDUE_ALERT_KEY_PREFIX}:{child.id}"
+    )
 
 
 async def test_api_reaper_enforces_deadlines_and_settles_expired_roots():


### PR DESCRIPTION
> Draft PR opened by Routine R3. Reda merges; I never mark ready.

Closes #756

## What was broken

`#713` moved agent-run maintenance into the API process. The loop logs through the
structured logger, and **none of that reaches the container's stdout**: 48 hours of
`illospace-api-1` logs held 14,854 lines and zero came from the reaper. Every `except`
inside `_run_once` logged to the same invisible place.

So a dead maintenance loop and a healthy one looked identical from outside the process.
That is how run 15926 sat **36 hours** past its deadline — unreaped, unexpired,
unalerted — while all three paths that should have caught it were, on paper, eligible.

**I re-confirmed the blind spot on the live box today:** `docker logs illospace-api-1
--since 6h` → **0** reaper lines out of 254. Still true on the deployed SHA.

## The fix

- **One JSON line per interval on stdout**, carrying `reaped`, `expired`,
  `closeout_requested` and `overdue_run_ids` — **including on a zero-work interval**, so
  a quiet system proves liveness instead of looking like a stopped one:

  ```json
  {"event":"agent_run_stale_reap","host":"api","ok":true,"checked_at":"...","reaped":0,"expired":0,"closeout_requested":0,"overdue_run_ids":[],"alert_sent":false,"errors":[]}
  ```

- Every failure path emits too, so an exception is visible rather than swallowed.
- The same counters surface on the runtime-evidence view from #737 / PR #748 — "is
  maintenance alive" is answerable without SSH.
- **Each of the four operations is bounded by a 10s timeout.** One blocked await could
  previously freeze every later interval without terminating the task.
- Loop ordering fixed: it slept a full interval *before* its first pass; it now runs
  first and sleeps the remainder.

## Read this before merging: the root cause is a hypothesis, not a finding

The ticket says *"do not close this on the observability half alone."* Being straight
with you: **the second half is not conclusively done.**

The worker proved a 15926-shaped row is selected by all three paths, and reproduced the
*mechanism* — a blocked await freezes the loop silently; with the timeout it errors,
emits, and the interval continues. It could not identify the actual production await:
its sandbox denied both port 5433 and the Docker socket.

I checked production myself, and the picture moved:

| | at ticket filing (12:47Z) | now |
|---|---|---|
| run 15926 | `running`, 36h overdue, `expired_at` NULL | **`expired`**, `expired_at` 2026-08-10 13:28:56Z |
| runs >2h past deadline | ≥1 | **0** |
| reaper lines in API stdout | 0 | **0** |

So the alarming symptom **cleared on its own** 41 minutes after the ticket was written,
and acceptance check 4 already passes. A loop that ignores a row for 36 hours and then
acts on it at once is consistent with a frozen loop revived by a process restart — which
is what the timeout hardening targets — but I could not prove that, and I am not going to
assert it.

What is certain is the durable half: **you still cannot tell whether maintenance is
alive.** That is fixed here, and it is what makes the next occurrence diagnosable instead
of invisible.

I did **not** touch run 15926 — production writes are out of scope for this routine, and
it settled itself anyway.

## Gates — run serially on an idle machine, all lanes the diff selects

- Backend fast suite (the repo's CI command): **4875 passed**, 11 skipped, 0 failed, 110s.
- Frontend lane (diff touches `frontend/**`): `npm test` **250 passed, 0 failed**;
  `svelte-check` **6700 files, 0 errors, 0 warnings**; production build **passed**.
- Acceptance checks 2, 3 and 5 are covered by real tests, including one asserting the
  counters are emitted when `reaped = 0`.

## After deploy, please confirm the two checks I cannot run from here

```bash
docker logs illospace-api-1 --since 10m | grep agent_run_stale_reap   # expect >= 5 lines, each with a reaped count
```

```sql
SELECT count(*) FROM agent_runs
WHERE status IN ('starting','running','verifying') AND deadline_at < now() - interval '2 hours';
-- expect 0 (it is already 0 today)
```

## One judgement call worth your eye

The 10s `operation_timeout_seconds` is a new bound on real work. If reaping 25 runs ever
legitimately takes longer than 10s, that operation will now fail every interval instead
of finishing slowly. It fails *loudly* — that is the point of the change — but the number
is a guess, and it is the one value here I would expect to tune after seeing a week of
the new stdout lines.
