### PR TITLE
refactor(failure-guard): declare trigger mode explicitly instead of inferring it (#769)

### DIFF
--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -35,6 +35,7 @@ from brain.systems.failure_guard.core import (
     FailureGuardTriggerKind,
     FailureGuardTriggerMode,
     FailureGuardTriggerRegistration,
+    require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
     async_evaluate_failure_guard_triggers,
@@ -526,6 +527,7 @@ class SchedulerFailureGuardRegistry:
     triggers: tuple[SchedulerRegisteredFailureGuardTrigger, ...]
 
     def __post_init__(self) -> None:
+        require_failure_guard_registrations(self.triggers, owner="Scheduler")
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):
             raise ValueError(

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,6 +11,7 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
+    cast,
 )
 
 from sqlalchemy import and_, delete, func, or_, select
@@ -32,6 +33,8 @@ from brain.systems.failure_guard.core import (
     FailureGuardStatefulTrigger,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
+    FailureGuardTriggerMode,
+    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
     async_evaluate_failure_guard_triggers,
@@ -167,25 +170,25 @@ class StandingFailuresTrigger:
         self,
         context: SchedulerFailureGuardLifecycleContext,
     ) -> FailureGuardTriggerResult:
-        return (await self.evaluate_many((context,)))[context.job.id]
+        return (
+            await self.evaluate_many(
+                context.session,
+                (context.job,),
+                now=context.now,
+            )
+        )[context.job.id]
 
     async def evaluate_many(
         self,
-        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+        session: AsyncSession,
+        jobs: Sequence[SchedulerJob],
+        *,
+        now: datetime,
     ) -> Mapping[int, FailureGuardTriggerResult]:
         """Project terminal failures since each job's last terminal success."""
-        if not contexts:
+        if not jobs:
             return {}
-        session = contexts[0].session
-        now = contexts[0].now
-        if any(
-            context.session is not session or context.now != now
-            for context in contexts
-        ):
-            raise ValueError(
-                "Bulk scheduler trigger contexts must share a session and time"
-            )
-        job_ids = [context.job.id for context in contexts]
+        job_ids = [job.id for job in jobs]
         last_successes = (
             select(
                 SchedulerRun.job_id.label("job_id"),
@@ -237,11 +240,11 @@ class StandingFailuresTrigger:
             for job_id, count, first_failure_at, last_success_at in result.all()
         }
         return {
-            context.job.id: self._result(
-                *history_by_job.get(context.job.id, (0, None, None)),
+            job.id: self._result(
+                *history_by_job.get(job.id, (0, None, None)),
                 now=now,
             )
-            for context in contexts
+            for job in jobs
         }
 
     def _result(
@@ -402,25 +405,25 @@ class RollingWindowFailuresTrigger:
         self,
         context: SchedulerFailureGuardLifecycleContext,
     ) -> FailureGuardTriggerResult:
-        return (await self.evaluate_many((context,)))[context.job.id]
+        return (
+            await self.evaluate_many(
+                context.session,
+                (context.job,),
+                now=context.now,
+            )
+        )[context.job.id]
 
     async def evaluate_many(
         self,
-        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+        session: AsyncSession,
+        jobs: Sequence[SchedulerJob],
+        *,
+        now: datetime,
     ) -> Mapping[int, FailureGuardTriggerResult]:
         """Evaluate one rolling-window count query for a job projection."""
-        if not contexts:
+        if not jobs:
             return {}
-        session = contexts[0].session
-        now = contexts[0].now
-        if any(
-            context.session is not session or context.now != now
-            for context in contexts
-        ):
-            raise ValueError(
-                "Bulk scheduler trigger contexts must share a session and time"
-            )
-        job_ids = [context.job.id for context in contexts]
+        job_ids = [job.id for job in jobs]
         result = await session.execute(
             select(SchedulerRun.job_id, func.count())
             .where(
@@ -436,10 +439,10 @@ class RollingWindowFailuresTrigger:
             for job_id, count in result.all()
         }
         return {
-            context.job.id: self._result(
-                counts.get(context.job.id, 0)
+            job.id: self._result(
+                counts.get(job.id, 0)
             )
-            for context in contexts
+            for job in jobs
         }
 
     def _result(self, count: int) -> FailureGuardTriggerResult:
@@ -492,7 +495,10 @@ class SchedulerFailureGuardTrigger(
 
     async def evaluate_many(
         self,
-        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+        session: AsyncSession,
+        jobs: Sequence[SchedulerJob],
+        *,
+        now: datetime,
     ) -> Mapping[int, FailureGuardTriggerResult]:
         """Evaluate this trigger for every projected job."""
 
@@ -505,8 +511,11 @@ class SchedulerFailureGuardStatefulTrigger(
     """One state-owning scheduler failure trigger."""
 
 
-SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
+SchedulerFailureGuardTriggerImplementation: TypeAlias = (
     SchedulerFailureGuardTrigger | SchedulerFailureGuardStatefulTrigger
+)
+SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
+    FailureGuardTriggerRegistration[SchedulerFailureGuardLifecycleContext]
 )
 
 
@@ -530,10 +539,22 @@ _FAILURE_GUARD_TRIGGER_PROVIDERS: tuple[
     Callable[[], SchedulerRegisteredFailureGuardTrigger],
     ...,
 ] = (
-    ConsecutiveFailuresTrigger.from_settings,
-    StandingFailuresTrigger.from_settings,
-    RollingWindowFailuresTrigger.from_settings,
-    ConfigurationFailureTrigger,
+    lambda: FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATEFUL,
+        trigger=ConsecutiveFailuresTrigger.from_settings(),
+    ),
+    lambda: FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATELESS,
+        trigger=StandingFailuresTrigger.from_settings(),
+    ),
+    lambda: FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATELESS,
+        trigger=RollingWindowFailuresTrigger.from_settings(),
+    ),
+    lambda: FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATEFUL,
+        trigger=ConfigurationFailureTrigger(),
+    ),
 )
 
 
@@ -541,8 +562,8 @@ def scheduler_failure_guard_registry() -> SchedulerFailureGuardRegistry:
     """Load the configured registry of independently owned triggers."""
     return SchedulerFailureGuardRegistry(
         triggers=tuple(
-            provide_trigger()
-            for provide_trigger in _FAILURE_GUARD_TRIGGER_PROVIDERS
+            provide_registration()
+            for provide_registration in _FAILURE_GUARD_TRIGGER_PROVIDERS
         )
     )
 
@@ -727,14 +748,17 @@ async def async_read_scheduler_failure_guards(
         job_id: {}
         for job_id in job_ids
     }
-    for trigger in registry.triggers:
-        if isinstance(trigger, FailureGuardStatefulTrigger):
+    for registration in registry.triggers:
+        if registration.mode is FailureGuardTriggerMode.STATEFUL:
             continue
-        trigger_results = dict(await trigger.evaluate_many(contexts))
+        trigger = cast(SchedulerFailureGuardTrigger, registration.trigger)
+        trigger_results = dict(
+            await trigger.evaluate_many(session, jobs, now=now)
+        )
         missing_job_ids = set(job_ids).difference(trigger_results)
         if missing_job_ids:
             raise ValueError(
-                f"Bulk scheduler trigger {trigger.kind} omitted jobs: "
+                f"Bulk scheduler trigger {registration.kind} omitted jobs: "
                 + ", ".join(
                     str(job_id)
                     for job_id in sorted(missing_job_ids)
@@ -744,9 +768,9 @@ async def async_read_scheduler_failure_guards(
             results_by_job[job_id][trigger.kind] = trigger_results[job_id]
 
     stateful_triggers = tuple(
-        trigger
-        for trigger in registry.triggers
-        if isinstance(trigger, FailureGuardStatefulTrigger)
+        registration
+        for registration in registry.triggers
+        if registration.mode is FailureGuardTriggerMode.STATEFUL
     )
     evaluations: dict[int, FailureGuardEvaluation] = {}
     for job, context in zip(jobs, contexts, strict=True):
@@ -757,8 +781,8 @@ async def async_read_scheduler_failure_guards(
         ):
             results_by_job[job.id][result.kind] = result
         ordered_results = tuple(
-            results_by_job[job.id][trigger.kind]
-            for trigger in registry.triggers
+            results_by_job[job.id][registration.kind]
+            for registration in registry.triggers
         )
         evaluations[job.id] = await async_evaluate_failure_edges(
             results=ordered_results,
@@ -841,13 +865,17 @@ async def async_record_scheduler_job_failure(
     if signature_changed:
         latches = dict(await latch_store.load_latches())
         reset_latch = False
-        for trigger in registry.triggers:
-            if trigger.kind not in latches or not await trigger.should_reset(
+        for registration in registry.triggers:
+            trigger = cast(
+                SchedulerFailureGuardResettableTrigger,
+                registration.trigger,
+            )
+            if registration.kind not in latches or not await trigger.should_reset(
                 context,
                 event="signature_change",
             ):
                 continue
-            await latch_store.delete_latch(trigger.kind)
+            await latch_store.delete_latch(registration.kind)
             reset_latch = True
         if reset_latch:
             await session.flush()
@@ -920,14 +948,18 @@ async def async_reset_scheduler_job_failure_guard(
         record=None,
     )
     latches = dict(await latch_store.load_latches())
-    for trigger in registry.triggers:
-        if trigger.kind not in latches:
+    for registration in registry.triggers:
+        trigger = cast(
+            SchedulerFailureGuardResettableTrigger,
+            registration.trigger,
+        )
+        if registration.kind not in latches:
             continue
         if await trigger.should_reset(
             context,
             event="success",
         ):
-            await latch_store.delete_latch(trigger.kind)
+            await latch_store.delete_latch(registration.kind)
 
     await async_transition_failure_guard_trigger_states(
         triggers=registry.triggers,

--- a/brain/systems/cycles/cycle_failure_guard.py
+++ b/brain/systems/cycles/cycle_failure_guard.py
@@ -30,6 +30,7 @@ from brain.systems.failure_guard.core import (
     FailureGuardTriggerKind,
     FailureGuardTriggerMode,
     FailureGuardTriggerRegistration,
+    require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
     async_evaluate_failure_guard_triggers,
@@ -324,6 +325,7 @@ class CycleFailureGuardRegistry:
     triggers: tuple[CycleRegisteredFailureGuardTrigger, ...]
 
     def __post_init__(self) -> None:
+        require_failure_guard_registrations(self.triggers, owner="Cycle")
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):
             raise ValueError("Cycle failure-guard trigger kinds must not be empty")

--- a/brain/systems/cycles/cycle_failure_guard.py
+++ b/brain/systems/cycles/cycle_failure_guard.py
@@ -28,6 +28,8 @@ from brain.systems.failure_guard.core import (
     FailureGuardStatefulTrigger,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
+    FailureGuardTriggerMode,
+    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
     async_evaluate_failure_guard_triggers,
@@ -307,8 +309,11 @@ class CycleFailureGuardStatefulTrigger(
     """One state-owning cycle failure trigger."""
 
 
-CycleRegisteredFailureGuardTrigger: TypeAlias = (
+CycleFailureGuardTriggerImplementation: TypeAlias = (
     CycleFailureGuardTrigger | CycleFailureGuardStatefulTrigger
+)
+CycleRegisteredFailureGuardTrigger: TypeAlias = (
+    FailureGuardTriggerRegistration[CycleFailureGuardLifecycleContext]
 )
 
 
@@ -329,7 +334,12 @@ class CycleFailureGuardRegistry:
 def cycle_failure_guard_registry() -> CycleFailureGuardRegistry:
     """Return every trigger applied to cycle terminal observations."""
     return CycleFailureGuardRegistry(
-        triggers=(CycleConsecutiveFailuresTrigger(),)
+        triggers=(
+            FailureGuardTriggerRegistration(
+                mode=FailureGuardTriggerMode.STATEFUL,
+                trigger=CycleConsecutiveFailuresTrigger(),
+            ),
+        )
     )
 
 
@@ -416,9 +426,9 @@ async def async_apply_cycle_terminal_failure_guard(
     state_store = _cycle_failure_guard_state_store(session, locked_cycle.id)
     if isinstance(policy, ResetCycleTerminalPolicy):
         latches = dict(await latch_store.load_latches())
-        for trigger in registry.triggers:
-            if trigger.kind in latches:
-                await latch_store.delete_latch(trigger.kind)
+        for registration in registry.triggers:
+            if registration.kind in latches:
+                await latch_store.delete_latch(registration.kind)
         await async_transition_failure_guard_trigger_states(
             triggers=registry.triggers,
             context=CycleFailureGuardLifecycleContext(
@@ -450,9 +460,9 @@ async def async_apply_cycle_terminal_failure_guard(
     if signature_changed:
         latches = dict(await latch_store.load_latches())
         reset_latch = False
-        for trigger in registry.triggers:
-            if trigger.kind in latches:
-                await latch_store.delete_latch(trigger.kind)
+        for registration in registry.triggers:
+            if registration.kind in latches:
+                await latch_store.delete_latch(registration.kind)
                 reset_latch = True
         if reset_latch:
             await session.flush()

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import datetime
+from enum import StrEnum
 from hashlib import sha256
 import re
 from typing import (
     Any,
+    Generic,
     Literal,
     Mapping,
     NewType,
@@ -14,7 +16,7 @@ from typing import (
     Sequence,
     TypeAlias,
     TypeVar,
-    runtime_checkable,
+    cast,
 )
 
 
@@ -129,7 +131,6 @@ class FailureGuardStateStore(Protocol):
         """Delete one trigger's state while preserving any active latch."""
 
 
-@runtime_checkable
 class FailureGuardTrigger(Protocol[FailureGuardContextT]):
     """A stateless trigger evaluated from consumer-owned context."""
 
@@ -142,7 +143,6 @@ class FailureGuardTrigger(Protocol[FailureGuardContextT]):
         """Evaluate the trigger and construct its public presentation."""
 
 
-@runtime_checkable
 class FailureGuardStatefulTrigger(Protocol[FailureGuardContextT]):
     """Complete contract for a trigger that owns persisted JSON state."""
 
@@ -166,55 +166,124 @@ class FailureGuardStatefulTrigger(Protocol[FailureGuardContextT]):
         """Return replacement state, or ``None`` to clear persisted state."""
 
 
-async def async_evaluate_failure_guard_triggers(
-    *,
-    triggers: Sequence[
+class FailureGuardTriggerMode(StrEnum):
+    """A registered trigger's explicit evaluation and persistence mode."""
+
+    STATELESS = "stateless"
+    STATEFUL = "stateful"
+
+
+@dataclass(frozen=True)
+class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
+    """Bind one trigger implementation to its declared dispatch mode."""
+
+    mode: FailureGuardTriggerMode
+    trigger: (
         FailureGuardTrigger[FailureGuardContextT]
         | FailureGuardStatefulTrigger[FailureGuardContextT]
-    ],
+    )
+
+    def __post_init__(self) -> None:
+        trigger_name = type(self.trigger).__name__
+        if not isinstance(self.mode, FailureGuardTriggerMode):
+            raise ValueError(
+                f"Failure-guard trigger {trigger_name} has invalid mode: "
+                f"{self.mode!r}"
+            )
+        stateless_method = "evaluate"
+        stateful_methods = ("evaluate_with_state", "transition_state")
+        if self.mode is FailureGuardTriggerMode.STATEFUL:
+            missing_methods = [
+                method
+                for method in stateful_methods
+                if not callable(getattr(self.trigger, method, None))
+            ]
+            if missing_methods:
+                raise ValueError(
+                    f"Failure-guard trigger {trigger_name} declared stateful "
+                    "but is missing required method(s): "
+                    + ", ".join(missing_methods)
+                )
+            return
+
+        if not callable(getattr(self.trigger, stateless_method, None)):
+            raise ValueError(
+                f"Failure-guard trigger {trigger_name} declared stateless "
+                f"but is missing required method: {stateless_method}"
+            )
+        surplus_methods = [
+            method
+            for method in stateful_methods
+            if callable(getattr(self.trigger, method, None))
+        ]
+        if surplus_methods:
+            raise ValueError(
+                f"Failure-guard trigger {trigger_name} declared stateless "
+                "but has surplus stateful method(s): "
+                + ", ".join(surplus_methods)
+            )
+
+    @property
+    def kind(self) -> FailureGuardTriggerKind:
+        return self.trigger.kind
+
+
+async def async_evaluate_failure_guard_triggers(
+    *,
+    triggers: Sequence[FailureGuardTriggerRegistration[FailureGuardContextT]],
     context: FailureGuardContextT,
     store: FailureGuardStateStore,
 ) -> tuple[FailureGuardTriggerResult, ...]:
     """Evaluate registered triggers through their declared public contract."""
     states = dict(await store.load_trigger_states())
     results: list[FailureGuardTriggerResult] = []
-    for trigger in triggers:
-        if isinstance(trigger, FailureGuardStatefulTrigger):
+    for registration in triggers:
+        trigger = registration.trigger
+        if registration.mode is FailureGuardTriggerMode.STATEFUL:
+            stateful_trigger = cast(
+                FailureGuardStatefulTrigger[FailureGuardContextT],
+                trigger,
+            )
             results.append(
-                await trigger.evaluate_with_state(
+                await stateful_trigger.evaluate_with_state(
                     context,
-                    state=dict(states.get(trigger.kind, {})),
+                    state=dict(states.get(registration.kind, {})),
                 )
             )
         else:
-            results.append(await trigger.evaluate(context))
+            stateless_trigger = cast(
+                FailureGuardTrigger[FailureGuardContextT],
+                trigger,
+            )
+            results.append(await stateless_trigger.evaluate(context))
     return tuple(results)
 
 
 async def async_transition_failure_guard_trigger_states(
     *,
-    triggers: Sequence[
-        FailureGuardTrigger[FailureGuardContextT]
-        | FailureGuardStatefulTrigger[FailureGuardContextT]
-    ],
+    triggers: Sequence[FailureGuardTriggerRegistration[FailureGuardContextT]],
     context: FailureGuardContextT,
     event: FailureGuardLifecycleEvent,
     store: FailureGuardStateStore,
 ) -> None:
     """Apply one lifecycle event to every registered state-owning trigger."""
     states = dict(await store.load_trigger_states())
-    for trigger in triggers:
-        if not isinstance(trigger, FailureGuardStatefulTrigger):
+    for registration in triggers:
+        if registration.mode is FailureGuardTriggerMode.STATELESS:
             continue
+        trigger = cast(
+            FailureGuardStatefulTrigger[FailureGuardContextT],
+            registration.trigger,
+        )
         next_state = await trigger.transition_state(
             context,
-            dict(states.get(trigger.kind, {})),
+            dict(states.get(registration.kind, {})),
             event=event,
         )
         if next_state is None:
-            await store.delete_trigger_state(trigger.kind)
+            await store.delete_trigger_state(registration.kind)
         else:
-            await store.save_trigger_state(trigger.kind, dict(next_state))
+            await store.save_trigger_state(registration.kind, dict(next_state))
 
 
 @dataclass(frozen=True)

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -228,6 +228,31 @@ class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
         return self.trigger.kind
 
 
+def require_failure_guard_registrations(
+    triggers: Sequence[object], *, owner: str
+) -> None:
+    """Reject a registry entry that is a bare trigger rather than a registration.
+
+    Without this, a raw trigger passes a consumer registry's own checks — it has
+    a ``kind`` — and skips ``FailureGuardTriggerRegistration.__post_init__``
+    entirely. The declared mode would then be missing at dispatch time, far from
+    the provider that omitted it, which is exactly the late failure this module
+    exists to prevent.
+    """
+
+    unregistered = [
+        type(trigger).__name__
+        for trigger in triggers
+        if not isinstance(trigger, FailureGuardTriggerRegistration)
+    ]
+    if unregistered:
+        raise ValueError(
+            f"{owner} failure-guard triggers must be wrapped in "
+            "FailureGuardTriggerRegistration with an explicit mode; got bare "
+            "trigger(s): " + ", ".join(unregistered)
+        )
+
+
 async def async_evaluate_failure_guard_triggers(
     *,
     triggers: Sequence[FailureGuardTriggerRegistration[FailureGuardContextT]],

--- a/tests/test_failure_guard_core.py
+++ b/tests/test_failure_guard_core.py
@@ -1,0 +1,163 @@
+"""Failure-guard trigger registration and dispatch contract tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from brain.systems.failure_guard.core import (
+    FailureGuardTriggerKind,
+    FailureGuardTriggerMode,
+    FailureGuardTriggerRegistration,
+    FailureGuardTriggerResult,
+    async_evaluate_failure_guard_triggers,
+    async_transition_failure_guard_trigger_states,
+)
+
+
+_STATELESS_KIND = FailureGuardTriggerKind("stateless_test")
+_STATEFUL_KIND = FailureGuardTriggerKind("stateful_test")
+
+
+@dataclass(frozen=True)
+class _StatelessTrigger:
+    kind: FailureGuardTriggerKind = field(
+        default=_STATELESS_KIND,
+        init=False,
+    )
+
+    async def evaluate(self, context) -> FailureGuardTriggerResult:
+        del context
+        return FailureGuardTriggerResult(
+            kind=self.kind,
+            active=False,
+            public_details={"branch": "stateless"},
+            alert_title="Stateless test",
+            alert_summary="Stateless test",
+        )
+
+
+@dataclass(frozen=True)
+class _DualContractTrigger(_StatelessTrigger):
+    kind: FailureGuardTriggerKind = field(
+        default=_STATEFUL_KIND,
+        init=False,
+    )
+
+    async def evaluate_with_state(
+        self,
+        context,
+        *,
+        state,
+    ) -> FailureGuardTriggerResult:
+        del context
+        return FailureGuardTriggerResult(
+            kind=self.kind,
+            active=True,
+            public_details={"branch": "stateful", "state": dict(state)},
+            alert_title="Stateful test",
+            alert_summary="Stateful test",
+        )
+
+    async def transition_state(self, context, state, *, event):
+        del context, state, event
+        return None
+
+
+@dataclass(frozen=True)
+class _StatefulTriggerMissingTransition:
+    kind: FailureGuardTriggerKind = field(
+        default=_STATEFUL_KIND,
+        init=False,
+    )
+
+    async def evaluate_with_state(self, context, *, state):
+        del context, state
+        raise AssertionError("registration must fail before evaluation")
+
+
+@dataclass
+class _MemoryStateStore:
+    states: dict[FailureGuardTriggerKind, dict[str, object]]
+    saved: list[FailureGuardTriggerKind] = field(default_factory=list)
+    deleted: list[FailureGuardTriggerKind] = field(default_factory=list)
+
+    async def load_trigger_states(self):
+        return self.states
+
+    async def save_trigger_state(self, trigger_kind, state):
+        self.states[trigger_kind] = dict(state)
+        self.saved.append(trigger_kind)
+
+    async def delete_trigger_state(self, trigger_kind):
+        self.states.pop(trigger_kind, None)
+        self.deleted.append(trigger_kind)
+
+
+def test_registration_rejects_stateful_trigger_missing_transition_method():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "_StatefulTriggerMissingTransition declared stateful.*"
+            "transition_state"
+        ),
+    ):
+        FailureGuardTriggerRegistration(
+            mode=FailureGuardTriggerMode.STATEFUL,
+            trigger=_StatefulTriggerMissingTransition(),
+        )
+
+
+def test_registration_rejects_stateless_trigger_with_stateful_methods():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "_DualContractTrigger declared stateless.*"
+            "evaluate_with_state.*transition_state"
+        ),
+    ):
+        FailureGuardTriggerRegistration(
+            mode=FailureGuardTriggerMode.STATELESS,
+            trigger=_DualContractTrigger(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_declared_mode_controls_evaluation_and_persistence():
+    stateless_registration = FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATELESS,
+        trigger=_StatelessTrigger(),
+    )
+    stateful_registration = FailureGuardTriggerRegistration(
+        mode=FailureGuardTriggerMode.STATEFUL,
+        trigger=_DualContractTrigger(),
+    )
+    store = _MemoryStateStore(
+        states={
+            _STATELESS_KIND: {"orphaned": True},
+            _STATEFUL_KIND: {"count": 3},
+        }
+    )
+
+    results = await async_evaluate_failure_guard_triggers(
+        triggers=(stateless_registration, stateful_registration),
+        context=object(),
+        store=store,
+    )
+
+    assert [result.public_details["branch"] for result in results] == [
+        "stateless",
+        "stateful",
+    ]
+    assert results[1].public_details["state"] == {"count": 3}
+
+    await async_transition_failure_guard_trigger_states(
+        triggers=(stateless_registration, stateful_registration),
+        context=object(),
+        event="success",
+        store=store,
+    )
+
+    assert store.states == {_STATELESS_KIND: {"orphaned": True}}
+    assert store.saved == []
+    assert store.deleted == [_STATEFUL_KIND]

--- a/tests/test_failure_guard_core.py
+++ b/tests/test_failure_guard_core.py
@@ -12,6 +12,7 @@ from brain.systems.failure_guard.core import (
     FailureGuardTriggerResult,
     async_evaluate_failure_guard_triggers,
     async_transition_failure_guard_trigger_states,
+    require_failure_guard_registrations,
 )
 
 
@@ -161,3 +162,39 @@ async def test_declared_mode_controls_evaluation_and_persistence():
     assert store.states == {_STATELESS_KIND: {"orphaned": True}}
     assert store.saved == []
     assert store.deleted == [_STATEFUL_KIND]
+
+
+def test_bare_trigger_is_refused_before_it_can_reach_dispatch():
+    """A raw trigger has a ``kind``, so a consumer registry's own checks pass it.
+
+    It never runs ``FailureGuardTriggerRegistration.__post_init__``, so its mode
+    would only be missed at dispatch, far from the provider that omitted it.
+    """
+
+    with pytest.raises(ValueError) as excinfo:
+        require_failure_guard_registrations(
+            (
+                FailureGuardTriggerRegistration(
+                    mode=FailureGuardTriggerMode.STATELESS,
+                    trigger=_StatelessTrigger(),
+                ),
+                _StatelessTrigger(),
+            ),
+            owner="Scheduler",
+        )
+
+    message = str(excinfo.value)
+    assert "Scheduler" in message
+    assert "_StatelessTrigger" in message
+
+
+def test_registrations_only_registry_is_accepted():
+    require_failure_guard_registrations(
+        (
+            FailureGuardTriggerRegistration(
+                mode=FailureGuardTriggerMode.STATELESS,
+                trigger=_StatelessTrigger(),
+            ),
+        ),
+        owner="Cycle",
+    )

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -20,6 +20,8 @@ from brain.systems.failure_guard.core import (
     FailureGuardEdge,
     FailureGuardEvaluation,
     FailureGuardTriggerKind,
+    FailureGuardTriggerMode,
+    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     serialize_failure_guard,
 )
@@ -330,7 +332,10 @@ async def test_registered_database_trigger_projects_once_across_jobs(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: database_trigger,
+            lambda: FailureGuardTriggerRegistration(
+                mode=FailureGuardTriggerMode.STATELESS,
+                trigger=database_trigger,
+            ),
         ),
     )
     session.add(
@@ -1377,29 +1382,35 @@ class _DatabaseBackedTrigger:
     )
 
     async def evaluate(self, context) -> FailureGuardTriggerResult:
-        return (await self.evaluate_many((context,)))[context.job.id]
+        return (
+            await self.evaluate_many(
+                context.session,
+                (context.job,),
+                now=context.now,
+            )
+        )[context.job.id]
 
-    async def evaluate_many(self, contexts):
-        self.projected_job_counts.append(len(contexts))
-        if not contexts:
+    async def evaluate_many(self, session, jobs, *, now):
+        del now
+        self.projected_job_counts.append(len(jobs))
+        if not jobs:
             return {}
-        session = contexts[0].session
-        job_ids = [context.job.id for context in contexts]
+        job_ids = [job.id for job in jobs]
         result = await session.scalars(
             select(SchedulerJob.id).where(SchedulerJob.id.in_(job_ids))
         )
         loaded_job_ids = set(result.all())
         return {
-            context.job.id: FailureGuardTriggerResult(
+            job.id: FailureGuardTriggerResult(
                 kind=self.kind,
-                active=context.job.id in loaded_job_ids,
+                active=job.id in loaded_job_ids,
                 public_details={
-                    "database_row_loaded": context.job.id in loaded_job_ids,
+                    "database_row_loaded": job.id in loaded_job_ids,
                 },
                 alert_title="Scheduler job row loaded",
                 alert_summary="Scheduler job exists in the projection",
             )
-            for context in contexts
+            for job in jobs
         }
 
     async def should_reset(
@@ -1429,21 +1440,28 @@ class _RuntimeDurationTrigger:
         self,
         context,
     ) -> FailureGuardTriggerResult:
-        return (await self.evaluate_many((context,)))[context.job.id]
+        return (
+            await self.evaluate_many(
+                context.session,
+                (context.job,),
+                now=context.now,
+            )
+        )[context.job.id]
 
-    async def evaluate_many(self, contexts):
+    async def evaluate_many(self, session, jobs, *, now):
+        del session
         return {
-            context.job.id: self._result(context)
-            for context in contexts
+            job.id: self._result(job, now=now)
+            for job in jobs
         }
 
-    def _result(self, context) -> FailureGuardTriggerResult:
-        assert context.job.last_started_at is not None
-        started_at = context.job.last_started_at
+    def _result(self, job, *, now) -> FailureGuardTriggerResult:
+        assert job.last_started_at is not None
+        started_at = job.last_started_at
         if started_at.tzinfo is None:
             started_at = started_at.replace(tzinfo=timezone.utc)
         elapsed_minutes = int(
-            (context.now - started_at).total_seconds() // 60
+            (now - started_at).total_seconds() // 60
         )
         return FailureGuardTriggerResult(
             kind=self.kind,
@@ -1504,7 +1522,10 @@ async def test_third_trigger_flows_through_production_apply_health_delivery_and_
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: _RuntimeDurationTrigger(minimum_runtime_minutes=30),
+            lambda: FailureGuardTriggerRegistration(
+                mode=FailureGuardTriggerMode.STATELESS,
+                trigger=_RuntimeDurationTrigger(minimum_runtime_minutes=30),
+            ),
         ),
     )
     assert [

--- a/tests/test_scheduler_failure_guard_stateful_trigger.py
+++ b/tests/test_scheduler_failure_guard_stateful_trigger.py
@@ -15,6 +15,8 @@ from brain.app.scheduler.scheduler_failure_guard import (
 from brain.platform.db.models.scheduler import SchedulerRun
 from brain.systems.failure_guard.core import (
     FailureGuardTriggerKind,
+    FailureGuardTriggerMode,
+    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
 )
 from tests.scheduler_test_support import (
@@ -111,7 +113,10 @@ async def test_stateful_third_trigger_flows_through_production_registry(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: _DistinctFailureClassesTrigger(threshold=2),
+            lambda: FailureGuardTriggerRegistration(
+                mode=FailureGuardTriggerMode.STATEFUL,
+                trigger=_DistinctFailureClassesTrigger(threshold=2),
+            ),
         ),
     )
     assert [


### PR DESCRIPTION
Closes #769

## What this does

A failure-guard trigger's mode — stateless or state-owning — is now **declared**
instead of guessed.

It used to be inferred from `@runtime_checkable` Protocol membership, so which
method names a class happened to have decided two things at once: which
evaluation branch ran, and whether the trigger's row was written or deleted.
Adding or removing one method silently changed persistence behavior, in a
different file, with no error.

That already happened. In #758 / PR #766, `StandingFailuresTrigger` dropped
`transition_state` for good reasons. The intended effect was "stop persisting a
drifting counter". The actual effect was that, plus a change of dispatch branch,
plus its state rows becoming permanently orphaned (#768) — three consequences
from deleting one method, none visible to the author or the reviewer.

Now: `FailureGuardTriggerRegistration` binds a trigger to a declared
`FailureGuardTriggerMode` and **rejects a mismatch at construction**, naming the
trigger and the missing or surplus methods. Evaluation, bulk projection and
state transitions dispatch on the tag. The protocols keep their typing role but
no longer decide behavior — `runtime_checkable` is gone from both.

`evaluate_many` now takes the shared `session`, `jobs` and `now` once, which
retires the runtime equality guard both triggers carried to reject a shape their
own signature invited.

## Behavior does not change

Same rows written, same rows deleted, same evaluation branch per trigger, for
both consumers — the scheduler (`scheduler_failure_guard.py`) and Cycles
(`cycle_failure_guard.py`). Scheduler modes: consecutive and configuration are
stateful; standing and rolling are stateless.

## How to check it after merge

1. Merge and let Illo deploy.
2. Let a scheduler job fail. The failure-guard alert fires exactly as before,
   once, with its latch.
3. On illo-dev, `SELECT trigger_kind, count(*) FROM
   scheduler_failure_guard_trigger_states GROUP BY trigger_kind;` — `consecutive`
   and `configuration` still get rows; the stateless kinds still get none.
4. A Cycle failure still alerts through the same path.

## Evidence

- Full backend fast suite on this branch, the repo's own CI command, run
  serially on an idle machine (zero Codex processes, load 4.1):
  `4900 passed, 11 skipped` in 113s.
- Backend lane only — the diff touches `brain/**` and `tests/**`.
- Verified mechanically: no `runtime_checkable` left in `failure_guard/`, no
  `isinstance` on a trigger protocol left in the dispatch path, and both
  `evaluate_many` equality guards are gone.

## Cross-family code-quality review

A Codex thermo-nuclear review of this diff returned 2 blocking findings.

**Fixed here**, in a second commit: both registries still accepted a *bare*
trigger at runtime. Their own checks only read `.kind`, which a raw trigger has,
so it skipped `FailureGuardTriggerRegistration.__post_init__` entirely and its
missing mode would surface only at dispatch — the exact late failure this ticket
exists to prevent. `require_failure_guard_registrations` now runs first in both
registries and names the offending class.

**Not fixed here, and worth your call:** the mode tag and the implementation
remain independent types, so `mode` does not narrow `trigger` and dispatch needs
three `cast(...)` calls; the scheduler's consumer alias likewise discards
`SchedulerFailureGuardTriggerImplementation`, so a new scheduler trigger could
register validly with `evaluate` but no `evaluate_many`. The fix is typed
stateless/stateful registration variants with literal mode tags, unioned as the
registration type. That is a type-level refactor of its own, so I filed it as
#773 rather than growing this diff. #773 stays open after this merges.

Review output: `state/evidence/769-thermo-review-20260810T1700.md`.
