### PR TITLE
refactor(runs): one codec owns the headless-worker workspace identity (#754)

### DIFF
--- a/brain/jobs/pipelines/workspace_gc.py
+++ b/brain/jobs/pipelines/workspace_gc.py
@@ -21,7 +21,7 @@ from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.runs.headless_worker_identity import (
     is_headless_worker_directory_candidate,
-    parse_headless_worker_identity,
+    parse_headless_worker_directory_name,
 )
 from brain.systems.runs.status import (
     TERMINAL_RUN_STATUSES,
@@ -57,7 +57,7 @@ def _empty_result() -> WorkspaceGCResult:
 
 
 def _parent_run_id(path: Path) -> int | None:
-    identity = parse_headless_worker_identity(path.name)
+    identity = parse_headless_worker_directory_name(path.name)
     return identity[0] if identity is not None else None
 
 

--- a/brain/jobs/pipelines/workspace_gc.py
+++ b/brain/jobs/pipelines/workspace_gc.py
@@ -19,6 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.kernel import config as brain_config
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.headless_worker_identity import (
+    is_headless_worker_directory_candidate,
+    parse_headless_worker_identity,
+)
 from brain.systems.runs.status import (
     TERMINAL_RUN_STATUSES,
     coerce_run_status,
@@ -27,7 +31,6 @@ from brain.systems.runs.status import (
 
 log = logging.getLogger(__name__)
 
-HEADLESS_WORKER_PREFIX = "headless-worker-"
 HEADLESS_WORKER_WORKSPACE_RETENTION = timedelta(hours=48)
 
 
@@ -54,15 +57,8 @@ def _empty_result() -> WorkspaceGCResult:
 
 
 def _parent_run_id(path: Path) -> int | None:
-    if not path.name.startswith(HEADLESS_WORKER_PREFIX):
-        return None
-    parent_run_id, separator, digest = path.name.removeprefix(
-        HEADLESS_WORKER_PREFIX
-    ).partition("-")
-    if not separator or not parent_run_id.isdigit() or not digest:
-        return None
-    parsed = int(parent_run_id)
-    return parsed if parsed > 0 else None
+    identity = parse_headless_worker_identity(path.name)
+    return identity[0] if identity is not None else None
 
 
 _ValidationCounter = Literal[
@@ -190,7 +186,7 @@ async def reclaim_headless_worker_workspaces(
 
     candidates: list[tuple[Path, int]] = []
     for path in entries:
-        if not path.name.startswith(HEADLESS_WORKER_PREFIX):
+        if not is_headless_worker_directory_candidate(path.name):
             continue
         result["directories_scanned"] += 1
         validation = _validate_headless_worker_workspace(

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -42,6 +42,7 @@ from brain.systems.runs.interruption import (
     interrupt_and_requeue_run,
     notify_run_interruption,
 )
+from brain.systems.runs.headless_worker_identity import headless_worker_directory_name
 from brain.systems.runs.slack_delivery import (
     SLACK_SURFACE as _SLACK_SURFACE,
     is_slack_origin as _run_is_slack_origin,
@@ -823,6 +824,9 @@ async def _record_spawned_worker_materialization_failure(
 def _project_context_root(run_id: int, *, thread_id: str | None = None) -> str:
     base = brain_config.resolve_workspace_root(default=Path(tempfile.gettempdir()) / "illo-agent-runs").expanduser()
     if thread_id:
+        worker_directory_name = headless_worker_directory_name(str(thread_id))
+        if worker_directory_name:
+            return str(base / "ideas" / worker_directory_name)
         safe_thread_id = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in str(thread_id))[:120]
         if safe_thread_id:
             return str(base / "ideas" / safe_thread_id)

--- a/brain/systems/runs/headless_worker_identity.py
+++ b/brain/systems/runs/headless_worker_identity.py
@@ -1,4 +1,10 @@
-"""Canonical codec for headless worker workspace identities."""
+"""Canonical codec for headless worker workspace identities.
+
+One headless worker has two spellings of the same identity: a thread id
+(``headless-worker:{run_id}:{digest}``) and the workspace directory name
+derived from it (``headless-worker-{run_id}-{digest}``). Every producer and
+consumer goes through this module, so the format is stated once.
+"""
 
 from __future__ import annotations
 
@@ -8,35 +14,16 @@ _THREAD_PREFIX = f"{_HEADLESS_WORKER_NAME}:"
 _DIRECTORY_PREFIX = f"{_HEADLESS_WORKER_NAME}-"
 
 
-def build_headless_worker_thread_id(parent_run_id: int, digest: str) -> str:
-    """Build the durable thread identity for one headless worker."""
+def _parse_components(
+    value: str, *, prefix: str, separator: str
+) -> tuple[int, str] | None:
+    """Split one spelling into ``(run_id, digest)``, or ``None`` when unrelated."""
 
-    return f"{_THREAD_PREFIX}{parent_run_id}:{digest}"
-
-
-def headless_worker_directory_name(thread_id: str) -> str | None:
-    """Derive the workspace directory name from a headless worker thread id."""
-
-    identity = parse_headless_worker_identity(thread_id)
-    if identity is None or not thread_id.startswith(_THREAD_PREFIX):
+    if not value.startswith(prefix):
         return None
-    parent_run_id, digest = identity
-    return f"{_DIRECTORY_PREFIX}{parent_run_id}-{digest}"
-
-
-def parse_headless_worker_identity(value: str) -> tuple[int, str] | None:
-    """Parse a thread id or directory name, or return ``None`` when unrelated."""
-
-    if value.startswith(_THREAD_PREFIX):
-        remainder = value.removeprefix(_THREAD_PREFIX)
-        separator = ":"
-    elif value.startswith(_DIRECTORY_PREFIX):
-        remainder = value.removeprefix(_DIRECTORY_PREFIX)
-        separator = "-"
-    else:
-        return None
-
-    parent_run_id, found_separator, digest = remainder.partition(separator)
+    parent_run_id, found_separator, digest = value.removeprefix(prefix).partition(
+        separator
+    )
     if not found_separator or not parent_run_id.isdigit() or not digest:
         return None
     parsed_run_id = int(parent_run_id)
@@ -45,8 +32,41 @@ def parse_headless_worker_identity(value: str) -> tuple[int, str] | None:
     return parsed_run_id, digest
 
 
+def build_headless_worker_thread_id(parent_run_id: int, digest: str) -> str:
+    """Build the durable thread identity for one headless worker."""
+
+    return f"{_THREAD_PREFIX}{parent_run_id}:{digest}"
+
+
+def parse_headless_worker_thread_id(value: str) -> tuple[int, str] | None:
+    """Parse a thread id, or return ``None`` when it is not one."""
+
+    return _parse_components(value, prefix=_THREAD_PREFIX, separator=":")
+
+
+def parse_headless_worker_directory_name(value: str) -> tuple[int, str] | None:
+    """Parse a workspace directory name, or return ``None`` when it is not one."""
+
+    return _parse_components(value, prefix=_DIRECTORY_PREFIX, separator="-")
+
+
+def headless_worker_directory_name(thread_id: str) -> str | None:
+    """Derive the workspace directory name from a headless worker thread id."""
+
+    identity = parse_headless_worker_thread_id(thread_id)
+    if identity is None:
+        return None
+    parent_run_id, digest = identity
+    return f"{_DIRECTORY_PREFIX}{parent_run_id}-{digest}"
+
+
 def is_headless_worker_directory_candidate(value: str) -> bool:
-    """Return whether a name belongs to the GC's existing scan namespace."""
+    """Return whether a name belongs to the GC's existing scan namespace.
+
+    Deliberately broader than :func:`parse_headless_worker_directory_name`: the
+    GC counts and refuses malformed names inside the prefix it owns, so it must
+    recognise them before it can judge them.
+    """
 
     return value.startswith(_DIRECTORY_PREFIX)
 
@@ -55,5 +75,6 @@ __all__ = [
     "build_headless_worker_thread_id",
     "headless_worker_directory_name",
     "is_headless_worker_directory_candidate",
-    "parse_headless_worker_identity",
+    "parse_headless_worker_directory_name",
+    "parse_headless_worker_thread_id",
 ]

--- a/brain/systems/runs/headless_worker_identity.py
+++ b/brain/systems/runs/headless_worker_identity.py
@@ -1,0 +1,59 @@
+"""Canonical codec for headless worker workspace identities."""
+
+from __future__ import annotations
+
+
+_HEADLESS_WORKER_NAME = "headless-worker"
+_THREAD_PREFIX = f"{_HEADLESS_WORKER_NAME}:"
+_DIRECTORY_PREFIX = f"{_HEADLESS_WORKER_NAME}-"
+
+
+def build_headless_worker_thread_id(parent_run_id: int, digest: str) -> str:
+    """Build the durable thread identity for one headless worker."""
+
+    return f"{_THREAD_PREFIX}{parent_run_id}:{digest}"
+
+
+def headless_worker_directory_name(thread_id: str) -> str | None:
+    """Derive the workspace directory name from a headless worker thread id."""
+
+    identity = parse_headless_worker_identity(thread_id)
+    if identity is None or not thread_id.startswith(_THREAD_PREFIX):
+        return None
+    parent_run_id, digest = identity
+    return f"{_DIRECTORY_PREFIX}{parent_run_id}-{digest}"
+
+
+def parse_headless_worker_identity(value: str) -> tuple[int, str] | None:
+    """Parse a thread id or directory name, or return ``None`` when unrelated."""
+
+    if value.startswith(_THREAD_PREFIX):
+        remainder = value.removeprefix(_THREAD_PREFIX)
+        separator = ":"
+    elif value.startswith(_DIRECTORY_PREFIX):
+        remainder = value.removeprefix(_DIRECTORY_PREFIX)
+        separator = "-"
+    else:
+        return None
+
+    parent_run_id, found_separator, digest = remainder.partition(separator)
+    if not found_separator or not parent_run_id.isdigit() or not digest:
+        return None
+    parsed_run_id = int(parent_run_id)
+    if parsed_run_id <= 0:
+        return None
+    return parsed_run_id, digest
+
+
+def is_headless_worker_directory_candidate(value: str) -> bool:
+    """Return whether a name belongs to the GC's existing scan namespace."""
+
+    return value.startswith(_DIRECTORY_PREFIX)
+
+
+__all__ = [
+    "build_headless_worker_thread_id",
+    "headless_worker_directory_name",
+    "is_headless_worker_directory_candidate",
+    "parse_headless_worker_identity",
+]

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -35,6 +35,7 @@ from brain.systems.runs.evidence_health import (
 )
 from brain.systems.runs.events import run_event
 from brain.systems.runs.execution_context import _agent_context
+from brain.systems.runs.headless_worker_identity import build_headless_worker_thread_id
 from brain.systems.runs.routing_metadata import effective_routing_snapshot
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.tool_policy import normalize_tool_policy
@@ -368,7 +369,7 @@ def _step_key(role: str, objective: str, idempotency_key: str | None) -> str:
 
 def _headless_thread_id(parent_run_id: int, step_key: str) -> str:
     digest = sha256(step_key.encode("utf-8")).hexdigest()[:16]
-    return f"headless-worker:{parent_run_id}:{digest}"
+    return build_headless_worker_thread_id(parent_run_id, digest)
 
 
 def _merge_tool_policy(tool_policy: Any, *, headless: bool) -> dict[str, Any]:

--- a/tests/test_headless_worker_identity.py
+++ b/tests/test_headless_worker_identity.py
@@ -1,7 +1,8 @@
 from brain.systems.runs.headless_worker_identity import (
     build_headless_worker_thread_id,
     headless_worker_directory_name,
-    parse_headless_worker_identity,
+    parse_headless_worker_directory_name,
+    parse_headless_worker_thread_id,
 )
 
 
@@ -13,20 +14,37 @@ def test_headless_worker_identity_round_trip_and_production_name():
 
     assert directory_name is not None
     assert directory_name == "headless-worker-16034-0434cc5ed822d9f7"
-    assert parse_headless_worker_identity(thread_id) == (16034, digest)
-    assert parse_headless_worker_identity(directory_name) == (16034, digest)
-    assert parse_headless_worker_identity(
+    assert parse_headless_worker_thread_id(thread_id) == (16034, digest)
+    assert parse_headless_worker_directory_name(directory_name) == (16034, digest)
+    assert parse_headless_worker_directory_name(
         "headless-worker-16034-0434cc5ed822d9f7"
     ) == (16034, digest)
 
 
 def test_headless_worker_identity_rejects_unowned_names_without_raising():
-    assert parse_headless_worker_identity("idea-16034") is None
+    assert parse_headless_worker_thread_id("idea:16034") is None
+    assert parse_headless_worker_directory_name("idea-16034") is None
     assert headless_worker_directory_name("idea:16034") is None
 
 
+def test_each_parser_rejects_the_other_spelling():
+    digest = "0434cc5ed822d9f7"
+    thread_id = build_headless_worker_thread_id(16034, digest)
+    directory_name = "headless-worker-16034-0434cc5ed822d9f7"
+
+    assert parse_headless_worker_thread_id(directory_name) is None
+    assert parse_headless_worker_directory_name(thread_id) is None
+    assert headless_worker_directory_name(directory_name) is None
+
+
 def test_directory_parser_preserves_existing_digest_acceptance():
-    assert parse_headless_worker_identity("headless-worker-001-digest-with-suffix") == (
-        1,
-        "digest-with-suffix",
-    )
+    assert parse_headless_worker_directory_name(
+        "headless-worker-001-digest-with-suffix"
+    ) == (1, "digest-with-suffix")
+
+
+def test_directory_parser_refuses_names_the_gc_must_not_delete():
+    assert parse_headless_worker_directory_name("headless-worker-0-digest") is None
+    assert parse_headless_worker_directory_name("headless-worker-abc-digest") is None
+    assert parse_headless_worker_directory_name("headless-worker-16034-") is None
+    assert parse_headless_worker_directory_name("headless-worker-16034") is None

--- a/tests/test_headless_worker_identity.py
+++ b/tests/test_headless_worker_identity.py
@@ -1,0 +1,32 @@
+from brain.systems.runs.headless_worker_identity import (
+    build_headless_worker_thread_id,
+    headless_worker_directory_name,
+    parse_headless_worker_identity,
+)
+
+
+def test_headless_worker_identity_round_trip_and_production_name():
+    digest = "0434cc5ed822d9f7"
+
+    thread_id = build_headless_worker_thread_id(16034, digest)
+    directory_name = headless_worker_directory_name(thread_id)
+
+    assert directory_name is not None
+    assert directory_name == "headless-worker-16034-0434cc5ed822d9f7"
+    assert parse_headless_worker_identity(thread_id) == (16034, digest)
+    assert parse_headless_worker_identity(directory_name) == (16034, digest)
+    assert parse_headless_worker_identity(
+        "headless-worker-16034-0434cc5ed822d9f7"
+    ) == (16034, digest)
+
+
+def test_headless_worker_identity_rejects_unowned_names_without_raising():
+    assert parse_headless_worker_identity("idea-16034") is None
+    assert headless_worker_directory_name("idea:16034") is None
+
+
+def test_directory_parser_preserves_existing_digest_acceptance():
+    assert parse_headless_worker_identity("headless-worker-001-digest-with-suffix") == (
+        1,
+        "digest-with-suffix",
+    )

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1368,6 +1368,27 @@ def test_project_context_root_is_scoped_by_thread(monkeypatch, tmp_path):
     assert _project_context_root(101, thread_id=None) == str(tmp_path / "run-101")
 
 
+def test_project_context_root_uses_the_headless_worker_codec(monkeypatch, tmp_path):
+    """The GC parses this directory name back to a run id and deletes it.
+
+    Pin the exact path here, at the caller, so a runner cleanup cannot bypass
+    the codec while the codec's own tests still pass.
+    """
+
+    from brain.systems.runs.cortex.runner import _project_context_root
+    from brain.systems.runs.headless_worker_identity import (
+        build_headless_worker_thread_id,
+    )
+
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+
+    thread_id = build_headless_worker_thread_id(16034, "0434cc5ed822d9f7")
+
+    assert _project_context_root(103, thread_id=thread_id) == str(
+        tmp_path / "ideas" / "headless-worker-16034-0434cc5ed822d9f7"
+    )
+
+
 def test_project_context_root_uses_workspace_root_in_deploy(monkeypatch, tmp_path):
     from brain.systems.runs.cortex.runner import _project_context_root
 

--- a/tests/test_workspace_gc.py
+++ b/tests/test_workspace_gc.py
@@ -5,9 +5,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from brain.jobs.pipelines.workspace_gc import reclaim_headless_worker_workspaces
+from brain.systems.runs.headless_worker_identity import (
+    build_headless_worker_thread_id,
+    headless_worker_directory_name,
+)
 
 
 NOW = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+DIGEST = "abcdef1234567890"
 
 
 class _Rows:
@@ -26,6 +31,13 @@ class _Session:
         return _Rows(self._statuses)
 
 
+def _worker_directory_name(parent_run_id: int) -> str:
+    thread_id = build_headless_worker_thread_id(parent_run_id, DIGEST)
+    directory_name = headless_worker_directory_name(thread_id)
+    assert directory_name is not None
+    return directory_name
+
+
 def _worker_workspace(
     workspace_root: Path,
     parent_run_id: int,
@@ -33,7 +45,7 @@ def _worker_workspace(
     age: timedelta,
     payload: bytes = b"workspace data",
 ) -> Path:
-    path = workspace_root / "ideas" / f"headless-worker-{parent_run_id}-abcdef1234567890"
+    path = workspace_root / "ideas" / _worker_directory_name(parent_run_id)
     path.mkdir(parents=True)
     (path / "payload.bin").write_bytes(payload)
     timestamp = (NOW - age).timestamp()
@@ -131,7 +143,7 @@ async def test_headless_worker_symlink_outside_root_is_refused(tmp_path):
     outside.mkdir()
     marker = outside / "keep.txt"
     marker.write_text("keep", encoding="utf-8")
-    link = ideas / "headless-worker-105-abcdef1234567890"
+    link = ideas / _worker_directory_name(105)
     link.symlink_to(outside, target_is_directory=True)
 
     result = await reclaim_headless_worker_workspaces(
@@ -150,10 +162,8 @@ async def test_project_roots_and_siblings_of_ideas_are_untouched(tmp_path):
     workspace_root = tmp_path / "workspaces"
     ideas = workspace_root / "ideas"
     ideas.mkdir(parents=True)
-    project_root = (
-        workspace_root / "project-roots" / "headless-worker-106-abcdef1234567890"
-    )
-    sibling = workspace_root / "other" / "headless-worker-107-abcdef1234567890"
+    project_root = workspace_root / "project-roots" / _worker_directory_name(106)
+    sibling = workspace_root / "other" / _worker_directory_name(107)
     project_root.mkdir(parents=True)
     sibling.mkdir(parents=True)
 


### PR DESCRIPTION
Closes #754

## What this does

One module now owns the `headless-worker` workspace identity.

The identity had three independent spellings. `workers.py` built the thread id
as `headless-worker:{run_id}:{digest}`, the materializer turned it into a
hyphen-separated directory name, and `workspace_gc.py` parsed that name back to
a run id with its own copy of the format — then **deleted** the directory.

Nothing tied the three together. A change on the producer side would have made
the parser silently stop matching: no error, no alarm, the GC just reports zero
reclaimed and the disk fills again. That silence is why this was worth closing
off rather than leaving to review vigilance.

`brain/systems/runs/headless_worker_identity.py` now builds the thread id,
derives the directory name, and parses each spelling with its own named parser.
`workers.py`, the runner's workspace-root selection, and `workspace_gc.py` all
call it. No other module spells the format out.

## Not a live defect

Verified on illo-dev in the ticket: the 25 real directories are
`headless-worker-<run_id>-<16 hex>` and the current parser reads them correctly.
This is drift risk, removed.

## How to check it after merge

1. Merge and let Illo deploy.
2. Spawn a headless worker from a run. Its workspace directory under
   `<workspace_root>/ideas/` is still named `headless-worker-<run_id>-<digest>`.
3. Next `workspace_gc` run still reclaims finished workers' directories — the
   job's `directories_scanned` and reclaimed counts behave as before.

The parser keeps the current acceptance set exactly: positive numeric run ids,
leading zeros, and any non-empty digest including one with extra hyphens.
Nothing that was deletable before became undeletable, or the reverse.

## Evidence

- Full backend fast suite on this branch, the repo's own CI command, run
  serially on an idle machine (zero Codex processes, load 3.6):
  `4901 passed, 11 skipped` in 83s.
- Backend lane only — the diff touches `brain/**` and `tests/**`, so the
  frontend lane is not selected.
- A round-trip test asserts build → derive → parse returns the original run id,
  and that the production-shaped name `headless-worker-16034-0434cc5ed822d9f7`
  parses to `16034`. GC fixtures now build their names through the codec instead
  of hard-coding the format.

## Cross-family code-quality review

A Codex thermo-nuclear review of this diff returned 1 blocking and 1
non-blocking finding. **Both are fixed in this PR**, in a second commit:

- *Blocking* — one parser accepted both spellings and returned a tuple that lost
  which one matched, so the converter had to re-check the prefix. Split into
  `parse_headless_worker_thread_id` and `parse_headless_worker_directory_name`
  over one private component parser. A caller can no longer pass a directory
  name where a thread id is required.
- *Non-blocking* — the runner's headless branch had no caller-level test. Added
  one that pins the exact path, so a cleanup there cannot bypass the codec while
  the codec's own tests still pass.

Review output: `state/evidence/754-thermo-review-20260810T1700.md`.

## What I changed in the worker's output

The worker rewrote the prose `headless-worker` → `headless worker` in the
`workspace_gc` job description and module docstring, purely to satisfy a grep
criterion in its brief. That edited a scheduler program's description, which
forced a re-pin of `_PINNED_PROJECTION_HASHES["workspace_gc"]`. That hash exists
so a scheduler-catalog change is a deliberate act; a cosmetic edit must not
consume it. Reverted.
