### PR TITLE
refactor(failure-guard): narrow trigger registrations by mode

### DIFF
--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,7 +11,6 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
-    cast,
 )
 
 from sqlalchemy import and_, delete, func, or_, select
@@ -31,10 +30,11 @@ from brain.systems.failure_guard.core import (
     FailureGuardLifecycleEvent,
     FailureGuardLatch,
     FailureGuardStatefulTrigger,
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
     FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
@@ -512,11 +512,11 @@ class SchedulerFailureGuardStatefulTrigger(
     """One state-owning scheduler failure trigger."""
 
 
-SchedulerFailureGuardTriggerImplementation: TypeAlias = (
-    SchedulerFailureGuardTrigger | SchedulerFailureGuardStatefulTrigger
-)
 SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
-    FailureGuardTriggerRegistration[SchedulerFailureGuardLifecycleContext]
+    FailureGuardStatelessTriggerRegistration[SchedulerFailureGuardTrigger]
+    | FailureGuardStatefulTriggerRegistration[
+        SchedulerFailureGuardStatefulTrigger
+    ]
 )
 
 
@@ -528,6 +528,22 @@ class SchedulerFailureGuardRegistry:
 
     def __post_init__(self) -> None:
         require_failure_guard_registrations(self.triggers, owner="Scheduler")
+        for registration in self.triggers:
+            required_methods = ["should_reset"]
+            if registration.mode is FailureGuardTriggerMode.STATELESS:
+                required_methods.insert(0, "evaluate_many")
+            missing_methods = [
+                method
+                for method in required_methods
+                if not callable(getattr(registration.trigger, method, None))
+            ]
+            if missing_methods:
+                raise ValueError(
+                    "Scheduler failure-guard trigger "
+                    f"{type(registration.trigger).__name__} declared "
+                    f"{registration.mode.value} but is missing required "
+                    "method(s): " + ", ".join(missing_methods)
+                )
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):
             raise ValueError(
@@ -541,20 +557,16 @@ _FAILURE_GUARD_TRIGGER_PROVIDERS: tuple[
     Callable[[], SchedulerRegisteredFailureGuardTrigger],
     ...,
 ] = (
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    lambda: FailureGuardStatefulTriggerRegistration(
         trigger=ConsecutiveFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    lambda: FailureGuardStatelessTriggerRegistration(
         trigger=StandingFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    lambda: FailureGuardStatelessTriggerRegistration(
         trigger=RollingWindowFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    lambda: FailureGuardStatefulTriggerRegistration(
         trigger=ConfigurationFailureTrigger(),
     ),
 )
@@ -753,7 +765,7 @@ async def async_read_scheduler_failure_guards(
     for registration in registry.triggers:
         if registration.mode is FailureGuardTriggerMode.STATEFUL:
             continue
-        trigger = cast(SchedulerFailureGuardTrigger, registration.trigger)
+        trigger = registration.trigger
         trigger_results = dict(
             await trigger.evaluate_many(session, jobs, now=now)
         )
@@ -868,13 +880,12 @@ async def async_record_scheduler_job_failure(
         latches = dict(await latch_store.load_latches())
         reset_latch = False
         for registration in registry.triggers:
-            trigger = cast(
-                SchedulerFailureGuardResettableTrigger,
-                registration.trigger,
-            )
-            if registration.kind not in latches or not await trigger.should_reset(
-                context,
-                event="signature_change",
+            if (
+                registration.kind not in latches
+                or not await registration.trigger.should_reset(
+                    context,
+                    event="signature_change",
+                )
             ):
                 continue
             await latch_store.delete_latch(registration.kind)
@@ -951,13 +962,9 @@ async def async_reset_scheduler_job_failure_guard(
     )
     latches = dict(await latch_store.load_latches())
     for registration in registry.triggers:
-        trigger = cast(
-            SchedulerFailureGuardResettableTrigger,
-            registration.trigger,
-        )
         if registration.kind not in latches:
             continue
-        if await trigger.should_reset(
+        if await registration.trigger.should_reset(
             context,
             event="success",
         ):

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,6 +11,7 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
+    runtime_checkable,
 )
 
 from sqlalchemy import and_, delete, func, or_, select
@@ -473,6 +474,7 @@ class RollingWindowFailuresTrigger:
         return not (await self.evaluate(context)).active
 
 
+@runtime_checkable
 class SchedulerFailureGuardResettableTrigger(Protocol):
     """Scheduler-owned latch-reset behavior shared by all trigger kinds."""
 
@@ -487,6 +489,7 @@ class SchedulerFailureGuardResettableTrigger(Protocol):
         """Return whether this trigger's latch should reset."""
 
 
+@runtime_checkable
 class SchedulerFailureGuardTrigger(
     SchedulerFailureGuardResettableTrigger,
     FailureGuardTrigger[SchedulerFailureGuardLifecycleContext],
@@ -504,6 +507,7 @@ class SchedulerFailureGuardTrigger(
         """Evaluate this trigger for every projected job."""
 
 
+@runtime_checkable
 class SchedulerFailureGuardStatefulTrigger(
     SchedulerFailureGuardResettableTrigger,
     FailureGuardStatefulTrigger[SchedulerFailureGuardLifecycleContext],
@@ -529,20 +533,30 @@ class SchedulerFailureGuardRegistry:
     def __post_init__(self) -> None:
         require_failure_guard_registrations(self.triggers, owner="Scheduler")
         for registration in self.triggers:
-            required_methods = ["should_reset"]
             if registration.mode is FailureGuardTriggerMode.STATELESS:
-                required_methods.insert(0, "evaluate_many")
-            missing_methods = [
-                method
-                for method in required_methods
-                if not callable(getattr(registration.trigger, method, None))
-            ]
-            if missing_methods:
+                trigger_protocol = SchedulerFailureGuardTrigger
+            else:
+                trigger_protocol = SchedulerFailureGuardStatefulTrigger
+            if not isinstance(registration.trigger, trigger_protocol):
+                missing_methods = sorted(
+                    method
+                    for method in trigger_protocol.__protocol_attrs__
+                    if callable(getattr(trigger_protocol, method, None))
+                    and not callable(
+                        getattr(registration.trigger, method, None)
+                    )
+                )
+                missing_detail = (
+                    "; missing required method(s): "
+                    + ", ".join(missing_methods)
+                    if missing_methods
+                    else ""
+                )
                 raise ValueError(
                     "Scheduler failure-guard trigger "
                     f"{type(registration.trigger).__name__} declared "
-                    f"{registration.mode.value} but is missing required "
-                    "method(s): " + ", ".join(missing_methods)
+                    f"{registration.mode.value} but does not satisfy "
+                    f"{trigger_protocol.__name__} protocol{missing_detail}"
                 )
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):

--- a/brain/systems/cycles/cycle_failure_guard.py
+++ b/brain/systems/cycles/cycle_failure_guard.py
@@ -26,10 +26,10 @@ from brain.systems.failure_guard.core import (
     FailureGuardEvaluation,
     FailureGuardLifecycleEvent,
     FailureGuardStatefulTrigger,
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
@@ -310,11 +310,11 @@ class CycleFailureGuardStatefulTrigger(
     """One state-owning cycle failure trigger."""
 
 
-CycleFailureGuardTriggerImplementation: TypeAlias = (
-    CycleFailureGuardTrigger | CycleFailureGuardStatefulTrigger
-)
 CycleRegisteredFailureGuardTrigger: TypeAlias = (
-    FailureGuardTriggerRegistration[CycleFailureGuardLifecycleContext]
+    FailureGuardStatelessTriggerRegistration[CycleFailureGuardTrigger]
+    | FailureGuardStatefulTriggerRegistration[
+        CycleFailureGuardStatefulTrigger
+    ]
 )
 
 
@@ -337,8 +337,7 @@ def cycle_failure_guard_registry() -> CycleFailureGuardRegistry:
     """Return every trigger applied to cycle terminal observations."""
     return CycleFailureGuardRegistry(
         triggers=(
-            FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATEFUL,
+            FailureGuardStatefulTriggerRegistration(
                 trigger=CycleConsecutiveFailuresTrigger(),
             ),
         )

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -1,7 +1,7 @@
 """Neutral failure identity and latch/edge evaluation primitives."""
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import StrEnum
 from hashlib import sha256
@@ -16,7 +16,7 @@ from typing import (
     Sequence,
     TypeAlias,
     TypeVar,
-    cast,
+    assert_never,
 )
 
 
@@ -166,6 +166,18 @@ class FailureGuardStatefulTrigger(Protocol[FailureGuardContextT]):
         """Return replacement state, or ``None`` to clear persisted state."""
 
 
+FailureGuardStatelessTriggerT = TypeVar(
+    "FailureGuardStatelessTriggerT",
+    bound=FailureGuardTrigger[Any],
+    covariant=True,
+)
+FailureGuardStatefulTriggerT = TypeVar(
+    "FailureGuardStatefulTriggerT",
+    bound=FailureGuardStatefulTrigger[Any],
+    covariant=True,
+)
+
+
 class FailureGuardTriggerMode(StrEnum):
     """A registered trigger's explicit evaluation and persistence mode."""
 
@@ -174,38 +186,21 @@ class FailureGuardTriggerMode(StrEnum):
 
 
 @dataclass(frozen=True)
-class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
-    """Bind one trigger implementation to its declared dispatch mode."""
+class FailureGuardStatelessTriggerRegistration(
+    Generic[FailureGuardStatelessTriggerT]
+):
+    """Bind one stateless trigger to its literal dispatch mode."""
 
-    mode: FailureGuardTriggerMode
-    trigger: (
-        FailureGuardTrigger[FailureGuardContextT]
-        | FailureGuardStatefulTrigger[FailureGuardContextT]
+    trigger: FailureGuardStatelessTriggerT
+    mode: Literal[FailureGuardTriggerMode.STATELESS] = field(
+        default=FailureGuardTriggerMode.STATELESS,
+        init=False,
     )
 
     def __post_init__(self) -> None:
         trigger_name = type(self.trigger).__name__
-        if not isinstance(self.mode, FailureGuardTriggerMode):
-            raise ValueError(
-                f"Failure-guard trigger {trigger_name} has invalid mode: "
-                f"{self.mode!r}"
-            )
         stateless_method = "evaluate"
         stateful_methods = ("evaluate_with_state", "transition_state")
-        if self.mode is FailureGuardTriggerMode.STATEFUL:
-            missing_methods = [
-                method
-                for method in stateful_methods
-                if not callable(getattr(self.trigger, method, None))
-            ]
-            if missing_methods:
-                raise ValueError(
-                    f"Failure-guard trigger {trigger_name} declared stateful "
-                    "but is missing required method(s): "
-                    + ", ".join(missing_methods)
-                )
-            return
-
         if not callable(getattr(self.trigger, stateless_method, None)):
             raise ValueError(
                 f"Failure-guard trigger {trigger_name} declared stateless "
@@ -228,27 +223,74 @@ class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
         return self.trigger.kind
 
 
+@dataclass(frozen=True)
+class FailureGuardStatefulTriggerRegistration(
+    Generic[FailureGuardStatefulTriggerT]
+):
+    """Bind one stateful trigger to its literal dispatch mode."""
+
+    trigger: FailureGuardStatefulTriggerT
+    mode: Literal[FailureGuardTriggerMode.STATEFUL] = field(
+        default=FailureGuardTriggerMode.STATEFUL,
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        trigger_name = type(self.trigger).__name__
+        stateful_methods = ("evaluate_with_state", "transition_state")
+        missing_methods = [
+            method
+            for method in stateful_methods
+            if not callable(getattr(self.trigger, method, None))
+        ]
+        if missing_methods:
+            raise ValueError(
+                f"Failure-guard trigger {trigger_name} declared stateful "
+                "but is missing required method(s): "
+                + ", ".join(missing_methods)
+            )
+
+    @property
+    def kind(self) -> FailureGuardTriggerKind:
+        return self.trigger.kind
+
+
+FailureGuardTriggerRegistration: TypeAlias = (
+    FailureGuardStatelessTriggerRegistration[
+        FailureGuardTrigger[FailureGuardContextT]
+    ]
+    | FailureGuardStatefulTriggerRegistration[
+        FailureGuardStatefulTrigger[FailureGuardContextT]
+    ]
+)
+
+
 def require_failure_guard_registrations(
     triggers: Sequence[object], *, owner: str
 ) -> None:
     """Reject a registry entry that is a bare trigger rather than a registration.
 
     Without this, a raw trigger passes a consumer registry's own checks — it has
-    a ``kind`` — and skips ``FailureGuardTriggerRegistration.__post_init__``
-    entirely. The declared mode would then be missing at dispatch time, far from
-    the provider that omitted it, which is exactly the late failure this module
-    exists to prevent.
+    a ``kind`` — and skips the registration variant's validation entirely. The
+    declared mode would then be missing at dispatch time, far from the provider
+    that omitted it, which is exactly the late failure this module prevents.
     """
 
     unregistered = [
         type(trigger).__name__
         for trigger in triggers
-        if not isinstance(trigger, FailureGuardTriggerRegistration)
+        if not isinstance(
+            trigger,
+            (
+                FailureGuardStatelessTriggerRegistration,
+                FailureGuardStatefulTriggerRegistration,
+            ),
+        )
     ]
     if unregistered:
         raise ValueError(
             f"{owner} failure-guard triggers must be wrapped in "
-            "FailureGuardTriggerRegistration with an explicit mode; got bare "
+            "a failure-guard trigger registration; got bare "
             "trigger(s): " + ", ".join(unregistered)
         )
 
@@ -263,24 +305,17 @@ async def async_evaluate_failure_guard_triggers(
     states = dict(await store.load_trigger_states())
     results: list[FailureGuardTriggerResult] = []
     for registration in triggers:
-        trigger = registration.trigger
         if registration.mode is FailureGuardTriggerMode.STATEFUL:
-            stateful_trigger = cast(
-                FailureGuardStatefulTrigger[FailureGuardContextT],
-                trigger,
-            )
             results.append(
-                await stateful_trigger.evaluate_with_state(
+                await registration.trigger.evaluate_with_state(
                     context,
                     state=dict(states.get(registration.kind, {})),
                 )
             )
+        elif registration.mode is FailureGuardTriggerMode.STATELESS:
+            results.append(await registration.trigger.evaluate(context))
         else:
-            stateless_trigger = cast(
-                FailureGuardTrigger[FailureGuardContextT],
-                trigger,
-            )
-            results.append(await stateless_trigger.evaluate(context))
+            assert_never(registration)
     return tuple(results)
 
 
@@ -296,19 +331,21 @@ async def async_transition_failure_guard_trigger_states(
     for registration in triggers:
         if registration.mode is FailureGuardTriggerMode.STATELESS:
             continue
-        trigger = cast(
-            FailureGuardStatefulTrigger[FailureGuardContextT],
-            registration.trigger,
-        )
-        next_state = await trigger.transition_state(
-            context,
-            dict(states.get(registration.kind, {})),
-            event=event,
-        )
-        if next_state is None:
-            await store.delete_trigger_state(registration.kind)
-        else:
-            await store.save_trigger_state(registration.kind, dict(next_state))
+        if registration.mode is FailureGuardTriggerMode.STATEFUL:
+            next_state = await registration.trigger.transition_state(
+                context,
+                dict(states.get(registration.kind, {})),
+                event=event,
+            )
+            if next_state is None:
+                await store.delete_trigger_state(registration.kind)
+            else:
+                await store.save_trigger_state(
+                    registration.kind,
+                    dict(next_state),
+                )
+            continue
+        assert_never(registration)
 
 
 @dataclass(frozen=True)

--- a/tests/test_failure_guard_core.py
+++ b/tests/test_failure_guard_core.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 import pytest
 
 from brain.systems.failure_guard.core import (
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     async_evaluate_failure_guard_triggers,
     async_transition_failure_guard_trigger_states,
@@ -103,8 +103,7 @@ def test_registration_rejects_stateful_trigger_missing_transition_method():
             "transition_state"
         ),
     ):
-        FailureGuardTriggerRegistration(
-            mode=FailureGuardTriggerMode.STATEFUL,
+        FailureGuardStatefulTriggerRegistration(
             trigger=_StatefulTriggerMissingTransition(),
         )
 
@@ -117,20 +116,17 @@ def test_registration_rejects_stateless_trigger_with_stateful_methods():
             "evaluate_with_state.*transition_state"
         ),
     ):
-        FailureGuardTriggerRegistration(
-            mode=FailureGuardTriggerMode.STATELESS,
+        FailureGuardStatelessTriggerRegistration(
             trigger=_DualContractTrigger(),
         )
 
 
 @pytest.mark.asyncio
 async def test_declared_mode_controls_evaluation_and_persistence():
-    stateless_registration = FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    stateless_registration = FailureGuardStatelessTriggerRegistration(
         trigger=_StatelessTrigger(),
     )
-    stateful_registration = FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    stateful_registration = FailureGuardStatefulTriggerRegistration(
         trigger=_DualContractTrigger(),
     )
     store = _MemoryStateStore(
@@ -167,15 +163,14 @@ async def test_declared_mode_controls_evaluation_and_persistence():
 def test_bare_trigger_is_refused_before_it_can_reach_dispatch():
     """A raw trigger has a ``kind``, so a consumer registry's own checks pass it.
 
-    It never runs ``FailureGuardTriggerRegistration.__post_init__``, so its mode
-    would only be missed at dispatch, far from the provider that omitted it.
+    It never runs a registration variant's validation, so its mode would only
+    be missed at dispatch, far from the provider that omitted it.
     """
 
     with pytest.raises(ValueError) as excinfo:
         require_failure_guard_registrations(
             (
-                FailureGuardTriggerRegistration(
-                    mode=FailureGuardTriggerMode.STATELESS,
+                FailureGuardStatelessTriggerRegistration(
                     trigger=_StatelessTrigger(),
                 ),
                 _StatelessTrigger(),
@@ -191,8 +186,7 @@ def test_bare_trigger_is_refused_before_it_can_reach_dispatch():
 def test_registrations_only_registry_is_accepted():
     require_failure_guard_registrations(
         (
-            FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            FailureGuardStatelessTriggerRegistration(
                 trigger=_StatelessTrigger(),
             ),
         ),

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -83,6 +83,7 @@ async def test_scheduler_registration_rejects_trigger_without_scheduler_contract
         ValueError,
         match=(
             "_EvaluateOnlySchedulerTrigger declared stateless.*"
+            "SchedulerFailureGuardTrigger protocol.*"
             "evaluate_many, should_reset"
         ),
     ):

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -19,9 +19,8 @@ from brain.app.scheduler.daemon import (
 from brain.systems.failure_guard.core import (
     FailureGuardEdge,
     FailureGuardEvaluation,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     serialize_failure_guard,
 )
@@ -59,6 +58,41 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def session(async_sqlite_session_factory):
     return await make_scheduler_test_session(async_sqlite_session_factory)
+
+
+@dataclass(frozen=True)
+class _EvaluateOnlySchedulerTrigger:
+    kind: FailureGuardTriggerKind = field(
+        default=FailureGuardTriggerKind("evaluate_only"),
+        init=False,
+    )
+
+    async def evaluate(self, context) -> FailureGuardTriggerResult:
+        del context
+        return FailureGuardTriggerResult(
+            kind=self.kind,
+            active=False,
+            public_details={},
+            alert_title="Evaluate-only trigger",
+            alert_summary="Evaluate-only trigger",
+        )
+
+
+async def test_scheduler_registration_rejects_trigger_without_scheduler_contract():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "_EvaluateOnlySchedulerTrigger declared stateless.*"
+            "evaluate_many, should_reset"
+        ),
+    ):
+        scheduler_failure_guard.SchedulerFailureGuardRegistry(
+            triggers=(
+                FailureGuardStatelessTriggerRegistration(
+                    trigger=_EvaluateOnlySchedulerTrigger(),
+                ),
+            )
+        )
 
 
 async def test_failure_signature_normalizes_volatile_runtime_identity():
@@ -332,8 +366,7 @@ async def test_registered_database_trigger_projects_once_across_jobs(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            lambda: FailureGuardStatelessTriggerRegistration(
                 trigger=database_trigger,
             ),
         ),
@@ -1522,8 +1555,7 @@ async def test_third_trigger_flows_through_production_apply_health_delivery_and_
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            lambda: FailureGuardStatelessTriggerRegistration(
                 trigger=_RuntimeDurationTrigger(minimum_runtime_minutes=30),
             ),
         ),

--- a/tests/test_scheduler_failure_guard_stateful_trigger.py
+++ b/tests/test_scheduler_failure_guard_stateful_trigger.py
@@ -14,9 +14,8 @@ from brain.app.scheduler.scheduler_failure_guard import (
 )
 from brain.platform.db.models.scheduler import SchedulerRun
 from brain.systems.failure_guard.core import (
+    FailureGuardStatefulTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
 )
 from tests.scheduler_test_support import (
@@ -113,8 +112,7 @@ async def test_stateful_third_trigger_flows_through_production_registry(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATEFUL,
+            lambda: FailureGuardStatefulTriggerRegistration(
                 trigger=_DistinctFailureClassesTrigger(threshold=2),
             ),
         ),


### PR DESCRIPTION
Closes #773

## What changed

`FailureGuardTriggerRegistration` carried `mode` and `trigger` as independent
fields, so the tag did not narrow the implementation type and dispatch needed six
`cast(...)` calls to assert what the mode had already declared.

- Adds `FailureGuardStatelessTriggerRegistration` and
  `FailureGuardStatefulTriggerRegistration` with literal `mode` tags.
  `mode` is `init=False`, so a caller can no longer construct a registration whose
  tag disagrees with its variant.
- `FailureGuardTriggerRegistration` is now their discriminated union.
- Consumer aliases bind each variant to the scheduler and Cycle protocols. The
  unused `SchedulerFailureGuardTriggerImplementation` alias is deleted.
- **All six casts are gone**; `assert_never` replaces them.
- A scheduler trigger missing `evaluate_many` or `should_reset` now fails at
  **registration**, not at dispatch far from the provider that registered it.

**Behavior is unchanged.** This is a type-level refactor.

## The review caught something and it is folded in

The cross-family code-quality review (Codex, thermo-nuclear rubric) found one
**blocking** issue in the first commit: the registry validated the scheduler
contract against a hand-written list of method names, so the protocols and the
check became two separate sources of truth. A maintainer adding a method to
`SchedulerFailureGuardTrigger` would leave the registration check silently
permissive — recreating the exact late failure this ticket exists to prevent.

Second commit fixes it: the scheduler protocols are `@runtime_checkable` and the
registry validates with `isinstance` against the protocol the mode selects. The
error message still names the missing methods, derived from `__protocol_attrs__`
rather than written out. The Cycle consumer carried no hand-listed methods and is
unchanged.

Runtime protocols check member presence, not signatures — the same guarantee the
previous `callable(getattr(...))` list gave. This is not a weakening.

## Verification

- Repo CI command, run serially on an idle machine (load 3.3 before, 5.3 after):
  `pytest tests/ -m "not requires_db and not requires_browser and not live_provider"`
  → **4868 passed, 11 skipped** (one more than `main`: the new registration test).
- New test: `test_scheduler_registration_rejects_trigger_without_scheduler_contract`
  proves an evaluate-only scheduler trigger fails registration.
- The repo configures no mypy or pyright, so there is no static type gate to run.
  That is the point of the ticket: the types are now checkable if one is ever added.

## How to judge this on staging

There is no UI. The scheduler either starts or it does not:

1. Deploy to illo-dev and confirm `illospace-scheduler-1` comes up healthy —
   registry construction runs at import, so a mistake here fails fast and loudly.
2. Let one scheduled Cycle run and fail, then confirm the failure guard still
   latches and still resets exactly as it does today.
