### PR TITLE
fix(context): stop reserving reasoning tokens for models that never reason

### DIFF
--- a/brain/systems/context/budget.py
+++ b/brain/systems/context/budget.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import os
 from typing import Any
 
-from brain.platform.model_catalog import get_model_catalog_entry
+from brain.platform.model_catalog import get_model_catalog_entry, model_accepts_effort
 from brain.platform.providers.model_policy import EFFORT_TIER_SET, infer_provider_from_model
 
 DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000
@@ -123,10 +123,15 @@ def _reserved_output_tokens(max_output_tokens: int | None) -> int:
     return 16_384
 
 
-def _reserved_reasoning_tokens(reasoning_effort: str | None) -> int:
+def _reserved_reasoning_tokens(
+    reasoning_effort: str | None,
+    model: str | None = None,
+) -> int:
     configured = os.environ.get("AGENT_CONTEXT_RESERVED_REASONING_TOKENS")
     if configured:
         return max(0, _env_int("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", 0))
+    if not model_accepts_effort(model, reasoning_effort):
+        return 0
     effort = str(reasoning_effort or "none").strip().lower()
     return _REASONING_RESERVES.get(effort, _REASONING_RESERVES["medium"])
 
@@ -151,7 +156,7 @@ def resolve_model_context_budget(
     normalized_model = _strip_provider_prefix(model)
     context_window = _context_window_for(resolved_provider, normalized_model)
     output_reserve = _reserved_output_tokens(max_output_tokens)
-    reasoning_reserve = _reserved_reasoning_tokens(reasoning_effort)
+    reasoning_reserve = _reserved_reasoning_tokens(reasoning_effort, model=model)
     tool_reserve = _reserved_tool_tokens(tools)
     safety_margin = max(
         0,

--- a/tests/test_context_runtime.py
+++ b/tests/test_context_runtime.py
@@ -179,6 +179,101 @@ def test_model_context_budget_is_model_and_provider_aware(monkeypatch):
     assert openai_budget.reserved_tool_tokens > 0
 
 
+def _clear_context_budget_overrides(monkeypatch):
+    for name in (
+        "AGENT_MODEL_CONTEXT_WINDOW_TOKENS",
+        "AGENT_AUTO_COMPACT_TOKEN_LIMIT",
+        "AGENT_AUTO_COMPACT_TARGET_TOKENS",
+        "AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS",
+        "AGENT_CONTEXT_RESERVED_REASONING_TOKENS",
+        "AGENT_CONTEXT_RESERVED_TOOL_TOKENS",
+        "AGENT_CONTEXT_SAFETY_MARGIN_TOKENS",
+        "AGENT_EMERGENCY_COMPACT_TARGET_TOKENS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_no_native_effort_models_do_not_reserve_reasoning_tokens(monkeypatch):
+    from brain.systems.context.budget import resolve_model_context_budget
+
+    _clear_context_budget_overrides(monkeypatch)
+    tools = [{"name": f"tool-{index}"} for index in range(79)]
+
+    qwen_high = resolve_model_context_budget(
+        model="ollama/qwen3.6-27b",
+        reasoning_effort="high",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+    qwen_none = resolve_model_context_budget(
+        model="ollama/qwen3.6-27b",
+        reasoning_effort="none",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+    haiku_high = resolve_model_context_budget(
+        model="anthropic/claude-haiku-4-5",
+        reasoning_effort="high",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+    haiku_none = resolve_model_context_budget(
+        model="anthropic/claude-haiku-4-5",
+        reasoning_effort="none",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+
+    assert qwen_high.reserved_reasoning_tokens == 0
+    assert qwen_high.effective_input_limit_tokens == 49_440
+    assert qwen_high.effective_input_limit_tokens == qwen_none.effective_input_limit_tokens
+    assert haiku_high.reserved_reasoning_tokens == 0
+    assert haiku_high.effective_input_limit_tokens == 181_952
+    assert haiku_high.effective_input_limit_tokens == haiku_none.effective_input_limit_tokens
+
+
+def test_native_and_unknown_model_reasoning_budgets_are_unchanged(monkeypatch):
+    from brain.systems.context.budget import resolve_model_context_budget
+
+    _clear_context_budget_overrides(monkeypatch)
+    tools = [{"name": f"tool-{index}"} for index in range(79)]
+
+    sol = resolve_model_context_budget(
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="high",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+    unknown = resolve_model_context_budget(
+        model="openai/not-in-catalog",
+        reasoning_effort="high",
+        max_output_tokens=2_048,
+        tools=tools,
+    )
+
+    assert sol.reserved_reasoning_tokens == 16_384
+    assert sol.effective_input_limit_tokens == 998_568
+    assert unknown.reserved_reasoning_tokens == 16_384
+    assert unknown.effective_input_limit_tokens == 95_008
+
+
+def test_reasoning_reserve_override_wins_for_no_effort_model(monkeypatch):
+    from brain.systems.context.budget import resolve_model_context_budget
+
+    _clear_context_budget_overrides(monkeypatch)
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "7777")
+
+    budget = resolve_model_context_budget(
+        model="ollama/qwen3.6-27b",
+        reasoning_effort="high",
+        max_output_tokens=2_048,
+        tools=[{"name": f"tool-{index}"} for index in range(79)],
+    )
+
+    assert budget.reserved_reasoning_tokens == 7_777
+    assert budget.effective_input_limit_tokens == 41_663
+
+
 def test_context_admission_floor_includes_canonical_checkpoint_and_healthy_path(monkeypatch):
     from brain.systems.context.compaction import estimate_session_tokens
     from brain.systems.context.window_policy import ContextWindowPolicy


### PR DESCRIPTION
Found while getting the free local lane (#759, #764) to actually run an agent.

## The defect

`_reserved_reasoning_tokens()` decided how much of the context window to hold back for reasoning from the **effort tier alone**, without asking whether the model can reason at all. A model that declares no native effort tiers still lost a large slice of its window to a reservation the transport never spends.

Both transports already gate the reasoning field on `model_accepts_effort()` — `openai_responses.py` and `anthropic.py` both call it before emitting anything. The budget simply was not consulting the same gate.

## Not an Ollama workaround

`anthropic/claude-haiku-4-5` declares `_NO_NATIVE_EFFORT` too and was over-reserved identically. This is a general correctness fix; Haiku is the proof.

Measured with 79 tools at effort `high`:

| model | reasoning reserve | input budget |
|---|---:|---:|
| `ollama/qwen3.6-27b` | 16384 → **0** | 33056 → **49440** |
| `anthropic/claude-haiku-4-5` | 16384 → **0** | 165568 → **181952** |
| `openai/gpt-5.6-sol` | 16384 → 16384 | 998568 → **unchanged** |
| unrecognised model id | 16384 → 16384 | 95008 → **unchanged** |

It matters most for the local lane, whose 64k window has to clear a ~27k agent floor before any conversation fits — this is the difference between a marginal 5.7k of headroom and a comfortable 22k.

## Safety

- The `AGENT_CONTEXT_RESERVED_REASONING_TOKENS` override still runs first and wins, including for no-effort models.
- `model_accepts_effort(None, ...)` returns `True`, so a caller that does not name a model keeps today's behaviour. There is exactly one call site, but the default is safe regardless.
- Unknown model ids keep the deliberate pass-through, pinned by a test so a future change to that behaviour is loud.

Full suite: **4833 passed, 98 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)