### PR TITLE
feat(cycles): behavior-policy command module and immutable change audit (behavior editor slice 1)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -44,7 +44,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle as command_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.serializers import (
     serialize_cycle,
     serialize_cycle_guidance,
@@ -1503,7 +1503,7 @@ async def _handle_mcp_request(
             cycle_change = tool_payload.pop("_cycle_change", None)
             await db.commit()
             if isinstance(cycle_change, dict):
-                publish_cycle_change(
+                publish_cycle_change_safe(
                     action=str(cycle_change.get("action") or "update"),
                     **dict(cycle_change.get("event") or {}),
                 )

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -1203,7 +1203,10 @@ async def _act_manage_cycle(
         )
         await db.flush()
         await db.refresh(cycle)
-        return _cycle_mutation_payload("update", cycle, {"cycle": serialize_cycle(cycle)})
+        return {
+            "cycle": serialize_cycle(cycle),
+            "_mutates_cycle": True,
+        }
 
     if action == "delete":
         await command_delete_cycle(db, cycle)
@@ -1239,11 +1242,11 @@ async def _act_manage_cycle(
             guidance=_required_capability_string(arguments, "guidance", capability="cycle.manage"),
             rationale=rationale,
         )
-        return _cycle_mutation_payload(
-            "update",
-            cycle,
-            {"cycle": serialize_cycle(cycle), "guidance": serialize_cycle_guidance(guidance)},
-        )
+        return {
+            "cycle": serialize_cycle(cycle),
+            "guidance": serialize_cycle_guidance(guidance),
+            "_mutates_cycle": True,
+        }
 
     if action == "add_output_target":
         target = await command_add_cycle_output_target(

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -22,7 +22,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle as command_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.common import SCHEDULED_DIGEST_RUN_KIND
 from brain.systems.cycles.serializers import serialize_cycle, serialize_cycle_run
 from brain.systems.cycles.service import async_run_cycle_now
@@ -114,7 +114,7 @@ async def create_cycle(
     payload = serialize_cycle(cycle)
     event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="create",
         **event,
     )
@@ -183,7 +183,7 @@ async def delete_cycle(
     await command_delete_cycle(db, cycle)
     event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="delete",
         **event,
     )
@@ -225,7 +225,7 @@ async def run_cycle(
         cycle_id,
         run_kind=SCHEDULED_DIGEST_RUN_KIND,
     )
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="run",
         **event,
     )

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -169,12 +169,7 @@ async def update_cycle(
     await db.flush()
     await db.refresh(cycle)
     payload = serialize_cycle(cycle)
-    event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
-        action="update",
-        **event,
-    )
     return payload
 
 

--- a/brain/platform/db/alembic/versions/0059_behavior_change_audits.py
+++ b/brain/platform/db/alembic/versions/0059_behavior_change_audits.py
@@ -1,0 +1,97 @@
+"""Add the immutable behavior-change audit envelope.
+
+Revision ID: 0059_behavior_change_audits
+Revises: 0058_delete_orphaned_standing_failure_states
+Create Date: 2026-08-10
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0059_behavior_change_audits"
+down_revision = "0058_delete_orphaned_standing_failure_states"
+branch_labels = None
+depends_on = None
+
+_TABLE = "behavior_change_audits"
+
+
+def upgrade() -> None:
+    # The public baseline creates current model tables on fresh installs before
+    # later migrations replay.
+    if sa.inspect(op.get_bind()).has_table(_TABLE):
+        return
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("workspace_id", sa.Text(), nullable=False),
+        sa.Column("policy_kind", sa.String(length=50), nullable=False),
+        sa.Column("target_type", sa.String(length=50), nullable=False),
+        sa.Column("target_id", sa.Text(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("actor_type", sa.String(length=30), nullable=False),
+        sa.Column("actor_id", sa.Text(), nullable=False),
+        sa.Column("source_reference", sa.Text(), nullable=False),
+        sa.Column("rationale", sa.Text(), nullable=False),
+        sa.Column("before_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("after_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("changed_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("cycle_revision_id", sa.Integer(), nullable=False),
+        sa.Column("reverted_from_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "applied_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["cycle_revision_id"],
+            ["cycle_revisions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["reverted_from_id"],
+            ["behavior_change_audits.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "cycle_revision_id",
+            name="uq_behavior_change_audits_cycle_revision",
+        ),
+        sa.UniqueConstraint(
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+            name="uq_behavior_change_audits_target_version",
+        ),
+    )
+    op.create_index(
+        "ix_behavior_change_audits_workspace_applied",
+        "behavior_change_audits",
+        ["workspace_id", "applied_at", "id"],
+    )
+    op.create_index(
+        "ix_behavior_change_audits_target_history",
+        "behavior_change_audits",
+        ["policy_kind", "target_type", "target_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    if not sa.inspect(op.get_bind()).has_table(_TABLE):
+        return
+    op.drop_index(
+        "ix_behavior_change_audits_target_history",
+        table_name=_TABLE,
+    )
+    op.drop_index(
+        "ix_behavior_change_audits_workspace_applied",
+        table_name=_TABLE,
+    )
+    op.drop_table(_TABLE)

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from brain.platform.db.base import Base, CreatedAtMixin, TimestampMixin
 
 __all__ = [
+    "BehaviorChangeAudit",
     "Cycle",
     "CycleFailureGuardLatch",
     "CycleFailureGuardObservation",
@@ -21,6 +22,67 @@ __all__ = [
     "CycleRun",
     "CycleRunEvaluation",
 ]
+
+
+class BehaviorChangeAudit(Base):
+    """Append-only, human-readable envelope for one behavior-policy apply."""
+
+    __tablename__ = "behavior_change_audits"
+    __table_args__ = (
+        UniqueConstraint(
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+            name="uq_behavior_change_audits_target_version",
+        ),
+        UniqueConstraint(
+            "cycle_revision_id",
+            name="uq_behavior_change_audits_cycle_revision",
+        ),
+        Index(
+            "ix_behavior_change_audits_workspace_applied",
+            "workspace_id",
+            "applied_at",
+            "id",
+        ),
+        Index(
+            "ix_behavior_change_audits_target_history",
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[str] = mapped_column(Text, nullable=False)
+    policy_kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_id: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    actor_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    actor_id: Mapped[str] = mapped_column(Text, nullable=False)
+    source_reference: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    before_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    after_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    changed_fields: Mapped[list] = mapped_column(JSONB, nullable=False)
+    cycle_revision_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("cycle_revisions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    reverted_from_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("behavior_change_audits.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    applied_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("NOW()"),
+    )
 
 
 class Cycle(Base, TimestampMixin):

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -1,0 +1,837 @@
+"""Reviewed Cycle behavior-policy commands and their immutable audit envelope.
+
+This module is the only write path for an existing Cycle's behavior fields and
+active guidance set. API and agent adapters can differ, but both must preview
+and apply through this contract.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy import func, select
+
+from brain.kernel.common.serialization import jsonable
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleRevision,
+)
+from brain.platform.db.models.idea import Idea
+from brain.systems.cycles.access import (
+    CycleActor,
+    cycle_scope_conditions,
+    target_idea_scope_conditions,
+)
+from brain.systems.cycles.common import (
+    canonical_execution_mode,
+    validate_cycle_timeout_seconds,
+    validate_model_override,
+    validate_nonempty_trimmed,
+    validate_thinking_override,
+)
+from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.execution_policy_registry import (
+    validate_cycle_execution_policy_key,
+)
+from brain.systems.cycles.memory import async_record_cycle_revision
+from brain.systems.cycles.schedules import (
+    build_one_time_schedule_expr,
+    compute_next_run_at,
+    validate_schedule_expr,
+    validate_timezone_name,
+)
+
+__all__ = [
+    "BehaviorChangeRecord",
+    "CyclePolicyApplied",
+    "CyclePolicyApplyResult",
+    "CyclePolicyConflict",
+    "CyclePolicyPatch",
+    "CyclePolicyPreview",
+    "EffectiveCyclePolicy",
+    "async_apply_cycle_policy_change",
+    "async_apply_cycle_policy_revert",
+    "async_list_cycle_policy_history",
+    "async_preview_cycle_policy_change",
+    "async_preview_cycle_policy_revert",
+    "async_read_effective_cycle_policy",
+]
+
+CYCLE_POLICY_KIND = "cycle"
+CYCLE_TARGET_TYPE = "cycle"
+
+
+class _UnsetPolicyField:
+    pass
+
+
+UNSET_POLICY_FIELD = _UnsetPolicyField()
+
+
+@dataclass(frozen=True)
+class CyclePolicyPatch:
+    """Typed changes to Cycle behavior, never arbitrary table columns."""
+
+    name: Any = UNSET_POLICY_FIELD
+    prompt: Any = UNSET_POLICY_FIELD
+    timezone_name: Any = UNSET_POLICY_FIELD
+    schedule_expr: Any = UNSET_POLICY_FIELD
+    run_at: Any = UNSET_POLICY_FIELD
+    enabled: Any = UNSET_POLICY_FIELD
+    max_concurrency: Any = UNSET_POLICY_FIELD
+    timeout_seconds: Any = UNSET_POLICY_FIELD
+    retry_policy: Any = UNSET_POLICY_FIELD
+    model_override: Any = UNSET_POLICY_FIELD
+    thinking_override: Any = UNSET_POLICY_FIELD
+    execution_policy_key: Any = UNSET_POLICY_FIELD
+    target_idea_id: Any = UNSET_POLICY_FIELD
+    guidance: Any = UNSET_POLICY_FIELD
+    guidance_additions: Any = UNSET_POLICY_FIELD
+
+
+@dataclass(frozen=True)
+class _CyclePolicyReplacement:
+    """Validated full replacement used only by the revert adapter."""
+
+    snapshot: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class EffectiveCyclePolicy:
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    version: int
+    revision_id: int | None
+    snapshot: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CyclePolicyPreview:
+    before: EffectiveCyclePolicy
+    after_snapshot: dict[str, Any]
+    changed_fields: tuple[str, ...]
+    preview_digest: str
+    reverted_from_id: int | None = None
+
+
+@dataclass(frozen=True)
+class BehaviorChangeRecord:
+    id: int
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    version: int
+    actor_type: str
+    actor_id: str
+    source_reference: str
+    rationale: str
+    before_snapshot: dict[str, Any]
+    after_snapshot: dict[str, Any]
+    changed_fields: tuple[str, ...]
+    cycle_revision_id: int
+    applied_at: datetime
+    reverted_from_id: int | None
+
+
+@dataclass(frozen=True)
+class CyclePolicyApplied:
+    effective_policy: EffectiveCyclePolicy
+    change: BehaviorChangeRecord
+    revision: CycleRevision
+
+
+@dataclass(frozen=True)
+class CyclePolicyConflict:
+    reason: str
+    latest_effective_policy: EffectiveCyclePolicy
+
+
+CyclePolicyApplyResult = CyclePolicyApplied | CyclePolicyConflict
+
+
+async def async_read_effective_cycle_policy(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+) -> EffectiveCyclePolicy:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    return await _effective_policy(session, cycle)
+
+
+async def async_preview_cycle_policy_change(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    proposal: CyclePolicyPatch,
+) -> CyclePolicyPreview:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    current = await _effective_policy(session, cycle)
+    return await _preview_for_cycle(
+        session,
+        actor=actor,
+        cycle=cycle,
+        current=current,
+        proposal=proposal,
+    )
+
+
+async def async_apply_cycle_policy_change(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    expected_version: int,
+    preview_digest: str,
+    rationale: str,
+    source_reference: str,
+    reverted_from_id: int | None = None,
+) -> CyclePolicyApplyResult:
+    """Apply one reviewed change inside the caller's transaction.
+
+    A savepoint keeps the policy write set atomic even when a caller catches an
+    apply-time exception and continues using its outer transaction. The Cycle
+    row lock serializes version allocation on PostgreSQL.
+    """
+
+    clean_rationale = validate_nonempty_trimmed(rationale, "rationale")
+    clean_source_reference = validate_nonempty_trimmed(
+        source_reference,
+        "source_reference",
+    )
+    if isinstance(expected_version, bool) or not isinstance(expected_version, int):
+        raise ValueError("expected_version must be an integer")
+    clean_digest = validate_nonempty_trimmed(preview_digest, "preview_digest")
+
+    async with session.begin_nested():
+        cycle = await _load_scoped_cycle(
+            session,
+            actor=actor,
+            cycle_id=cycle_id,
+            for_update=True,
+        )
+        current = await _effective_policy(session, cycle)
+        if current.version != expected_version:
+            return CyclePolicyConflict(
+                reason="stale_version",
+                latest_effective_policy=current,
+            )
+
+        if reverted_from_id is not None:
+            await _load_revert_source(
+                session,
+                cycle=cycle,
+                change_id=reverted_from_id,
+            )
+
+        preview = await _preview_for_cycle(
+            session,
+            actor=actor,
+            cycle=cycle,
+            current=current,
+            proposal=proposal,
+            reverted_from_id=reverted_from_id,
+        )
+        if preview.preview_digest != clean_digest:
+            return CyclePolicyConflict(
+                reason="stale_preview_digest",
+                latest_effective_policy=current,
+            )
+        if not preview.changed_fields:
+            raise ValueError("proposed change does not change Cycle policy")
+
+        _apply_cycle_snapshot(cycle, preview.after_snapshot)
+        cycle.maintainer_type = actor.source_type
+        cycle.maintainer_id = actor.revision_source_id
+        revision = await async_record_cycle_revision(
+            session,
+            cycle,
+            source_type=actor.source_type,
+            source_id=actor.revision_source_id,
+            rationale=clean_rationale,
+        )
+        await _replace_active_guidance(
+            session,
+            cycle=cycle,
+            desired_guidance=preview.after_snapshot["guidance"],
+            actor=actor,
+            rationale=clean_rationale,
+            revision_id=revision.id,
+        )
+
+        change = BehaviorChangeAudit(
+            workspace_id=current.workspace_id,
+            policy_kind=CYCLE_POLICY_KIND,
+            target_type=CYCLE_TARGET_TYPE,
+            target_id=str(cycle.id),
+            version=current.version + 1,
+            actor_type=actor.source_type,
+            actor_id=actor.revision_source_id,
+            source_reference=clean_source_reference,
+            rationale=clean_rationale,
+            before_snapshot=deepcopy(current.snapshot),
+            after_snapshot=deepcopy(preview.after_snapshot),
+            changed_fields=list(preview.changed_fields),
+            cycle_revision_id=revision.id,
+            reverted_from_id=reverted_from_id,
+            applied_at=datetime.now(timezone.utc),
+        )
+        session.add(change)
+        await session.flush()
+
+        publish_cycle_change(
+            action="update",
+            org_id=cycle.org_id,
+            user_id=cycle.user_id,
+            cycle_id=cycle.id,
+            target_idea_id=cycle.target_idea_id,
+            strict=True,
+        )
+
+        effective = EffectiveCyclePolicy(
+            workspace_id=current.workspace_id,
+            policy_kind=CYCLE_POLICY_KIND,
+            target_type=CYCLE_TARGET_TYPE,
+            target_id=str(cycle.id),
+            version=change.version,
+            revision_id=revision.id,
+            snapshot=deepcopy(preview.after_snapshot),
+        )
+        return CyclePolicyApplied(
+            effective_policy=effective,
+            change=_record(change),
+            revision=revision,
+        )
+
+
+async def async_list_cycle_policy_history(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    limit: int = 100,
+) -> list[BehaviorChangeRecord]:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    clean_limit = max(1, min(int(limit), 500))
+    rows = list(
+        (
+            await session.scalars(
+                select(BehaviorChangeAudit)
+                .where(*_audit_target_conditions(cycle))
+                .order_by(BehaviorChangeAudit.version.desc())
+                .limit(clean_limit)
+            )
+        ).all()
+    )
+    return [_record(row) for row in rows]
+
+
+async def async_preview_cycle_policy_revert(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    change_id: int,
+) -> CyclePolicyPreview:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
+    current = await _effective_policy(session, cycle)
+    return await _preview_for_cycle(
+        session,
+        actor=actor,
+        cycle=cycle,
+        current=current,
+        proposal=_CyclePolicyReplacement(source.before_snapshot),
+        reverted_from_id=source.id,
+    )
+
+
+async def async_apply_cycle_policy_revert(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    change_id: int,
+    expected_version: int,
+    preview_digest: str,
+    rationale: str,
+    source_reference: str,
+) -> CyclePolicyApplyResult:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
+    return await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle_id,
+        proposal=_CyclePolicyReplacement(source.before_snapshot),
+        expected_version=expected_version,
+        preview_digest=preview_digest,
+        rationale=rationale,
+        source_reference=source_reference,
+        reverted_from_id=source.id,
+    )
+
+
+async def _load_scoped_cycle(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    for_update: bool = False,
+) -> Cycle:
+    statement = select(Cycle).where(
+        Cycle.id == cycle_id,
+        *cycle_scope_conditions(actor),
+    )
+    if for_update:
+        statement = statement.with_for_update()
+    cycle = (await session.scalars(statement)).first()
+    if cycle is None:
+        raise ValueError("Cycle not found")
+    return cycle
+
+
+async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
+    guidance_rows = list(
+        (
+            await session.scalars(
+                select(CycleGuidance)
+                .where(
+                    CycleGuidance.cycle_id == cycle.id,
+                    CycleGuidance.is_active.is_(True),
+                )
+                .order_by(CycleGuidance.created_at.asc(), CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    version = int(
+        (
+            await session.scalar(
+                select(func.coalesce(func.max(BehaviorChangeAudit.version), 0)).where(
+                    *_audit_target_conditions(cycle)
+                )
+            )
+        )
+        or 0
+    )
+    revision_id = await session.scalar(
+        select(CycleRevision.id)
+        .where(CycleRevision.cycle_id == cycle.id)
+        .order_by(CycleRevision.revision_number.desc(), CycleRevision.id.desc())
+        .limit(1)
+    )
+    return EffectiveCyclePolicy(
+        workspace_id=_workspace_id(cycle),
+        policy_kind=CYCLE_POLICY_KIND,
+        target_type=CYCLE_TARGET_TYPE,
+        target_id=str(cycle.id),
+        version=version,
+        revision_id=revision_id,
+        snapshot=_cycle_snapshot(cycle, guidance_rows),
+    )
+
+
+async def _preview_for_cycle(
+    session,
+    *,
+    actor: CycleActor,
+    cycle: Cycle,
+    current: EffectiveCyclePolicy,
+    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    reverted_from_id: int | None = None,
+) -> CyclePolicyPreview:
+    if isinstance(proposal, _CyclePolicyReplacement):
+        after = _validated_snapshot(proposal.snapshot)
+    else:
+        after = _project_patch(current.snapshot, proposal)
+    if after["target_idea_id"] != current.snapshot["target_idea_id"]:
+        await _validate_target_idea(
+            session,
+            actor=actor,
+            target_idea_id=after["target_idea_id"],
+        )
+    changed_fields = tuple(
+        key for key in sorted(after) if current.snapshot.get(key) != after.get(key)
+    )
+    digest = _preview_digest(
+        current=current,
+        after_snapshot=after,
+        changed_fields=changed_fields,
+        reverted_from_id=reverted_from_id,
+    )
+    return CyclePolicyPreview(
+        before=current,
+        after_snapshot=after,
+        changed_fields=changed_fields,
+        preview_digest=digest,
+        reverted_from_id=reverted_from_id,
+    )
+
+
+def _project_patch(
+    current_snapshot: Mapping[str, Any],
+    patch: CyclePolicyPatch,
+) -> dict[str, Any]:
+    after = deepcopy(dict(current_snapshot))
+    timezone_name = after["timezone"]
+    if _set(patch.timezone_name) and patch.timezone_name is not None:
+        timezone_name = validate_timezone_name(patch.timezone_name)
+        after["timezone"] = timezone_name
+
+    if _set(patch.run_at) and patch.run_at is not None:
+        after["schedule_expr"] = build_one_time_schedule_expr(
+            patch.run_at,
+            timezone_name,
+        )
+    elif _set(patch.schedule_expr) and patch.schedule_expr is not None:
+        after["schedule_expr"] = validate_schedule_expr(
+            patch.schedule_expr,
+            timezone_name,
+        )
+    elif after["timezone"] != current_snapshot["timezone"]:
+        after["schedule_expr"] = validate_schedule_expr(
+            after["schedule_expr"],
+            timezone_name,
+        )
+
+    for field in ("name", "prompt"):
+        value = getattr(patch, field)
+        if _set(value) and value is not None:
+            after[field] = validate_nonempty_trimmed(value, field)
+
+    if _set(patch.enabled) and patch.enabled is not None:
+        if not isinstance(patch.enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        after["enabled"] = patch.enabled
+    if _set(patch.max_concurrency):
+        after["max_concurrency"] = _validated_max_concurrency(patch.max_concurrency)
+    if _set(patch.timeout_seconds):
+        after["timeout_seconds"] = validate_cycle_timeout_seconds(
+            patch.timeout_seconds
+        )
+    if _set(patch.retry_policy):
+        if not isinstance(patch.retry_policy, dict):
+            raise ValueError("retry_policy must be an object")
+        after["retry_policy"] = jsonable(deepcopy(patch.retry_policy))
+    if _set(patch.model_override):
+        after["model_override"] = validate_model_override(patch.model_override)
+    if _set(patch.thinking_override):
+        after["thinking_override"] = validate_thinking_override(
+            patch.thinking_override
+        )
+    if _set(patch.execution_policy_key):
+        after["execution_policy_key"] = validate_cycle_execution_policy_key(
+            patch.execution_policy_key
+        )
+    else:
+        validate_cycle_execution_policy_key(after["execution_policy_key"])
+    if _set(patch.target_idea_id):
+        after["target_idea_id"] = (
+            str(patch.target_idea_id) if patch.target_idea_id is not None else None
+        )
+    if _set(patch.guidance) and _set(patch.guidance_additions):
+        raise ValueError("guidance and guidance_additions cannot be changed together")
+    if _set(patch.guidance):
+        if not isinstance(patch.guidance, (list, tuple)):
+            raise ValueError("guidance must be a list of strings")
+        after["guidance"] = sorted(
+            validate_nonempty_trimmed(value, "guidance")
+            for value in patch.guidance
+        )
+    elif _set(patch.guidance_additions):
+        if not isinstance(patch.guidance_additions, (list, tuple)):
+            raise ValueError("guidance_additions must be a list of strings")
+        after["guidance"] = sorted(
+            [
+                *after["guidance"],
+                *(
+                    validate_nonempty_trimmed(value, "guidance")
+                    for value in patch.guidance_additions
+                ),
+            ]
+        )
+    return _validated_snapshot(after)
+
+
+def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    expected_fields = {
+        "name",
+        "prompt",
+        "schedule_expr",
+        "timezone",
+        "enabled",
+        "max_concurrency",
+        "timeout_seconds",
+        "retry_policy",
+        "model_override",
+        "thinking_override",
+        "execution_policy_key",
+        "target_idea_id",
+        "guidance",
+    }
+    if set(snapshot) != expected_fields:
+        raise ValueError("Cycle policy snapshot has an invalid field set")
+    timezone_name = validate_timezone_name(snapshot["timezone"])
+    if not isinstance(snapshot["enabled"], bool):
+        raise ValueError("enabled must be a boolean")
+    if not isinstance(snapshot["retry_policy"], dict):
+        raise ValueError("retry_policy must be an object")
+    if not isinstance(snapshot["guidance"], (list, tuple)):
+        raise ValueError("guidance must be a list of strings")
+    return {
+        "name": validate_nonempty_trimmed(snapshot["name"], "name"),
+        "prompt": validate_nonempty_trimmed(snapshot["prompt"], "prompt"),
+        "schedule_expr": validate_schedule_expr(
+            snapshot["schedule_expr"],
+            timezone_name,
+        ),
+        "timezone": timezone_name,
+        "enabled": snapshot["enabled"],
+        "max_concurrency": _validated_max_concurrency(
+            snapshot["max_concurrency"]
+        ),
+        "timeout_seconds": validate_cycle_timeout_seconds(
+            snapshot["timeout_seconds"]
+        ),
+        "retry_policy": jsonable(deepcopy(snapshot["retry_policy"])),
+        "model_override": validate_model_override(snapshot["model_override"]),
+        "thinking_override": validate_thinking_override(
+            snapshot["thinking_override"]
+        ),
+        "execution_policy_key": validate_cycle_execution_policy_key(
+            snapshot["execution_policy_key"]
+        ),
+        "target_idea_id": (
+            str(snapshot["target_idea_id"])
+            if snapshot["target_idea_id"] is not None
+            else None
+        ),
+        "guidance": sorted(
+            validate_nonempty_trimmed(value, "guidance")
+            for value in snapshot["guidance"]
+        ),
+    }
+
+
+def _cycle_snapshot(cycle: Cycle, guidance_rows: list[CycleGuidance]) -> dict[str, Any]:
+    return _validated_snapshot(
+        {
+            "name": cycle.name,
+            "prompt": cycle.prompt,
+            "schedule_expr": cycle.schedule_expr,
+            "timezone": cycle.timezone,
+            "enabled": bool(cycle.enabled),
+            "max_concurrency": max(int(cycle.max_concurrency or 1), 1),
+            "timeout_seconds": cycle.timeout_seconds,
+            "retry_policy": dict(cycle.retry_policy or {}),
+            "model_override": cycle.model_override,
+            "thinking_override": cycle.thinking_override,
+            "execution_policy_key": cycle.execution_policy_key,
+            "target_idea_id": (
+                str(cycle.target_idea_id) if cycle.target_idea_id is not None else None
+            ),
+            "guidance": [row.guidance for row in guidance_rows],
+        }
+    )
+
+
+def _apply_cycle_snapshot(cycle: Cycle, snapshot: Mapping[str, Any]) -> None:
+    cycle.name = snapshot["name"]
+    cycle.prompt = snapshot["prompt"]
+    cycle.schedule_expr = snapshot["schedule_expr"]
+    cycle.timezone = snapshot["timezone"]
+    cycle.enabled = snapshot["enabled"]
+    cycle.max_concurrency = snapshot["max_concurrency"]
+    cycle.timeout_seconds = snapshot["timeout_seconds"]
+    cycle.retry_policy = deepcopy(snapshot["retry_policy"])
+    cycle.model_override = snapshot["model_override"]
+    cycle.thinking_override = snapshot["thinking_override"]
+    cycle.execution_policy_key = snapshot["execution_policy_key"]
+    cycle.target_idea_id = snapshot["target_idea_id"]
+    cycle.execution_mode = canonical_execution_mode()
+    cycle.reopen_archived = True
+    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
+    cycle.updated_at = datetime.now(timezone.utc)
+
+
+async def _replace_active_guidance(
+    session,
+    *,
+    cycle: Cycle,
+    desired_guidance: list[str],
+    actor: CycleActor,
+    rationale: str,
+    revision_id: int,
+) -> None:
+    active_rows = list(
+        (
+            await session.scalars(
+                select(CycleGuidance)
+                .where(
+                    CycleGuidance.cycle_id == cycle.id,
+                    CycleGuidance.is_active.is_(True),
+                )
+                .order_by(CycleGuidance.created_at.asc(), CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    unmatched = list(desired_guidance)
+    for row in active_rows:
+        try:
+            index = unmatched.index(row.guidance)
+        except ValueError:
+            row.is_active = False
+        else:
+            unmatched.pop(index)
+
+    for guidance in unmatched:
+        session.add(
+            CycleGuidance(
+                cycle_id=cycle.id,
+                revision_id=revision_id,
+                source_type=actor.source_type,
+                source_id=actor.revision_source_id,
+                guidance=guidance,
+                rationale=rationale,
+                is_active=True,
+            )
+        )
+
+
+async def _validate_target_idea(
+    session,
+    *,
+    actor: CycleActor,
+    target_idea_id: str | None,
+) -> None:
+    if target_idea_id is None:
+        return
+    row = await session.scalar(
+        select(Idea.id).where(*target_idea_scope_conditions(target_idea_id, actor))
+    )
+    if row is None:
+        raise ValueError("target_idea_id must belong to the current workspace")
+
+
+async def _load_revert_source(
+    session,
+    *,
+    cycle: Cycle,
+    change_id: int,
+) -> BehaviorChangeAudit:
+    row = await session.scalar(
+        select(BehaviorChangeAudit).where(
+            BehaviorChangeAudit.id == change_id,
+            *_audit_target_conditions(cycle),
+        )
+    )
+    if row is None:
+        raise ValueError("Behavior change not found")
+    return row
+
+
+def _preview_digest(
+    *,
+    current: EffectiveCyclePolicy,
+    after_snapshot: Mapping[str, Any],
+    changed_fields: tuple[str, ...],
+    reverted_from_id: int | None,
+) -> str:
+    payload = {
+        "workspace_id": current.workspace_id,
+        "policy_kind": current.policy_kind,
+        "target_type": current.target_type,
+        "target_id": current.target_id,
+        "expected_version": current.version,
+        "before_snapshot": current.snapshot,
+        "after_snapshot": after_snapshot,
+        "changed_fields": list(changed_fields),
+        "reverted_from_id": reverted_from_id,
+    }
+    canonical = json.dumps(
+        jsonable(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
+    applied_at = row.applied_at
+    if applied_at.tzinfo is None:
+        applied_at = applied_at.replace(tzinfo=timezone.utc)
+    return BehaviorChangeRecord(
+        id=row.id,
+        workspace_id=row.workspace_id,
+        policy_kind=row.policy_kind,
+        target_type=row.target_type,
+        target_id=row.target_id,
+        version=row.version,
+        actor_type=row.actor_type,
+        actor_id=row.actor_id,
+        source_reference=row.source_reference,
+        rationale=row.rationale,
+        before_snapshot=deepcopy(row.before_snapshot),
+        after_snapshot=deepcopy(row.after_snapshot),
+        changed_fields=tuple(row.changed_fields or []),
+        cycle_revision_id=row.cycle_revision_id,
+        applied_at=applied_at,
+        reverted_from_id=row.reverted_from_id,
+    )
+
+
+def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
+    if row is None:
+        return None
+    record = _record(row)
+    return {
+        "id": record.id,
+        "workspace_id": record.workspace_id,
+        "policy_kind": record.policy_kind,
+        "target_type": record.target_type,
+        "target_id": record.target_id,
+        "version": record.version,
+        "actor_type": record.actor_type,
+        "actor_id": record.actor_id,
+        "source_reference": record.source_reference,
+        "rationale": record.rationale,
+        "before_snapshot": record.before_snapshot,
+        "after_snapshot": record.after_snapshot,
+        "changed_fields": list(record.changed_fields),
+        "cycle_revision_id": record.cycle_revision_id,
+        "applied_at": record.applied_at.isoformat(),
+        "reverted_from_id": record.reverted_from_id,
+    }
+
+
+def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
+    return (
+        BehaviorChangeAudit.policy_kind == CYCLE_POLICY_KIND,
+        BehaviorChangeAudit.target_type == CYCLE_TARGET_TYPE,
+        BehaviorChangeAudit.target_id == str(cycle.id),
+    )
+
+
+def _workspace_id(cycle: Cycle) -> str:
+    return str(cycle.org_id or cycle.user_id)
+
+
+def _validated_max_concurrency(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("max_concurrency must be an integer >= 1")
+    return value
+
+
+def _set(value: Any) -> bool:
+    return value is not UNSET_POLICY_FIELD

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -35,7 +35,7 @@ from brain.systems.cycles.common import (
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_strict
 from brain.systems.cycles.execution_policy_registry import (
     validate_cycle_execution_policy_key,
 )
@@ -55,6 +55,7 @@ __all__ = [
     "CyclePolicyPatch",
     "CyclePolicyPreview",
     "EffectiveCyclePolicy",
+    "UNSET_CYCLE_FIELD",
     "async_apply_cycle_policy_change",
     "async_apply_cycle_policy_revert",
     "async_list_cycle_policy_history",
@@ -65,34 +66,53 @@ __all__ = [
 
 CYCLE_POLICY_KIND = "cycle"
 CYCLE_TARGET_TYPE = "cycle"
+CYCLE_POLICY_SNAPSHOT_VERSION = 1
+_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD = "snapshot_version"
+_CYCLE_POLICY_SNAPSHOT_FIELDS = frozenset(
+    {
+        "name",
+        "prompt",
+        "schedule_expr",
+        "timezone",
+        "enabled",
+        "max_concurrency",
+        "timeout_seconds",
+        "retry_policy",
+        "model_override",
+        "thinking_override",
+        "execution_policy_key",
+        "target_idea_id",
+        "guidance",
+    }
+)
 
 
-class _UnsetPolicyField:
+class _UnsetCycleField:
     pass
 
 
-UNSET_POLICY_FIELD = _UnsetPolicyField()
+UNSET_CYCLE_FIELD = _UnsetCycleField()
 
 
 @dataclass(frozen=True)
 class CyclePolicyPatch:
     """Typed changes to Cycle behavior, never arbitrary table columns."""
 
-    name: Any = UNSET_POLICY_FIELD
-    prompt: Any = UNSET_POLICY_FIELD
-    timezone_name: Any = UNSET_POLICY_FIELD
-    schedule_expr: Any = UNSET_POLICY_FIELD
-    run_at: Any = UNSET_POLICY_FIELD
-    enabled: Any = UNSET_POLICY_FIELD
-    max_concurrency: Any = UNSET_POLICY_FIELD
-    timeout_seconds: Any = UNSET_POLICY_FIELD
-    retry_policy: Any = UNSET_POLICY_FIELD
-    model_override: Any = UNSET_POLICY_FIELD
-    thinking_override: Any = UNSET_POLICY_FIELD
-    execution_policy_key: Any = UNSET_POLICY_FIELD
-    target_idea_id: Any = UNSET_POLICY_FIELD
-    guidance: Any = UNSET_POLICY_FIELD
-    guidance_additions: Any = UNSET_POLICY_FIELD
+    name: Any = UNSET_CYCLE_FIELD
+    prompt: Any = UNSET_CYCLE_FIELD
+    timezone_name: Any = UNSET_CYCLE_FIELD
+    schedule_expr: Any = UNSET_CYCLE_FIELD
+    run_at: Any = UNSET_CYCLE_FIELD
+    enabled: Any = UNSET_CYCLE_FIELD
+    max_concurrency: Any = UNSET_CYCLE_FIELD
+    timeout_seconds: Any = UNSET_CYCLE_FIELD
+    retry_policy: Any = UNSET_CYCLE_FIELD
+    model_override: Any = UNSET_CYCLE_FIELD
+    thinking_override: Any = UNSET_CYCLE_FIELD
+    execution_policy_key: Any = UNSET_CYCLE_FIELD
+    target_idea_id: Any = UNSET_CYCLE_FIELD
+    guidance: Any = UNSET_CYCLE_FIELD
+    guidance_additions: Any = UNSET_CYCLE_FIELD
 
 
 @dataclass(frozen=True)
@@ -280,8 +300,8 @@ async def async_apply_cycle_policy_change(
             actor_id=actor.revision_source_id,
             source_reference=clean_source_reference,
             rationale=clean_rationale,
-            before_snapshot=deepcopy(current.snapshot),
-            after_snapshot=deepcopy(preview.after_snapshot),
+            before_snapshot=_encode_stored_snapshot(current.snapshot),
+            after_snapshot=_encode_stored_snapshot(preview.after_snapshot),
             changed_fields=list(preview.changed_fields),
             cycle_revision_id=revision.id,
             reverted_from_id=reverted_from_id,
@@ -290,13 +310,12 @@ async def async_apply_cycle_policy_change(
         session.add(change)
         await session.flush()
 
-        publish_cycle_change(
+        publish_cycle_change_strict(
             action="update",
             org_id=cycle.org_id,
             user_id=cycle.user_id,
             cycle_id=cycle.id,
             target_idea_id=cycle.target_idea_id,
-            strict=True,
         )
 
         effective = EffectiveCyclePolicy(
@@ -310,7 +329,7 @@ async def async_apply_cycle_policy_change(
         )
         return CyclePolicyApplied(
             effective_policy=effective,
-            change=_record(change),
+            change=_record(change, current_snapshot=preview.after_snapshot),
             revision=revision,
         )
 
@@ -323,6 +342,7 @@ async def async_list_cycle_policy_history(
     limit: int = 100,
 ) -> list[BehaviorChangeRecord]:
     cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    current = await _effective_policy(session, cycle)
     clean_limit = max(1, min(int(limit), 500))
     rows = list(
         (
@@ -334,7 +354,10 @@ async def async_list_cycle_policy_history(
             )
         ).all()
     )
-    return [_record(row) for row in rows]
+    return [
+        _record(row, current_snapshot=current.snapshot)
+        for row in rows
+    ]
 
 
 async def async_preview_cycle_policy_revert(
@@ -452,7 +475,10 @@ async def _preview_for_cycle(
     reverted_from_id: int | None = None,
 ) -> CyclePolicyPreview:
     if isinstance(proposal, _CyclePolicyReplacement):
-        after = _validated_snapshot(proposal.snapshot)
+        after = _decode_stored_snapshot(
+            proposal.snapshot,
+            current_snapshot=current.snapshot,
+        )
     else:
         after = _project_patch(current.snapshot, proposal)
     if after["target_idea_id"] != current.snapshot["target_idea_id"]:
@@ -565,22 +591,7 @@ def _project_patch(
 
 
 def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
-    expected_fields = {
-        "name",
-        "prompt",
-        "schedule_expr",
-        "timezone",
-        "enabled",
-        "max_concurrency",
-        "timeout_seconds",
-        "retry_policy",
-        "model_override",
-        "thinking_override",
-        "execution_policy_key",
-        "target_idea_id",
-        "guidance",
-    }
-    if set(snapshot) != expected_fields:
+    if set(snapshot) != _CYCLE_POLICY_SNAPSHOT_FIELDS:
         raise ValueError("Cycle policy snapshot has an invalid field set")
     timezone_name = validate_timezone_name(snapshot["timezone"])
     if not isinstance(snapshot["enabled"], bool):
@@ -622,6 +633,39 @@ def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             for value in snapshot["guidance"]
         ),
     }
+
+
+def _encode_stored_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        _CYCLE_POLICY_SNAPSHOT_VERSION_FIELD: CYCLE_POLICY_SNAPSHOT_VERSION,
+        **_validated_snapshot(snapshot),
+    }
+
+
+def _decode_stored_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    current_snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("Cycle policy snapshot must be an object")
+    snapshot_version = snapshot.get(_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD)
+    if snapshot_version is not None and (
+        isinstance(snapshot_version, bool)
+        or not isinstance(snapshot_version, int)
+        or snapshot_version < 1
+    ):
+        raise ValueError("Cycle policy snapshot has an invalid version")
+
+    decoded = _validated_snapshot(current_snapshot)
+    decoded.update(
+        {
+            field: deepcopy(snapshot[field])
+            for field in _CYCLE_POLICY_SNAPSHOT_FIELDS
+            if field in snapshot
+        }
+    )
+    return _validated_snapshot(decoded)
 
 
 def _cycle_snapshot(cycle: Cycle, guidance_rows: list[CycleGuidance]) -> dict[str, Any]:
@@ -767,7 +811,11 @@ def _preview_digest(
     return hashlib.sha256(canonical).hexdigest()
 
 
-def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
+def _record(
+    row: BehaviorChangeAudit,
+    *,
+    current_snapshot: Mapping[str, Any],
+) -> BehaviorChangeRecord:
     applied_at = row.applied_at
     if applied_at.tzinfo is None:
         applied_at = applied_at.replace(tzinfo=timezone.utc)
@@ -782,38 +830,19 @@ def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
         actor_id=row.actor_id,
         source_reference=row.source_reference,
         rationale=row.rationale,
-        before_snapshot=deepcopy(row.before_snapshot),
-        after_snapshot=deepcopy(row.after_snapshot),
+        before_snapshot=_decode_stored_snapshot(
+            row.before_snapshot,
+            current_snapshot=current_snapshot,
+        ),
+        after_snapshot=_decode_stored_snapshot(
+            row.after_snapshot,
+            current_snapshot=current_snapshot,
+        ),
         changed_fields=tuple(row.changed_fields or []),
         cycle_revision_id=row.cycle_revision_id,
         applied_at=applied_at,
         reverted_from_id=row.reverted_from_id,
     )
-
-
-def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
-    if row is None:
-        return None
-    record = _record(row)
-    return {
-        "id": record.id,
-        "workspace_id": record.workspace_id,
-        "policy_kind": record.policy_kind,
-        "target_type": record.target_type,
-        "target_id": record.target_id,
-        "version": record.version,
-        "actor_type": record.actor_type,
-        "actor_id": record.actor_id,
-        "source_reference": record.source_reference,
-        "rationale": record.rationale,
-        "before_snapshot": record.before_snapshot,
-        "after_snapshot": record.after_snapshot,
-        "changed_fields": list(record.changed_fields),
-        "cycle_revision_id": record.cycle_revision_id,
-        "applied_at": record.applied_at.isoformat(),
-        "reverted_from_id": record.reverted_from_id,
-    }
-
 
 def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
     return (
@@ -834,4 +863,4 @@ def _validated_max_concurrency(value: Any) -> int:
 
 
 def _set(value: Any) -> bool:
-    return value is not UNSET_POLICY_FIELD
+    return value is not UNSET_CYCLE_FIELD

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -10,7 +10,7 @@ from brain.systems.cycles.access import CycleActor
 from brain.systems.cycles.behavior_policy import (
     CyclePolicyApplied,
     CyclePolicyPatch,
-    UNSET_POLICY_FIELD,
+    UNSET_CYCLE_FIELD,
     async_apply_cycle_policy_change,
     async_preview_cycle_policy_change,
 )
@@ -37,14 +37,6 @@ from brain.systems.cycles.schedules import (
     validate_schedule_expr,
     validate_timezone_name,
 )
-
-
-class _UnsetCycleField:
-    pass
-
-
-UNSET_CYCLE_FIELD = _UnsetCycleField()
-
 
 def _validated_max_concurrency(value: int) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
@@ -170,7 +162,7 @@ async def async_update_cycle(
         execution_policy_key=_policy_field(execution_policy_key),
         target_idea_id=_policy_field(target_idea_id),
         guidance_additions=(
-            [guidance] if guidance else UNSET_POLICY_FIELD
+            [guidance] if guidance else UNSET_CYCLE_FIELD
         ),
     )
     preview = await async_preview_cycle_policy_change(
@@ -321,7 +313,7 @@ def _is_patch_field_set(value) -> bool:
 
 def _policy_field(value, *, ignore_none: bool = False):
     if value is UNSET_CYCLE_FIELD or (ignore_none and value is None):
-        return UNSET_POLICY_FIELD
+        return UNSET_CYCLE_FIELD
     return value
 
 

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from brain.platform.db.models.cycle import Cycle
+from sqlalchemy import select
+
+from brain.platform.db.models.cycle import Cycle, CycleGuidance
 from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyPatch,
+    UNSET_POLICY_FIELD,
+    async_apply_cycle_policy_change,
+    async_preview_cycle_policy_change,
+)
 from brain.systems.cycles.common import (
     canonical_execution_mode,
     validate_cycle_timeout_seconds,
@@ -137,80 +146,51 @@ async def async_update_cycle(
     guidance: str | None = None,
     rationale: str | None = None,
 ) -> Cycle:
+    # Validate a stored key before any query or mutation. This preserves the
+    # existing fail-fast repair signal for legacy rows with invalid keys.
     if _is_patch_field_set(execution_policy_key):
-        next_execution_policy_key = validate_cycle_execution_policy_key(
+        validate_cycle_execution_policy_key(
             execution_policy_key
         )
     else:
         validate_cycle_execution_policy_key(
             getattr(cycle, "execution_policy_key", None)
         )
-        next_execution_policy_key = UNSET_CYCLE_FIELD
-    next_timezone = validate_timezone_name(timezone_name) if _has_patch_value(timezone_name) else cycle.timezone
-    next_schedule_expr = cycle.schedule_expr
-    next_model_override = (
-        validate_model_override(model_override)
-        if _is_patch_field_set(model_override)
-        else UNSET_CYCLE_FIELD
+    patch = CyclePolicyPatch(
+        name=_policy_field(name, ignore_none=True),
+        prompt=_policy_field(prompt, ignore_none=True),
+        timezone_name=_policy_field(timezone_name, ignore_none=True),
+        schedule_expr=_policy_field(schedule_expr, ignore_none=True),
+        run_at=_policy_field(run_at, ignore_none=True),
+        enabled=_policy_field(enabled, ignore_none=True),
+        max_concurrency=_policy_field(max_concurrency),
+        timeout_seconds=_policy_field(timeout_seconds),
+        model_override=_policy_field(model_override),
+        thinking_override=_policy_field(thinking_override),
+        execution_policy_key=_policy_field(execution_policy_key),
+        target_idea_id=_policy_field(target_idea_id),
+        guidance_additions=(
+            [guidance] if guidance else UNSET_POLICY_FIELD
+        ),
     )
-    next_thinking_override = (
-        validate_thinking_override(thinking_override)
-        if _is_patch_field_set(thinking_override)
-        else UNSET_CYCLE_FIELD
-    )
-    next_timeout_seconds = (
-        validate_cycle_timeout_seconds(timeout_seconds)
-        if _is_patch_field_set(timeout_seconds)
-        else UNSET_CYCLE_FIELD
-    )
-    if _has_patch_value(run_at):
-        next_schedule_expr = build_one_time_schedule_expr(run_at, next_timezone)
-    elif _has_patch_value(schedule_expr):
-        next_schedule_expr = validate_schedule_expr(schedule_expr, next_timezone)
-
-    if _has_patch_value(name):
-        cycle.name = validate_nonempty_trimmed(name, "name")
-    if _has_patch_value(prompt):
-        cycle.prompt = validate_nonempty_trimmed(prompt, "prompt")
-    cycle.timezone = next_timezone
-    cycle.schedule_expr = next_schedule_expr
-    if _is_patch_field_set(enabled) and enabled is not None:
-        cycle.enabled = enabled
-    if _is_patch_field_set(max_concurrency):
-        cycle.max_concurrency = _validated_max_concurrency(max_concurrency)
-    if _is_patch_field_set(next_timeout_seconds):
-        cycle.timeout_seconds = next_timeout_seconds
-    if _is_patch_field_set(next_model_override):
-        cycle.model_override = next_model_override
-    if _is_patch_field_set(next_thinking_override):
-        cycle.thinking_override = next_thinking_override
-    if _is_patch_field_set(next_execution_policy_key):
-        cycle.execution_policy_key = next_execution_policy_key
-    if _is_patch_field_set(target_idea_id):
-        cycle.target_idea_id = target_idea_id
-
-    cycle.execution_mode = canonical_execution_mode()
-    cycle.reopen_archived = True
-    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
-    cycle.updated_at = datetime.now(timezone.utc)
-
-    revision = await async_record_cycle_revision(
+    preview = await async_preview_cycle_policy_change(
         session,
-        cycle,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
-        rationale=rationale or "Cycle updated.",
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
     )
-    if guidance:
-        await async_add_cycle_guidance(
-            session,
-            cycle,
-            guidance=guidance,
-            source_type=actor.source_type,
-            source_id=actor.revision_source_id,
-            rationale=rationale,
-            revision_id=revision.id,
-        )
+    result = await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
+        rationale=rationale or "Cycle updated.",
+        source_reference=_command_source_reference(actor),
+    )
+    if not isinstance(result, CyclePolicyApplied):
+        raise ValueError("Cycle policy changed while the update was being applied")
     return cycle
 
 
@@ -229,22 +209,35 @@ async def async_add_guidance_to_cycle(
     guidance: str,
     rationale: str | None = None,
 ):
-    revision = await async_record_cycle_revision(
+    clean_guidance = validate_nonempty_trimmed(guidance, "guidance")
+    patch = CyclePolicyPatch(guidance_additions=[clean_guidance])
+    preview = await async_preview_cycle_policy_change(
         session,
-        cycle,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+    )
+    result = await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
         rationale=rationale or "Cycle guidance added.",
+        source_reference=_command_source_reference(actor),
     )
-    return await async_add_cycle_guidance(
-        session,
-        cycle,
-        guidance=guidance,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
-        rationale=rationale,
-        revision_id=revision.id,
+    if not isinstance(result, CyclePolicyApplied):
+        raise ValueError("Cycle policy changed while guidance was being added")
+    rows = await session.scalars(
+        select(CycleGuidance).where(
+            CycleGuidance.cycle_id == cycle.id,
+            CycleGuidance.revision_id == result.revision.id,
+            CycleGuidance.guidance == clean_guidance,
+            CycleGuidance.is_active.is_(True),
+        )
     )
+    return rows.first()
 
 
 async def async_add_output_target_to_cycle(
@@ -326,8 +319,14 @@ def _is_patch_field_set(value) -> bool:
     return value is not UNSET_CYCLE_FIELD
 
 
-def _has_patch_value(value) -> bool:
-    return _is_patch_field_set(value) and value is not None
+def _policy_field(value, *, ignore_none: bool = False):
+    if value is UNSET_CYCLE_FIELD or (ignore_none and value is None):
+        return UNSET_POLICY_FIELD
+    return value
+
+
+def _command_source_reference(actor: CycleActor) -> str:
+    return f"{actor.source_type}:{actor.revision_source_id}"
 
 
 async def _seed_default_output_targets(

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -7,15 +7,59 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def publish_cycle_change(
+def publish_cycle_change_safe(
     *,
     action: str,
     org_id: str | None = None,
     user_id: str | None = None,
     cycle_id: int | None = None,
     target_idea_id: str | None = None,
-    strict: bool = False,
 ) -> None:
+    payload = _cycle_change_payload(
+        action=action,
+        org_id=org_id,
+        user_id=user_id,
+        cycle_id=cycle_id,
+        target_idea_id=target_idea_id,
+    )
+    try:
+        from brain.platform.events import publish_safe
+
+        publish_safe("cycles_changed", payload)
+    except Exception:
+        logger.debug("cycle_change_publish_failed", exc_info=True)
+
+
+def publish_cycle_change_strict(
+    *,
+    action: str,
+    org_id: str | None = None,
+    user_id: str | None = None,
+    cycle_id: int | None = None,
+    target_idea_id: str | None = None,
+) -> None:
+    from brain.platform.events import publish
+
+    publish(
+        "cycles_changed",
+        _cycle_change_payload(
+            action=action,
+            org_id=org_id,
+            user_id=user_id,
+            cycle_id=cycle_id,
+            target_idea_id=target_idea_id,
+        ),
+    )
+
+
+def _cycle_change_payload(
+    *,
+    action: str,
+    org_id: str | None,
+    user_id: str | None,
+    cycle_id: int | None,
+    target_idea_id: str | None,
+) -> dict[str, Any]:
     payload: dict[str, Any] = {"action": action}
     if org_id:
         payload["org_id"] = str(org_id)
@@ -26,13 +70,4 @@ def publish_cycle_change(
     if target_idea_id:
         payload["idea_id"] = str(target_idea_id)
         payload["target_idea_id"] = str(target_idea_id)
-
-    try:
-        from brain.platform.events import publish, publish_safe
-
-        publisher = publish if strict else publish_safe
-        publisher("cycles_changed", payload)
-    except Exception:
-        if strict:
-            raise
-        logger.debug("cycle_change_publish_failed", exc_info=True)
+    return payload

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -14,6 +14,7 @@ def publish_cycle_change(
     user_id: str | None = None,
     cycle_id: int | None = None,
     target_idea_id: str | None = None,
+    strict: bool = False,
 ) -> None:
     payload: dict[str, Any] = {"action": action}
     if org_id:
@@ -27,8 +28,11 @@ def publish_cycle_change(
         payload["target_idea_id"] = str(target_idea_id)
 
     try:
-        from brain.platform.events import publish_safe
+        from brain.platform.events import publish, publish_safe
 
-        publish_safe("cycles_changed", payload)
+        publisher = publish if strict else publish_safe
+        publisher("cycles_changed", payload)
     except Exception:
+        if strict:
+            raise
         logger.debug("cycle_change_publish_failed", exc_info=True)

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -48,6 +48,7 @@ from brain.systems.cycles.cycle_failure_guard import (
     async_apply_cycle_terminal_failure_guard,
 )
 from brain.systems.cycles.serializers import (
+    serialize_behavior_change,
     serialize_cycle_guidance,
     serialize_cycle_output_target,
     serialize_cycle_revision,
@@ -238,10 +239,6 @@ def _build_cycle_run_memory_snapshot(
 
     revision_context = {"revision": serialize_cycle_revision(revision)}
     if behavior_change is not None:
-        # Local import avoids a module cycle: behavior_policy uses the existing
-        # revision writer from this module.
-        from brain.systems.cycles.behavior_policy import serialize_behavior_change
-
         revision_context["behavior_change"] = serialize_behavior_change(
             behavior_change
         )

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 from brain.kernel.common.serialization import jsonable
 from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
     CycleOutputTarget,
@@ -181,6 +182,10 @@ async def async_remove_cycle_output_target(
 
 async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: CycleRun) -> None:
     revision = await _async_latest_cycle_revision(session, cycle.id)
+    behavior_change = await _async_behavior_change_for_revision(
+        session,
+        revision.id if revision is not None else None,
+    )
     guidance_rows = await _async_active_cycle_guidance(session, cycle.id)
     target_rows = await _async_active_cycle_output_targets(session, cycle.id)
     degradation_tracking = degradation_tracking_for_run(
@@ -191,6 +196,7 @@ async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: Cy
         cycle,
         run=run,
         revision=revision,
+        behavior_change=behavior_change,
         guidance_rows=guidance_rows,
         target_rows=target_rows,
         degradation_tracking=degradation_tracking,
@@ -209,6 +215,7 @@ def _build_cycle_run_memory_snapshot(
     *,
     run: CycleRun | None = None,
     revision: CycleRevision | None,
+    behavior_change: BehaviorChangeAudit | None = None,
     guidance_rows: list[CycleGuidance],
     target_rows: list[CycleOutputTarget],
     degradation_tracking: dict | None = None,
@@ -229,6 +236,16 @@ def _build_cycle_run_memory_snapshot(
         ),
     )
 
+    revision_context = {"revision": serialize_cycle_revision(revision)}
+    if behavior_change is not None:
+        # Local import avoids a module cycle: behavior_policy uses the existing
+        # revision writer from this module.
+        from brain.systems.cycles.behavior_policy import serialize_behavior_change
+
+        revision_context["behavior_change"] = serialize_behavior_change(
+            behavior_change
+        )
+
     return {
         "revision_id": revision.id if revision is not None else None,
         "guidance_snapshot": jsonable(
@@ -237,7 +254,7 @@ def _build_cycle_run_memory_snapshot(
         "output_targets_snapshot": jsonable(output_targets),
         "context_snapshot": jsonable(
             {
-                "revision": serialize_cycle_revision(revision),
+                **revision_context,
                 "workspace_id": string_or_none(cycle.org_id),
                 "owner_user_id": string_or_none(cycle.user_id),
                 "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),
@@ -515,6 +532,19 @@ async def _async_latest_cycle_revision(session, cycle_id: int) -> CycleRevision 
         .limit(1)
     )
     return result.first()
+
+
+async def _async_behavior_change_for_revision(
+    session,
+    revision_id: int | None,
+) -> BehaviorChangeAudit | None:
+    if revision_id is None:
+        return None
+    return await session.scalar(
+        select(BehaviorChangeAudit).where(
+            BehaviorChangeAudit.cycle_revision_id == revision_id
+        )
+    )
 
 
 async def _async_active_cycle_guidance(session, cycle_id: int) -> list[CycleGuidance]:

--- a/brain/systems/cycles/serializers.py
+++ b/brain/systems/cycles/serializers.py
@@ -1,7 +1,11 @@
 """Cycle read-model serializers."""
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import timezone
+
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
     CycleOutputTarget,
@@ -18,6 +22,32 @@ from brain.systems.cycles.common import (
     string_or_none,
 )
 from brain.systems.cycles.schedules import safe_humanize_schedule
+
+
+def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
+    if row is None:
+        return None
+    applied_at = row.applied_at
+    if applied_at.tzinfo is None:
+        applied_at = applied_at.replace(tzinfo=timezone.utc)
+    return {
+        "id": row.id,
+        "workspace_id": row.workspace_id,
+        "policy_kind": row.policy_kind,
+        "target_type": row.target_type,
+        "target_id": row.target_id,
+        "version": row.version,
+        "actor_type": row.actor_type,
+        "actor_id": row.actor_id,
+        "source_reference": row.source_reference,
+        "rationale": row.rationale,
+        "before_snapshot": deepcopy(row.before_snapshot),
+        "after_snapshot": deepcopy(row.after_snapshot),
+        "changed_fields": list(row.changed_fields or []),
+        "cycle_revision_id": row.cycle_revision_id,
+        "applied_at": applied_at.isoformat(),
+        "reverted_from_id": row.reverted_from_id,
+    }
 
 
 def serialize_cycle_revision(revision: CycleRevision | None) -> dict | None:

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -356,7 +356,6 @@ async def _action_update(ctx: ManageCycleContext) -> dict[str, Any]:
             rationale=_optional_text(args.rationale),
         )
         payload = serialize_cycle(cycle)
-    publish_cycle_change(action="update", **_event_from_payload(payload))
     return {"updated": payload}
 
 

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -32,7 +32,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.serializers import (
     serialize_cycle,
     serialize_cycle_guidance,
@@ -323,7 +323,7 @@ async def _action_create(ctx: ManageCycleContext) -> dict[str, Any]:
             rationale=_optional_text(args.rationale),
         )
         payload = serialize_cycle(cycle)
-    publish_cycle_change(action="create", **_event_from_payload(payload))
+    publish_cycle_change_safe(action="create", **_event_from_payload(payload))
     return {"created": payload}
 
 
@@ -364,7 +364,7 @@ async def _action_delete(ctx: ManageCycleContext) -> dict[str, Any]:
         cycle = await _load_cycle(uow.session, ctx.actor, ctx.args.id)
         await async_delete_cycle(uow.session, cycle)
         event = cycle_change_event(cycle)
-    publish_cycle_change(action="delete", **event)
+    publish_cycle_change_safe(action="delete", **event)
     return {"deleted": {"id": ctx.args.id}}
 
 
@@ -387,7 +387,7 @@ async def _action_run(ctx: ManageCycleContext) -> dict[str, Any]:
             "rationale": _optional_text(ctx.args.rationale),
         },
     )
-    publish_cycle_change(action="run", **event)
+    publish_cycle_change_safe(action="run", **event)
     return {"run": payload}
 
 

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -57,6 +57,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0050_scheduler_cold_start_reconciliation.py",
     # Downgrade removes only the scheduler alert-latch table introduced here.
     "0054_scheduler_alert_latches.py",
+    # Downgrade removes only the behavior-change audit table introduced here.
+    "0059_behavior_change_audits.py",
 }
 
 

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleOutputTarget,
+    CycleRevision,
+    CycleRun,
+)
+from brain.platform.db.models.org import Org, User
+from brain.platform import events as platform_events
+from brain.systems.cycles import behavior_policy
+from brain.systems.cycles import events as cycle_events
+from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyConflict,
+    CyclePolicyPatch,
+    async_apply_cycle_policy_change,
+    async_apply_cycle_policy_revert,
+    async_list_cycle_policy_history,
+    async_preview_cycle_policy_change,
+    async_preview_cycle_policy_revert,
+    async_read_effective_cycle_policy,
+)
+from brain.systems.cycles.memory import async_prepare_cycle_run_memory_snapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _PolicyWorkspace:
+    session: object
+    cycle: Cycle
+    owner: CycleActor
+    teammate: CycleActor
+    outsider: CycleActor
+    initial_revision: CycleRevision
+    initial_guidance: tuple[CycleGuidance, ...]
+
+
+@pytest.fixture
+async def policy_workspace(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Cycle.__table__,
+            CycleRevision.__table__,
+            CycleGuidance.__table__,
+            CycleOutputTarget.__table__,
+            CycleRun.__table__,
+            BehaviorChangeAudit.__table__,
+        ]
+    )
+    org_id = str(uuid4())
+    other_org_id = str(uuid4())
+    owner_id = str(uuid4())
+    teammate_id = str(uuid4())
+    outsider_id = str(uuid4())
+    session.add_all(
+        [
+            Org(id=org_id, name="Policy workspace", slug=f"policy-{org_id[:8]}"),
+            Org(
+                id=other_org_id,
+                name="Other workspace",
+                slug=f"other-{other_org_id[:8]}",
+            ),
+            User(
+                id=owner_id,
+                org_id=org_id,
+                name="Owner",
+                email=f"owner-{owner_id[:8]}@example.com",
+            ),
+            User(
+                id=teammate_id,
+                org_id=org_id,
+                name="Teammate",
+                email=f"teammate-{teammate_id[:8]}@example.com",
+            ),
+            User(
+                id=outsider_id,
+                org_id=other_org_id,
+                name="Outsider",
+                email=f"outsider-{outsider_id[:8]}@example.com",
+            ),
+        ]
+    )
+    await session.flush()
+    cycle = Cycle(
+        user_id=owner_id,
+        org_id=org_id,
+        creator_type="user",
+        creator_id=owner_id,
+        maintainer_type="user",
+        maintainer_id=owner_id,
+        name="Morning review",
+        prompt="Review the workspace.",
+        schedule_expr="0 9 * * *",
+        timezone="UTC",
+        enabled=True,
+        max_concurrency=1,
+        retry_policy={},
+        execution_mode="reuse_same_idea",
+        reopen_archived=True,
+    )
+    session.add(cycle)
+    await session.flush()
+    revision = CycleRevision(
+        cycle_id=cycle.id,
+        revision_number=1,
+        source_type="user",
+        source_id=owner_id,
+        rationale="Initial definition.",
+        name=cycle.name,
+        prompt=cycle.prompt,
+        schedule_expr=cycle.schedule_expr,
+        timezone=cycle.timezone,
+        enabled=cycle.enabled,
+        model_override=None,
+        thinking_override=None,
+        execution_policy_key=None,
+        target_idea_id=None,
+        context_policy={"workspace_id": org_id},
+    )
+    session.add(revision)
+    await session.flush()
+    guidance = (
+        CycleGuidance(
+            cycle_id=cycle.id,
+            revision_id=revision.id,
+            source_type="user",
+            source_id=owner_id,
+            guidance="Keep this guidance",
+            rationale="Initial definition.",
+            is_active=True,
+        ),
+        CycleGuidance(
+            cycle_id=cycle.id,
+            revision_id=revision.id,
+            source_type="user",
+            source_id=owner_id,
+            guidance="Old wording",
+            rationale="Initial definition.",
+            is_active=True,
+        ),
+    )
+    session.add_all(guidance)
+    await session.flush()
+    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    return _PolicyWorkspace(
+        session=session,
+        cycle=cycle,
+        owner=CycleActor(user_id=owner_id, org_id=org_id),
+        teammate=CycleActor(user_id=teammate_id, org_id=org_id),
+        outsider=CycleActor(user_id=outsider_id, org_id=other_org_id),
+        initial_revision=revision,
+        initial_guidance=guidance,
+    )
+
+
+async def _preview_and_apply(
+    workspace: _PolicyWorkspace,
+    patch: CyclePolicyPatch,
+    *,
+    actor: CycleActor | None = None,
+    rationale: str = "Reviewed behavior change.",
+    source_reference: str = "api:cycle-policy-test",
+):
+    acting = actor or workspace.owner
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=acting,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+    result = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=acting,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
+        rationale=rationale,
+        source_reference=source_reference,
+    )
+    assert isinstance(result, CyclePolicyApplied)
+    return preview, result
+
+
+async def test_read_preview_apply_history_and_human_audit_envelope(policy_workspace):
+    workspace = policy_workspace
+    effective = await async_read_effective_cycle_policy(
+        workspace.session,
+        actor=workspace.teammate,
+        cycle_id=workspace.cycle.id,
+    )
+    assert effective.version == 0
+    assert effective.revision_id == workspace.initial_revision.id
+    assert effective.snapshot["name"] == "Morning review"
+    assert effective.snapshot["guidance"] == [
+        "Keep this guidance",
+        "Old wording",
+    ]
+
+    published = []
+    behavior_policy.publish_cycle_change = lambda **payload: published.append(payload)
+    patch = CyclePolicyPatch(
+        name="Morning policy review",
+        guidance=["Keep this guidance", "New wording"],
+    )
+    preview, applied = await _preview_and_apply(
+        workspace,
+        patch,
+        rationale="Use the reviewed wording.",
+        source_reference="api:/cycles/1/behavior-policy",
+    )
+
+    assert preview.changed_fields == ("guidance", "name")
+    assert len(preview.preview_digest) == 64
+    assert applied.effective_policy.version == 1
+    assert workspace.cycle.name == "Morning policy review"
+    assert published == [
+        {
+            "action": "update",
+            "org_id": workspace.cycle.org_id,
+            "user_id": workspace.cycle.user_id,
+            "cycle_id": workspace.cycle.id,
+            "target_idea_id": None,
+            "strict": True,
+        }
+    ]
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert len(history) == 1
+    change = history[0]
+    assert change.workspace_id == str(workspace.cycle.org_id)
+    assert change.policy_kind == "cycle"
+    assert change.target_type == "cycle"
+    assert change.target_id == str(workspace.cycle.id)
+    assert change.version == 1
+    assert change.actor_type == "user"
+    assert change.actor_id == workspace.owner.user_id
+    assert change.source_reference == "api:/cycles/1/behavior-policy"
+    assert change.rationale == "Use the reviewed wording."
+    assert change.before_snapshot == preview.before.snapshot
+    assert change.after_snapshot == preview.after_snapshot
+    assert change.changed_fields == preview.changed_fields
+    assert change.cycle_revision_id == applied.revision.id
+    assert isinstance(change.applied_at, datetime)
+    assert change.applied_at.tzinfo is not None
+    assert change.reverted_from_id is None
+
+
+async def test_stale_version_and_stale_digest_return_latest_policy(policy_workspace):
+    workspace = policy_workspace
+    first_patch = CyclePolicyPatch(name="First editor")
+    second_patch = CyclePolicyPatch(name="Second editor")
+    first_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=first_patch,
+    )
+    second_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+    )
+
+    first = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=first_patch,
+        expected_version=first_preview.before.version,
+        preview_digest=first_preview.preview_digest,
+        rationale="First editor won.",
+        source_reference="editor:first",
+    )
+    assert isinstance(first, CyclePolicyApplied)
+
+    stale_version = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+        expected_version=second_preview.before.version,
+        preview_digest=second_preview.preview_digest,
+        rationale="Second editor tried.",
+        source_reference="editor:second",
+    )
+    assert isinstance(stale_version, CyclePolicyConflict)
+    assert stale_version.reason == "stale_version"
+    assert stale_version.latest_effective_policy.version == 1
+    assert stale_version.latest_effective_policy.snapshot["name"] == "First editor"
+
+    fresh_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+    )
+    stale_digest = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+        expected_version=fresh_preview.before.version,
+        preview_digest="0" * 64,
+        rationale="Digest must match.",
+        source_reference="editor:second",
+    )
+    assert isinstance(stale_digest, CyclePolicyConflict)
+    assert stale_digest.reason == "stale_preview_digest"
+    assert stale_digest.latest_effective_policy.version == 1
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 1
+
+
+async def test_apply_requires_nonempty_rationale(policy_workspace):
+    workspace = policy_workspace
+    patch = CyclePolicyPatch(name="Unreviewed name")
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+    with pytest.raises(ValueError, match="rationale is required"):
+        await async_apply_cycle_policy_change(
+            workspace.session,
+            actor=workspace.owner,
+            cycle_id=workspace.cycle.id,
+            proposal=patch,
+            expected_version=preview.before.version,
+            preview_digest=preview.preview_digest,
+            rationale="   ",
+            source_reference="api:test",
+        )
+    assert workspace.cycle.name == "Morning review"
+
+
+async def test_guidance_wording_replacement_retires_without_deleting(policy_workspace):
+    workspace = policy_workspace
+    keep_row, old_row = workspace.initial_guidance
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(guidance=["Keep this guidance", "New wording"]),
+    )
+    rows = list(
+        (
+            await workspace.session.scalars(
+                select(CycleGuidance)
+                .where(CycleGuidance.cycle_id == workspace.cycle.id)
+                .order_by(CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    assert [(row.guidance, row.is_active) for row in rows] == [
+        ("Keep this guidance", True),
+        ("Old wording", False),
+        ("New wording", True),
+    ]
+    assert rows[0].id == keep_row.id
+    assert rows[1].id == old_row.id
+    assert rows[2].id not in {keep_row.id, old_row.id}
+    assert rows[2].revision_id == applied.revision.id
+
+
+async def test_apply_failure_rolls_back_the_entire_policy_write_set(
+    policy_workspace,
+    monkeypatch,
+):
+    workspace = policy_workspace
+    cycle_id = workspace.cycle.id
+    patch = CyclePolicyPatch(
+        name="Must roll back",
+        guidance=["Replacement guidance"],
+    )
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+
+    def fail_publish(_event_type, _payload):
+        raise RuntimeError("event publish failed")
+
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change",
+        cycle_events.publish_cycle_change,
+    )
+    monkeypatch.setattr(platform_events, "publish", fail_publish)
+    with pytest.raises(RuntimeError, match="event publish failed"):
+        await async_apply_cycle_policy_change(
+            workspace.session,
+            actor=workspace.owner,
+            cycle_id=workspace.cycle.id,
+            proposal=patch,
+            expected_version=preview.before.version,
+            preview_digest=preview.preview_digest,
+            rationale="Verify atomic rollback.",
+            source_reference="test:rollback",
+        )
+
+    workspace.session.expire_all()
+    cycle = await workspace.session.get(Cycle, cycle_id)
+    guidance = list(
+        (
+            await workspace.session.scalars(
+                select(CycleGuidance)
+                .where(CycleGuidance.cycle_id == cycle_id)
+                .order_by(CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    assert cycle.name == "Morning review"
+    assert [(row.guidance, row.is_active) for row in guidance] == [
+        ("Keep this guidance", True),
+        ("Old wording", True),
+    ]
+    assert await workspace.session.scalar(
+        select(func.count(CycleRevision.id)).where(
+            CycleRevision.cycle_id == cycle_id
+        )
+    ) == 1
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0
+
+
+async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_workspace):
+    workspace = policy_workspace
+    _, first = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(name="Changed policy"),
+        rationale="Make the first change.",
+    )
+    revert_preview = await async_preview_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+    )
+    assert revert_preview.after_snapshot["name"] == "Morning review"
+    assert revert_preview.reverted_from_id == first.change.id
+
+    reverted = await async_apply_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+        expected_version=revert_preview.before.version,
+        preview_digest=revert_preview.preview_digest,
+        rationale="Revert the reviewed change.",
+        source_reference="api:revert",
+    )
+    assert isinstance(reverted, CyclePolicyApplied)
+    assert reverted.effective_policy.version == 2
+    assert reverted.effective_policy.snapshot["name"] == "Morning review"
+    assert reverted.change.reverted_from_id == first.change.id
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert [change.version for change in history] == [2, 1]
+    assert history[1].after_snapshot["name"] == "Changed policy"
+
+
+async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_workspace):
+    workspace = policy_workspace
+    first_run = CycleRun(
+        cycle_id=workspace.cycle.id,
+        scheduled_for=datetime.now(timezone.utc),
+        prompt_snapshot=workspace.cycle.prompt,
+        status="queued",
+        context_snapshot={},
+    )
+    workspace.session.add(first_run)
+    await workspace.session.flush()
+    await async_prepare_cycle_run_memory_snapshot(
+        workspace.session,
+        workspace.cycle,
+        first_run,
+    )
+    first_revision_id = first_run.revision_id
+    first_guidance = list(first_run.guidance_snapshot)
+    first_context = dict(first_run.context_snapshot)
+
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(
+            prompt="Use the new policy.",
+            guidance=["New admission guidance"],
+        ),
+    )
+    second_run = CycleRun(
+        cycle_id=workspace.cycle.id,
+        scheduled_for=datetime.now(timezone.utc),
+        prompt_snapshot=workspace.cycle.prompt,
+        status="queued",
+        context_snapshot={},
+    )
+    workspace.session.add(second_run)
+    await workspace.session.flush()
+    await async_prepare_cycle_run_memory_snapshot(
+        workspace.session,
+        workspace.cycle,
+        second_run,
+    )
+
+    assert first_run.revision_id == first_revision_id == workspace.initial_revision.id
+    assert first_run.guidance_snapshot == first_guidance
+    assert first_run.context_snapshot == first_context
+    assert "behavior_change" not in first_run.context_snapshot
+    assert second_run.revision_id == applied.revision.id
+    assert [row["guidance"] for row in second_run.guidance_snapshot] == [
+        "New admission guidance"
+    ]
+    assert second_run.context_snapshot["revision"]["id"] == applied.revision.id
+    assert second_run.context_snapshot["behavior_change"]["id"] == applied.change.id
+
+
+async def test_workspace_authorization_and_delegated_agent_attribution(policy_workspace):
+    workspace = policy_workspace
+    same_workspace = await async_read_effective_cycle_policy(
+        workspace.session,
+        actor=workspace.teammate,
+        cycle_id=workspace.cycle.id,
+    )
+    assert same_workspace.workspace_id == str(workspace.cycle.org_id)
+
+    with pytest.raises(ValueError, match="Cycle not found"):
+        await async_read_effective_cycle_policy(
+            workspace.session,
+            actor=workspace.outsider,
+            cycle_id=workspace.cycle.id,
+        )
+
+    _, teammate_change = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(enabled=False),
+        actor=workspace.teammate,
+        rationale="A workspace teammate reviewed this change.",
+        source_reference="api:teammate",
+    )
+    assert teammate_change.change.actor_type == "user"
+    assert teammate_change.change.actor_id == workspace.teammate.user_id
+
+    agent = CycleActor(
+        user_id=workspace.teammate.user_id,
+        org_id=workspace.teammate.org_id,
+        principal_type="agent",
+        source_id="agent-run-42",
+    )
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(enabled=True),
+        actor=agent,
+        rationale="Agent applied a delegated reviewed change.",
+        source_reference="agent_run:42",
+    )
+    assert applied.change.actor_type == "agent"
+    assert applied.change.actor_id == "agent-run-42"
+    assert applied.change.source_reference == "agent_run:42"
+    assert applied.change.rationale == "Agent applied a delegated reviewed change."
+    assert applied.change.before_snapshot["enabled"] is False
+    assert applied.change.after_snapshot["enabled"] is True
+    assert applied.change.version == 2
+    assert applied.change.applied_at.tzinfo is not None

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -159,7 +159,11 @@ async def policy_workspace(
     )
     session.add_all(guidance)
     await session.flush()
-    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change_strict",
+        lambda **_kwargs: None,
+    )
     return _PolicyWorkspace(
         session=session,
         cycle=cycle,
@@ -216,7 +220,9 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     ]
 
     published = []
-    behavior_policy.publish_cycle_change = lambda **payload: published.append(payload)
+    behavior_policy.publish_cycle_change_strict = (
+        lambda **payload: published.append(payload)
+    )
     patch = CyclePolicyPatch(
         name="Morning policy review",
         guidance=["Keep this guidance", "New wording"],
@@ -239,7 +245,6 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
             "user_id": workspace.cycle.user_id,
             "cycle_id": workspace.cycle.id,
             "target_idea_id": None,
-            "strict": True,
         }
     ]
 
@@ -261,6 +266,9 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     assert change.rationale == "Use the reviewed wording."
     assert change.before_snapshot == preview.before.snapshot
     assert change.after_snapshot == preview.after_snapshot
+    stored_change = await workspace.session.get(BehaviorChangeAudit, change.id)
+    assert stored_change.before_snapshot["snapshot_version"] == 1
+    assert stored_change.after_snapshot["snapshot_version"] == 1
     assert change.changed_fields == preview.changed_fields
     assert change.cycle_revision_id == applied.revision.id
     assert isinstance(change.applied_at, datetime)
@@ -408,8 +416,8 @@ async def test_apply_failure_rolls_back_the_entire_policy_write_set(
 
     monkeypatch.setattr(
         behavior_policy,
-        "publish_cycle_change",
-        cycle_events.publish_cycle_change,
+        "publish_cycle_change_strict",
+        cycle_events.publish_cycle_change_strict,
     )
     monkeypatch.setattr(platform_events, "publish", fail_publish)
     with pytest.raises(RuntimeError, match="event publish failed"):
@@ -488,6 +496,60 @@ async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_works
     )
     assert [change.version for change in history] == [2, 1]
     assert history[1].after_snapshot["name"] == "Changed policy"
+
+
+async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_workspace):
+    workspace = policy_workspace
+    _, first = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(name="Changed policy"),
+    )
+    stored_change = await workspace.session.get(BehaviorChangeAudit, first.change.id)
+    stored_before = dict(stored_change.before_snapshot)
+    stored_before.pop("max_concurrency")
+    stored_before["retired_policy_field"] = "legacy value"
+    stored_change.before_snapshot = stored_before
+    await workspace.session.flush()
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert history[0].before_snapshot["max_concurrency"] == 1
+    assert "retired_policy_field" not in history[0].before_snapshot
+
+    revert_preview = await async_preview_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+    )
+    assert revert_preview.after_snapshot["name"] == "Morning review"
+    assert revert_preview.after_snapshot["max_concurrency"] == 1
+    assert "retired_policy_field" not in revert_preview.after_snapshot
+
+    reverted = await async_apply_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+        expected_version=revert_preview.before.version,
+        preview_digest=revert_preview.preview_digest,
+        rationale="Revert a snapshot written with an older schema.",
+        source_reference="api:compat-revert",
+    )
+    assert isinstance(reverted, CyclePolicyApplied)
+    assert reverted.effective_policy.version == 2
+    assert set(reverted.effective_policy.snapshot) == set(
+        revert_preview.before.snapshot
+    )
+    new_stored_change = await workspace.session.get(
+        BehaviorChangeAudit,
+        reverted.change.id,
+    )
+    assert new_stored_change.before_snapshot["snapshot_version"] == 1
+    assert new_stored_change.after_snapshot["snapshot_version"] == 1
 
 
 async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_workspace):

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -1,0 +1,261 @@
+"""PostgreSQL proof for Cycle policy locking and optimistic concurrency."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.schema import CreateTable
+
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleRevision,
+)
+from brain.platform.db.models.org import Org, User
+from brain.systems.cycles import behavior_policy
+from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyConflict,
+    CyclePolicyPatch,
+    async_apply_cycle_policy_change,
+    async_preview_cycle_policy_change,
+)
+from tests.conftest import TEST_DB_URL
+from tests.db_engine_utils import create_async_test_engine
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.requires_db]
+
+LOCK_WAIT_TIMEOUT_SECONDS = 15.0
+RACE_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class _PostgresPolicyWorkspace:
+    engine: object
+    factory: object
+    app_name: str
+    cycle_id: int
+    actor: CycleActor
+
+    @asynccontextmanager
+    async def held_cycle_lock(self):
+        connection = await self.engine.connect()
+        transaction = await connection.begin()
+        try:
+            await connection.execute(
+                text("SELECT id FROM cycles WHERE id = :cycle_id FOR UPDATE"),
+                {"cycle_id": self.cycle_id},
+            )
+            yield
+        finally:
+            await transaction.commit()
+            await connection.close()
+
+    async def await_lock_waiters(self, expected: int) -> None:
+        connection = await (await self.engine.connect()).execution_options(
+            isolation_level="AUTOCOMMIT"
+        )
+        try:
+            deadline = asyncio.get_running_loop().time() + LOCK_WAIT_TIMEOUT_SECONDS
+            blocked = 0
+            while asyncio.get_running_loop().time() < deadline:
+                blocked = int(
+                    (
+                        await connection.execute(
+                            text(
+                                "SELECT count(*) FROM pg_stat_activity "
+                                "WHERE datname = current_database() "
+                                "AND application_name = :app_name "
+                                "AND cardinality(pg_blocking_pids(pid)) > 0"
+                            ),
+                            {"app_name": self.app_name},
+                        )
+                    ).scalar_one()
+                )
+                if blocked >= expected:
+                    return
+                await asyncio.sleep(0.05)
+            raise AssertionError(
+                f"expected {expected} policy editor(s) waiting on the Cycle lock; "
+                f"saw {blocked}"
+            )
+        finally:
+            await connection.close()
+
+
+@pytest.fixture
+async def postgres_policy_workspace(monkeypatch):
+    schema = f"policy_conc_{uuid4().hex[:12]}"
+    app_name = f"policy-conc-{uuid4().hex[:8]}"
+    admin_engine = create_async_test_engine(TEST_DB_URL)
+    admin = await (await admin_engine.connect()).execution_options(
+        isolation_level="AUTOCOMMIT"
+    )
+    await admin.execute(text(f'CREATE SCHEMA "{schema}"'))
+    engine = create_async_test_engine(
+        TEST_DB_URL,
+        connect_args={
+            "server_settings": {
+                "search_path": f'"{schema}",public',
+                "application_name": app_name,
+            }
+        },
+    )
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id = str(uuid4())
+    user_id = str(uuid4())
+    cycle_id = None
+    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    try:
+        async with engine.begin() as connection:
+            for table in (
+                Org.__table__,
+                User.__table__,
+                Cycle.__table__,
+                CycleRevision.__table__,
+                CycleGuidance.__table__,
+                BehaviorChangeAudit.__table__,
+            ):
+                await connection.execute(CreateTable(table))
+
+        async with factory.begin() as session:
+            session.add(
+                Org(
+                    id=org_id,
+                    name="Policy concurrency org",
+                    slug=f"policy-concurrency-{org_id[:8]}",
+                )
+            )
+            session.add(
+                User(
+                    id=user_id,
+                    org_id=org_id,
+                    name="Policy editor",
+                    email=f"policy-editor-{user_id[:8]}@example.com",
+                )
+            )
+            await session.flush()
+            cycle = Cycle(
+                user_id=user_id,
+                org_id=org_id,
+                name="Concurrent policy",
+                prompt="Review concurrency.",
+                schedule_expr="0 9 * * *",
+                timezone="UTC",
+                enabled=True,
+                max_concurrency=1,
+                retry_policy={},
+                execution_mode="reuse_same_idea",
+                reopen_archived=True,
+            )
+            session.add(cycle)
+            await session.flush()
+            cycle_id = cycle.id
+            session.add(
+                CycleRevision(
+                    cycle_id=cycle.id,
+                    revision_number=1,
+                    source_type="user",
+                    source_id=user_id,
+                    rationale="Initial definition.",
+                    name=cycle.name,
+                    prompt=cycle.prompt,
+                    schedule_expr=cycle.schedule_expr,
+                    timezone=cycle.timezone,
+                    enabled=cycle.enabled,
+                    model_override=None,
+                    thinking_override=None,
+                    execution_policy_key=None,
+                    target_idea_id=None,
+                    context_policy={"workspace_id": org_id},
+                )
+            )
+
+        yield _PostgresPolicyWorkspace(
+            engine=engine,
+            factory=factory,
+            app_name=app_name,
+            cycle_id=cycle_id,
+            actor=CycleActor(user_id=user_id, org_id=org_id),
+        )
+    finally:
+        await engine.dispose()
+        await admin.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await admin.close()
+        await admin_engine.dispose()
+
+
+async def test_two_reviewed_editors_serialize_and_second_gets_latest_conflict(
+    postgres_policy_workspace,
+):
+    workspace = postgres_policy_workspace
+    first_patch = CyclePolicyPatch(name="First reviewed edit")
+    second_patch = CyclePolicyPatch(name="Second reviewed edit")
+    async with workspace.factory() as session:
+        first_preview = await async_preview_cycle_policy_change(
+            session,
+            actor=workspace.actor,
+            cycle_id=workspace.cycle_id,
+            proposal=first_patch,
+        )
+        second_preview = await async_preview_cycle_policy_change(
+            session,
+            actor=workspace.actor,
+            cycle_id=workspace.cycle_id,
+            proposal=second_patch,
+        )
+
+    async def apply(patch, preview, editor):
+        async with workspace.factory.begin() as session:
+            return await async_apply_cycle_policy_change(
+                session,
+                actor=workspace.actor,
+                cycle_id=workspace.cycle_id,
+                proposal=patch,
+                expected_version=preview.before.version,
+                preview_digest=preview.preview_digest,
+                rationale=f"{editor} reviewed this edit.",
+                source_reference=f"editor:{editor}",
+            )
+
+    async with workspace.held_cycle_lock():
+        first_task = asyncio.create_task(apply(first_patch, first_preview, "first"))
+        second_task = asyncio.create_task(apply(second_patch, second_preview, "second"))
+        await workspace.await_lock_waiters(2)
+        assert not first_task.done() and not second_task.done()
+
+    results = await asyncio.wait_for(
+        asyncio.gather(first_task, second_task),
+        RACE_TIMEOUT_SECONDS,
+    )
+    applied = [result for result in results if isinstance(result, CyclePolicyApplied)]
+    conflicts = [result for result in results if isinstance(result, CyclePolicyConflict)]
+    assert len(applied) == 1
+    assert len(conflicts) == 1
+    assert conflicts[0].reason == "stale_version"
+    assert conflicts[0].latest_effective_policy.version == 1
+    assert conflicts[0].latest_effective_policy.snapshot["name"] in {
+        "First reviewed edit",
+        "Second reviewed edit",
+    }
+
+    async with workspace.factory() as session:
+        changes = list(
+            (
+                await session.scalars(
+                    select(BehaviorChangeAudit).order_by(
+                        BehaviorChangeAudit.version.asc()
+                    )
+                )
+            ).all()
+        )
+    assert [(change.version, change.target_id) for change in changes] == [
+        (1, str(workspace.cycle_id))
+    ]

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -112,7 +112,11 @@ async def postgres_policy_workspace(monkeypatch):
     org_id = str(uuid4())
     user_id = str(uuid4())
     cycle_id = None
-    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change_strict",
+        lambda **_kwargs: None,
+    )
     try:
         async with engine.begin() as connection:
             for table in (

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -34,10 +34,12 @@ from brain.systems.cycles.promotion_readiness import (
 )
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleFailureGuardLatch,
     CycleFailureGuardObservation,
     CycleFailureGuardTriggerState,
+    CycleGuidance,
     CycleRevision,
     CycleRun,
     CycleRunEvaluation,
@@ -317,10 +319,46 @@ class _RouterCycleSession:
         self.committed = False
 
     async def scalars(self, statement):
+        sql = str(statement)
+        if "FROM cycle_guidance" in sql:
+            return _AllResult(
+                row
+                for row in self.added
+                if isinstance(row, CycleGuidance) and row.is_active
+            )
         return _RouterCycleResult(self._cycle)
 
     async def execute(self, statement):
+        if "max(cycle_revisions.revision_number)" in str(statement):
+            return _FirstResult(
+                max(
+                    (
+                        row.revision_number
+                        for row in self.added
+                        if isinstance(row, CycleRevision)
+                    ),
+                    default=0,
+                )
+            )
         return _FirstResult((self._cycle.target_idea_id,))
+
+    async def scalar(self, statement):
+        sql = str(statement)
+        if "max(behavior_change_audits.version)" in sql:
+            return max(
+                (
+                    row.version
+                    for row in self.added
+                    if isinstance(row, BehaviorChangeAudit)
+                ),
+                default=0,
+            )
+        if "FROM cycle_revisions" in sql:
+            revisions = [row for row in self.added if isinstance(row, CycleRevision)]
+            return revisions[-1].id if revisions else None
+        if "FROM ideas" in sql:
+            return self._cycle.target_idea_id
+        return None
 
     def add(self, value):
         self.added.append(value)
@@ -337,6 +375,9 @@ class _RouterCycleSession:
 
     async def commit(self):
         self.committed = True
+
+    def begin_nested(self):
+        return _AsyncNestedTransaction()
 
 
 class _ExecuteCycleSession:
@@ -1131,6 +1172,12 @@ async def test_cycle_update_persists_and_serializes_max_concurrency():
 
     assert cycle.max_concurrency == 4
     assert response["max_concurrency"] == 4
+    audit = next(row for row in db.added if isinstance(row, BehaviorChangeAudit))
+    assert audit.before_snapshot["max_concurrency"] == 1
+    assert audit.after_snapshot["max_concurrency"] == 4
+    assert audit.cycle_revision_id == next(
+        row.id for row in db.added if isinstance(row, CycleRevision)
+    )
     CycleRead.model_validate(response)
 
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1122,7 +1122,7 @@ async def test_cycle_create_persists_and_serializes_max_concurrency(monkeypatch)
     monkeypatch.setattr(cycles_router, "command_create_cycle", fake_create_cycle)
     monkeypatch.setattr(
         cycles_router,
-        "publish_cycle_change",
+        "publish_cycle_change_safe",
         lambda **_kwargs: None,
     )
 
@@ -3152,7 +3152,11 @@ async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch)
 
     monkeypatch.setattr(cycle_handlers, "UnitOfWork", factory)
     monkeypatch.setattr(cycle_handlers, "async_run_cycle_now", fake_run_cycle_now)
-    monkeypatch.setattr(cycle_handlers, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        cycle_handlers,
+        "publish_cycle_change_safe",
+        lambda **_kwargs: None,
+    )
 
     with bind_agent_context(
         {
@@ -3205,7 +3209,11 @@ async def test_manage_cycle_run_can_select_explicit_scheduled_digest_contract(mo
 
     monkeypatch.setattr(cycle_handlers, "UnitOfWork", factory)
     monkeypatch.setattr(cycle_handlers, "async_run_cycle_now", fake_run_cycle_now)
-    monkeypatch.setattr(cycle_handlers, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        cycle_handlers,
+        "publish_cycle_change_safe",
+        lambda **_kwargs: None,
+    )
 
     with bind_agent_context(
         {

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -933,7 +933,7 @@ async def test_hosted_mcp_cycle_manage_create_commits_and_publishes_change():
         "brain.app.api.routers.agent_mcp._validate_cycle_target_idea",
         new=AsyncMock(),
     ), patch(
-        "brain.app.api.routers.agent_mcp.publish_cycle_change",
+        "brain.app.api.routers.agent_mcp.publish_cycle_change_safe",
         side_effect=publish_change,
     ):
         response = await _request(

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -11,6 +11,7 @@ EXPECTED_TABLES = {
     "agent_run_events",
     "agent_runs",
     "agent_sessions",
+    "behavior_change_audits",
     "browser_pool_entries",
     "browser_sessions",
     "chat_conversation_members",


### PR DESCRIPTION
Closes #782

Slice 1 of 6 of the workspace behavior editor (#738). This is the keystone —
#783, #784, #785, #786 and #787 all build on this module and this audit contract.

## What changed

`brain/systems/cycles/behavior_policy.py` owns read, preview, apply, history and
revert for Cycle policy. `async_update_cycle` now routes through it, and the old
direct-mutation block is **deleted**, so API routes and agent tools share one
path and one audit contract. Nothing mutates policy tables directly any more.

Apply is one transaction boundary. It runs in a savepoint under a
`SELECT ... FOR UPDATE` on the Cycle row, and in that single unit it: writes the
Cycle fields, retires guidance dropped from the active set, adds new immutable
guidance rows, records a `CycleRevision`, writes the `BehaviorChangeAudit` row,
and publishes the existing `cycles_changed` event.

The guarantees the ticket asked for:

- **Guidance text is immutable.** A wording edit retires the old row and creates
  a new one. Retirement changes effective state; it never deletes content.
- **An admitted CycleRun never changes.** It keeps its revision and guidance
  snapshots; only later admissions see the new policy.
- **Apply requires** the expected version, the preview digest, and a non-empty
  rationale. A stale version or digest returns a conflict carrying the latest
  effective policy.
- **Revert reuses the same preview and apply path** and produces a new version,
  linked through `reverted_from_id`. It never rewrites history.

Migration `0059` adds `behavior_change_audits`. Its `has_table` guard has no
explicit schema, matching the idiom `0058` established so the check resolves
through the same `search_path` as the statements it guards.

## The review found a real forward-compatibility bug, and it is fixed here

The cross-family code-quality review (Codex, thermo-nuclear rubric) flagged that
snapshot validation required an **exact** field set. That is right when building
a snapshot from a live Cycle and wrong when reading one back out of the audit
table: the first policy field slices 2–6 add would have made every earlier
`before_snapshot` unreadable, so **revert and history would break on old rows**.
Immutable history you cannot read is not history.

Second commit fixes it. Persisted snapshots carry `snapshot_version`. Decoding a
stored snapshot starts from the current effective policy, overlays the stored
fields it recognises, drops the rest, and validates what survives. A test writes
a snapshot with one field missing and one unknown field present and proves a
revert from it still succeeds.

Three smaller seam fixes rode along: one omission sentinel instead of two,
`publish_cycle_change_safe` / `publish_cycle_change_strict` instead of a boolean
mode flag, and `serialize_behavior_change` moved to `serializers.py` — which
removes the module cycle `memory.py` was working around with a local import.

## Two findings I did NOT fold, filed instead

- **#790** — the snapshot boundary is still a raw dict contract and five slices
  are about to build on it. That is a typed-representation redesign, and it
  should be decided **before #783** starts rather than grown into this PR.
- **#791** — `behavior_change_audits` is named generically but requires a
  non-null `cycle_revision_id`. Which way to resolve that is a design decision,
  not a mechanical fix.

## Verification

- Repo CI command, run serially on an idle machine (load 3.9 at start):
  `pytest tests/ -m "not requires_db and not requires_browser and not live_provider"`
  → **4876 passed, 11 skipped**.
- `alembic heads` prints exactly one head: `0059_behavior_change_audits`.
- The diff is backend only; it touches no `frontend/**` file, so that lane does
  not apply.

**One acceptance line I could not execute:** the PostgreSQL locking and
two-editor concurrency test. It is written
(`tests/test_cycle_behavior_policy_concurrency.py`), correctly marked
`requires_db`, and was collected and skipped because `TEST_DB_URL` is not set
here. SQLite cannot prove live locking, so that check is genuinely unverified on
this machine — it needs a run against real Postgres.

## How to judge this on staging

There is no UI yet — that is slice 3. The behavior is visible through the Cycle
edit path that already exists:

1. Edit a Cycle on illo-dev (name, prompt or schedule) and save. It should work
   exactly as before.
2. Check `behavior_change_audits` — that edit should now have a row with your
   actor, the rationale, before and after snapshots, and version 1.
3. Edit the same Cycle's guidance text. The old guidance row should be **retired,
   not deleted**, and a new row should exist.
4. Ask Illo to change the same Cycle. The agent's change must produce a row in
   the same table, with the actor recorded as the agent — same path, same audit.
