### PR TITLE
chore: consolidate the four open draft PRs into one merge (#755, #773, #782, #790)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -44,7 +44,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle as command_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.serializers import (
     serialize_cycle,
     serialize_cycle_guidance,
@@ -1503,7 +1503,7 @@ async def _handle_mcp_request(
             cycle_change = tool_payload.pop("_cycle_change", None)
             await db.commit()
             if isinstance(cycle_change, dict):
-                publish_cycle_change(
+                publish_cycle_change_safe(
                     action=str(cycle_change.get("action") or "update"),
                     **dict(cycle_change.get("event") or {}),
                 )

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -1203,7 +1203,10 @@ async def _act_manage_cycle(
         )
         await db.flush()
         await db.refresh(cycle)
-        return _cycle_mutation_payload("update", cycle, {"cycle": serialize_cycle(cycle)})
+        return {
+            "cycle": serialize_cycle(cycle),
+            "_mutates_cycle": True,
+        }
 
     if action == "delete":
         await command_delete_cycle(db, cycle)
@@ -1239,11 +1242,11 @@ async def _act_manage_cycle(
             guidance=_required_capability_string(arguments, "guidance", capability="cycle.manage"),
             rationale=rationale,
         )
-        return _cycle_mutation_payload(
-            "update",
-            cycle,
-            {"cycle": serialize_cycle(cycle), "guidance": serialize_cycle_guidance(guidance)},
-        )
+        return {
+            "cycle": serialize_cycle(cycle),
+            "guidance": serialize_cycle_guidance(guidance),
+            "_mutates_cycle": True,
+        }
 
     if action == "add_output_target":
         target = await command_add_cycle_output_target(

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -22,7 +22,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle as command_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.common import SCHEDULED_DIGEST_RUN_KIND
 from brain.systems.cycles.serializers import serialize_cycle, serialize_cycle_run
 from brain.systems.cycles.service import async_run_cycle_now
@@ -114,7 +114,7 @@ async def create_cycle(
     payload = serialize_cycle(cycle)
     event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="create",
         **event,
     )
@@ -183,7 +183,7 @@ async def delete_cycle(
     await command_delete_cycle(db, cycle)
     event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="delete",
         **event,
     )
@@ -225,7 +225,7 @@ async def run_cycle(
         cycle_id,
         run_kind=SCHEDULED_DIGEST_RUN_KIND,
     )
-    publish_cycle_change(
+    publish_cycle_change_safe(
         action="run",
         **event,
     )

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -169,12 +169,7 @@ async def update_cycle(
     await db.flush()
     await db.refresh(cycle)
     payload = serialize_cycle(cycle)
-    event = cycle_change_event(cycle)
     await db.commit()
-    publish_cycle_change(
-        action="update",
-        **event,
-    )
     return payload
 
 

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,7 +11,6 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
-    cast,
 )
 
 from sqlalchemy import and_, delete, func, or_, select
@@ -31,10 +30,11 @@ from brain.systems.failure_guard.core import (
     FailureGuardLifecycleEvent,
     FailureGuardLatch,
     FailureGuardStatefulTrigger,
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
     FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
@@ -512,11 +512,11 @@ class SchedulerFailureGuardStatefulTrigger(
     """One state-owning scheduler failure trigger."""
 
 
-SchedulerFailureGuardTriggerImplementation: TypeAlias = (
-    SchedulerFailureGuardTrigger | SchedulerFailureGuardStatefulTrigger
-)
 SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
-    FailureGuardTriggerRegistration[SchedulerFailureGuardLifecycleContext]
+    FailureGuardStatelessTriggerRegistration[SchedulerFailureGuardTrigger]
+    | FailureGuardStatefulTriggerRegistration[
+        SchedulerFailureGuardStatefulTrigger
+    ]
 )
 
 
@@ -528,6 +528,22 @@ class SchedulerFailureGuardRegistry:
 
     def __post_init__(self) -> None:
         require_failure_guard_registrations(self.triggers, owner="Scheduler")
+        for registration in self.triggers:
+            required_methods = ["should_reset"]
+            if registration.mode is FailureGuardTriggerMode.STATELESS:
+                required_methods.insert(0, "evaluate_many")
+            missing_methods = [
+                method
+                for method in required_methods
+                if not callable(getattr(registration.trigger, method, None))
+            ]
+            if missing_methods:
+                raise ValueError(
+                    "Scheduler failure-guard trigger "
+                    f"{type(registration.trigger).__name__} declared "
+                    f"{registration.mode.value} but is missing required "
+                    "method(s): " + ", ".join(missing_methods)
+                )
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):
             raise ValueError(
@@ -541,20 +557,16 @@ _FAILURE_GUARD_TRIGGER_PROVIDERS: tuple[
     Callable[[], SchedulerRegisteredFailureGuardTrigger],
     ...,
 ] = (
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    lambda: FailureGuardStatefulTriggerRegistration(
         trigger=ConsecutiveFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    lambda: FailureGuardStatelessTriggerRegistration(
         trigger=StandingFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    lambda: FailureGuardStatelessTriggerRegistration(
         trigger=RollingWindowFailuresTrigger.from_settings(),
     ),
-    lambda: FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    lambda: FailureGuardStatefulTriggerRegistration(
         trigger=ConfigurationFailureTrigger(),
     ),
 )
@@ -753,7 +765,7 @@ async def async_read_scheduler_failure_guards(
     for registration in registry.triggers:
         if registration.mode is FailureGuardTriggerMode.STATEFUL:
             continue
-        trigger = cast(SchedulerFailureGuardTrigger, registration.trigger)
+        trigger = registration.trigger
         trigger_results = dict(
             await trigger.evaluate_many(session, jobs, now=now)
         )
@@ -868,13 +880,12 @@ async def async_record_scheduler_job_failure(
         latches = dict(await latch_store.load_latches())
         reset_latch = False
         for registration in registry.triggers:
-            trigger = cast(
-                SchedulerFailureGuardResettableTrigger,
-                registration.trigger,
-            )
-            if registration.kind not in latches or not await trigger.should_reset(
-                context,
-                event="signature_change",
+            if (
+                registration.kind not in latches
+                or not await registration.trigger.should_reset(
+                    context,
+                    event="signature_change",
+                )
             ):
                 continue
             await latch_store.delete_latch(registration.kind)
@@ -951,13 +962,9 @@ async def async_reset_scheduler_job_failure_guard(
     )
     latches = dict(await latch_store.load_latches())
     for registration in registry.triggers:
-        trigger = cast(
-            SchedulerFailureGuardResettableTrigger,
-            registration.trigger,
-        )
         if registration.kind not in latches:
             continue
-        if await trigger.should_reset(
+        if await registration.trigger.should_reset(
             context,
             event="success",
         ):

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,6 +11,7 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
+    runtime_checkable,
 )
 
 from sqlalchemy import and_, delete, func, or_, select
@@ -473,6 +474,7 @@ class RollingWindowFailuresTrigger:
         return not (await self.evaluate(context)).active
 
 
+@runtime_checkable
 class SchedulerFailureGuardResettableTrigger(Protocol):
     """Scheduler-owned latch-reset behavior shared by all trigger kinds."""
 
@@ -487,6 +489,7 @@ class SchedulerFailureGuardResettableTrigger(Protocol):
         """Return whether this trigger's latch should reset."""
 
 
+@runtime_checkable
 class SchedulerFailureGuardTrigger(
     SchedulerFailureGuardResettableTrigger,
     FailureGuardTrigger[SchedulerFailureGuardLifecycleContext],
@@ -504,6 +507,7 @@ class SchedulerFailureGuardTrigger(
         """Evaluate this trigger for every projected job."""
 
 
+@runtime_checkable
 class SchedulerFailureGuardStatefulTrigger(
     SchedulerFailureGuardResettableTrigger,
     FailureGuardStatefulTrigger[SchedulerFailureGuardLifecycleContext],
@@ -529,20 +533,30 @@ class SchedulerFailureGuardRegistry:
     def __post_init__(self) -> None:
         require_failure_guard_registrations(self.triggers, owner="Scheduler")
         for registration in self.triggers:
-            required_methods = ["should_reset"]
             if registration.mode is FailureGuardTriggerMode.STATELESS:
-                required_methods.insert(0, "evaluate_many")
-            missing_methods = [
-                method
-                for method in required_methods
-                if not callable(getattr(registration.trigger, method, None))
-            ]
-            if missing_methods:
+                trigger_protocol = SchedulerFailureGuardTrigger
+            else:
+                trigger_protocol = SchedulerFailureGuardStatefulTrigger
+            if not isinstance(registration.trigger, trigger_protocol):
+                missing_methods = sorted(
+                    method
+                    for method in trigger_protocol.__protocol_attrs__
+                    if callable(getattr(trigger_protocol, method, None))
+                    and not callable(
+                        getattr(registration.trigger, method, None)
+                    )
+                )
+                missing_detail = (
+                    "; missing required method(s): "
+                    + ", ".join(missing_methods)
+                    if missing_methods
+                    else ""
+                )
                 raise ValueError(
                     "Scheduler failure-guard trigger "
                     f"{type(registration.trigger).__name__} declared "
-                    f"{registration.mode.value} but is missing required "
-                    "method(s): " + ", ".join(missing_methods)
+                    f"{registration.mode.value} but does not satisfy "
+                    f"{trigger_protocol.__name__} protocol{missing_detail}"
                 )
         kinds = [str(trigger.kind) for trigger in self.triggers]
         if any(not kind for kind in kinds):

--- a/brain/platform/db/alembic/versions/0059_behavior_change_audits.py
+++ b/brain/platform/db/alembic/versions/0059_behavior_change_audits.py
@@ -1,0 +1,97 @@
+"""Add the immutable behavior-change audit envelope.
+
+Revision ID: 0059_behavior_change_audits
+Revises: 0058_delete_orphaned_standing_failure_states
+Create Date: 2026-08-10
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0059_behavior_change_audits"
+down_revision = "0058_delete_orphaned_standing_failure_states"
+branch_labels = None
+depends_on = None
+
+_TABLE = "behavior_change_audits"
+
+
+def upgrade() -> None:
+    # The public baseline creates current model tables on fresh installs before
+    # later migrations replay.
+    if sa.inspect(op.get_bind()).has_table(_TABLE):
+        return
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("workspace_id", sa.Text(), nullable=False),
+        sa.Column("policy_kind", sa.String(length=50), nullable=False),
+        sa.Column("target_type", sa.String(length=50), nullable=False),
+        sa.Column("target_id", sa.Text(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("actor_type", sa.String(length=30), nullable=False),
+        sa.Column("actor_id", sa.Text(), nullable=False),
+        sa.Column("source_reference", sa.Text(), nullable=False),
+        sa.Column("rationale", sa.Text(), nullable=False),
+        sa.Column("before_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("after_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("changed_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("cycle_revision_id", sa.Integer(), nullable=False),
+        sa.Column("reverted_from_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "applied_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["cycle_revision_id"],
+            ["cycle_revisions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["reverted_from_id"],
+            ["behavior_change_audits.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "cycle_revision_id",
+            name="uq_behavior_change_audits_cycle_revision",
+        ),
+        sa.UniqueConstraint(
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+            name="uq_behavior_change_audits_target_version",
+        ),
+    )
+    op.create_index(
+        "ix_behavior_change_audits_workspace_applied",
+        "behavior_change_audits",
+        ["workspace_id", "applied_at", "id"],
+    )
+    op.create_index(
+        "ix_behavior_change_audits_target_history",
+        "behavior_change_audits",
+        ["policy_kind", "target_type", "target_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    if not sa.inspect(op.get_bind()).has_table(_TABLE):
+        return
+    op.drop_index(
+        "ix_behavior_change_audits_target_history",
+        table_name=_TABLE,
+    )
+    op.drop_index(
+        "ix_behavior_change_audits_workspace_applied",
+        table_name=_TABLE,
+    )
+    op.drop_table(_TABLE)

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from brain.platform.db.base import Base, CreatedAtMixin, TimestampMixin
 
 __all__ = [
+    "BehaviorChangeAudit",
     "Cycle",
     "CycleFailureGuardLatch",
     "CycleFailureGuardObservation",
@@ -21,6 +22,67 @@ __all__ = [
     "CycleRun",
     "CycleRunEvaluation",
 ]
+
+
+class BehaviorChangeAudit(Base):
+    """Append-only, human-readable envelope for one behavior-policy apply."""
+
+    __tablename__ = "behavior_change_audits"
+    __table_args__ = (
+        UniqueConstraint(
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+            name="uq_behavior_change_audits_target_version",
+        ),
+        UniqueConstraint(
+            "cycle_revision_id",
+            name="uq_behavior_change_audits_cycle_revision",
+        ),
+        Index(
+            "ix_behavior_change_audits_workspace_applied",
+            "workspace_id",
+            "applied_at",
+            "id",
+        ),
+        Index(
+            "ix_behavior_change_audits_target_history",
+            "policy_kind",
+            "target_type",
+            "target_id",
+            "version",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[str] = mapped_column(Text, nullable=False)
+    policy_kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_id: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    actor_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    actor_id: Mapped[str] = mapped_column(Text, nullable=False)
+    source_reference: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    before_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    after_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    changed_fields: Mapped[list] = mapped_column(JSONB, nullable=False)
+    cycle_revision_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("cycle_revisions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    reverted_from_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("behavior_change_audits.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    applied_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("NOW()"),
+    )
 
 
 class Cycle(Base, TimestampMixin):

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -9,9 +9,18 @@ from __future__ import annotations
 import hashlib
 import json
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import (
+    Any,
+    ClassVar,
+    Final,
+    Mapping,
+    TypeAlias,
+    TypeGuard,
+    TypeVar,
+    cast,
+)
 
 from sqlalchemy import func, select
 
@@ -54,6 +63,7 @@ __all__ = [
     "CyclePolicyConflict",
     "CyclePolicyPatch",
     "CyclePolicyPreview",
+    "CyclePolicySnapshot",
     "EffectiveCyclePolicy",
     "UNSET_CYCLE_FIELD",
     "async_apply_cycle_policy_change",
@@ -66,60 +76,206 @@ __all__ = [
 
 CYCLE_POLICY_KIND = "cycle"
 CYCLE_TARGET_TYPE = "cycle"
-CYCLE_POLICY_SNAPSHOT_VERSION = 1
-_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD = "snapshot_version"
-_CYCLE_POLICY_SNAPSHOT_FIELDS = frozenset(
-    {
-        "name",
-        "prompt",
-        "schedule_expr",
-        "timezone",
-        "enabled",
-        "max_concurrency",
-        "timeout_seconds",
-        "retry_policy",
-        "model_override",
-        "thinking_override",
-        "execution_policy_key",
-        "target_idea_id",
-        "guidance",
-    }
-)
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+CycleGuidanceValues: TypeAlias = list[str] | tuple[str, ...]
+_PatchValueT = TypeVar("_PatchValueT")
 
 
 class _UnsetCycleField:
-    pass
+    __slots__ = ()
 
 
-UNSET_CYCLE_FIELD = _UnsetCycleField()
+UNSET_CYCLE_FIELD: Final = _UnsetCycleField()
+_CyclePatchField: TypeAlias = _PatchValueT | _UnsetCycleField
+
+
+@dataclass(frozen=True)
+class CyclePolicySnapshot:
+    """One validated Cycle policy, with versioned JSON persistence.
+
+    Fields stay required so schema growth makes typed constructor sites fail
+    until their live-Cycle mapping and normalization are updated here.
+    """
+
+    SNAPSHOT_VERSION: ClassVar[int] = 1
+
+    name: str
+    prompt: str
+    schedule_expr: str
+    timezone: str
+    enabled: bool
+    max_concurrency: int
+    timeout_seconds: int | None
+    retry_policy: dict[str, JsonValue]
+    model_override: str | None
+    thinking_override: str | None
+    execution_policy_key: str | None
+    target_idea_id: str | None
+    guidance: list[str]
+
+    @classmethod
+    def from_cycle(
+        cls,
+        cycle: Cycle,
+        guidance_rows: list[CycleGuidance],
+    ) -> CyclePolicySnapshot:
+        """Build the effective policy from the live Cycle read model."""
+
+        return cls(
+            name=cycle.name,
+            prompt=cycle.prompt,
+            schedule_expr=cycle.schedule_expr,
+            timezone=cycle.timezone,
+            enabled=bool(cycle.enabled),
+            max_concurrency=max(int(cycle.max_concurrency or 1), 1),
+            timeout_seconds=cycle.timeout_seconds,
+            retry_policy=dict(cycle.retry_policy or {}),
+            model_override=cycle.model_override,
+            thinking_override=cycle.thinking_override,
+            execution_policy_key=cycle.execution_policy_key,
+            target_idea_id=(
+                str(cycle.target_idea_id)
+                if cycle.target_idea_id is not None
+                else None
+            ),
+            guidance=[row.guidance for row in guidance_rows],
+        ).validated()
+
+    def apply_to(self, cycle: Cycle) -> None:
+        """Apply this policy explicitly to its live Cycle fields."""
+
+        cycle.name = self.name
+        cycle.prompt = self.prompt
+        cycle.schedule_expr = self.schedule_expr
+        cycle.timezone = self.timezone
+        cycle.enabled = self.enabled
+        cycle.max_concurrency = self.max_concurrency
+        cycle.timeout_seconds = self.timeout_seconds
+        cycle.retry_policy = deepcopy(self.retry_policy)
+        cycle.model_override = self.model_override
+        cycle.thinking_override = self.thinking_override
+        cycle.execution_policy_key = self.execution_policy_key
+        cycle.target_idea_id = self.target_idea_id
+        cycle.execution_mode = canonical_execution_mode()
+        cycle.reopen_archived = True
+        cycle.next_run_at = compute_next_run_at(
+            cycle.schedule_expr,
+            cycle.timezone,
+        )
+        cycle.updated_at = datetime.now(timezone.utc)
+
+    def validated(self) -> CyclePolicySnapshot:
+        """Return a normalized snapshot or raise for an invalid policy."""
+
+        timezone_name = validate_timezone_name(self.timezone)
+        if not isinstance(self.enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        if not isinstance(self.retry_policy, dict):
+            raise ValueError("retry_policy must be an object")
+        if not isinstance(self.guidance, (list, tuple)):
+            raise ValueError("guidance must be a list of strings")
+        retry_policy = cast(
+            dict[str, JsonValue],
+            jsonable(deepcopy(self.retry_policy)),
+        )
+        return CyclePolicySnapshot(
+            name=validate_nonempty_trimmed(self.name, "name"),
+            prompt=validate_nonempty_trimmed(self.prompt, "prompt"),
+            schedule_expr=validate_schedule_expr(
+                self.schedule_expr,
+                timezone_name,
+            ),
+            timezone=timezone_name,
+            enabled=self.enabled,
+            max_concurrency=_validated_max_concurrency(self.max_concurrency),
+            timeout_seconds=validate_cycle_timeout_seconds(self.timeout_seconds),
+            retry_policy=retry_policy,
+            model_override=validate_model_override(self.model_override),
+            thinking_override=validate_thinking_override(self.thinking_override),
+            execution_policy_key=validate_cycle_execution_policy_key(
+                self.execution_policy_key
+            ),
+            target_idea_id=(
+                str(self.target_idea_id)
+                if self.target_idea_id is not None
+                else None
+            ),
+            guidance=sorted(
+                validate_nonempty_trimmed(value, "guidance")
+                for value in self.guidance
+            ),
+        )
+
+    def encode(self) -> dict[str, Any]:
+        """Encode the current schema for the JSON database boundary."""
+
+        encoded = {
+            field.name: jsonable(deepcopy(getattr(self, field.name)))
+            for field in fields(self)
+        }
+        return {"snapshot_version": self.SNAPSHOT_VERSION, **encoded}
+
+    @classmethod
+    def decode(
+        cls,
+        snapshot: Mapping[str, Any],
+        *,
+        current: CyclePolicySnapshot,
+    ) -> CyclePolicySnapshot:
+        """Decode a legacy or versioned shape against today's effective policy.
+
+        Positive versions remain readable for forward compatibility. Unknown
+        fields are ignored, and missing fields retain their current values.
+        """
+
+        if not isinstance(snapshot, Mapping):
+            raise ValueError("Cycle policy snapshot must be an object")
+        snapshot_version = snapshot.get("snapshot_version")
+        if snapshot_version is not None and (
+            isinstance(snapshot_version, bool)
+            or not isinstance(snapshot_version, int)
+            or snapshot_version < 1
+        ):
+            raise ValueError("Cycle policy snapshot has an invalid version")
+
+        validated_current = current.validated()
+        decoded = {
+            field.name: deepcopy(
+                snapshot.get(field.name, getattr(validated_current, field.name))
+            )
+            for field in fields(cls)
+        }
+        return cls(**decoded).validated()
 
 
 @dataclass(frozen=True)
 class CyclePolicyPatch:
     """Typed changes to Cycle behavior, never arbitrary table columns."""
 
-    name: Any = UNSET_CYCLE_FIELD
-    prompt: Any = UNSET_CYCLE_FIELD
-    timezone_name: Any = UNSET_CYCLE_FIELD
-    schedule_expr: Any = UNSET_CYCLE_FIELD
-    run_at: Any = UNSET_CYCLE_FIELD
-    enabled: Any = UNSET_CYCLE_FIELD
-    max_concurrency: Any = UNSET_CYCLE_FIELD
-    timeout_seconds: Any = UNSET_CYCLE_FIELD
-    retry_policy: Any = UNSET_CYCLE_FIELD
-    model_override: Any = UNSET_CYCLE_FIELD
-    thinking_override: Any = UNSET_CYCLE_FIELD
-    execution_policy_key: Any = UNSET_CYCLE_FIELD
-    target_idea_id: Any = UNSET_CYCLE_FIELD
-    guidance: Any = UNSET_CYCLE_FIELD
-    guidance_additions: Any = UNSET_CYCLE_FIELD
+    name: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    prompt: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    timezone_name: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    schedule_expr: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    run_at: _CyclePatchField[str | datetime | None] = UNSET_CYCLE_FIELD
+    enabled: _CyclePatchField[bool | None] = UNSET_CYCLE_FIELD
+    max_concurrency: _CyclePatchField[int] = UNSET_CYCLE_FIELD
+    timeout_seconds: _CyclePatchField[int | None] = UNSET_CYCLE_FIELD
+    retry_policy: _CyclePatchField[dict[str, JsonValue]] = UNSET_CYCLE_FIELD
+    model_override: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    thinking_override: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    execution_policy_key: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    target_idea_id: _CyclePatchField[str | None] = UNSET_CYCLE_FIELD
+    guidance: _CyclePatchField[CycleGuidanceValues] = UNSET_CYCLE_FIELD
+    guidance_additions: _CyclePatchField[CycleGuidanceValues] = UNSET_CYCLE_FIELD
 
 
 @dataclass(frozen=True)
-class _CyclePolicyReplacement:
-    """Validated full replacement used only by the revert adapter."""
+class _CyclePolicyRevert:
+    """Typed adapter request used only by the revert path."""
 
-    snapshot: Mapping[str, Any]
+    change_id: int
 
 
 @dataclass(frozen=True)
@@ -130,16 +286,29 @@ class EffectiveCyclePolicy:
     target_id: str
     version: int
     revision_id: int | None
-    snapshot: dict[str, Any]
+    snapshot: CyclePolicySnapshot
 
 
 @dataclass(frozen=True)
 class CyclePolicyPreview:
     before: EffectiveCyclePolicy
-    after_snapshot: dict[str, Any]
+    after_snapshot: CyclePolicySnapshot
     changed_fields: tuple[str, ...]
     preview_digest: str
     reverted_from_id: int | None = None
+
+
+@dataclass(frozen=True)
+class _CyclePolicyPreviewDigestPayload:
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    expected_version: int
+    before_snapshot: CyclePolicySnapshot
+    after_snapshot: CyclePolicySnapshot
+    changed_fields: tuple[str, ...]
+    reverted_from_id: int | None
 
 
 @dataclass(frozen=True)
@@ -154,8 +323,8 @@ class BehaviorChangeRecord:
     actor_id: str
     source_reference: str
     rationale: str
-    before_snapshot: dict[str, Any]
-    after_snapshot: dict[str, Any]
+    before_snapshot: CyclePolicySnapshot
+    after_snapshot: CyclePolicySnapshot
     changed_fields: tuple[str, ...]
     cycle_revision_id: int
     applied_at: datetime
@@ -211,7 +380,7 @@ async def async_apply_cycle_policy_change(
     *,
     actor: CycleActor,
     cycle_id: int,
-    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    proposal: CyclePolicyPatch | _CyclePolicyRevert,
     expected_version: int,
     preview_digest: str,
     rationale: str,
@@ -248,7 +417,10 @@ async def async_apply_cycle_policy_change(
                 latest_effective_policy=current,
             )
 
-        if reverted_from_id is not None:
+        if reverted_from_id is not None and not isinstance(
+            proposal,
+            _CyclePolicyRevert,
+        ):
             await _load_revert_source(
                 session,
                 cycle=cycle,
@@ -271,7 +443,7 @@ async def async_apply_cycle_policy_change(
         if not preview.changed_fields:
             raise ValueError("proposed change does not change Cycle policy")
 
-        _apply_cycle_snapshot(cycle, preview.after_snapshot)
+        preview.after_snapshot.apply_to(cycle)
         cycle.maintainer_type = actor.source_type
         cycle.maintainer_id = actor.revision_source_id
         revision = await async_record_cycle_revision(
@@ -284,7 +456,7 @@ async def async_apply_cycle_policy_change(
         await _replace_active_guidance(
             session,
             cycle=cycle,
-            desired_guidance=preview.after_snapshot["guidance"],
+            desired_guidance=preview.after_snapshot.guidance,
             actor=actor,
             rationale=clean_rationale,
             revision_id=revision.id,
@@ -300,8 +472,8 @@ async def async_apply_cycle_policy_change(
             actor_id=actor.revision_source_id,
             source_reference=clean_source_reference,
             rationale=clean_rationale,
-            before_snapshot=_encode_stored_snapshot(current.snapshot),
-            after_snapshot=_encode_stored_snapshot(preview.after_snapshot),
+            before_snapshot=current.snapshot.encode(),
+            after_snapshot=preview.after_snapshot.encode(),
             changed_fields=list(preview.changed_fields),
             cycle_revision_id=revision.id,
             reverted_from_id=reverted_from_id,
@@ -368,15 +540,14 @@ async def async_preview_cycle_policy_revert(
     change_id: int,
 ) -> CyclePolicyPreview:
     cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
-    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
     current = await _effective_policy(session, cycle)
     return await _preview_for_cycle(
         session,
         actor=actor,
         cycle=cycle,
         current=current,
-        proposal=_CyclePolicyReplacement(source.before_snapshot),
-        reverted_from_id=source.id,
+        proposal=_CyclePolicyRevert(change_id),
+        reverted_from_id=change_id,
     )
 
 
@@ -391,18 +562,16 @@ async def async_apply_cycle_policy_revert(
     rationale: str,
     source_reference: str,
 ) -> CyclePolicyApplyResult:
-    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
-    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
     return await async_apply_cycle_policy_change(
         session,
         actor=actor,
         cycle_id=cycle_id,
-        proposal=_CyclePolicyReplacement(source.before_snapshot),
+        proposal=_CyclePolicyRevert(change_id),
         expected_version=expected_version,
         preview_digest=preview_digest,
         rationale=rationale,
         source_reference=source_reference,
-        reverted_from_id=source.id,
+        reverted_from_id=change_id,
     )
 
 
@@ -461,7 +630,7 @@ async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
         target_id=str(cycle.id),
         version=version,
         revision_id=revision_id,
-        snapshot=_cycle_snapshot(cycle, guidance_rows),
+        snapshot=CyclePolicySnapshot.from_cycle(cycle, guidance_rows),
     )
 
 
@@ -471,24 +640,33 @@ async def _preview_for_cycle(
     actor: CycleActor,
     cycle: Cycle,
     current: EffectiveCyclePolicy,
-    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    proposal: CyclePolicyPatch | _CyclePolicyRevert,
     reverted_from_id: int | None = None,
 ) -> CyclePolicyPreview:
-    if isinstance(proposal, _CyclePolicyReplacement):
-        after = _decode_stored_snapshot(
-            proposal.snapshot,
-            current_snapshot=current.snapshot,
+    if isinstance(proposal, _CyclePolicyRevert):
+        source = await _load_revert_source(
+            session,
+            cycle=cycle,
+            change_id=proposal.change_id,
+        )
+        after = CyclePolicySnapshot.decode(
+            source.before_snapshot,
+            current=current.snapshot,
         )
     else:
         after = _project_patch(current.snapshot, proposal)
-    if after["target_idea_id"] != current.snapshot["target_idea_id"]:
+    if after.target_idea_id != current.snapshot.target_idea_id:
         await _validate_target_idea(
             session,
             actor=actor,
-            target_idea_id=after["target_idea_id"],
+            target_idea_id=after.target_idea_id,
         )
     changed_fields = tuple(
-        key for key in sorted(after) if current.snapshot.get(key) != after.get(key)
+        sorted(
+            field.name
+            for field in fields(after)
+            if getattr(current.snapshot, field.name) != getattr(after, field.name)
+        )
     )
     digest = _preview_digest(
         current=current,
@@ -506,207 +684,133 @@ async def _preview_for_cycle(
 
 
 def _project_patch(
-    current_snapshot: Mapping[str, Any],
+    current_snapshot: CyclePolicySnapshot,
     patch: CyclePolicyPatch,
-) -> dict[str, Any]:
-    after = deepcopy(dict(current_snapshot))
-    timezone_name = after["timezone"]
+) -> CyclePolicySnapshot:
+    after = deepcopy(current_snapshot)
+    timezone_name = after.timezone
     if _set(patch.timezone_name) and patch.timezone_name is not None:
         timezone_name = validate_timezone_name(patch.timezone_name)
-        after["timezone"] = timezone_name
+        after = replace(after, timezone=timezone_name)
 
     if _set(patch.run_at) and patch.run_at is not None:
-        after["schedule_expr"] = build_one_time_schedule_expr(
-            patch.run_at,
-            timezone_name,
+        after = replace(
+            after,
+            schedule_expr=build_one_time_schedule_expr(
+                patch.run_at,
+                timezone_name,
+            ),
         )
     elif _set(patch.schedule_expr) and patch.schedule_expr is not None:
-        after["schedule_expr"] = validate_schedule_expr(
-            patch.schedule_expr,
-            timezone_name,
+        after = replace(
+            after,
+            schedule_expr=validate_schedule_expr(
+                patch.schedule_expr,
+                timezone_name,
+            ),
         )
-    elif after["timezone"] != current_snapshot["timezone"]:
-        after["schedule_expr"] = validate_schedule_expr(
-            after["schedule_expr"],
-            timezone_name,
+    elif after.timezone != current_snapshot.timezone:
+        after = replace(
+            after,
+            schedule_expr=validate_schedule_expr(
+                after.schedule_expr,
+                timezone_name,
+            ),
         )
 
-    for field in ("name", "prompt"):
-        value = getattr(patch, field)
-        if _set(value) and value is not None:
-            after[field] = validate_nonempty_trimmed(value, field)
+    if _set(patch.name) and patch.name is not None:
+        after = replace(
+            after,
+            name=validate_nonempty_trimmed(patch.name, "name"),
+        )
+    if _set(patch.prompt) and patch.prompt is not None:
+        after = replace(
+            after,
+            prompt=validate_nonempty_trimmed(patch.prompt, "prompt"),
+        )
 
     if _set(patch.enabled) and patch.enabled is not None:
         if not isinstance(patch.enabled, bool):
             raise ValueError("enabled must be a boolean")
-        after["enabled"] = patch.enabled
+        after = replace(after, enabled=patch.enabled)
     if _set(patch.max_concurrency):
-        after["max_concurrency"] = _validated_max_concurrency(patch.max_concurrency)
+        after = replace(
+            after,
+            max_concurrency=_validated_max_concurrency(patch.max_concurrency),
+        )
     if _set(patch.timeout_seconds):
-        after["timeout_seconds"] = validate_cycle_timeout_seconds(
-            patch.timeout_seconds
+        after = replace(
+            after,
+            timeout_seconds=validate_cycle_timeout_seconds(patch.timeout_seconds),
         )
     if _set(patch.retry_policy):
         if not isinstance(patch.retry_policy, dict):
             raise ValueError("retry_policy must be an object")
-        after["retry_policy"] = jsonable(deepcopy(patch.retry_policy))
+        after = replace(
+            after,
+            retry_policy=cast(
+                dict[str, JsonValue],
+                jsonable(deepcopy(patch.retry_policy)),
+            ),
+        )
     if _set(patch.model_override):
-        after["model_override"] = validate_model_override(patch.model_override)
+        after = replace(
+            after,
+            model_override=validate_model_override(patch.model_override),
+        )
     if _set(patch.thinking_override):
-        after["thinking_override"] = validate_thinking_override(
-            patch.thinking_override
+        after = replace(
+            after,
+            thinking_override=validate_thinking_override(
+                patch.thinking_override
+            ),
         )
     if _set(patch.execution_policy_key):
-        after["execution_policy_key"] = validate_cycle_execution_policy_key(
-            patch.execution_policy_key
+        after = replace(
+            after,
+            execution_policy_key=validate_cycle_execution_policy_key(
+                patch.execution_policy_key
+            ),
         )
     else:
-        validate_cycle_execution_policy_key(after["execution_policy_key"])
+        validate_cycle_execution_policy_key(after.execution_policy_key)
     if _set(patch.target_idea_id):
-        after["target_idea_id"] = (
-            str(patch.target_idea_id) if patch.target_idea_id is not None else None
+        after = replace(
+            after,
+            target_idea_id=(
+                str(patch.target_idea_id)
+                if patch.target_idea_id is not None
+                else None
+            ),
         )
     if _set(patch.guidance) and _set(patch.guidance_additions):
         raise ValueError("guidance and guidance_additions cannot be changed together")
     if _set(patch.guidance):
         if not isinstance(patch.guidance, (list, tuple)):
             raise ValueError("guidance must be a list of strings")
-        after["guidance"] = sorted(
-            validate_nonempty_trimmed(value, "guidance")
-            for value in patch.guidance
+        after = replace(
+            after,
+            guidance=sorted(
+                validate_nonempty_trimmed(value, "guidance")
+                for value in patch.guidance
+            ),
         )
     elif _set(patch.guidance_additions):
         if not isinstance(patch.guidance_additions, (list, tuple)):
             raise ValueError("guidance_additions must be a list of strings")
-        after["guidance"] = sorted(
-            [
-                *after["guidance"],
-                *(
-                    validate_nonempty_trimmed(value, "guidance")
-                    for value in patch.guidance_additions
-                ),
-            ]
-        )
-    return _validated_snapshot(after)
-
-
-def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
-    if set(snapshot) != _CYCLE_POLICY_SNAPSHOT_FIELDS:
-        raise ValueError("Cycle policy snapshot has an invalid field set")
-    timezone_name = validate_timezone_name(snapshot["timezone"])
-    if not isinstance(snapshot["enabled"], bool):
-        raise ValueError("enabled must be a boolean")
-    if not isinstance(snapshot["retry_policy"], dict):
-        raise ValueError("retry_policy must be an object")
-    if not isinstance(snapshot["guidance"], (list, tuple)):
-        raise ValueError("guidance must be a list of strings")
-    return {
-        "name": validate_nonempty_trimmed(snapshot["name"], "name"),
-        "prompt": validate_nonempty_trimmed(snapshot["prompt"], "prompt"),
-        "schedule_expr": validate_schedule_expr(
-            snapshot["schedule_expr"],
-            timezone_name,
-        ),
-        "timezone": timezone_name,
-        "enabled": snapshot["enabled"],
-        "max_concurrency": _validated_max_concurrency(
-            snapshot["max_concurrency"]
-        ),
-        "timeout_seconds": validate_cycle_timeout_seconds(
-            snapshot["timeout_seconds"]
-        ),
-        "retry_policy": jsonable(deepcopy(snapshot["retry_policy"])),
-        "model_override": validate_model_override(snapshot["model_override"]),
-        "thinking_override": validate_thinking_override(
-            snapshot["thinking_override"]
-        ),
-        "execution_policy_key": validate_cycle_execution_policy_key(
-            snapshot["execution_policy_key"]
-        ),
-        "target_idea_id": (
-            str(snapshot["target_idea_id"])
-            if snapshot["target_idea_id"] is not None
-            else None
-        ),
-        "guidance": sorted(
-            validate_nonempty_trimmed(value, "guidance")
-            for value in snapshot["guidance"]
-        ),
-    }
-
-
-def _encode_stored_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        _CYCLE_POLICY_SNAPSHOT_VERSION_FIELD: CYCLE_POLICY_SNAPSHOT_VERSION,
-        **_validated_snapshot(snapshot),
-    }
-
-
-def _decode_stored_snapshot(
-    snapshot: Mapping[str, Any],
-    *,
-    current_snapshot: Mapping[str, Any],
-) -> dict[str, Any]:
-    if not isinstance(snapshot, Mapping):
-        raise ValueError("Cycle policy snapshot must be an object")
-    snapshot_version = snapshot.get(_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD)
-    if snapshot_version is not None and (
-        isinstance(snapshot_version, bool)
-        or not isinstance(snapshot_version, int)
-        or snapshot_version < 1
-    ):
-        raise ValueError("Cycle policy snapshot has an invalid version")
-
-    decoded = _validated_snapshot(current_snapshot)
-    decoded.update(
-        {
-            field: deepcopy(snapshot[field])
-            for field in _CYCLE_POLICY_SNAPSHOT_FIELDS
-            if field in snapshot
-        }
-    )
-    return _validated_snapshot(decoded)
-
-
-def _cycle_snapshot(cycle: Cycle, guidance_rows: list[CycleGuidance]) -> dict[str, Any]:
-    return _validated_snapshot(
-        {
-            "name": cycle.name,
-            "prompt": cycle.prompt,
-            "schedule_expr": cycle.schedule_expr,
-            "timezone": cycle.timezone,
-            "enabled": bool(cycle.enabled),
-            "max_concurrency": max(int(cycle.max_concurrency or 1), 1),
-            "timeout_seconds": cycle.timeout_seconds,
-            "retry_policy": dict(cycle.retry_policy or {}),
-            "model_override": cycle.model_override,
-            "thinking_override": cycle.thinking_override,
-            "execution_policy_key": cycle.execution_policy_key,
-            "target_idea_id": (
-                str(cycle.target_idea_id) if cycle.target_idea_id is not None else None
+        after = replace(
+            after,
+            guidance=sorted(
+                [
+                    *after.guidance,
+                    *(
+                        validate_nonempty_trimmed(value, "guidance")
+                        for value in patch.guidance_additions
+                    ),
+                ]
             ),
-            "guidance": [row.guidance for row in guidance_rows],
-        }
-    )
-
-
-def _apply_cycle_snapshot(cycle: Cycle, snapshot: Mapping[str, Any]) -> None:
-    cycle.name = snapshot["name"]
-    cycle.prompt = snapshot["prompt"]
-    cycle.schedule_expr = snapshot["schedule_expr"]
-    cycle.timezone = snapshot["timezone"]
-    cycle.enabled = snapshot["enabled"]
-    cycle.max_concurrency = snapshot["max_concurrency"]
-    cycle.timeout_seconds = snapshot["timeout_seconds"]
-    cycle.retry_policy = deepcopy(snapshot["retry_policy"])
-    cycle.model_override = snapshot["model_override"]
-    cycle.thinking_override = snapshot["thinking_override"]
-    cycle.execution_policy_key = snapshot["execution_policy_key"]
-    cycle.target_idea_id = snapshot["target_idea_id"]
-    cycle.execution_mode = canonical_execution_mode()
-    cycle.reopen_archived = True
-    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
-    cycle.updated_at = datetime.now(timezone.utc)
+        )
+    return after.validated()
 
 
 async def _replace_active_guidance(
@@ -788,21 +892,21 @@ async def _load_revert_source(
 def _preview_digest(
     *,
     current: EffectiveCyclePolicy,
-    after_snapshot: Mapping[str, Any],
+    after_snapshot: CyclePolicySnapshot,
     changed_fields: tuple[str, ...],
     reverted_from_id: int | None,
 ) -> str:
-    payload = {
-        "workspace_id": current.workspace_id,
-        "policy_kind": current.policy_kind,
-        "target_type": current.target_type,
-        "target_id": current.target_id,
-        "expected_version": current.version,
-        "before_snapshot": current.snapshot,
-        "after_snapshot": after_snapshot,
-        "changed_fields": list(changed_fields),
-        "reverted_from_id": reverted_from_id,
-    }
+    payload = _CyclePolicyPreviewDigestPayload(
+        workspace_id=current.workspace_id,
+        policy_kind=current.policy_kind,
+        target_type=current.target_type,
+        target_id=current.target_id,
+        expected_version=current.version,
+        before_snapshot=current.snapshot,
+        after_snapshot=after_snapshot,
+        changed_fields=changed_fields,
+        reverted_from_id=reverted_from_id,
+    )
     canonical = json.dumps(
         jsonable(payload),
         sort_keys=True,
@@ -814,7 +918,7 @@ def _preview_digest(
 def _record(
     row: BehaviorChangeAudit,
     *,
-    current_snapshot: Mapping[str, Any],
+    current_snapshot: CyclePolicySnapshot,
 ) -> BehaviorChangeRecord:
     applied_at = row.applied_at
     if applied_at.tzinfo is None:
@@ -830,19 +934,20 @@ def _record(
         actor_id=row.actor_id,
         source_reference=row.source_reference,
         rationale=row.rationale,
-        before_snapshot=_decode_stored_snapshot(
+        before_snapshot=CyclePolicySnapshot.decode(
             row.before_snapshot,
-            current_snapshot=current_snapshot,
+            current=current_snapshot,
         ),
-        after_snapshot=_decode_stored_snapshot(
+        after_snapshot=CyclePolicySnapshot.decode(
             row.after_snapshot,
-            current_snapshot=current_snapshot,
+            current=current_snapshot,
         ),
         changed_fields=tuple(row.changed_fields or []),
         cycle_revision_id=row.cycle_revision_id,
         applied_at=applied_at,
         reverted_from_id=row.reverted_from_id,
     )
+
 
 def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
     return (
@@ -856,11 +961,13 @@ def _workspace_id(cycle: Cycle) -> str:
     return str(cycle.org_id or cycle.user_id)
 
 
-def _validated_max_concurrency(value: Any) -> int:
+def _validated_max_concurrency(value: object) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ValueError("max_concurrency must be an integer >= 1")
     return value
 
 
-def _set(value: Any) -> bool:
+def _set(
+    value: _CyclePatchField[_PatchValueT],
+) -> TypeGuard[_PatchValueT]:
     return value is not UNSET_CYCLE_FIELD

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -1,0 +1,837 @@
+"""Reviewed Cycle behavior-policy commands and their immutable audit envelope.
+
+This module is the only write path for an existing Cycle's behavior fields and
+active guidance set. API and agent adapters can differ, but both must preview
+and apply through this contract.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy import func, select
+
+from brain.kernel.common.serialization import jsonable
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleRevision,
+)
+from brain.platform.db.models.idea import Idea
+from brain.systems.cycles.access import (
+    CycleActor,
+    cycle_scope_conditions,
+    target_idea_scope_conditions,
+)
+from brain.systems.cycles.common import (
+    canonical_execution_mode,
+    validate_cycle_timeout_seconds,
+    validate_model_override,
+    validate_nonempty_trimmed,
+    validate_thinking_override,
+)
+from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.execution_policy_registry import (
+    validate_cycle_execution_policy_key,
+)
+from brain.systems.cycles.memory import async_record_cycle_revision
+from brain.systems.cycles.schedules import (
+    build_one_time_schedule_expr,
+    compute_next_run_at,
+    validate_schedule_expr,
+    validate_timezone_name,
+)
+
+__all__ = [
+    "BehaviorChangeRecord",
+    "CyclePolicyApplied",
+    "CyclePolicyApplyResult",
+    "CyclePolicyConflict",
+    "CyclePolicyPatch",
+    "CyclePolicyPreview",
+    "EffectiveCyclePolicy",
+    "async_apply_cycle_policy_change",
+    "async_apply_cycle_policy_revert",
+    "async_list_cycle_policy_history",
+    "async_preview_cycle_policy_change",
+    "async_preview_cycle_policy_revert",
+    "async_read_effective_cycle_policy",
+]
+
+CYCLE_POLICY_KIND = "cycle"
+CYCLE_TARGET_TYPE = "cycle"
+
+
+class _UnsetPolicyField:
+    pass
+
+
+UNSET_POLICY_FIELD = _UnsetPolicyField()
+
+
+@dataclass(frozen=True)
+class CyclePolicyPatch:
+    """Typed changes to Cycle behavior, never arbitrary table columns."""
+
+    name: Any = UNSET_POLICY_FIELD
+    prompt: Any = UNSET_POLICY_FIELD
+    timezone_name: Any = UNSET_POLICY_FIELD
+    schedule_expr: Any = UNSET_POLICY_FIELD
+    run_at: Any = UNSET_POLICY_FIELD
+    enabled: Any = UNSET_POLICY_FIELD
+    max_concurrency: Any = UNSET_POLICY_FIELD
+    timeout_seconds: Any = UNSET_POLICY_FIELD
+    retry_policy: Any = UNSET_POLICY_FIELD
+    model_override: Any = UNSET_POLICY_FIELD
+    thinking_override: Any = UNSET_POLICY_FIELD
+    execution_policy_key: Any = UNSET_POLICY_FIELD
+    target_idea_id: Any = UNSET_POLICY_FIELD
+    guidance: Any = UNSET_POLICY_FIELD
+    guidance_additions: Any = UNSET_POLICY_FIELD
+
+
+@dataclass(frozen=True)
+class _CyclePolicyReplacement:
+    """Validated full replacement used only by the revert adapter."""
+
+    snapshot: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class EffectiveCyclePolicy:
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    version: int
+    revision_id: int | None
+    snapshot: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CyclePolicyPreview:
+    before: EffectiveCyclePolicy
+    after_snapshot: dict[str, Any]
+    changed_fields: tuple[str, ...]
+    preview_digest: str
+    reverted_from_id: int | None = None
+
+
+@dataclass(frozen=True)
+class BehaviorChangeRecord:
+    id: int
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    version: int
+    actor_type: str
+    actor_id: str
+    source_reference: str
+    rationale: str
+    before_snapshot: dict[str, Any]
+    after_snapshot: dict[str, Any]
+    changed_fields: tuple[str, ...]
+    cycle_revision_id: int
+    applied_at: datetime
+    reverted_from_id: int | None
+
+
+@dataclass(frozen=True)
+class CyclePolicyApplied:
+    effective_policy: EffectiveCyclePolicy
+    change: BehaviorChangeRecord
+    revision: CycleRevision
+
+
+@dataclass(frozen=True)
+class CyclePolicyConflict:
+    reason: str
+    latest_effective_policy: EffectiveCyclePolicy
+
+
+CyclePolicyApplyResult = CyclePolicyApplied | CyclePolicyConflict
+
+
+async def async_read_effective_cycle_policy(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+) -> EffectiveCyclePolicy:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    return await _effective_policy(session, cycle)
+
+
+async def async_preview_cycle_policy_change(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    proposal: CyclePolicyPatch,
+) -> CyclePolicyPreview:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    current = await _effective_policy(session, cycle)
+    return await _preview_for_cycle(
+        session,
+        actor=actor,
+        cycle=cycle,
+        current=current,
+        proposal=proposal,
+    )
+
+
+async def async_apply_cycle_policy_change(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    expected_version: int,
+    preview_digest: str,
+    rationale: str,
+    source_reference: str,
+    reverted_from_id: int | None = None,
+) -> CyclePolicyApplyResult:
+    """Apply one reviewed change inside the caller's transaction.
+
+    A savepoint keeps the policy write set atomic even when a caller catches an
+    apply-time exception and continues using its outer transaction. The Cycle
+    row lock serializes version allocation on PostgreSQL.
+    """
+
+    clean_rationale = validate_nonempty_trimmed(rationale, "rationale")
+    clean_source_reference = validate_nonempty_trimmed(
+        source_reference,
+        "source_reference",
+    )
+    if isinstance(expected_version, bool) or not isinstance(expected_version, int):
+        raise ValueError("expected_version must be an integer")
+    clean_digest = validate_nonempty_trimmed(preview_digest, "preview_digest")
+
+    async with session.begin_nested():
+        cycle = await _load_scoped_cycle(
+            session,
+            actor=actor,
+            cycle_id=cycle_id,
+            for_update=True,
+        )
+        current = await _effective_policy(session, cycle)
+        if current.version != expected_version:
+            return CyclePolicyConflict(
+                reason="stale_version",
+                latest_effective_policy=current,
+            )
+
+        if reverted_from_id is not None:
+            await _load_revert_source(
+                session,
+                cycle=cycle,
+                change_id=reverted_from_id,
+            )
+
+        preview = await _preview_for_cycle(
+            session,
+            actor=actor,
+            cycle=cycle,
+            current=current,
+            proposal=proposal,
+            reverted_from_id=reverted_from_id,
+        )
+        if preview.preview_digest != clean_digest:
+            return CyclePolicyConflict(
+                reason="stale_preview_digest",
+                latest_effective_policy=current,
+            )
+        if not preview.changed_fields:
+            raise ValueError("proposed change does not change Cycle policy")
+
+        _apply_cycle_snapshot(cycle, preview.after_snapshot)
+        cycle.maintainer_type = actor.source_type
+        cycle.maintainer_id = actor.revision_source_id
+        revision = await async_record_cycle_revision(
+            session,
+            cycle,
+            source_type=actor.source_type,
+            source_id=actor.revision_source_id,
+            rationale=clean_rationale,
+        )
+        await _replace_active_guidance(
+            session,
+            cycle=cycle,
+            desired_guidance=preview.after_snapshot["guidance"],
+            actor=actor,
+            rationale=clean_rationale,
+            revision_id=revision.id,
+        )
+
+        change = BehaviorChangeAudit(
+            workspace_id=current.workspace_id,
+            policy_kind=CYCLE_POLICY_KIND,
+            target_type=CYCLE_TARGET_TYPE,
+            target_id=str(cycle.id),
+            version=current.version + 1,
+            actor_type=actor.source_type,
+            actor_id=actor.revision_source_id,
+            source_reference=clean_source_reference,
+            rationale=clean_rationale,
+            before_snapshot=deepcopy(current.snapshot),
+            after_snapshot=deepcopy(preview.after_snapshot),
+            changed_fields=list(preview.changed_fields),
+            cycle_revision_id=revision.id,
+            reverted_from_id=reverted_from_id,
+            applied_at=datetime.now(timezone.utc),
+        )
+        session.add(change)
+        await session.flush()
+
+        publish_cycle_change(
+            action="update",
+            org_id=cycle.org_id,
+            user_id=cycle.user_id,
+            cycle_id=cycle.id,
+            target_idea_id=cycle.target_idea_id,
+            strict=True,
+        )
+
+        effective = EffectiveCyclePolicy(
+            workspace_id=current.workspace_id,
+            policy_kind=CYCLE_POLICY_KIND,
+            target_type=CYCLE_TARGET_TYPE,
+            target_id=str(cycle.id),
+            version=change.version,
+            revision_id=revision.id,
+            snapshot=deepcopy(preview.after_snapshot),
+        )
+        return CyclePolicyApplied(
+            effective_policy=effective,
+            change=_record(change),
+            revision=revision,
+        )
+
+
+async def async_list_cycle_policy_history(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    limit: int = 100,
+) -> list[BehaviorChangeRecord]:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    clean_limit = max(1, min(int(limit), 500))
+    rows = list(
+        (
+            await session.scalars(
+                select(BehaviorChangeAudit)
+                .where(*_audit_target_conditions(cycle))
+                .order_by(BehaviorChangeAudit.version.desc())
+                .limit(clean_limit)
+            )
+        ).all()
+    )
+    return [_record(row) for row in rows]
+
+
+async def async_preview_cycle_policy_revert(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    change_id: int,
+) -> CyclePolicyPreview:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
+    current = await _effective_policy(session, cycle)
+    return await _preview_for_cycle(
+        session,
+        actor=actor,
+        cycle=cycle,
+        current=current,
+        proposal=_CyclePolicyReplacement(source.before_snapshot),
+        reverted_from_id=source.id,
+    )
+
+
+async def async_apply_cycle_policy_revert(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    change_id: int,
+    expected_version: int,
+    preview_digest: str,
+    rationale: str,
+    source_reference: str,
+) -> CyclePolicyApplyResult:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    source = await _load_revert_source(session, cycle=cycle, change_id=change_id)
+    return await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle_id,
+        proposal=_CyclePolicyReplacement(source.before_snapshot),
+        expected_version=expected_version,
+        preview_digest=preview_digest,
+        rationale=rationale,
+        source_reference=source_reference,
+        reverted_from_id=source.id,
+    )
+
+
+async def _load_scoped_cycle(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    for_update: bool = False,
+) -> Cycle:
+    statement = select(Cycle).where(
+        Cycle.id == cycle_id,
+        *cycle_scope_conditions(actor),
+    )
+    if for_update:
+        statement = statement.with_for_update()
+    cycle = (await session.scalars(statement)).first()
+    if cycle is None:
+        raise ValueError("Cycle not found")
+    return cycle
+
+
+async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
+    guidance_rows = list(
+        (
+            await session.scalars(
+                select(CycleGuidance)
+                .where(
+                    CycleGuidance.cycle_id == cycle.id,
+                    CycleGuidance.is_active.is_(True),
+                )
+                .order_by(CycleGuidance.created_at.asc(), CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    version = int(
+        (
+            await session.scalar(
+                select(func.coalesce(func.max(BehaviorChangeAudit.version), 0)).where(
+                    *_audit_target_conditions(cycle)
+                )
+            )
+        )
+        or 0
+    )
+    revision_id = await session.scalar(
+        select(CycleRevision.id)
+        .where(CycleRevision.cycle_id == cycle.id)
+        .order_by(CycleRevision.revision_number.desc(), CycleRevision.id.desc())
+        .limit(1)
+    )
+    return EffectiveCyclePolicy(
+        workspace_id=_workspace_id(cycle),
+        policy_kind=CYCLE_POLICY_KIND,
+        target_type=CYCLE_TARGET_TYPE,
+        target_id=str(cycle.id),
+        version=version,
+        revision_id=revision_id,
+        snapshot=_cycle_snapshot(cycle, guidance_rows),
+    )
+
+
+async def _preview_for_cycle(
+    session,
+    *,
+    actor: CycleActor,
+    cycle: Cycle,
+    current: EffectiveCyclePolicy,
+    proposal: CyclePolicyPatch | _CyclePolicyReplacement,
+    reverted_from_id: int | None = None,
+) -> CyclePolicyPreview:
+    if isinstance(proposal, _CyclePolicyReplacement):
+        after = _validated_snapshot(proposal.snapshot)
+    else:
+        after = _project_patch(current.snapshot, proposal)
+    if after["target_idea_id"] != current.snapshot["target_idea_id"]:
+        await _validate_target_idea(
+            session,
+            actor=actor,
+            target_idea_id=after["target_idea_id"],
+        )
+    changed_fields = tuple(
+        key for key in sorted(after) if current.snapshot.get(key) != after.get(key)
+    )
+    digest = _preview_digest(
+        current=current,
+        after_snapshot=after,
+        changed_fields=changed_fields,
+        reverted_from_id=reverted_from_id,
+    )
+    return CyclePolicyPreview(
+        before=current,
+        after_snapshot=after,
+        changed_fields=changed_fields,
+        preview_digest=digest,
+        reverted_from_id=reverted_from_id,
+    )
+
+
+def _project_patch(
+    current_snapshot: Mapping[str, Any],
+    patch: CyclePolicyPatch,
+) -> dict[str, Any]:
+    after = deepcopy(dict(current_snapshot))
+    timezone_name = after["timezone"]
+    if _set(patch.timezone_name) and patch.timezone_name is not None:
+        timezone_name = validate_timezone_name(patch.timezone_name)
+        after["timezone"] = timezone_name
+
+    if _set(patch.run_at) and patch.run_at is not None:
+        after["schedule_expr"] = build_one_time_schedule_expr(
+            patch.run_at,
+            timezone_name,
+        )
+    elif _set(patch.schedule_expr) and patch.schedule_expr is not None:
+        after["schedule_expr"] = validate_schedule_expr(
+            patch.schedule_expr,
+            timezone_name,
+        )
+    elif after["timezone"] != current_snapshot["timezone"]:
+        after["schedule_expr"] = validate_schedule_expr(
+            after["schedule_expr"],
+            timezone_name,
+        )
+
+    for field in ("name", "prompt"):
+        value = getattr(patch, field)
+        if _set(value) and value is not None:
+            after[field] = validate_nonempty_trimmed(value, field)
+
+    if _set(patch.enabled) and patch.enabled is not None:
+        if not isinstance(patch.enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        after["enabled"] = patch.enabled
+    if _set(patch.max_concurrency):
+        after["max_concurrency"] = _validated_max_concurrency(patch.max_concurrency)
+    if _set(patch.timeout_seconds):
+        after["timeout_seconds"] = validate_cycle_timeout_seconds(
+            patch.timeout_seconds
+        )
+    if _set(patch.retry_policy):
+        if not isinstance(patch.retry_policy, dict):
+            raise ValueError("retry_policy must be an object")
+        after["retry_policy"] = jsonable(deepcopy(patch.retry_policy))
+    if _set(patch.model_override):
+        after["model_override"] = validate_model_override(patch.model_override)
+    if _set(patch.thinking_override):
+        after["thinking_override"] = validate_thinking_override(
+            patch.thinking_override
+        )
+    if _set(patch.execution_policy_key):
+        after["execution_policy_key"] = validate_cycle_execution_policy_key(
+            patch.execution_policy_key
+        )
+    else:
+        validate_cycle_execution_policy_key(after["execution_policy_key"])
+    if _set(patch.target_idea_id):
+        after["target_idea_id"] = (
+            str(patch.target_idea_id) if patch.target_idea_id is not None else None
+        )
+    if _set(patch.guidance) and _set(patch.guidance_additions):
+        raise ValueError("guidance and guidance_additions cannot be changed together")
+    if _set(patch.guidance):
+        if not isinstance(patch.guidance, (list, tuple)):
+            raise ValueError("guidance must be a list of strings")
+        after["guidance"] = sorted(
+            validate_nonempty_trimmed(value, "guidance")
+            for value in patch.guidance
+        )
+    elif _set(patch.guidance_additions):
+        if not isinstance(patch.guidance_additions, (list, tuple)):
+            raise ValueError("guidance_additions must be a list of strings")
+        after["guidance"] = sorted(
+            [
+                *after["guidance"],
+                *(
+                    validate_nonempty_trimmed(value, "guidance")
+                    for value in patch.guidance_additions
+                ),
+            ]
+        )
+    return _validated_snapshot(after)
+
+
+def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    expected_fields = {
+        "name",
+        "prompt",
+        "schedule_expr",
+        "timezone",
+        "enabled",
+        "max_concurrency",
+        "timeout_seconds",
+        "retry_policy",
+        "model_override",
+        "thinking_override",
+        "execution_policy_key",
+        "target_idea_id",
+        "guidance",
+    }
+    if set(snapshot) != expected_fields:
+        raise ValueError("Cycle policy snapshot has an invalid field set")
+    timezone_name = validate_timezone_name(snapshot["timezone"])
+    if not isinstance(snapshot["enabled"], bool):
+        raise ValueError("enabled must be a boolean")
+    if not isinstance(snapshot["retry_policy"], dict):
+        raise ValueError("retry_policy must be an object")
+    if not isinstance(snapshot["guidance"], (list, tuple)):
+        raise ValueError("guidance must be a list of strings")
+    return {
+        "name": validate_nonempty_trimmed(snapshot["name"], "name"),
+        "prompt": validate_nonempty_trimmed(snapshot["prompt"], "prompt"),
+        "schedule_expr": validate_schedule_expr(
+            snapshot["schedule_expr"],
+            timezone_name,
+        ),
+        "timezone": timezone_name,
+        "enabled": snapshot["enabled"],
+        "max_concurrency": _validated_max_concurrency(
+            snapshot["max_concurrency"]
+        ),
+        "timeout_seconds": validate_cycle_timeout_seconds(
+            snapshot["timeout_seconds"]
+        ),
+        "retry_policy": jsonable(deepcopy(snapshot["retry_policy"])),
+        "model_override": validate_model_override(snapshot["model_override"]),
+        "thinking_override": validate_thinking_override(
+            snapshot["thinking_override"]
+        ),
+        "execution_policy_key": validate_cycle_execution_policy_key(
+            snapshot["execution_policy_key"]
+        ),
+        "target_idea_id": (
+            str(snapshot["target_idea_id"])
+            if snapshot["target_idea_id"] is not None
+            else None
+        ),
+        "guidance": sorted(
+            validate_nonempty_trimmed(value, "guidance")
+            for value in snapshot["guidance"]
+        ),
+    }
+
+
+def _cycle_snapshot(cycle: Cycle, guidance_rows: list[CycleGuidance]) -> dict[str, Any]:
+    return _validated_snapshot(
+        {
+            "name": cycle.name,
+            "prompt": cycle.prompt,
+            "schedule_expr": cycle.schedule_expr,
+            "timezone": cycle.timezone,
+            "enabled": bool(cycle.enabled),
+            "max_concurrency": max(int(cycle.max_concurrency or 1), 1),
+            "timeout_seconds": cycle.timeout_seconds,
+            "retry_policy": dict(cycle.retry_policy or {}),
+            "model_override": cycle.model_override,
+            "thinking_override": cycle.thinking_override,
+            "execution_policy_key": cycle.execution_policy_key,
+            "target_idea_id": (
+                str(cycle.target_idea_id) if cycle.target_idea_id is not None else None
+            ),
+            "guidance": [row.guidance for row in guidance_rows],
+        }
+    )
+
+
+def _apply_cycle_snapshot(cycle: Cycle, snapshot: Mapping[str, Any]) -> None:
+    cycle.name = snapshot["name"]
+    cycle.prompt = snapshot["prompt"]
+    cycle.schedule_expr = snapshot["schedule_expr"]
+    cycle.timezone = snapshot["timezone"]
+    cycle.enabled = snapshot["enabled"]
+    cycle.max_concurrency = snapshot["max_concurrency"]
+    cycle.timeout_seconds = snapshot["timeout_seconds"]
+    cycle.retry_policy = deepcopy(snapshot["retry_policy"])
+    cycle.model_override = snapshot["model_override"]
+    cycle.thinking_override = snapshot["thinking_override"]
+    cycle.execution_policy_key = snapshot["execution_policy_key"]
+    cycle.target_idea_id = snapshot["target_idea_id"]
+    cycle.execution_mode = canonical_execution_mode()
+    cycle.reopen_archived = True
+    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
+    cycle.updated_at = datetime.now(timezone.utc)
+
+
+async def _replace_active_guidance(
+    session,
+    *,
+    cycle: Cycle,
+    desired_guidance: list[str],
+    actor: CycleActor,
+    rationale: str,
+    revision_id: int,
+) -> None:
+    active_rows = list(
+        (
+            await session.scalars(
+                select(CycleGuidance)
+                .where(
+                    CycleGuidance.cycle_id == cycle.id,
+                    CycleGuidance.is_active.is_(True),
+                )
+                .order_by(CycleGuidance.created_at.asc(), CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    unmatched = list(desired_guidance)
+    for row in active_rows:
+        try:
+            index = unmatched.index(row.guidance)
+        except ValueError:
+            row.is_active = False
+        else:
+            unmatched.pop(index)
+
+    for guidance in unmatched:
+        session.add(
+            CycleGuidance(
+                cycle_id=cycle.id,
+                revision_id=revision_id,
+                source_type=actor.source_type,
+                source_id=actor.revision_source_id,
+                guidance=guidance,
+                rationale=rationale,
+                is_active=True,
+            )
+        )
+
+
+async def _validate_target_idea(
+    session,
+    *,
+    actor: CycleActor,
+    target_idea_id: str | None,
+) -> None:
+    if target_idea_id is None:
+        return
+    row = await session.scalar(
+        select(Idea.id).where(*target_idea_scope_conditions(target_idea_id, actor))
+    )
+    if row is None:
+        raise ValueError("target_idea_id must belong to the current workspace")
+
+
+async def _load_revert_source(
+    session,
+    *,
+    cycle: Cycle,
+    change_id: int,
+) -> BehaviorChangeAudit:
+    row = await session.scalar(
+        select(BehaviorChangeAudit).where(
+            BehaviorChangeAudit.id == change_id,
+            *_audit_target_conditions(cycle),
+        )
+    )
+    if row is None:
+        raise ValueError("Behavior change not found")
+    return row
+
+
+def _preview_digest(
+    *,
+    current: EffectiveCyclePolicy,
+    after_snapshot: Mapping[str, Any],
+    changed_fields: tuple[str, ...],
+    reverted_from_id: int | None,
+) -> str:
+    payload = {
+        "workspace_id": current.workspace_id,
+        "policy_kind": current.policy_kind,
+        "target_type": current.target_type,
+        "target_id": current.target_id,
+        "expected_version": current.version,
+        "before_snapshot": current.snapshot,
+        "after_snapshot": after_snapshot,
+        "changed_fields": list(changed_fields),
+        "reverted_from_id": reverted_from_id,
+    }
+    canonical = json.dumps(
+        jsonable(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
+    applied_at = row.applied_at
+    if applied_at.tzinfo is None:
+        applied_at = applied_at.replace(tzinfo=timezone.utc)
+    return BehaviorChangeRecord(
+        id=row.id,
+        workspace_id=row.workspace_id,
+        policy_kind=row.policy_kind,
+        target_type=row.target_type,
+        target_id=row.target_id,
+        version=row.version,
+        actor_type=row.actor_type,
+        actor_id=row.actor_id,
+        source_reference=row.source_reference,
+        rationale=row.rationale,
+        before_snapshot=deepcopy(row.before_snapshot),
+        after_snapshot=deepcopy(row.after_snapshot),
+        changed_fields=tuple(row.changed_fields or []),
+        cycle_revision_id=row.cycle_revision_id,
+        applied_at=applied_at,
+        reverted_from_id=row.reverted_from_id,
+    )
+
+
+def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
+    if row is None:
+        return None
+    record = _record(row)
+    return {
+        "id": record.id,
+        "workspace_id": record.workspace_id,
+        "policy_kind": record.policy_kind,
+        "target_type": record.target_type,
+        "target_id": record.target_id,
+        "version": record.version,
+        "actor_type": record.actor_type,
+        "actor_id": record.actor_id,
+        "source_reference": record.source_reference,
+        "rationale": record.rationale,
+        "before_snapshot": record.before_snapshot,
+        "after_snapshot": record.after_snapshot,
+        "changed_fields": list(record.changed_fields),
+        "cycle_revision_id": record.cycle_revision_id,
+        "applied_at": record.applied_at.isoformat(),
+        "reverted_from_id": record.reverted_from_id,
+    }
+
+
+def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
+    return (
+        BehaviorChangeAudit.policy_kind == CYCLE_POLICY_KIND,
+        BehaviorChangeAudit.target_type == CYCLE_TARGET_TYPE,
+        BehaviorChangeAudit.target_id == str(cycle.id),
+    )
+
+
+def _workspace_id(cycle: Cycle) -> str:
+    return str(cycle.org_id or cycle.user_id)
+
+
+def _validated_max_concurrency(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("max_concurrency must be an integer >= 1")
+    return value
+
+
+def _set(value: Any) -> bool:
+    return value is not UNSET_POLICY_FIELD

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -35,7 +35,7 @@ from brain.systems.cycles.common import (
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_strict
 from brain.systems.cycles.execution_policy_registry import (
     validate_cycle_execution_policy_key,
 )
@@ -55,6 +55,7 @@ __all__ = [
     "CyclePolicyPatch",
     "CyclePolicyPreview",
     "EffectiveCyclePolicy",
+    "UNSET_CYCLE_FIELD",
     "async_apply_cycle_policy_change",
     "async_apply_cycle_policy_revert",
     "async_list_cycle_policy_history",
@@ -65,34 +66,53 @@ __all__ = [
 
 CYCLE_POLICY_KIND = "cycle"
 CYCLE_TARGET_TYPE = "cycle"
+CYCLE_POLICY_SNAPSHOT_VERSION = 1
+_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD = "snapshot_version"
+_CYCLE_POLICY_SNAPSHOT_FIELDS = frozenset(
+    {
+        "name",
+        "prompt",
+        "schedule_expr",
+        "timezone",
+        "enabled",
+        "max_concurrency",
+        "timeout_seconds",
+        "retry_policy",
+        "model_override",
+        "thinking_override",
+        "execution_policy_key",
+        "target_idea_id",
+        "guidance",
+    }
+)
 
 
-class _UnsetPolicyField:
+class _UnsetCycleField:
     pass
 
 
-UNSET_POLICY_FIELD = _UnsetPolicyField()
+UNSET_CYCLE_FIELD = _UnsetCycleField()
 
 
 @dataclass(frozen=True)
 class CyclePolicyPatch:
     """Typed changes to Cycle behavior, never arbitrary table columns."""
 
-    name: Any = UNSET_POLICY_FIELD
-    prompt: Any = UNSET_POLICY_FIELD
-    timezone_name: Any = UNSET_POLICY_FIELD
-    schedule_expr: Any = UNSET_POLICY_FIELD
-    run_at: Any = UNSET_POLICY_FIELD
-    enabled: Any = UNSET_POLICY_FIELD
-    max_concurrency: Any = UNSET_POLICY_FIELD
-    timeout_seconds: Any = UNSET_POLICY_FIELD
-    retry_policy: Any = UNSET_POLICY_FIELD
-    model_override: Any = UNSET_POLICY_FIELD
-    thinking_override: Any = UNSET_POLICY_FIELD
-    execution_policy_key: Any = UNSET_POLICY_FIELD
-    target_idea_id: Any = UNSET_POLICY_FIELD
-    guidance: Any = UNSET_POLICY_FIELD
-    guidance_additions: Any = UNSET_POLICY_FIELD
+    name: Any = UNSET_CYCLE_FIELD
+    prompt: Any = UNSET_CYCLE_FIELD
+    timezone_name: Any = UNSET_CYCLE_FIELD
+    schedule_expr: Any = UNSET_CYCLE_FIELD
+    run_at: Any = UNSET_CYCLE_FIELD
+    enabled: Any = UNSET_CYCLE_FIELD
+    max_concurrency: Any = UNSET_CYCLE_FIELD
+    timeout_seconds: Any = UNSET_CYCLE_FIELD
+    retry_policy: Any = UNSET_CYCLE_FIELD
+    model_override: Any = UNSET_CYCLE_FIELD
+    thinking_override: Any = UNSET_CYCLE_FIELD
+    execution_policy_key: Any = UNSET_CYCLE_FIELD
+    target_idea_id: Any = UNSET_CYCLE_FIELD
+    guidance: Any = UNSET_CYCLE_FIELD
+    guidance_additions: Any = UNSET_CYCLE_FIELD
 
 
 @dataclass(frozen=True)
@@ -280,8 +300,8 @@ async def async_apply_cycle_policy_change(
             actor_id=actor.revision_source_id,
             source_reference=clean_source_reference,
             rationale=clean_rationale,
-            before_snapshot=deepcopy(current.snapshot),
-            after_snapshot=deepcopy(preview.after_snapshot),
+            before_snapshot=_encode_stored_snapshot(current.snapshot),
+            after_snapshot=_encode_stored_snapshot(preview.after_snapshot),
             changed_fields=list(preview.changed_fields),
             cycle_revision_id=revision.id,
             reverted_from_id=reverted_from_id,
@@ -290,13 +310,12 @@ async def async_apply_cycle_policy_change(
         session.add(change)
         await session.flush()
 
-        publish_cycle_change(
+        publish_cycle_change_strict(
             action="update",
             org_id=cycle.org_id,
             user_id=cycle.user_id,
             cycle_id=cycle.id,
             target_idea_id=cycle.target_idea_id,
-            strict=True,
         )
 
         effective = EffectiveCyclePolicy(
@@ -310,7 +329,7 @@ async def async_apply_cycle_policy_change(
         )
         return CyclePolicyApplied(
             effective_policy=effective,
-            change=_record(change),
+            change=_record(change, current_snapshot=preview.after_snapshot),
             revision=revision,
         )
 
@@ -323,6 +342,7 @@ async def async_list_cycle_policy_history(
     limit: int = 100,
 ) -> list[BehaviorChangeRecord]:
     cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    current = await _effective_policy(session, cycle)
     clean_limit = max(1, min(int(limit), 500))
     rows = list(
         (
@@ -334,7 +354,10 @@ async def async_list_cycle_policy_history(
             )
         ).all()
     )
-    return [_record(row) for row in rows]
+    return [
+        _record(row, current_snapshot=current.snapshot)
+        for row in rows
+    ]
 
 
 async def async_preview_cycle_policy_revert(
@@ -452,7 +475,10 @@ async def _preview_for_cycle(
     reverted_from_id: int | None = None,
 ) -> CyclePolicyPreview:
     if isinstance(proposal, _CyclePolicyReplacement):
-        after = _validated_snapshot(proposal.snapshot)
+        after = _decode_stored_snapshot(
+            proposal.snapshot,
+            current_snapshot=current.snapshot,
+        )
     else:
         after = _project_patch(current.snapshot, proposal)
     if after["target_idea_id"] != current.snapshot["target_idea_id"]:
@@ -565,22 +591,7 @@ def _project_patch(
 
 
 def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
-    expected_fields = {
-        "name",
-        "prompt",
-        "schedule_expr",
-        "timezone",
-        "enabled",
-        "max_concurrency",
-        "timeout_seconds",
-        "retry_policy",
-        "model_override",
-        "thinking_override",
-        "execution_policy_key",
-        "target_idea_id",
-        "guidance",
-    }
-    if set(snapshot) != expected_fields:
+    if set(snapshot) != _CYCLE_POLICY_SNAPSHOT_FIELDS:
         raise ValueError("Cycle policy snapshot has an invalid field set")
     timezone_name = validate_timezone_name(snapshot["timezone"])
     if not isinstance(snapshot["enabled"], bool):
@@ -622,6 +633,39 @@ def _validated_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             for value in snapshot["guidance"]
         ),
     }
+
+
+def _encode_stored_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        _CYCLE_POLICY_SNAPSHOT_VERSION_FIELD: CYCLE_POLICY_SNAPSHOT_VERSION,
+        **_validated_snapshot(snapshot),
+    }
+
+
+def _decode_stored_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    current_snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("Cycle policy snapshot must be an object")
+    snapshot_version = snapshot.get(_CYCLE_POLICY_SNAPSHOT_VERSION_FIELD)
+    if snapshot_version is not None and (
+        isinstance(snapshot_version, bool)
+        or not isinstance(snapshot_version, int)
+        or snapshot_version < 1
+    ):
+        raise ValueError("Cycle policy snapshot has an invalid version")
+
+    decoded = _validated_snapshot(current_snapshot)
+    decoded.update(
+        {
+            field: deepcopy(snapshot[field])
+            for field in _CYCLE_POLICY_SNAPSHOT_FIELDS
+            if field in snapshot
+        }
+    )
+    return _validated_snapshot(decoded)
 
 
 def _cycle_snapshot(cycle: Cycle, guidance_rows: list[CycleGuidance]) -> dict[str, Any]:
@@ -767,7 +811,11 @@ def _preview_digest(
     return hashlib.sha256(canonical).hexdigest()
 
 
-def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
+def _record(
+    row: BehaviorChangeAudit,
+    *,
+    current_snapshot: Mapping[str, Any],
+) -> BehaviorChangeRecord:
     applied_at = row.applied_at
     if applied_at.tzinfo is None:
         applied_at = applied_at.replace(tzinfo=timezone.utc)
@@ -782,38 +830,19 @@ def _record(row: BehaviorChangeAudit) -> BehaviorChangeRecord:
         actor_id=row.actor_id,
         source_reference=row.source_reference,
         rationale=row.rationale,
-        before_snapshot=deepcopy(row.before_snapshot),
-        after_snapshot=deepcopy(row.after_snapshot),
+        before_snapshot=_decode_stored_snapshot(
+            row.before_snapshot,
+            current_snapshot=current_snapshot,
+        ),
+        after_snapshot=_decode_stored_snapshot(
+            row.after_snapshot,
+            current_snapshot=current_snapshot,
+        ),
         changed_fields=tuple(row.changed_fields or []),
         cycle_revision_id=row.cycle_revision_id,
         applied_at=applied_at,
         reverted_from_id=row.reverted_from_id,
     )
-
-
-def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
-    if row is None:
-        return None
-    record = _record(row)
-    return {
-        "id": record.id,
-        "workspace_id": record.workspace_id,
-        "policy_kind": record.policy_kind,
-        "target_type": record.target_type,
-        "target_id": record.target_id,
-        "version": record.version,
-        "actor_type": record.actor_type,
-        "actor_id": record.actor_id,
-        "source_reference": record.source_reference,
-        "rationale": record.rationale,
-        "before_snapshot": record.before_snapshot,
-        "after_snapshot": record.after_snapshot,
-        "changed_fields": list(record.changed_fields),
-        "cycle_revision_id": record.cycle_revision_id,
-        "applied_at": record.applied_at.isoformat(),
-        "reverted_from_id": record.reverted_from_id,
-    }
-
 
 def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
     return (
@@ -834,4 +863,4 @@ def _validated_max_concurrency(value: Any) -> int:
 
 
 def _set(value: Any) -> bool:
-    return value is not UNSET_POLICY_FIELD
+    return value is not UNSET_CYCLE_FIELD

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -10,7 +10,7 @@ from brain.systems.cycles.access import CycleActor
 from brain.systems.cycles.behavior_policy import (
     CyclePolicyApplied,
     CyclePolicyPatch,
-    UNSET_POLICY_FIELD,
+    UNSET_CYCLE_FIELD,
     async_apply_cycle_policy_change,
     async_preview_cycle_policy_change,
 )
@@ -37,14 +37,6 @@ from brain.systems.cycles.schedules import (
     validate_schedule_expr,
     validate_timezone_name,
 )
-
-
-class _UnsetCycleField:
-    pass
-
-
-UNSET_CYCLE_FIELD = _UnsetCycleField()
-
 
 def _validated_max_concurrency(value: int) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
@@ -170,7 +162,7 @@ async def async_update_cycle(
         execution_policy_key=_policy_field(execution_policy_key),
         target_idea_id=_policy_field(target_idea_id),
         guidance_additions=(
-            [guidance] if guidance else UNSET_POLICY_FIELD
+            [guidance] if guidance else UNSET_CYCLE_FIELD
         ),
     )
     preview = await async_preview_cycle_policy_change(
@@ -321,7 +313,7 @@ def _is_patch_field_set(value) -> bool:
 
 def _policy_field(value, *, ignore_none: bool = False):
     if value is UNSET_CYCLE_FIELD or (ignore_none and value is None):
-        return UNSET_POLICY_FIELD
+        return UNSET_CYCLE_FIELD
     return value
 
 

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from brain.platform.db.models.cycle import Cycle
+from sqlalchemy import select
+
+from brain.platform.db.models.cycle import Cycle, CycleGuidance
 from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyPatch,
+    UNSET_POLICY_FIELD,
+    async_apply_cycle_policy_change,
+    async_preview_cycle_policy_change,
+)
 from brain.systems.cycles.common import (
     canonical_execution_mode,
     validate_cycle_timeout_seconds,
@@ -137,80 +146,51 @@ async def async_update_cycle(
     guidance: str | None = None,
     rationale: str | None = None,
 ) -> Cycle:
+    # Validate a stored key before any query or mutation. This preserves the
+    # existing fail-fast repair signal for legacy rows with invalid keys.
     if _is_patch_field_set(execution_policy_key):
-        next_execution_policy_key = validate_cycle_execution_policy_key(
+        validate_cycle_execution_policy_key(
             execution_policy_key
         )
     else:
         validate_cycle_execution_policy_key(
             getattr(cycle, "execution_policy_key", None)
         )
-        next_execution_policy_key = UNSET_CYCLE_FIELD
-    next_timezone = validate_timezone_name(timezone_name) if _has_patch_value(timezone_name) else cycle.timezone
-    next_schedule_expr = cycle.schedule_expr
-    next_model_override = (
-        validate_model_override(model_override)
-        if _is_patch_field_set(model_override)
-        else UNSET_CYCLE_FIELD
+    patch = CyclePolicyPatch(
+        name=_policy_field(name, ignore_none=True),
+        prompt=_policy_field(prompt, ignore_none=True),
+        timezone_name=_policy_field(timezone_name, ignore_none=True),
+        schedule_expr=_policy_field(schedule_expr, ignore_none=True),
+        run_at=_policy_field(run_at, ignore_none=True),
+        enabled=_policy_field(enabled, ignore_none=True),
+        max_concurrency=_policy_field(max_concurrency),
+        timeout_seconds=_policy_field(timeout_seconds),
+        model_override=_policy_field(model_override),
+        thinking_override=_policy_field(thinking_override),
+        execution_policy_key=_policy_field(execution_policy_key),
+        target_idea_id=_policy_field(target_idea_id),
+        guidance_additions=(
+            [guidance] if guidance else UNSET_POLICY_FIELD
+        ),
     )
-    next_thinking_override = (
-        validate_thinking_override(thinking_override)
-        if _is_patch_field_set(thinking_override)
-        else UNSET_CYCLE_FIELD
-    )
-    next_timeout_seconds = (
-        validate_cycle_timeout_seconds(timeout_seconds)
-        if _is_patch_field_set(timeout_seconds)
-        else UNSET_CYCLE_FIELD
-    )
-    if _has_patch_value(run_at):
-        next_schedule_expr = build_one_time_schedule_expr(run_at, next_timezone)
-    elif _has_patch_value(schedule_expr):
-        next_schedule_expr = validate_schedule_expr(schedule_expr, next_timezone)
-
-    if _has_patch_value(name):
-        cycle.name = validate_nonempty_trimmed(name, "name")
-    if _has_patch_value(prompt):
-        cycle.prompt = validate_nonempty_trimmed(prompt, "prompt")
-    cycle.timezone = next_timezone
-    cycle.schedule_expr = next_schedule_expr
-    if _is_patch_field_set(enabled) and enabled is not None:
-        cycle.enabled = enabled
-    if _is_patch_field_set(max_concurrency):
-        cycle.max_concurrency = _validated_max_concurrency(max_concurrency)
-    if _is_patch_field_set(next_timeout_seconds):
-        cycle.timeout_seconds = next_timeout_seconds
-    if _is_patch_field_set(next_model_override):
-        cycle.model_override = next_model_override
-    if _is_patch_field_set(next_thinking_override):
-        cycle.thinking_override = next_thinking_override
-    if _is_patch_field_set(next_execution_policy_key):
-        cycle.execution_policy_key = next_execution_policy_key
-    if _is_patch_field_set(target_idea_id):
-        cycle.target_idea_id = target_idea_id
-
-    cycle.execution_mode = canonical_execution_mode()
-    cycle.reopen_archived = True
-    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
-    cycle.updated_at = datetime.now(timezone.utc)
-
-    revision = await async_record_cycle_revision(
+    preview = await async_preview_cycle_policy_change(
         session,
-        cycle,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
-        rationale=rationale or "Cycle updated.",
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
     )
-    if guidance:
-        await async_add_cycle_guidance(
-            session,
-            cycle,
-            guidance=guidance,
-            source_type=actor.source_type,
-            source_id=actor.revision_source_id,
-            rationale=rationale,
-            revision_id=revision.id,
-        )
+    result = await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
+        rationale=rationale or "Cycle updated.",
+        source_reference=_command_source_reference(actor),
+    )
+    if not isinstance(result, CyclePolicyApplied):
+        raise ValueError("Cycle policy changed while the update was being applied")
     return cycle
 
 
@@ -229,22 +209,35 @@ async def async_add_guidance_to_cycle(
     guidance: str,
     rationale: str | None = None,
 ):
-    revision = await async_record_cycle_revision(
+    clean_guidance = validate_nonempty_trimmed(guidance, "guidance")
+    patch = CyclePolicyPatch(guidance_additions=[clean_guidance])
+    preview = await async_preview_cycle_policy_change(
         session,
-        cycle,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+    )
+    result = await async_apply_cycle_policy_change(
+        session,
+        actor=actor,
+        cycle_id=cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
         rationale=rationale or "Cycle guidance added.",
+        source_reference=_command_source_reference(actor),
     )
-    return await async_add_cycle_guidance(
-        session,
-        cycle,
-        guidance=guidance,
-        source_type=actor.source_type,
-        source_id=actor.revision_source_id,
-        rationale=rationale,
-        revision_id=revision.id,
+    if not isinstance(result, CyclePolicyApplied):
+        raise ValueError("Cycle policy changed while guidance was being added")
+    rows = await session.scalars(
+        select(CycleGuidance).where(
+            CycleGuidance.cycle_id == cycle.id,
+            CycleGuidance.revision_id == result.revision.id,
+            CycleGuidance.guidance == clean_guidance,
+            CycleGuidance.is_active.is_(True),
+        )
     )
+    return rows.first()
 
 
 async def async_add_output_target_to_cycle(
@@ -326,8 +319,14 @@ def _is_patch_field_set(value) -> bool:
     return value is not UNSET_CYCLE_FIELD
 
 
-def _has_patch_value(value) -> bool:
-    return _is_patch_field_set(value) and value is not None
+def _policy_field(value, *, ignore_none: bool = False):
+    if value is UNSET_CYCLE_FIELD or (ignore_none and value is None):
+        return UNSET_POLICY_FIELD
+    return value
+
+
+def _command_source_reference(actor: CycleActor) -> str:
+    return f"{actor.source_type}:{actor.revision_source_id}"
 
 
 async def _seed_default_output_targets(

--- a/brain/systems/cycles/cycle_failure_guard.py
+++ b/brain/systems/cycles/cycle_failure_guard.py
@@ -26,10 +26,10 @@ from brain.systems.failure_guard.core import (
     FailureGuardEvaluation,
     FailureGuardLifecycleEvent,
     FailureGuardStatefulTrigger,
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTrigger,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     require_failure_guard_registrations,
     FailureGuardTriggerResult,
     FailureGuardTriggerState,
@@ -310,11 +310,11 @@ class CycleFailureGuardStatefulTrigger(
     """One state-owning cycle failure trigger."""
 
 
-CycleFailureGuardTriggerImplementation: TypeAlias = (
-    CycleFailureGuardTrigger | CycleFailureGuardStatefulTrigger
-)
 CycleRegisteredFailureGuardTrigger: TypeAlias = (
-    FailureGuardTriggerRegistration[CycleFailureGuardLifecycleContext]
+    FailureGuardStatelessTriggerRegistration[CycleFailureGuardTrigger]
+    | FailureGuardStatefulTriggerRegistration[
+        CycleFailureGuardStatefulTrigger
+    ]
 )
 
 
@@ -337,8 +337,7 @@ def cycle_failure_guard_registry() -> CycleFailureGuardRegistry:
     """Return every trigger applied to cycle terminal observations."""
     return CycleFailureGuardRegistry(
         triggers=(
-            FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATEFUL,
+            FailureGuardStatefulTriggerRegistration(
                 trigger=CycleConsecutiveFailuresTrigger(),
             ),
         )

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -7,15 +7,59 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def publish_cycle_change(
+def publish_cycle_change_safe(
     *,
     action: str,
     org_id: str | None = None,
     user_id: str | None = None,
     cycle_id: int | None = None,
     target_idea_id: str | None = None,
-    strict: bool = False,
 ) -> None:
+    payload = _cycle_change_payload(
+        action=action,
+        org_id=org_id,
+        user_id=user_id,
+        cycle_id=cycle_id,
+        target_idea_id=target_idea_id,
+    )
+    try:
+        from brain.platform.events import publish_safe
+
+        publish_safe("cycles_changed", payload)
+    except Exception:
+        logger.debug("cycle_change_publish_failed", exc_info=True)
+
+
+def publish_cycle_change_strict(
+    *,
+    action: str,
+    org_id: str | None = None,
+    user_id: str | None = None,
+    cycle_id: int | None = None,
+    target_idea_id: str | None = None,
+) -> None:
+    from brain.platform.events import publish
+
+    publish(
+        "cycles_changed",
+        _cycle_change_payload(
+            action=action,
+            org_id=org_id,
+            user_id=user_id,
+            cycle_id=cycle_id,
+            target_idea_id=target_idea_id,
+        ),
+    )
+
+
+def _cycle_change_payload(
+    *,
+    action: str,
+    org_id: str | None,
+    user_id: str | None,
+    cycle_id: int | None,
+    target_idea_id: str | None,
+) -> dict[str, Any]:
     payload: dict[str, Any] = {"action": action}
     if org_id:
         payload["org_id"] = str(org_id)
@@ -26,13 +70,4 @@ def publish_cycle_change(
     if target_idea_id:
         payload["idea_id"] = str(target_idea_id)
         payload["target_idea_id"] = str(target_idea_id)
-
-    try:
-        from brain.platform.events import publish, publish_safe
-
-        publisher = publish if strict else publish_safe
-        publisher("cycles_changed", payload)
-    except Exception:
-        if strict:
-            raise
-        logger.debug("cycle_change_publish_failed", exc_info=True)
+    return payload

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -14,6 +14,7 @@ def publish_cycle_change(
     user_id: str | None = None,
     cycle_id: int | None = None,
     target_idea_id: str | None = None,
+    strict: bool = False,
 ) -> None:
     payload: dict[str, Any] = {"action": action}
     if org_id:
@@ -27,8 +28,11 @@ def publish_cycle_change(
         payload["target_idea_id"] = str(target_idea_id)
 
     try:
-        from brain.platform.events import publish_safe
+        from brain.platform.events import publish, publish_safe
 
-        publish_safe("cycles_changed", payload)
+        publisher = publish if strict else publish_safe
+        publisher("cycles_changed", payload)
     except Exception:
+        if strict:
+            raise
         logger.debug("cycle_change_publish_failed", exc_info=True)

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -48,6 +48,7 @@ from brain.systems.cycles.cycle_failure_guard import (
     async_apply_cycle_terminal_failure_guard,
 )
 from brain.systems.cycles.serializers import (
+    serialize_behavior_change,
     serialize_cycle_guidance,
     serialize_cycle_output_target,
     serialize_cycle_revision,
@@ -238,10 +239,6 @@ def _build_cycle_run_memory_snapshot(
 
     revision_context = {"revision": serialize_cycle_revision(revision)}
     if behavior_change is not None:
-        # Local import avoids a module cycle: behavior_policy uses the existing
-        # revision writer from this module.
-        from brain.systems.cycles.behavior_policy import serialize_behavior_change
-
         revision_context["behavior_change"] = serialize_behavior_change(
             behavior_change
         )

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 from brain.kernel.common.serialization import jsonable
 from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
     CycleOutputTarget,
@@ -181,6 +182,10 @@ async def async_remove_cycle_output_target(
 
 async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: CycleRun) -> None:
     revision = await _async_latest_cycle_revision(session, cycle.id)
+    behavior_change = await _async_behavior_change_for_revision(
+        session,
+        revision.id if revision is not None else None,
+    )
     guidance_rows = await _async_active_cycle_guidance(session, cycle.id)
     target_rows = await _async_active_cycle_output_targets(session, cycle.id)
     degradation_tracking = degradation_tracking_for_run(
@@ -191,6 +196,7 @@ async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: Cy
         cycle,
         run=run,
         revision=revision,
+        behavior_change=behavior_change,
         guidance_rows=guidance_rows,
         target_rows=target_rows,
         degradation_tracking=degradation_tracking,
@@ -209,6 +215,7 @@ def _build_cycle_run_memory_snapshot(
     *,
     run: CycleRun | None = None,
     revision: CycleRevision | None,
+    behavior_change: BehaviorChangeAudit | None = None,
     guidance_rows: list[CycleGuidance],
     target_rows: list[CycleOutputTarget],
     degradation_tracking: dict | None = None,
@@ -229,6 +236,16 @@ def _build_cycle_run_memory_snapshot(
         ),
     )
 
+    revision_context = {"revision": serialize_cycle_revision(revision)}
+    if behavior_change is not None:
+        # Local import avoids a module cycle: behavior_policy uses the existing
+        # revision writer from this module.
+        from brain.systems.cycles.behavior_policy import serialize_behavior_change
+
+        revision_context["behavior_change"] = serialize_behavior_change(
+            behavior_change
+        )
+
     return {
         "revision_id": revision.id if revision is not None else None,
         "guidance_snapshot": jsonable(
@@ -237,7 +254,7 @@ def _build_cycle_run_memory_snapshot(
         "output_targets_snapshot": jsonable(output_targets),
         "context_snapshot": jsonable(
             {
-                "revision": serialize_cycle_revision(revision),
+                **revision_context,
                 "workspace_id": string_or_none(cycle.org_id),
                 "owner_user_id": string_or_none(cycle.user_id),
                 "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),
@@ -515,6 +532,19 @@ async def _async_latest_cycle_revision(session, cycle_id: int) -> CycleRevision 
         .limit(1)
     )
     return result.first()
+
+
+async def _async_behavior_change_for_revision(
+    session,
+    revision_id: int | None,
+) -> BehaviorChangeAudit | None:
+    if revision_id is None:
+        return None
+    return await session.scalar(
+        select(BehaviorChangeAudit).where(
+            BehaviorChangeAudit.cycle_revision_id == revision_id
+        )
+    )
 
 
 async def _async_active_cycle_guidance(session, cycle_id: int) -> list[CycleGuidance]:

--- a/brain/systems/cycles/serializers.py
+++ b/brain/systems/cycles/serializers.py
@@ -1,7 +1,11 @@
 """Cycle read-model serializers."""
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import timezone
+
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
     CycleOutputTarget,
@@ -18,6 +22,32 @@ from brain.systems.cycles.common import (
     string_or_none,
 )
 from brain.systems.cycles.schedules import safe_humanize_schedule
+
+
+def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
+    if row is None:
+        return None
+    applied_at = row.applied_at
+    if applied_at.tzinfo is None:
+        applied_at = applied_at.replace(tzinfo=timezone.utc)
+    return {
+        "id": row.id,
+        "workspace_id": row.workspace_id,
+        "policy_kind": row.policy_kind,
+        "target_type": row.target_type,
+        "target_id": row.target_id,
+        "version": row.version,
+        "actor_type": row.actor_type,
+        "actor_id": row.actor_id,
+        "source_reference": row.source_reference,
+        "rationale": row.rationale,
+        "before_snapshot": deepcopy(row.before_snapshot),
+        "after_snapshot": deepcopy(row.after_snapshot),
+        "changed_fields": list(row.changed_fields or []),
+        "cycle_revision_id": row.cycle_revision_id,
+        "applied_at": applied_at.isoformat(),
+        "reverted_from_id": row.reverted_from_id,
+    }
 
 
 def serialize_cycle_revision(revision: CycleRevision | None) -> dict | None:

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -1,7 +1,7 @@
 """Neutral failure identity and latch/edge evaluation primitives."""
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import StrEnum
 from hashlib import sha256
@@ -16,7 +16,7 @@ from typing import (
     Sequence,
     TypeAlias,
     TypeVar,
-    cast,
+    assert_never,
 )
 
 
@@ -166,6 +166,18 @@ class FailureGuardStatefulTrigger(Protocol[FailureGuardContextT]):
         """Return replacement state, or ``None`` to clear persisted state."""
 
 
+FailureGuardStatelessTriggerT = TypeVar(
+    "FailureGuardStatelessTriggerT",
+    bound=FailureGuardTrigger[Any],
+    covariant=True,
+)
+FailureGuardStatefulTriggerT = TypeVar(
+    "FailureGuardStatefulTriggerT",
+    bound=FailureGuardStatefulTrigger[Any],
+    covariant=True,
+)
+
+
 class FailureGuardTriggerMode(StrEnum):
     """A registered trigger's explicit evaluation and persistence mode."""
 
@@ -174,38 +186,21 @@ class FailureGuardTriggerMode(StrEnum):
 
 
 @dataclass(frozen=True)
-class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
-    """Bind one trigger implementation to its declared dispatch mode."""
+class FailureGuardStatelessTriggerRegistration(
+    Generic[FailureGuardStatelessTriggerT]
+):
+    """Bind one stateless trigger to its literal dispatch mode."""
 
-    mode: FailureGuardTriggerMode
-    trigger: (
-        FailureGuardTrigger[FailureGuardContextT]
-        | FailureGuardStatefulTrigger[FailureGuardContextT]
+    trigger: FailureGuardStatelessTriggerT
+    mode: Literal[FailureGuardTriggerMode.STATELESS] = field(
+        default=FailureGuardTriggerMode.STATELESS,
+        init=False,
     )
 
     def __post_init__(self) -> None:
         trigger_name = type(self.trigger).__name__
-        if not isinstance(self.mode, FailureGuardTriggerMode):
-            raise ValueError(
-                f"Failure-guard trigger {trigger_name} has invalid mode: "
-                f"{self.mode!r}"
-            )
         stateless_method = "evaluate"
         stateful_methods = ("evaluate_with_state", "transition_state")
-        if self.mode is FailureGuardTriggerMode.STATEFUL:
-            missing_methods = [
-                method
-                for method in stateful_methods
-                if not callable(getattr(self.trigger, method, None))
-            ]
-            if missing_methods:
-                raise ValueError(
-                    f"Failure-guard trigger {trigger_name} declared stateful "
-                    "but is missing required method(s): "
-                    + ", ".join(missing_methods)
-                )
-            return
-
         if not callable(getattr(self.trigger, stateless_method, None)):
             raise ValueError(
                 f"Failure-guard trigger {trigger_name} declared stateless "
@@ -228,27 +223,74 @@ class FailureGuardTriggerRegistration(Generic[FailureGuardContextT]):
         return self.trigger.kind
 
 
+@dataclass(frozen=True)
+class FailureGuardStatefulTriggerRegistration(
+    Generic[FailureGuardStatefulTriggerT]
+):
+    """Bind one stateful trigger to its literal dispatch mode."""
+
+    trigger: FailureGuardStatefulTriggerT
+    mode: Literal[FailureGuardTriggerMode.STATEFUL] = field(
+        default=FailureGuardTriggerMode.STATEFUL,
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        trigger_name = type(self.trigger).__name__
+        stateful_methods = ("evaluate_with_state", "transition_state")
+        missing_methods = [
+            method
+            for method in stateful_methods
+            if not callable(getattr(self.trigger, method, None))
+        ]
+        if missing_methods:
+            raise ValueError(
+                f"Failure-guard trigger {trigger_name} declared stateful "
+                "but is missing required method(s): "
+                + ", ".join(missing_methods)
+            )
+
+    @property
+    def kind(self) -> FailureGuardTriggerKind:
+        return self.trigger.kind
+
+
+FailureGuardTriggerRegistration: TypeAlias = (
+    FailureGuardStatelessTriggerRegistration[
+        FailureGuardTrigger[FailureGuardContextT]
+    ]
+    | FailureGuardStatefulTriggerRegistration[
+        FailureGuardStatefulTrigger[FailureGuardContextT]
+    ]
+)
+
+
 def require_failure_guard_registrations(
     triggers: Sequence[object], *, owner: str
 ) -> None:
     """Reject a registry entry that is a bare trigger rather than a registration.
 
     Without this, a raw trigger passes a consumer registry's own checks — it has
-    a ``kind`` — and skips ``FailureGuardTriggerRegistration.__post_init__``
-    entirely. The declared mode would then be missing at dispatch time, far from
-    the provider that omitted it, which is exactly the late failure this module
-    exists to prevent.
+    a ``kind`` — and skips the registration variant's validation entirely. The
+    declared mode would then be missing at dispatch time, far from the provider
+    that omitted it, which is exactly the late failure this module prevents.
     """
 
     unregistered = [
         type(trigger).__name__
         for trigger in triggers
-        if not isinstance(trigger, FailureGuardTriggerRegistration)
+        if not isinstance(
+            trigger,
+            (
+                FailureGuardStatelessTriggerRegistration,
+                FailureGuardStatefulTriggerRegistration,
+            ),
+        )
     ]
     if unregistered:
         raise ValueError(
             f"{owner} failure-guard triggers must be wrapped in "
-            "FailureGuardTriggerRegistration with an explicit mode; got bare "
+            "a failure-guard trigger registration; got bare "
             "trigger(s): " + ", ".join(unregistered)
         )
 
@@ -263,24 +305,17 @@ async def async_evaluate_failure_guard_triggers(
     states = dict(await store.load_trigger_states())
     results: list[FailureGuardTriggerResult] = []
     for registration in triggers:
-        trigger = registration.trigger
         if registration.mode is FailureGuardTriggerMode.STATEFUL:
-            stateful_trigger = cast(
-                FailureGuardStatefulTrigger[FailureGuardContextT],
-                trigger,
-            )
             results.append(
-                await stateful_trigger.evaluate_with_state(
+                await registration.trigger.evaluate_with_state(
                     context,
                     state=dict(states.get(registration.kind, {})),
                 )
             )
+        elif registration.mode is FailureGuardTriggerMode.STATELESS:
+            results.append(await registration.trigger.evaluate(context))
         else:
-            stateless_trigger = cast(
-                FailureGuardTrigger[FailureGuardContextT],
-                trigger,
-            )
-            results.append(await stateless_trigger.evaluate(context))
+            assert_never(registration)
     return tuple(results)
 
 
@@ -296,19 +331,21 @@ async def async_transition_failure_guard_trigger_states(
     for registration in triggers:
         if registration.mode is FailureGuardTriggerMode.STATELESS:
             continue
-        trigger = cast(
-            FailureGuardStatefulTrigger[FailureGuardContextT],
-            registration.trigger,
-        )
-        next_state = await trigger.transition_state(
-            context,
-            dict(states.get(registration.kind, {})),
-            event=event,
-        )
-        if next_state is None:
-            await store.delete_trigger_state(registration.kind)
-        else:
-            await store.save_trigger_state(registration.kind, dict(next_state))
+        if registration.mode is FailureGuardTriggerMode.STATEFUL:
+            next_state = await registration.trigger.transition_state(
+                context,
+                dict(states.get(registration.kind, {})),
+                event=event,
+            )
+            if next_state is None:
+                await store.delete_trigger_state(registration.kind)
+            else:
+                await store.save_trigger_state(
+                    registration.kind,
+                    dict(next_state),
+                )
+            continue
+        assert_never(registration)
 
 
 @dataclass(frozen=True)

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -356,7 +356,6 @@ async def _action_update(ctx: ManageCycleContext) -> dict[str, Any]:
             rationale=_optional_text(args.rationale),
         )
         payload = serialize_cycle(cycle)
-    publish_cycle_change(action="update", **_event_from_payload(payload))
     return {"updated": payload}
 
 

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -32,7 +32,7 @@ from brain.systems.cycles.commands import (
     async_update_cycle,
     cycle_change_event,
 )
-from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.serializers import (
     serialize_cycle,
     serialize_cycle_guidance,
@@ -323,7 +323,7 @@ async def _action_create(ctx: ManageCycleContext) -> dict[str, Any]:
             rationale=_optional_text(args.rationale),
         )
         payload = serialize_cycle(cycle)
-    publish_cycle_change(action="create", **_event_from_payload(payload))
+    publish_cycle_change_safe(action="create", **_event_from_payload(payload))
     return {"created": payload}
 
 
@@ -364,7 +364,7 @@ async def _action_delete(ctx: ManageCycleContext) -> dict[str, Any]:
         cycle = await _load_cycle(uow.session, ctx.actor, ctx.args.id)
         await async_delete_cycle(uow.session, cycle)
         event = cycle_change_event(cycle)
-    publish_cycle_change(action="delete", **event)
+    publish_cycle_change_safe(action="delete", **event)
     return {"deleted": {"id": ctx.args.id}}
 
 
@@ -387,7 +387,7 @@ async def _action_run(ctx: ManageCycleContext) -> dict[str, Any]:
             "rationale": _optional_text(ctx.args.rationale),
         },
     )
-    publish_cycle_change(action="run", **event)
+    publish_cycle_change_safe(action="run", **event)
     return {"run": payload}
 
 

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -483,8 +483,17 @@ record_worker_drain_timeout() {
     > "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
 }
 
-# Waits for the outgoing worker to drain, and -- when a handoff worker is
-# covering for it -- for that cover to still exist.
+# Exit statuses for the covered-worker wait.
+COVERED_WORKER_EXITED_STATUS=0
+COVERED_WORKER_DRAIN_TIMEOUT_STATUS=1
+COVERED_WORKER_COVER_LOST_STATUS=2
+
+# Exit statuses for the no-handoff idle wait.
+IDLE_WORKER_EXITED_STATUS=0
+IDLE_WORKER_DRAIN_TIMEOUT_STATUS=1
+IDLE_WORKER_EXIT_TIMEOUT_STATUS=3
+
+# Waits for the outgoing worker to drain while a handoff worker covers it.
 #
 # Watching only the clock is what turned the 2026-07-28 illo-dev deploy into a
 # 2h16m outage. The handoff came up, passed the one-shot liveness check, claimed
@@ -496,20 +505,19 @@ record_worker_drain_timeout() {
 # loop happily kept waiting, because the only thing it looked at was whether the
 # drained worker had exited, against a deadline 24h away by default.
 #
-# So the wait now ends on either condition, and the caller escalates for both:
-#   1 = the drain deadline passed          2 = the cover is gone
-#   3 = the confirmed-idle exit deadline passed
+# Exit contract:
+#   COVERED_WORKER_EXITED_STATUS        = the outgoing worker exited
+#   COVERED_WORKER_DRAIN_TIMEOUT_STATUS = the drain deadline passed
+#   COVERED_WORKER_COVER_LOST_STATUS    = the cover stopped claiming
 wait_for_worker_exit() {
   local id="$1"
-  local handoff_id="${2:-}"
+  local handoff_id="$2"
   local wait_seconds="${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
-  local idle_wait_seconds="${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}"
   local started_at="$SECONDS"
   local deadline=$((started_at + wait_seconds))
-  local idle_deadline=""
   local wait_iterations=0
-  local consecutive_zero_checks=0
-  local hint_printed=0
+  local consecutive_zero_run_snapshots=0
+  local zero_run_hint_printed=0
   local active_runs affected_runs affected_ids elapsed snapshot handoff_observation
   while container_running "$id"; do
     if [ "$SECONDS" -ge "$deadline" ]; then
@@ -518,64 +526,102 @@ wait_for_worker_exit() {
       affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
       echo "Worker did not drain within ${wait_seconds}s. Affected run ids: ${affected_ids:-unknown} (id/status: $affected_runs)." >&2
       record_worker_drain_timeout "$snapshot"
-      return 1
+      return "$COVERED_WORKER_DRAIN_TIMEOUT_STATUS"
     fi
-    if [ -n "$handoff_id" ]; then
-      handoff_observation="$(worker_cover_observation "$handoff_id")"
-      case "$handoff_observation" in
-        claiming) ;;
-        pending)
-          # Unknown Docker/exec observations never authorize an escalation.
-          ;;
-        definitively_not_claiming)
-          elapsed=$((SECONDS - started_at))
-          echo "Worker: handoff worker $handoff_id stopped claiming after ${elapsed}s while worker $id was still draining, so NOTHING is claiming AgentRuns." >&2
-          echo "Worker: the handoff either exited or published draining/stopped. Handoff containers have restart=no, and a draining worker cannot resume claiming; ending the wait now instead of holding zero capacity until the ${wait_seconds}s deadline." >&2
-          return 2
-          ;;
-        *) ;;
-      esac
-    fi
-    if [ -n "$idle_deadline" ] && [ "$SECONDS" -ge "$idle_deadline" ]; then
-      snapshot="$(worker_swap_snapshot)"
-      active_runs="$(worker_swap_snapshot_count "$snapshot")"
-      if [ "$active_runs" = "0" ]; then
-        echo "Worker: canonical snapshot still has 0 active AgentRuns at the idle exit deadline of ${idle_wait_seconds}s. Ending the wait so the existing safe replacement path can continue. No interactive AgentRuns are affected." >&2
-        return 3
-      fi
-      echo "Worker: active AgentRuns reappeared before the idle exit deadline; abandoning that deadline and continuing the ${wait_seconds}s drain." >&2
-      consecutive_zero_checks=0
-      idle_deadline=""
-      hint_printed=0
-    fi
+    handoff_observation="$(worker_cover_observation "$handoff_id")"
+    case "$handoff_observation" in
+      claiming) ;;
+      pending)
+        # Unknown Docker/exec observations never authorize an escalation.
+        ;;
+      definitively_not_claiming)
+        elapsed=$((SECONDS - started_at))
+        echo "Worker: handoff worker $handoff_id stopped claiming after ${elapsed}s while worker $id was still draining, so NOTHING is claiming AgentRuns." >&2
+        echo "Worker: the handoff either exited or published draining/stopped. Handoff containers have restart=no, and a draining worker cannot resume claiming; ending the wait now instead of holding zero capacity until the ${wait_seconds}s deadline." >&2
+        return "$COVERED_WORKER_COVER_LOST_STATUS"
+        ;;
+      *) ;;
+    esac
     sleep 5
     wait_iterations=$((wait_iterations + 1))
     if [ $((wait_iterations % 6)) -eq 0 ] && container_running "$id"; then
       snapshot="$(worker_swap_snapshot)"
       active_runs="$(worker_swap_snapshot_count "$snapshot")"
       if [ "$active_runs" = "0" ]; then
-        consecutive_zero_checks=$((consecutive_zero_checks + 1))
-        if [ "$consecutive_zero_checks" -ge 2 ] && [ "$hint_printed" = "0" ]; then
+        consecutive_zero_run_snapshots=$((consecutive_zero_run_snapshots + 1))
+        if [ "$consecutive_zero_run_snapshots" -ge 2 ] && [ "$zero_run_hint_printed" = "0" ]; then
           elapsed=$((SECONDS - started_at))
           echo "Hint: worker has 0 active AgentRuns but its process has not exited after ${elapsed}s." >&2
-          if [ -z "$handoff_id" ]; then
-            idle_deadline=$((SECONDS + idle_wait_seconds))
-            echo "Worker: two consecutive canonical snapshots confirm it is idle. Waiting at most ${idle_wait_seconds}s more before safe replacement; the shorter deadline will be abandoned if an active AgentRun appears." >&2
-          else
-            echo "Leave it alone: it is already draining and the swap completes on its own. At the ${wait_seconds}s deadline this deploy force-replaces it rather than keeping a worker that can no longer claim." >&2
-          fi
-          hint_printed=1
+          echo "Leave it alone: it is already draining and the swap completes on its own. At the ${wait_seconds}s deadline this deploy force-replaces it rather than keeping a worker that can no longer claim." >&2
+          zero_run_hint_printed=1
         fi
       else
+        consecutive_zero_run_snapshots=0
+        zero_run_hint_printed=0
+      fi
+    fi
+  done
+  return "$COVERED_WORKER_EXITED_STATUS"
+}
+
+# Waits for an outgoing worker that had a confirmed-idle snapshot before it was
+# signalled. No handoff worker exists on this path.
+#
+# Exit contract:
+#   IDLE_WORKER_EXITED_STATUS        = the outgoing worker exited
+#   IDLE_WORKER_DRAIN_TIMEOUT_STATUS = the full drain deadline passed
+#   IDLE_WORKER_EXIT_TIMEOUT_STATUS  = the shorter confirmed-idle deadline passed
+wait_for_idle_worker_exit() {
+  local id="$1"
+  local wait_seconds="${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
+  local idle_wait_seconds="${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}"
+  local started_at="$SECONDS"
+  local deadline=$((started_at + wait_seconds))
+  local idle_deadline=""
+  local wait_iterations=0
+  local consecutive_zero_checks=0
+  local hint_printed=0
+  local active_runs affected_runs affected_ids elapsed snapshot
+  while container_running "$id"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      snapshot="$(worker_swap_snapshot)"
+      affected_runs="$(worker_swap_snapshot_details "$snapshot")"
+      affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
+      echo "Worker did not drain within ${wait_seconds}s. Affected run ids: ${affected_ids:-unknown} (id/status: $affected_runs)." >&2
+      record_worker_drain_timeout "$snapshot"
+      return "$IDLE_WORKER_DRAIN_TIMEOUT_STATUS"
+    fi
+    sleep 5
+    wait_iterations=$((wait_iterations + 1))
+    if container_running "$id" && {
+      [ $((wait_iterations % 6)) -eq 0 ] ||
+        { [ -n "$idle_deadline" ] && [ "$SECONDS" -ge "$idle_deadline" ] && [ "$SECONDS" -lt "$deadline" ]; }
+    }; then
+      snapshot="$(worker_swap_snapshot)"
+      active_runs="$(worker_swap_snapshot_count "$snapshot")"
+      if [ "$active_runs" != "0" ]; then
         if [ -n "$idle_deadline" ]; then
           echo "Worker: active AgentRuns reappeared before the idle exit deadline; abandoning that deadline and continuing the ${wait_seconds}s drain." >&2
         fi
         consecutive_zero_checks=0
         idle_deadline=""
         hint_printed=0
+      elif [ -n "$idle_deadline" ] && [ "$SECONDS" -ge "$idle_deadline" ] && [ "$SECONDS" -lt "$deadline" ]; then
+        echo "Worker: canonical snapshot still has 0 active AgentRuns at the idle exit deadline of ${idle_wait_seconds}s. Ending the wait so the existing safe replacement path can continue. No interactive AgentRuns are affected." >&2
+        return "$IDLE_WORKER_EXIT_TIMEOUT_STATUS"
+      elif [ $((wait_iterations % 6)) -eq 0 ]; then
+        consecutive_zero_checks=$((consecutive_zero_checks + 1))
+        if [ "$consecutive_zero_checks" -ge 2 ] && [ "$hint_printed" = "0" ]; then
+          elapsed=$((SECONDS - started_at))
+          echo "Hint: worker has 0 active AgentRuns but its process has not exited after ${elapsed}s." >&2
+          idle_deadline=$((SECONDS + idle_wait_seconds))
+          echo "Worker: two consecutive canonical snapshots confirm it is idle. Waiting at most ${idle_wait_seconds}s more before safe replacement; the shorter deadline will be abandoned if an active AgentRun appears." >&2
+          hint_printed=1
+        fi
       fi
     fi
   done
+  return "$IDLE_WORKER_EXITED_STATUS"
 }
 
 # The drain timeout is the operator's own statement of how long a graceful
@@ -602,14 +648,14 @@ escalate_worker_swap_after_drain_timeout() {
   local worker_id="$1"
   local handoff_id="$2"
   local wait_seconds="$3"
-  local drain_status="${4:-1}"
+  local drain_status="${4:-$COVERED_WORKER_DRAIN_TIMEOUT_STATUS}"
   local snapshot affected_ids run_details
 
   snapshot="$(worker_swap_snapshot)"
   affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
   run_details="$(worker_swap_snapshot_details "$snapshot")"
 
-  if [ "$drain_status" = "2" ]; then
+  if [ "$drain_status" = "$COVERED_WORKER_COVER_LOST_STATUS" ]; then
     echo "FORCED WORKER SWAP: handoff worker ${handoff_id:-none} lost claiming capacity while worker $worker_id was still draining, so nothing is claiming AgentRuns right now; replacing the drained worker immediately rather than waiting out the remaining ${wait_seconds}s deadline. Open run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
     echo "Worker: capacity is already zero, so this escalation IS the recovery -- it is not a precaution. Runs interrupted here are requeued by the stale-run reaper." >&2
     record_worker_drain_timeout "$snapshot" "worker_handoff_lost"
@@ -666,12 +712,19 @@ update_worker_after_drain() {
   echo "Worker: ${active_runs} interactive AgentRun(s); signaling existing worker to drain. Affected run ids: $affected_ids."
   suspend_worker_restart_policy "$worker_id"
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  drain_status=0
+  drain_status="$COVERED_WORKER_EXITED_STATUS"
   wait_for_worker_exit "$worker_id" "$handoff_id" || drain_status=$?
-  if [ "$drain_status" -ne 0 ]; then
-    escalate_worker_swap_after_drain_timeout \
-      "$worker_id" "$handoff_id" "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}" "$drain_status" || return 1
-  fi
+  case "$drain_status" in
+    "$COVERED_WORKER_EXITED_STATUS") ;;
+    "$COVERED_WORKER_DRAIN_TIMEOUT_STATUS"|"$COVERED_WORKER_COVER_LOST_STATUS")
+      escalate_worker_swap_after_drain_timeout \
+        "$worker_id" "$handoff_id" "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}" "$drain_status" || return 1
+      ;;
+    *)
+      echo "Worker: covered-worker wait returned unexpected status $drain_status; refusing to continue the swap." >&2
+      return 1
+      ;;
+  esac
   # Only drop the suspension once a replacement actually exists. If the recreate
   # failed there is no new worker, so the outgoing container is still the only
   # one -- leaving the suspension armed lets the trap hand it back its restart
@@ -745,22 +798,26 @@ replace_idle_worker() {
   echo "Worker: no interactive AgentRuns; signaling a graceful replacement."
   suspend_worker_restart_policy "$worker_id"
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  # No handoff exists on this path, so there is no cover to monitor. Both the
-  # full drain deadline and the shorter confirmed-idle deadline apply.
-  drain_status=0
-  wait_for_worker_exit "$worker_id" "" || drain_status=$?
-  if [ "$drain_status" -ne 0 ]; then
-    # Returning here would leave a container that is running, healthy-looking and
-    # permanently unable to claim -- and this path has no handoff worker to cover
-    # for it. There are no interactive runs to protect, so nothing weighs against
-    # replacing it.
-    if [ "$drain_status" = "3" ]; then
-      echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within the ${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}s idle exit deadline after consecutive zero-active checks; replacing it. No interactive AgentRuns are affected." >&2
-    else
+  drain_status="$IDLE_WORKER_EXITED_STATUS"
+  wait_for_idle_worker_exit "$worker_id" || drain_status=$?
+  case "$drain_status" in
+    "$IDLE_WORKER_EXITED_STATUS") ;;
+    "$IDLE_WORKER_DRAIN_TIMEOUT_STATUS")
+      # Returning here would leave a container that is running, healthy-looking
+      # and permanently unable to claim. There is no handoff worker on this path,
+      # and there are no interactive runs to protect.
       echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within ${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}s and will never claim another AgentRun; replacing it. No interactive AgentRuns are affected." >&2
-    fi
-    docker kill "$worker_id" >/dev/null 2>&1 || true
-  fi
+      docker kill "$worker_id" >/dev/null 2>&1 || true
+      ;;
+    "$IDLE_WORKER_EXIT_TIMEOUT_STATUS")
+      echo "FORCED WORKER SWAP: idle worker $worker_id did not exit within the ${COMPOSE_RUNTIME_WORKER_IDLE_EXIT_TIMEOUT_SECONDS:-120}s idle exit deadline after consecutive zero-active checks; replacing it. No interactive AgentRuns are affected." >&2
+      docker kill "$worker_id" >/dev/null 2>&1 || true
+      ;;
+    *)
+      echo "Worker: idle-worker wait returned unexpected status $drain_status; refusing to continue the swap." >&2
+      return 1
+      ;;
+  esac
   # A failed recreate here IS the outage: the outgoing worker was already told to
   # drain and there is no handoff worker. This used to fall off the end of the
   # `if` and report success.

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -57,6 +57,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0050_scheduler_cold_start_reconciliation.py",
     # Downgrade removes only the scheduler alert-latch table introduced here.
     "0054_scheduler_alert_latches.py",
+    # Downgrade removes only the behavior-change audit table introduced here.
+    "0059_behavior_change_audits.py",
 }
 
 

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleOutputTarget,
+    CycleRevision,
+    CycleRun,
+)
+from brain.platform.db.models.org import Org, User
+from brain.platform import events as platform_events
+from brain.systems.cycles import behavior_policy
+from brain.systems.cycles import events as cycle_events
+from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyConflict,
+    CyclePolicyPatch,
+    async_apply_cycle_policy_change,
+    async_apply_cycle_policy_revert,
+    async_list_cycle_policy_history,
+    async_preview_cycle_policy_change,
+    async_preview_cycle_policy_revert,
+    async_read_effective_cycle_policy,
+)
+from brain.systems.cycles.memory import async_prepare_cycle_run_memory_snapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _PolicyWorkspace:
+    session: object
+    cycle: Cycle
+    owner: CycleActor
+    teammate: CycleActor
+    outsider: CycleActor
+    initial_revision: CycleRevision
+    initial_guidance: tuple[CycleGuidance, ...]
+
+
+@pytest.fixture
+async def policy_workspace(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Cycle.__table__,
+            CycleRevision.__table__,
+            CycleGuidance.__table__,
+            CycleOutputTarget.__table__,
+            CycleRun.__table__,
+            BehaviorChangeAudit.__table__,
+        ]
+    )
+    org_id = str(uuid4())
+    other_org_id = str(uuid4())
+    owner_id = str(uuid4())
+    teammate_id = str(uuid4())
+    outsider_id = str(uuid4())
+    session.add_all(
+        [
+            Org(id=org_id, name="Policy workspace", slug=f"policy-{org_id[:8]}"),
+            Org(
+                id=other_org_id,
+                name="Other workspace",
+                slug=f"other-{other_org_id[:8]}",
+            ),
+            User(
+                id=owner_id,
+                org_id=org_id,
+                name="Owner",
+                email=f"owner-{owner_id[:8]}@example.com",
+            ),
+            User(
+                id=teammate_id,
+                org_id=org_id,
+                name="Teammate",
+                email=f"teammate-{teammate_id[:8]}@example.com",
+            ),
+            User(
+                id=outsider_id,
+                org_id=other_org_id,
+                name="Outsider",
+                email=f"outsider-{outsider_id[:8]}@example.com",
+            ),
+        ]
+    )
+    await session.flush()
+    cycle = Cycle(
+        user_id=owner_id,
+        org_id=org_id,
+        creator_type="user",
+        creator_id=owner_id,
+        maintainer_type="user",
+        maintainer_id=owner_id,
+        name="Morning review",
+        prompt="Review the workspace.",
+        schedule_expr="0 9 * * *",
+        timezone="UTC",
+        enabled=True,
+        max_concurrency=1,
+        retry_policy={},
+        execution_mode="reuse_same_idea",
+        reopen_archived=True,
+    )
+    session.add(cycle)
+    await session.flush()
+    revision = CycleRevision(
+        cycle_id=cycle.id,
+        revision_number=1,
+        source_type="user",
+        source_id=owner_id,
+        rationale="Initial definition.",
+        name=cycle.name,
+        prompt=cycle.prompt,
+        schedule_expr=cycle.schedule_expr,
+        timezone=cycle.timezone,
+        enabled=cycle.enabled,
+        model_override=None,
+        thinking_override=None,
+        execution_policy_key=None,
+        target_idea_id=None,
+        context_policy={"workspace_id": org_id},
+    )
+    session.add(revision)
+    await session.flush()
+    guidance = (
+        CycleGuidance(
+            cycle_id=cycle.id,
+            revision_id=revision.id,
+            source_type="user",
+            source_id=owner_id,
+            guidance="Keep this guidance",
+            rationale="Initial definition.",
+            is_active=True,
+        ),
+        CycleGuidance(
+            cycle_id=cycle.id,
+            revision_id=revision.id,
+            source_type="user",
+            source_id=owner_id,
+            guidance="Old wording",
+            rationale="Initial definition.",
+            is_active=True,
+        ),
+    )
+    session.add_all(guidance)
+    await session.flush()
+    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    return _PolicyWorkspace(
+        session=session,
+        cycle=cycle,
+        owner=CycleActor(user_id=owner_id, org_id=org_id),
+        teammate=CycleActor(user_id=teammate_id, org_id=org_id),
+        outsider=CycleActor(user_id=outsider_id, org_id=other_org_id),
+        initial_revision=revision,
+        initial_guidance=guidance,
+    )
+
+
+async def _preview_and_apply(
+    workspace: _PolicyWorkspace,
+    patch: CyclePolicyPatch,
+    *,
+    actor: CycleActor | None = None,
+    rationale: str = "Reviewed behavior change.",
+    source_reference: str = "api:cycle-policy-test",
+):
+    acting = actor or workspace.owner
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=acting,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+    result = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=acting,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+        expected_version=preview.before.version,
+        preview_digest=preview.preview_digest,
+        rationale=rationale,
+        source_reference=source_reference,
+    )
+    assert isinstance(result, CyclePolicyApplied)
+    return preview, result
+
+
+async def test_read_preview_apply_history_and_human_audit_envelope(policy_workspace):
+    workspace = policy_workspace
+    effective = await async_read_effective_cycle_policy(
+        workspace.session,
+        actor=workspace.teammate,
+        cycle_id=workspace.cycle.id,
+    )
+    assert effective.version == 0
+    assert effective.revision_id == workspace.initial_revision.id
+    assert effective.snapshot["name"] == "Morning review"
+    assert effective.snapshot["guidance"] == [
+        "Keep this guidance",
+        "Old wording",
+    ]
+
+    published = []
+    behavior_policy.publish_cycle_change = lambda **payload: published.append(payload)
+    patch = CyclePolicyPatch(
+        name="Morning policy review",
+        guidance=["Keep this guidance", "New wording"],
+    )
+    preview, applied = await _preview_and_apply(
+        workspace,
+        patch,
+        rationale="Use the reviewed wording.",
+        source_reference="api:/cycles/1/behavior-policy",
+    )
+
+    assert preview.changed_fields == ("guidance", "name")
+    assert len(preview.preview_digest) == 64
+    assert applied.effective_policy.version == 1
+    assert workspace.cycle.name == "Morning policy review"
+    assert published == [
+        {
+            "action": "update",
+            "org_id": workspace.cycle.org_id,
+            "user_id": workspace.cycle.user_id,
+            "cycle_id": workspace.cycle.id,
+            "target_idea_id": None,
+            "strict": True,
+        }
+    ]
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert len(history) == 1
+    change = history[0]
+    assert change.workspace_id == str(workspace.cycle.org_id)
+    assert change.policy_kind == "cycle"
+    assert change.target_type == "cycle"
+    assert change.target_id == str(workspace.cycle.id)
+    assert change.version == 1
+    assert change.actor_type == "user"
+    assert change.actor_id == workspace.owner.user_id
+    assert change.source_reference == "api:/cycles/1/behavior-policy"
+    assert change.rationale == "Use the reviewed wording."
+    assert change.before_snapshot == preview.before.snapshot
+    assert change.after_snapshot == preview.after_snapshot
+    assert change.changed_fields == preview.changed_fields
+    assert change.cycle_revision_id == applied.revision.id
+    assert isinstance(change.applied_at, datetime)
+    assert change.applied_at.tzinfo is not None
+    assert change.reverted_from_id is None
+
+
+async def test_stale_version_and_stale_digest_return_latest_policy(policy_workspace):
+    workspace = policy_workspace
+    first_patch = CyclePolicyPatch(name="First editor")
+    second_patch = CyclePolicyPatch(name="Second editor")
+    first_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=first_patch,
+    )
+    second_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+    )
+
+    first = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=first_patch,
+        expected_version=first_preview.before.version,
+        preview_digest=first_preview.preview_digest,
+        rationale="First editor won.",
+        source_reference="editor:first",
+    )
+    assert isinstance(first, CyclePolicyApplied)
+
+    stale_version = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+        expected_version=second_preview.before.version,
+        preview_digest=second_preview.preview_digest,
+        rationale="Second editor tried.",
+        source_reference="editor:second",
+    )
+    assert isinstance(stale_version, CyclePolicyConflict)
+    assert stale_version.reason == "stale_version"
+    assert stale_version.latest_effective_policy.version == 1
+    assert stale_version.latest_effective_policy.snapshot["name"] == "First editor"
+
+    fresh_preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+    )
+    stale_digest = await async_apply_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=second_patch,
+        expected_version=fresh_preview.before.version,
+        preview_digest="0" * 64,
+        rationale="Digest must match.",
+        source_reference="editor:second",
+    )
+    assert isinstance(stale_digest, CyclePolicyConflict)
+    assert stale_digest.reason == "stale_preview_digest"
+    assert stale_digest.latest_effective_policy.version == 1
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 1
+
+
+async def test_apply_requires_nonempty_rationale(policy_workspace):
+    workspace = policy_workspace
+    patch = CyclePolicyPatch(name="Unreviewed name")
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+    with pytest.raises(ValueError, match="rationale is required"):
+        await async_apply_cycle_policy_change(
+            workspace.session,
+            actor=workspace.owner,
+            cycle_id=workspace.cycle.id,
+            proposal=patch,
+            expected_version=preview.before.version,
+            preview_digest=preview.preview_digest,
+            rationale="   ",
+            source_reference="api:test",
+        )
+    assert workspace.cycle.name == "Morning review"
+
+
+async def test_guidance_wording_replacement_retires_without_deleting(policy_workspace):
+    workspace = policy_workspace
+    keep_row, old_row = workspace.initial_guidance
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(guidance=["Keep this guidance", "New wording"]),
+    )
+    rows = list(
+        (
+            await workspace.session.scalars(
+                select(CycleGuidance)
+                .where(CycleGuidance.cycle_id == workspace.cycle.id)
+                .order_by(CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    assert [(row.guidance, row.is_active) for row in rows] == [
+        ("Keep this guidance", True),
+        ("Old wording", False),
+        ("New wording", True),
+    ]
+    assert rows[0].id == keep_row.id
+    assert rows[1].id == old_row.id
+    assert rows[2].id not in {keep_row.id, old_row.id}
+    assert rows[2].revision_id == applied.revision.id
+
+
+async def test_apply_failure_rolls_back_the_entire_policy_write_set(
+    policy_workspace,
+    monkeypatch,
+):
+    workspace = policy_workspace
+    cycle_id = workspace.cycle.id
+    patch = CyclePolicyPatch(
+        name="Must roll back",
+        guidance=["Replacement guidance"],
+    )
+    preview = await async_preview_cycle_policy_change(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        proposal=patch,
+    )
+
+    def fail_publish(_event_type, _payload):
+        raise RuntimeError("event publish failed")
+
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change",
+        cycle_events.publish_cycle_change,
+    )
+    monkeypatch.setattr(platform_events, "publish", fail_publish)
+    with pytest.raises(RuntimeError, match="event publish failed"):
+        await async_apply_cycle_policy_change(
+            workspace.session,
+            actor=workspace.owner,
+            cycle_id=workspace.cycle.id,
+            proposal=patch,
+            expected_version=preview.before.version,
+            preview_digest=preview.preview_digest,
+            rationale="Verify atomic rollback.",
+            source_reference="test:rollback",
+        )
+
+    workspace.session.expire_all()
+    cycle = await workspace.session.get(Cycle, cycle_id)
+    guidance = list(
+        (
+            await workspace.session.scalars(
+                select(CycleGuidance)
+                .where(CycleGuidance.cycle_id == cycle_id)
+                .order_by(CycleGuidance.id.asc())
+            )
+        ).all()
+    )
+    assert cycle.name == "Morning review"
+    assert [(row.guidance, row.is_active) for row in guidance] == [
+        ("Keep this guidance", True),
+        ("Old wording", True),
+    ]
+    assert await workspace.session.scalar(
+        select(func.count(CycleRevision.id)).where(
+            CycleRevision.cycle_id == cycle_id
+        )
+    ) == 1
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0
+
+
+async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_workspace):
+    workspace = policy_workspace
+    _, first = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(name="Changed policy"),
+        rationale="Make the first change.",
+    )
+    revert_preview = await async_preview_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+    )
+    assert revert_preview.after_snapshot["name"] == "Morning review"
+    assert revert_preview.reverted_from_id == first.change.id
+
+    reverted = await async_apply_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+        expected_version=revert_preview.before.version,
+        preview_digest=revert_preview.preview_digest,
+        rationale="Revert the reviewed change.",
+        source_reference="api:revert",
+    )
+    assert isinstance(reverted, CyclePolicyApplied)
+    assert reverted.effective_policy.version == 2
+    assert reverted.effective_policy.snapshot["name"] == "Morning review"
+    assert reverted.change.reverted_from_id == first.change.id
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert [change.version for change in history] == [2, 1]
+    assert history[1].after_snapshot["name"] == "Changed policy"
+
+
+async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_workspace):
+    workspace = policy_workspace
+    first_run = CycleRun(
+        cycle_id=workspace.cycle.id,
+        scheduled_for=datetime.now(timezone.utc),
+        prompt_snapshot=workspace.cycle.prompt,
+        status="queued",
+        context_snapshot={},
+    )
+    workspace.session.add(first_run)
+    await workspace.session.flush()
+    await async_prepare_cycle_run_memory_snapshot(
+        workspace.session,
+        workspace.cycle,
+        first_run,
+    )
+    first_revision_id = first_run.revision_id
+    first_guidance = list(first_run.guidance_snapshot)
+    first_context = dict(first_run.context_snapshot)
+
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(
+            prompt="Use the new policy.",
+            guidance=["New admission guidance"],
+        ),
+    )
+    second_run = CycleRun(
+        cycle_id=workspace.cycle.id,
+        scheduled_for=datetime.now(timezone.utc),
+        prompt_snapshot=workspace.cycle.prompt,
+        status="queued",
+        context_snapshot={},
+    )
+    workspace.session.add(second_run)
+    await workspace.session.flush()
+    await async_prepare_cycle_run_memory_snapshot(
+        workspace.session,
+        workspace.cycle,
+        second_run,
+    )
+
+    assert first_run.revision_id == first_revision_id == workspace.initial_revision.id
+    assert first_run.guidance_snapshot == first_guidance
+    assert first_run.context_snapshot == first_context
+    assert "behavior_change" not in first_run.context_snapshot
+    assert second_run.revision_id == applied.revision.id
+    assert [row["guidance"] for row in second_run.guidance_snapshot] == [
+        "New admission guidance"
+    ]
+    assert second_run.context_snapshot["revision"]["id"] == applied.revision.id
+    assert second_run.context_snapshot["behavior_change"]["id"] == applied.change.id
+
+
+async def test_workspace_authorization_and_delegated_agent_attribution(policy_workspace):
+    workspace = policy_workspace
+    same_workspace = await async_read_effective_cycle_policy(
+        workspace.session,
+        actor=workspace.teammate,
+        cycle_id=workspace.cycle.id,
+    )
+    assert same_workspace.workspace_id == str(workspace.cycle.org_id)
+
+    with pytest.raises(ValueError, match="Cycle not found"):
+        await async_read_effective_cycle_policy(
+            workspace.session,
+            actor=workspace.outsider,
+            cycle_id=workspace.cycle.id,
+        )
+
+    _, teammate_change = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(enabled=False),
+        actor=workspace.teammate,
+        rationale="A workspace teammate reviewed this change.",
+        source_reference="api:teammate",
+    )
+    assert teammate_change.change.actor_type == "user"
+    assert teammate_change.change.actor_id == workspace.teammate.user_id
+
+    agent = CycleActor(
+        user_id=workspace.teammate.user_id,
+        org_id=workspace.teammate.org_id,
+        principal_type="agent",
+        source_id="agent-run-42",
+    )
+    _, applied = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(enabled=True),
+        actor=agent,
+        rationale="Agent applied a delegated reviewed change.",
+        source_reference="agent_run:42",
+    )
+    assert applied.change.actor_type == "agent"
+    assert applied.change.actor_id == "agent-run-42"
+    assert applied.change.source_reference == "agent_run:42"
+    assert applied.change.rationale == "Agent applied a delegated reviewed change."
+    assert applied.change.before_snapshot["enabled"] is False
+    assert applied.change.after_snapshot["enabled"] is True
+    assert applied.change.version == 2
+    assert applied.change.applied_at.tzinfo is not None

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -159,7 +159,11 @@ async def policy_workspace(
     )
     session.add_all(guidance)
     await session.flush()
-    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change_strict",
+        lambda **_kwargs: None,
+    )
     return _PolicyWorkspace(
         session=session,
         cycle=cycle,
@@ -216,7 +220,9 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     ]
 
     published = []
-    behavior_policy.publish_cycle_change = lambda **payload: published.append(payload)
+    behavior_policy.publish_cycle_change_strict = (
+        lambda **payload: published.append(payload)
+    )
     patch = CyclePolicyPatch(
         name="Morning policy review",
         guidance=["Keep this guidance", "New wording"],
@@ -239,7 +245,6 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
             "user_id": workspace.cycle.user_id,
             "cycle_id": workspace.cycle.id,
             "target_idea_id": None,
-            "strict": True,
         }
     ]
 
@@ -261,6 +266,9 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     assert change.rationale == "Use the reviewed wording."
     assert change.before_snapshot == preview.before.snapshot
     assert change.after_snapshot == preview.after_snapshot
+    stored_change = await workspace.session.get(BehaviorChangeAudit, change.id)
+    assert stored_change.before_snapshot["snapshot_version"] == 1
+    assert stored_change.after_snapshot["snapshot_version"] == 1
     assert change.changed_fields == preview.changed_fields
     assert change.cycle_revision_id == applied.revision.id
     assert isinstance(change.applied_at, datetime)
@@ -408,8 +416,8 @@ async def test_apply_failure_rolls_back_the_entire_policy_write_set(
 
     monkeypatch.setattr(
         behavior_policy,
-        "publish_cycle_change",
-        cycle_events.publish_cycle_change,
+        "publish_cycle_change_strict",
+        cycle_events.publish_cycle_change_strict,
     )
     monkeypatch.setattr(platform_events, "publish", fail_publish)
     with pytest.raises(RuntimeError, match="event publish failed"):
@@ -488,6 +496,60 @@ async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_works
     )
     assert [change.version for change in history] == [2, 1]
     assert history[1].after_snapshot["name"] == "Changed policy"
+
+
+async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_workspace):
+    workspace = policy_workspace
+    _, first = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(name="Changed policy"),
+    )
+    stored_change = await workspace.session.get(BehaviorChangeAudit, first.change.id)
+    stored_before = dict(stored_change.before_snapshot)
+    stored_before.pop("max_concurrency")
+    stored_before["retired_policy_field"] = "legacy value"
+    stored_change.before_snapshot = stored_before
+    await workspace.session.flush()
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert history[0].before_snapshot["max_concurrency"] == 1
+    assert "retired_policy_field" not in history[0].before_snapshot
+
+    revert_preview = await async_preview_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+    )
+    assert revert_preview.after_snapshot["name"] == "Morning review"
+    assert revert_preview.after_snapshot["max_concurrency"] == 1
+    assert "retired_policy_field" not in revert_preview.after_snapshot
+
+    reverted = await async_apply_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+        expected_version=revert_preview.before.version,
+        preview_digest=revert_preview.preview_digest,
+        rationale="Revert a snapshot written with an older schema.",
+        source_reference="api:compat-revert",
+    )
+    assert isinstance(reverted, CyclePolicyApplied)
+    assert reverted.effective_policy.version == 2
+    assert set(reverted.effective_policy.snapshot) == set(
+        revert_preview.before.snapshot
+    )
+    new_stored_change = await workspace.session.get(
+        BehaviorChangeAudit,
+        reverted.change.id,
+    )
+    assert new_stored_change.before_snapshot["snapshot_version"] == 1
+    assert new_stored_change.after_snapshot["snapshot_version"] == 1
 
 
 async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_workspace):

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -24,6 +24,7 @@ from brain.systems.cycles.behavior_policy import (
     CyclePolicyApplied,
     CyclePolicyConflict,
     CyclePolicyPatch,
+    CyclePolicySnapshot,
     async_apply_cycle_policy_change,
     async_apply_cycle_policy_revert,
     async_list_cycle_policy_history,
@@ -213,8 +214,9 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     )
     assert effective.version == 0
     assert effective.revision_id == workspace.initial_revision.id
-    assert effective.snapshot["name"] == "Morning review"
-    assert effective.snapshot["guidance"] == [
+    assert isinstance(effective.snapshot, CyclePolicySnapshot)
+    assert effective.snapshot.name == "Morning review"
+    assert effective.snapshot.guidance == [
         "Keep this guidance",
         "Old wording",
     ]
@@ -234,6 +236,7 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
         source_reference="api:/cycles/1/behavior-policy",
     )
 
+    assert isinstance(preview.after_snapshot, CyclePolicySnapshot)
     assert preview.changed_fields == ("guidance", "name")
     assert len(preview.preview_digest) == 64
     assert applied.effective_policy.version == 1
@@ -264,6 +267,8 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     assert change.actor_id == workspace.owner.user_id
     assert change.source_reference == "api:/cycles/1/behavior-policy"
     assert change.rationale == "Use the reviewed wording."
+    assert isinstance(change.before_snapshot, CyclePolicySnapshot)
+    assert isinstance(change.after_snapshot, CyclePolicySnapshot)
     assert change.before_snapshot == preview.before.snapshot
     assert change.after_snapshot == preview.after_snapshot
     stored_change = await workspace.session.get(BehaviorChangeAudit, change.id)
@@ -318,7 +323,7 @@ async def test_stale_version_and_stale_digest_return_latest_policy(policy_worksp
     assert isinstance(stale_version, CyclePolicyConflict)
     assert stale_version.reason == "stale_version"
     assert stale_version.latest_effective_policy.version == 1
-    assert stale_version.latest_effective_policy.snapshot["name"] == "First editor"
+    assert stale_version.latest_effective_policy.snapshot.name == "First editor"
 
     fresh_preview = await async_preview_cycle_policy_change(
         workspace.session,
@@ -471,7 +476,7 @@ async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_works
         cycle_id=workspace.cycle.id,
         change_id=first.change.id,
     )
-    assert revert_preview.after_snapshot["name"] == "Morning review"
+    assert revert_preview.after_snapshot.name == "Morning review"
     assert revert_preview.reverted_from_id == first.change.id
 
     reverted = await async_apply_cycle_policy_revert(
@@ -486,7 +491,7 @@ async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_works
     )
     assert isinstance(reverted, CyclePolicyApplied)
     assert reverted.effective_policy.version == 2
-    assert reverted.effective_policy.snapshot["name"] == "Morning review"
+    assert reverted.effective_policy.snapshot.name == "Morning review"
     assert reverted.change.reverted_from_id == first.change.id
 
     history = await async_list_cycle_policy_history(
@@ -495,7 +500,7 @@ async def test_revert_uses_reviewed_apply_and_creates_a_new_version(policy_works
         cycle_id=workspace.cycle.id,
     )
     assert [change.version for change in history] == [2, 1]
-    assert history[1].after_snapshot["name"] == "Changed policy"
+    assert history[1].after_snapshot.name == "Changed policy"
 
 
 async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_workspace):
@@ -516,8 +521,8 @@ async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_works
         actor=workspace.owner,
         cycle_id=workspace.cycle.id,
     )
-    assert history[0].before_snapshot["max_concurrency"] == 1
-    assert "retired_policy_field" not in history[0].before_snapshot
+    assert history[0].before_snapshot.max_concurrency == 1
+    assert not hasattr(history[0].before_snapshot, "retired_policy_field")
 
     revert_preview = await async_preview_cycle_policy_revert(
         workspace.session,
@@ -525,9 +530,9 @@ async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_works
         cycle_id=workspace.cycle.id,
         change_id=first.change.id,
     )
-    assert revert_preview.after_snapshot["name"] == "Morning review"
-    assert revert_preview.after_snapshot["max_concurrency"] == 1
-    assert "retired_policy_field" not in revert_preview.after_snapshot
+    assert revert_preview.after_snapshot.name == "Morning review"
+    assert revert_preview.after_snapshot.max_concurrency == 1
+    assert not hasattr(revert_preview.after_snapshot, "retired_policy_field")
 
     reverted = await async_apply_cycle_policy_revert(
         workspace.session,
@@ -541,15 +546,71 @@ async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_works
     )
     assert isinstance(reverted, CyclePolicyApplied)
     assert reverted.effective_policy.version == 2
-    assert set(reverted.effective_policy.snapshot) == set(
-        revert_preview.before.snapshot
-    )
+    assert isinstance(reverted.effective_policy.snapshot, CyclePolicySnapshot)
     new_stored_change = await workspace.session.get(
         BehaviorChangeAudit,
         reverted.change.id,
     )
     assert new_stored_change.before_snapshot["snapshot_version"] == 1
     assert new_stored_change.after_snapshot["snapshot_version"] == 1
+
+
+async def test_revert_decodes_snapshot_written_before_versioning(policy_workspace):
+    workspace = policy_workspace
+    _, first = await _preview_and_apply(
+        workspace,
+        CyclePolicyPatch(name="Changed policy"),
+    )
+    stored_change = await workspace.session.get(BehaviorChangeAudit, first.change.id)
+    stored_before = dict(stored_change.before_snapshot)
+    stored_before.pop("snapshot_version")
+    stored_change.before_snapshot = stored_before
+    await workspace.session.flush()
+
+    history = await async_list_cycle_policy_history(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+    )
+    assert history[0].before_snapshot.name == "Morning review"
+
+    revert_preview = await async_preview_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+    )
+    assert revert_preview.after_snapshot.name == "Morning review"
+
+    reverted = await async_apply_cycle_policy_revert(
+        workspace.session,
+        actor=workspace.owner,
+        cycle_id=workspace.cycle.id,
+        change_id=first.change.id,
+        expected_version=revert_preview.before.version,
+        preview_digest=revert_preview.preview_digest,
+        rationale="Revert a snapshot written before versioning.",
+        source_reference="api:legacy-revert",
+    )
+    assert isinstance(reverted, CyclePolicyApplied)
+    assert reverted.effective_policy.snapshot.name == "Morning review"
+
+
+@pytest.mark.parametrize("invalid_version", [False, 0, -1, "1"])
+async def test_snapshot_decode_rejects_invalid_versions(
+    policy_workspace,
+    invalid_version,
+):
+    current = await async_read_effective_cycle_policy(
+        policy_workspace.session,
+        actor=policy_workspace.owner,
+        cycle_id=policy_workspace.cycle.id,
+    )
+    encoded = current.snapshot.encode()
+    encoded["snapshot_version"] = invalid_version
+
+    with pytest.raises(ValueError, match="invalid version"):
+        CyclePolicySnapshot.decode(encoded, current=current.snapshot)
 
 
 async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_workspace):
@@ -649,7 +710,7 @@ async def test_workspace_authorization_and_delegated_agent_attribution(policy_wo
     assert applied.change.actor_id == "agent-run-42"
     assert applied.change.source_reference == "agent_run:42"
     assert applied.change.rationale == "Agent applied a delegated reviewed change."
-    assert applied.change.before_snapshot["enabled"] is False
-    assert applied.change.after_snapshot["enabled"] is True
+    assert applied.change.before_snapshot.enabled is False
+    assert applied.change.after_snapshot.enabled is True
     assert applied.change.version == 2
     assert applied.change.applied_at.tzinfo is not None

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -203,6 +203,45 @@ async def _preview_and_apply(
     )
     assert isinstance(result, CyclePolicyApplied)
     return preview, result
+
+
+async def test_snapshot_apply_covers_every_scalar_dataclass_field(
+    policy_workspace,
+    monkeypatch,
+):
+    workspace = policy_workspace
+    snapshot = CyclePolicySnapshot.from_cycle(
+        workspace.cycle,
+        list(workspace.initial_guidance),
+    )
+    monkeypatch.setattr(
+        behavior_policy,
+        "compute_next_run_at",
+        lambda *_args: None,
+    )
+
+    for snapshot_field in fields(snapshot):
+        # Guidance is deliberately excluded because the apply command writes it
+        # separately through _replace_active_guidance().
+        if snapshot_field.name == "guidance":
+            continue
+
+        marker = f"__snapshot_write_coverage__:{snapshot_field.name}"
+        current_value = getattr(snapshot, snapshot_field.name)
+        changed_value = (
+            {marker: True} if isinstance(current_value, dict) else marker
+        )
+        mutated = replace(
+            snapshot,
+            **{snapshot_field.name: changed_value},
+        )
+
+        mutated.apply_to(workspace.cycle)
+
+        assert getattr(workspace.cycle, snapshot_field.name, None) == changed_value, (
+            "CyclePolicySnapshot.apply_to() did not write snapshot field "
+            f"{snapshot_field.name!r}"
+        )
 
 
 async def test_read_preview_apply_history_and_human_audit_envelope(policy_workspace):

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -1,0 +1,261 @@
+"""PostgreSQL proof for Cycle policy locking and optimistic concurrency."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.schema import CreateTable
+
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleRevision,
+)
+from brain.platform.db.models.org import Org, User
+from brain.systems.cycles import behavior_policy
+from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyConflict,
+    CyclePolicyPatch,
+    async_apply_cycle_policy_change,
+    async_preview_cycle_policy_change,
+)
+from tests.conftest import TEST_DB_URL
+from tests.db_engine_utils import create_async_test_engine
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.requires_db]
+
+LOCK_WAIT_TIMEOUT_SECONDS = 15.0
+RACE_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class _PostgresPolicyWorkspace:
+    engine: object
+    factory: object
+    app_name: str
+    cycle_id: int
+    actor: CycleActor
+
+    @asynccontextmanager
+    async def held_cycle_lock(self):
+        connection = await self.engine.connect()
+        transaction = await connection.begin()
+        try:
+            await connection.execute(
+                text("SELECT id FROM cycles WHERE id = :cycle_id FOR UPDATE"),
+                {"cycle_id": self.cycle_id},
+            )
+            yield
+        finally:
+            await transaction.commit()
+            await connection.close()
+
+    async def await_lock_waiters(self, expected: int) -> None:
+        connection = await (await self.engine.connect()).execution_options(
+            isolation_level="AUTOCOMMIT"
+        )
+        try:
+            deadline = asyncio.get_running_loop().time() + LOCK_WAIT_TIMEOUT_SECONDS
+            blocked = 0
+            while asyncio.get_running_loop().time() < deadline:
+                blocked = int(
+                    (
+                        await connection.execute(
+                            text(
+                                "SELECT count(*) FROM pg_stat_activity "
+                                "WHERE datname = current_database() "
+                                "AND application_name = :app_name "
+                                "AND cardinality(pg_blocking_pids(pid)) > 0"
+                            ),
+                            {"app_name": self.app_name},
+                        )
+                    ).scalar_one()
+                )
+                if blocked >= expected:
+                    return
+                await asyncio.sleep(0.05)
+            raise AssertionError(
+                f"expected {expected} policy editor(s) waiting on the Cycle lock; "
+                f"saw {blocked}"
+            )
+        finally:
+            await connection.close()
+
+
+@pytest.fixture
+async def postgres_policy_workspace(monkeypatch):
+    schema = f"policy_conc_{uuid4().hex[:12]}"
+    app_name = f"policy-conc-{uuid4().hex[:8]}"
+    admin_engine = create_async_test_engine(TEST_DB_URL)
+    admin = await (await admin_engine.connect()).execution_options(
+        isolation_level="AUTOCOMMIT"
+    )
+    await admin.execute(text(f'CREATE SCHEMA "{schema}"'))
+    engine = create_async_test_engine(
+        TEST_DB_URL,
+        connect_args={
+            "server_settings": {
+                "search_path": f'"{schema}",public',
+                "application_name": app_name,
+            }
+        },
+    )
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id = str(uuid4())
+    user_id = str(uuid4())
+    cycle_id = None
+    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    try:
+        async with engine.begin() as connection:
+            for table in (
+                Org.__table__,
+                User.__table__,
+                Cycle.__table__,
+                CycleRevision.__table__,
+                CycleGuidance.__table__,
+                BehaviorChangeAudit.__table__,
+            ):
+                await connection.execute(CreateTable(table))
+
+        async with factory.begin() as session:
+            session.add(
+                Org(
+                    id=org_id,
+                    name="Policy concurrency org",
+                    slug=f"policy-concurrency-{org_id[:8]}",
+                )
+            )
+            session.add(
+                User(
+                    id=user_id,
+                    org_id=org_id,
+                    name="Policy editor",
+                    email=f"policy-editor-{user_id[:8]}@example.com",
+                )
+            )
+            await session.flush()
+            cycle = Cycle(
+                user_id=user_id,
+                org_id=org_id,
+                name="Concurrent policy",
+                prompt="Review concurrency.",
+                schedule_expr="0 9 * * *",
+                timezone="UTC",
+                enabled=True,
+                max_concurrency=1,
+                retry_policy={},
+                execution_mode="reuse_same_idea",
+                reopen_archived=True,
+            )
+            session.add(cycle)
+            await session.flush()
+            cycle_id = cycle.id
+            session.add(
+                CycleRevision(
+                    cycle_id=cycle.id,
+                    revision_number=1,
+                    source_type="user",
+                    source_id=user_id,
+                    rationale="Initial definition.",
+                    name=cycle.name,
+                    prompt=cycle.prompt,
+                    schedule_expr=cycle.schedule_expr,
+                    timezone=cycle.timezone,
+                    enabled=cycle.enabled,
+                    model_override=None,
+                    thinking_override=None,
+                    execution_policy_key=None,
+                    target_idea_id=None,
+                    context_policy={"workspace_id": org_id},
+                )
+            )
+
+        yield _PostgresPolicyWorkspace(
+            engine=engine,
+            factory=factory,
+            app_name=app_name,
+            cycle_id=cycle_id,
+            actor=CycleActor(user_id=user_id, org_id=org_id),
+        )
+    finally:
+        await engine.dispose()
+        await admin.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await admin.close()
+        await admin_engine.dispose()
+
+
+async def test_two_reviewed_editors_serialize_and_second_gets_latest_conflict(
+    postgres_policy_workspace,
+):
+    workspace = postgres_policy_workspace
+    first_patch = CyclePolicyPatch(name="First reviewed edit")
+    second_patch = CyclePolicyPatch(name="Second reviewed edit")
+    async with workspace.factory() as session:
+        first_preview = await async_preview_cycle_policy_change(
+            session,
+            actor=workspace.actor,
+            cycle_id=workspace.cycle_id,
+            proposal=first_patch,
+        )
+        second_preview = await async_preview_cycle_policy_change(
+            session,
+            actor=workspace.actor,
+            cycle_id=workspace.cycle_id,
+            proposal=second_patch,
+        )
+
+    async def apply(patch, preview, editor):
+        async with workspace.factory.begin() as session:
+            return await async_apply_cycle_policy_change(
+                session,
+                actor=workspace.actor,
+                cycle_id=workspace.cycle_id,
+                proposal=patch,
+                expected_version=preview.before.version,
+                preview_digest=preview.preview_digest,
+                rationale=f"{editor} reviewed this edit.",
+                source_reference=f"editor:{editor}",
+            )
+
+    async with workspace.held_cycle_lock():
+        first_task = asyncio.create_task(apply(first_patch, first_preview, "first"))
+        second_task = asyncio.create_task(apply(second_patch, second_preview, "second"))
+        await workspace.await_lock_waiters(2)
+        assert not first_task.done() and not second_task.done()
+
+    results = await asyncio.wait_for(
+        asyncio.gather(first_task, second_task),
+        RACE_TIMEOUT_SECONDS,
+    )
+    applied = [result for result in results if isinstance(result, CyclePolicyApplied)]
+    conflicts = [result for result in results if isinstance(result, CyclePolicyConflict)]
+    assert len(applied) == 1
+    assert len(conflicts) == 1
+    assert conflicts[0].reason == "stale_version"
+    assert conflicts[0].latest_effective_policy.version == 1
+    assert conflicts[0].latest_effective_policy.snapshot["name"] in {
+        "First reviewed edit",
+        "Second reviewed edit",
+    }
+
+    async with workspace.factory() as session:
+        changes = list(
+            (
+                await session.scalars(
+                    select(BehaviorChangeAudit).order_by(
+                        BehaviorChangeAudit.version.asc()
+                    )
+                )
+            ).all()
+        )
+    assert [(change.version, change.target_id) for change in changes] == [
+        (1, str(workspace.cycle_id))
+    ]

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -112,7 +112,11 @@ async def postgres_policy_workspace(monkeypatch):
     org_id = str(uuid4())
     user_id = str(uuid4())
     cycle_id = None
-    monkeypatch.setattr(behavior_policy, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change_strict",
+        lambda **_kwargs: None,
+    )
     try:
         async with engine.begin() as connection:
             for table in (

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -245,7 +245,7 @@ async def test_two_reviewed_editors_serialize_and_second_gets_latest_conflict(
     assert len(conflicts) == 1
     assert conflicts[0].reason == "stale_version"
     assert conflicts[0].latest_effective_policy.version == 1
-    assert conflicts[0].latest_effective_policy.snapshot["name"] in {
+    assert conflicts[0].latest_effective_policy.snapshot.name in {
         "First reviewed edit",
         "Second reviewed edit",
     }

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -34,10 +34,12 @@ from brain.systems.cycles.promotion_readiness import (
 )
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
     Cycle,
     CycleFailureGuardLatch,
     CycleFailureGuardObservation,
     CycleFailureGuardTriggerState,
+    CycleGuidance,
     CycleRevision,
     CycleRun,
     CycleRunEvaluation,
@@ -317,10 +319,46 @@ class _RouterCycleSession:
         self.committed = False
 
     async def scalars(self, statement):
+        sql = str(statement)
+        if "FROM cycle_guidance" in sql:
+            return _AllResult(
+                row
+                for row in self.added
+                if isinstance(row, CycleGuidance) and row.is_active
+            )
         return _RouterCycleResult(self._cycle)
 
     async def execute(self, statement):
+        if "max(cycle_revisions.revision_number)" in str(statement):
+            return _FirstResult(
+                max(
+                    (
+                        row.revision_number
+                        for row in self.added
+                        if isinstance(row, CycleRevision)
+                    ),
+                    default=0,
+                )
+            )
         return _FirstResult((self._cycle.target_idea_id,))
+
+    async def scalar(self, statement):
+        sql = str(statement)
+        if "max(behavior_change_audits.version)" in sql:
+            return max(
+                (
+                    row.version
+                    for row in self.added
+                    if isinstance(row, BehaviorChangeAudit)
+                ),
+                default=0,
+            )
+        if "FROM cycle_revisions" in sql:
+            revisions = [row for row in self.added if isinstance(row, CycleRevision)]
+            return revisions[-1].id if revisions else None
+        if "FROM ideas" in sql:
+            return self._cycle.target_idea_id
+        return None
 
     def add(self, value):
         self.added.append(value)
@@ -337,6 +375,9 @@ class _RouterCycleSession:
 
     async def commit(self):
         self.committed = True
+
+    def begin_nested(self):
+        return _AsyncNestedTransaction()
 
 
 class _ExecuteCycleSession:
@@ -1131,6 +1172,12 @@ async def test_cycle_update_persists_and_serializes_max_concurrency():
 
     assert cycle.max_concurrency == 4
     assert response["max_concurrency"] == 4
+    audit = next(row for row in db.added if isinstance(row, BehaviorChangeAudit))
+    assert audit.before_snapshot["max_concurrency"] == 1
+    assert audit.after_snapshot["max_concurrency"] == 4
+    assert audit.cycle_revision_id == next(
+        row.id for row in db.added if isinstance(row, CycleRevision)
+    )
     CycleRead.model_validate(response)
 
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1122,7 +1122,7 @@ async def test_cycle_create_persists_and_serializes_max_concurrency(monkeypatch)
     monkeypatch.setattr(cycles_router, "command_create_cycle", fake_create_cycle)
     monkeypatch.setattr(
         cycles_router,
-        "publish_cycle_change",
+        "publish_cycle_change_safe",
         lambda **_kwargs: None,
     )
 
@@ -3152,7 +3152,11 @@ async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch)
 
     monkeypatch.setattr(cycle_handlers, "UnitOfWork", factory)
     monkeypatch.setattr(cycle_handlers, "async_run_cycle_now", fake_run_cycle_now)
-    monkeypatch.setattr(cycle_handlers, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        cycle_handlers,
+        "publish_cycle_change_safe",
+        lambda **_kwargs: None,
+    )
 
     with bind_agent_context(
         {
@@ -3205,7 +3209,11 @@ async def test_manage_cycle_run_can_select_explicit_scheduled_digest_contract(mo
 
     monkeypatch.setattr(cycle_handlers, "UnitOfWork", factory)
     monkeypatch.setattr(cycle_handlers, "async_run_cycle_now", fake_run_cycle_now)
-    monkeypatch.setattr(cycle_handlers, "publish_cycle_change", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        cycle_handlers,
+        "publish_cycle_change_safe",
+        lambda **_kwargs: None,
+    )
 
     with bind_agent_context(
         {

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -933,7 +933,7 @@ async def test_hosted_mcp_cycle_manage_create_commits_and_publishes_change():
         "brain.app.api.routers.agent_mcp._validate_cycle_target_idea",
         new=AsyncMock(),
     ), patch(
-        "brain.app.api.routers.agent_mcp.publish_cycle_change",
+        "brain.app.api.routers.agent_mcp.publish_cycle_change_safe",
         side_effect=publish_change,
     ):
         response = await _request(

--- a/tests/test_failure_guard_core.py
+++ b/tests/test_failure_guard_core.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 import pytest
 
 from brain.systems.failure_guard.core import (
+    FailureGuardStatefulTriggerRegistration,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     async_evaluate_failure_guard_triggers,
     async_transition_failure_guard_trigger_states,
@@ -103,8 +103,7 @@ def test_registration_rejects_stateful_trigger_missing_transition_method():
             "transition_state"
         ),
     ):
-        FailureGuardTriggerRegistration(
-            mode=FailureGuardTriggerMode.STATEFUL,
+        FailureGuardStatefulTriggerRegistration(
             trigger=_StatefulTriggerMissingTransition(),
         )
 
@@ -117,20 +116,17 @@ def test_registration_rejects_stateless_trigger_with_stateful_methods():
             "evaluate_with_state.*transition_state"
         ),
     ):
-        FailureGuardTriggerRegistration(
-            mode=FailureGuardTriggerMode.STATELESS,
+        FailureGuardStatelessTriggerRegistration(
             trigger=_DualContractTrigger(),
         )
 
 
 @pytest.mark.asyncio
 async def test_declared_mode_controls_evaluation_and_persistence():
-    stateless_registration = FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATELESS,
+    stateless_registration = FailureGuardStatelessTriggerRegistration(
         trigger=_StatelessTrigger(),
     )
-    stateful_registration = FailureGuardTriggerRegistration(
-        mode=FailureGuardTriggerMode.STATEFUL,
+    stateful_registration = FailureGuardStatefulTriggerRegistration(
         trigger=_DualContractTrigger(),
     )
     store = _MemoryStateStore(
@@ -167,15 +163,14 @@ async def test_declared_mode_controls_evaluation_and_persistence():
 def test_bare_trigger_is_refused_before_it_can_reach_dispatch():
     """A raw trigger has a ``kind``, so a consumer registry's own checks pass it.
 
-    It never runs ``FailureGuardTriggerRegistration.__post_init__``, so its mode
-    would only be missed at dispatch, far from the provider that omitted it.
+    It never runs a registration variant's validation, so its mode would only
+    be missed at dispatch, far from the provider that omitted it.
     """
 
     with pytest.raises(ValueError) as excinfo:
         require_failure_guard_registrations(
             (
-                FailureGuardTriggerRegistration(
-                    mode=FailureGuardTriggerMode.STATELESS,
+                FailureGuardStatelessTriggerRegistration(
                     trigger=_StatelessTrigger(),
                 ),
                 _StatelessTrigger(),
@@ -191,8 +186,7 @@ def test_bare_trigger_is_refused_before_it_can_reach_dispatch():
 def test_registrations_only_registry_is_accepted():
     require_failure_guard_registrations(
         (
-            FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            FailureGuardStatelessTriggerRegistration(
                 trigger=_StatelessTrigger(),
             ),
         ),

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -11,6 +11,7 @@ EXPECTED_TABLES = {
     "agent_run_events",
     "agent_runs",
     "agent_sessions",
+    "behavior_change_audits",
     "browser_pool_entries",
     "browser_sessions",
     "chat_conversation_members",

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -439,6 +439,7 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "docker update --restart=no" in runtime_lib
     assert 'docker kill -s TERM "$worker_id"' in runtime_lib
     assert "wait_for_worker_exit" in runtime_lib
+    assert "wait_for_idle_worker_exit" in runtime_lib
     assert "compose up -d --force-recreate --no-deps worker" in runtime_lib
     assert "compose up -d --force-recreate --remove-orphans" in upgrade
     assert "replace_idle_worker" in combined
@@ -975,7 +976,7 @@ compose() {{ :; }}
 worker_container_id() {{ printf 'old-worker\\n'; }}
 worker_swap_snapshot() {{ printf 'snapshot\\n'; }}
 worker_swap_snapshot_decision() {{ printf 'replace\\n'; }}
-wait_for_worker_exit() {{ return 0; }}
+wait_for_idle_worker_exit() {{ return 0; }}
 replace_idle_worker
 '''
 
@@ -1004,7 +1005,7 @@ compose() {{ :; }}
 worker_container_id() {{ printf 'old-worker\\n'; }}
 worker_swap_snapshot() {{ printf 'snapshot\\n'; }}
 worker_swap_snapshot_decision() {{ printf 'replace\\n'; }}
-wait_for_worker_exit() {{ return 0; }}
+wait_for_idle_worker_exit() {{ return 0; }}
 replace_idle_worker
 '''
 
@@ -1246,7 +1247,7 @@ compose() {{ return 1; }}
 worker_container_id() {{ printf 'old-worker\\n'; }}
 worker_swap_snapshot() {{ printf 'snapshot\\n'; }}
 worker_swap_snapshot_decision() {{ printf 'replace\\n'; }}
-wait_for_worker_exit() {{ return 0; }}
+wait_for_idle_worker_exit() {{ return 0; }}
 replace_idle_worker
 '''
 

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -83,6 +83,7 @@ async def test_scheduler_registration_rejects_trigger_without_scheduler_contract
         ValueError,
         match=(
             "_EvaluateOnlySchedulerTrigger declared stateless.*"
+            "SchedulerFailureGuardTrigger protocol.*"
             "evaluate_many, should_reset"
         ),
     ):

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -19,9 +19,8 @@ from brain.app.scheduler.daemon import (
 from brain.systems.failure_guard.core import (
     FailureGuardEdge,
     FailureGuardEvaluation,
+    FailureGuardStatelessTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
     serialize_failure_guard,
 )
@@ -59,6 +58,41 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def session(async_sqlite_session_factory):
     return await make_scheduler_test_session(async_sqlite_session_factory)
+
+
+@dataclass(frozen=True)
+class _EvaluateOnlySchedulerTrigger:
+    kind: FailureGuardTriggerKind = field(
+        default=FailureGuardTriggerKind("evaluate_only"),
+        init=False,
+    )
+
+    async def evaluate(self, context) -> FailureGuardTriggerResult:
+        del context
+        return FailureGuardTriggerResult(
+            kind=self.kind,
+            active=False,
+            public_details={},
+            alert_title="Evaluate-only trigger",
+            alert_summary="Evaluate-only trigger",
+        )
+
+
+async def test_scheduler_registration_rejects_trigger_without_scheduler_contract():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "_EvaluateOnlySchedulerTrigger declared stateless.*"
+            "evaluate_many, should_reset"
+        ),
+    ):
+        scheduler_failure_guard.SchedulerFailureGuardRegistry(
+            triggers=(
+                FailureGuardStatelessTriggerRegistration(
+                    trigger=_EvaluateOnlySchedulerTrigger(),
+                ),
+            )
+        )
 
 
 async def test_failure_signature_normalizes_volatile_runtime_identity():
@@ -332,8 +366,7 @@ async def test_registered_database_trigger_projects_once_across_jobs(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            lambda: FailureGuardStatelessTriggerRegistration(
                 trigger=database_trigger,
             ),
         ),
@@ -1522,8 +1555,7 @@ async def test_third_trigger_flows_through_production_apply_health_delivery_and_
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATELESS,
+            lambda: FailureGuardStatelessTriggerRegistration(
                 trigger=_RuntimeDurationTrigger(minimum_runtime_minutes=30),
             ),
         ),

--- a/tests/test_scheduler_failure_guard_stateful_trigger.py
+++ b/tests/test_scheduler_failure_guard_stateful_trigger.py
@@ -14,9 +14,8 @@ from brain.app.scheduler.scheduler_failure_guard import (
 )
 from brain.platform.db.models.scheduler import SchedulerRun
 from brain.systems.failure_guard.core import (
+    FailureGuardStatefulTriggerRegistration,
     FailureGuardTriggerKind,
-    FailureGuardTriggerMode,
-    FailureGuardTriggerRegistration,
     FailureGuardTriggerResult,
 )
 from tests.scheduler_test_support import (
@@ -113,8 +112,7 @@ async def test_stateful_third_trigger_flows_through_production_registry(
         "_FAILURE_GUARD_TRIGGER_PROVIDERS",
         (
             *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: FailureGuardTriggerRegistration(
-                mode=FailureGuardTriggerMode.STATEFUL,
+            lambda: FailureGuardStatefulTriggerRegistration(
                 trigger=_DistinctFailureClassesTrigger(threshold=2),
             ),
         ),

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -38,10 +38,10 @@ def _simulator(
     it, `docker rm` removes it, and `compose up --force-recreate` swaps the
     service container for a new id. Handoff ids carry Compose's one-off label.
 
-    With `stub_drain_wait=False` the real `wait_for_worker_exit` runs, with
-    `sleep` replaced by a tick counter so the loop is instantaneous. The worker
-    it waits on never drains, so the only way the wait can end is the condition
-    under test.
+    With `stub_drain_wait=False` the real covered and idle wait functions run,
+    with `sleep` replaced by a tick counter so the loop is instantaneous. The
+    worker they wait on never drains, so the only way the wait can end is the
+    condition under test.
     """
 
     state.mkdir(parents=True, exist_ok=True)
@@ -178,7 +178,8 @@ start_worker_handoff() {{
 
 # The drain never completes: the worker is wedged on an in-flight run, which is
 # what run 2896 did on illo-dev for 65 minutes.
-{'wait_for_worker_exit() { [ ! -f "$STATE/$1.running" ]; }' if stub_drain_wait else ''}
+{'''wait_for_worker_exit() { [ ! -f "$STATE/$1.running" ]; }
+wait_for_idle_worker_exit() { [ ! -f "$STATE/$1.running" ]; }''' if stub_drain_wait else ''}
 
 {body}
 echo "STATUS=$?"
@@ -415,7 +416,7 @@ def test_idle_deadline_is_abandoned_and_rearmed_when_active_runs_reappear(tmp_pa
             'case "$(ticks)" in 18) printf \'1\\n\' ;; *) printf \'0\\n\' ;; esac; }\n'
             'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
             "SECONDS=$((SECONDS + $1)); return 0; }\n"
-            "wait_for_worker_exit worker-1 ''"
+            "wait_for_idle_worker_exit worker-1"
         ),
         stub_drain_wait=False,
         drain_timeout_seconds=300,
@@ -441,7 +442,7 @@ def test_active_run_at_idle_deadline_requires_two_fresh_zero_snapshots(tmp_path)
             'case "$(ticks)" in 19) printf \'1\\n\' ;; *) printf \'0\\n\' ;; esac; }\n'
             'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
             "SECONDS=$((SECONDS + $1)); return 0; }\n"
-            "wait_for_worker_exit worker-1 ''"
+            "wait_for_idle_worker_exit worker-1"
         ),
         stub_drain_wait=False,
         drain_timeout_seconds=300,


### PR DESCRIPTION
> *This was generated by AI during an autonomous routine run (R3).*

One branch folding the four draft PRs that were open at 20:40Z, per the standing
rule that more than two open PRs become one merge instead of N.

Closes #755
Closes #773
Closes #782
Closes #790

## Why this exists instead of the four PRs

[#793](https://github.com/Illospace/illospace/pull/793) was stacked on
[#792](https://github.com/Illospace/illospace/pull/792). This repo squash-merges,
and a squash-merged parent leaves the child branch with no shared ancestry — the
child then conflicts across every file the parent touched. Folding removes that
trap before you hit it.

It also fixes a second thing: `Closes #790` could not register on #793, because
GitHub refuses closing links on a PR based on a feature branch. On this branch it
registers, so #790 closes on merge instead of needing a manual close.

The four originals stay open. Close them by hand after this merges, or merge them
individually instead and close this one — nothing here depends on which you pick.

## What is in it

| Was | Issue | Change |
|---|---|---|
| #788 | #755 | `wait_for_worker_exit` splits into a covered wait and an idle wait, one drain policy each |
| #789 | #773 | The failure-guard trigger mode tag narrows the trigger type; all six casts are gone |
| #792 | #782 | Behavior-policy command module, one immutable audit row per change, migration `0059` |
| #793 | #790 | The Cycle policy snapshot becomes a typed, versioned record; the untyped dict contract is gone |

Merged with **zero conflicts** — the three source branches share no files except
`behavior_policy.py`, which #792 and #793 already owned as a pair.

## Verification (local — this repo has no CI minutes)

- `alembic heads` → exactly **one** (`0059_behavior_change_audits`).
- Fast suite: **4883 passed, 11 skipped** in 113s, machine load 2.3 (uncontended,
  so the number means something).
- No `frontend/**` file changes, so no frontend lane applies.

## What to watch after you deploy

1. A Cycle policy edit writes exactly one row in `behavior_change_audits`, and the
   Cycle keeps running on the new policy.
2. Reverting that edit restores the prior policy and writes a second audit row —
   it does not mutate the first.
3. A deploy still drains workers normally (the `#755` split is a pure refactor; a
   stuck or skipped drain is the failure to look for).

## Known gap, unchanged from #792

The PostgreSQL two-editor locking test is written and correctly marked
`requires_db`. `TEST_DB_URL` is not set on this machine, so it is collected and
skipped, and SQLite cannot prove live row locking. It needs one run against real
Postgres — that is the one claim here no local run has earned.
