### PR TITLE
feat(runtime): runtime-editable storage policy row (#779)

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -213,8 +213,9 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
             "allowed_actions": ["scheduler.run"],
             "output_channel": "scheduler",
             "success_criteria": [
-                "Headless-worker workspaces older than 48 hours are reclaimed only when "
-                "the parent run is terminal or absent from the database"
+                "Headless-worker workspaces past the active storage-policy retention "
+                "window are reclaimed only when the parent run is terminal or absent "
+                "from the database"
             ],
         },
         "priority": 70,

--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -234,7 +234,9 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "timezone": "UTC",
         "default_payload": {
             "name": "Cortex Canvas Occupancy",
-            "description": "Archive emerged thoughts after 24 quiet hours",
+            "description": (
+                "Archive emerged thoughts after the active storage-policy quiet window"
+            ),
         },
         "task_contract": {
             "memory_scope": {"visibility": "system"},

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -97,8 +97,8 @@ SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
         command=("python3", "-m", "brain.jobs.pipelines.workspace_gc"),
         step_key="workspace_gc",
         description=(
-            "Reclaim headless-worker workspaces older than 48 hours when parent runs are "
-            "terminal or absent from the database"
+            "Reclaim headless-worker workspaces past the active storage-policy retention "
+            "window when parent runs are terminal or absent from the database"
         ),
     ),
     "cortex_canvas_occupancy": SingleCommandProgram(

--- a/brain/jobs/pipelines/cortex_occupancy.py
+++ b/brain/jobs/pipelines/cortex_occupancy.py
@@ -14,18 +14,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.thought_lifecycle import ThoughtStatusCommand, transition_thought_status
+from brain.systems.storage_policy import async_get_storage_policy
 
 log = logging.getLogger(__name__)
 
-CANVAS_QUIET_HOURS = 24
-ARCHIVE_TRIGGER = "canvas_occupancy_24h_quiet"
+ARCHIVE_TRIGGER = "canvas_occupancy_quiet"
 
 
 async def archive_dormant_emerged(
     session: AsyncSession,
     *,
     now: datetime | None = None,
-    quiet_hours: int = CANVAS_QUIET_HOURS,
+    quiet_hours: int | None = None,
     batch_size: int = 250,
 ) -> int:
     """Archive emerged thoughts after a bounded quiet period.
@@ -33,6 +33,9 @@ async def archive_dormant_emerged(
     The canonical lifecycle service sets ``archived_at`` and records the
     transition in ``idea_state_log``. Other states are never changed here.
     """
+    if quiet_hours is None:
+        policy = await async_get_storage_policy(session)
+        quiet_hours = policy.canvas_quiet_hours
     changed_at = now or datetime.now(timezone.utc)
     cutoff = changed_at - timedelta(hours=quiet_hours)
     archived = 0
@@ -73,8 +76,13 @@ async def archive_dormant_emerged(
 
 async def run() -> dict[str, int]:
     async with UnitOfWork() as uow:
-        archived = await archive_dormant_emerged(uow.session)  # type: ignore[arg-type]
-    result = {"archived": archived, "quiet_hours": CANVAS_QUIET_HOURS}
+        policy = await async_get_storage_policy(uow.session)
+        archived = await archive_dormant_emerged(
+            uow.session,  # type: ignore[arg-type]
+            quiet_hours=policy.canvas_quiet_hours,
+        )
+        quiet_hours = policy.canvas_quiet_hours
+    result = {"archived": archived, "quiet_hours": quiet_hours}
     log.info("Cortex occupancy maintenance complete: %s", result)
     return result
 

--- a/brain/jobs/pipelines/workspace_gc.py
+++ b/brain/jobs/pipelines/workspace_gc.py
@@ -28,10 +28,9 @@ from brain.systems.runs.status import (
     coerce_run_status,
     project_run_status_value,
 )
+from brain.systems.storage_policy import async_get_storage_policy
 
 log = logging.getLogger(__name__)
-
-HEADLESS_WORKER_WORKSPACE_RETENTION = timedelta(hours=48)
 
 
 class WorkspaceGCResult(TypedDict):
@@ -153,17 +152,21 @@ async def reclaim_headless_worker_workspaces(
     *,
     workspace_root: Path,
     now: datetime | None = None,
-    retention: timedelta = HEADLESS_WORKER_WORKSPACE_RETENTION,
+    retention: timedelta | None = None,
 ) -> WorkspaceGCResult:
     """Delete old worker workspaces whose parent run is terminal or absent."""
 
     result = _empty_result()
-    cutoff = now or datetime.now(timezone.utc)
-    cutoff = cutoff.astimezone(timezone.utc) - retention
     ideas = workspace_root.expanduser() / "ideas"
     if not ideas.exists():
         log.info("Workspace GC complete: %s", result)
         return result
+    if retention is None:
+        policy = await async_get_storage_policy(session)
+        retention = timedelta(hours=policy.finished_workspace_retention_hours)
+    if retention.total_seconds() <= 0:
+        raise ValueError("retention must be positive")
+    cutoff = (now or datetime.now(timezone.utc)).astimezone(timezone.utc) - retention
 
     try:
         root = workspace_root.expanduser().resolve(strict=True)

--- a/brain/platform/db/alembic/versions/0060_storage_policies.py
+++ b/brain/platform/db/alembic/versions/0060_storage_policies.py
@@ -1,0 +1,160 @@
+"""Add runtime-editable storage policy revisions.
+
+Revision ID: 0060_storage_policies
+Revises: 0059_behavior_change_audits
+Create Date: 2026-08-10
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0060_storage_policies"
+down_revision = "0059_behavior_change_audits"
+branch_labels = None
+depends_on = None
+
+_TABLE = "storage_policies"
+
+
+def _table_exists() -> bool:
+    return sa.inspect(op.get_bind()).has_table(_TABLE)
+
+
+def _index_exists(index_name: str) -> bool:
+    if not _table_exists():
+        return False
+    return any(
+        index.get("name") == index_name
+        for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+    )
+
+
+def upgrade() -> None:
+    # The public baseline creates current model tables on fresh installs before
+    # later migrations replay.
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column(
+                "finished_workspace_retention_hours",
+                sa.Integer(),
+                nullable=False,
+            ),
+            sa.Column("project_draft_retention_hours", sa.Integer(), nullable=False),
+            sa.Column("canvas_quiet_hours", sa.Integer(), nullable=False),
+            sa.Column("capacity_warn_percent", sa.Integer(), nullable=False),
+            sa.Column("capacity_critical_percent", sa.Integer(), nullable=False),
+            sa.Column(
+                "automatic_reclamation_allowed",
+                sa.Boolean(),
+                server_default=sa.text("FALSE"),
+                nullable=False,
+            ),
+            sa.Column("rationale", sa.Text(), nullable=False),
+            sa.Column(
+                "source_type",
+                sa.String(length=30),
+                server_default="system",
+                nullable=False,
+            ),
+            sa.Column("source_id", sa.Text(), nullable=True),
+            sa.Column("reverted_from_id", sa.Integer(), nullable=True),
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                server_default=sa.text("TRUE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "finished_workspace_retention_hours > 0",
+                name="ck_storage_policies_finished_workspace_retention_positive",
+            ),
+            sa.CheckConstraint(
+                "project_draft_retention_hours > 0",
+                name="ck_storage_policies_project_draft_retention_positive",
+            ),
+            sa.CheckConstraint(
+                "canvas_quiet_hours > 0",
+                name="ck_storage_policies_canvas_quiet_positive",
+            ),
+            sa.CheckConstraint(
+                "capacity_warn_percent >= 1 AND capacity_warn_percent <= 99",
+                name="ck_storage_policies_warn_percent",
+            ),
+            sa.CheckConstraint(
+                "capacity_critical_percent >= 2 AND capacity_critical_percent <= 100",
+                name="ck_storage_policies_critical_percent",
+            ),
+            sa.CheckConstraint(
+                "capacity_warn_percent < capacity_critical_percent",
+                name="ck_storage_policies_threshold_order",
+            ),
+            sa.ForeignKeyConstraint(
+                ["reverted_from_id"],
+                ["storage_policies.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    if not _index_exists("uq_storage_policies_one_active"):
+        op.create_index(
+            "uq_storage_policies_one_active",
+            _TABLE,
+            ["is_active"],
+            unique=True,
+            postgresql_where=sa.text("is_active"),
+        )
+    if not _index_exists("ix_storage_policies_created"):
+        op.create_index(
+            "ix_storage_policies_created",
+            _TABLE,
+            ["created_at", "id"],
+        )
+
+    active_count = op.get_bind().execute(
+        sa.text("SELECT count(*) FROM storage_policies WHERE is_active = TRUE")
+    ).scalar_one()
+    if active_count == 0:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO storage_policies (
+                    finished_workspace_retention_hours,
+                    project_draft_retention_hours,
+                    canvas_quiet_hours,
+                    capacity_warn_percent,
+                    capacity_critical_percent,
+                    automatic_reclamation_allowed,
+                    rationale,
+                    source_type,
+                    is_active
+                ) VALUES (
+                    48,
+                    168,
+                    24,
+                    80,
+                    90,
+                    FALSE,
+                    'Initial policy migrated from deployed retention behavior.',
+                    'system',
+                    TRUE
+                )
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    if _table_exists():
+        op.drop_table(_TABLE)

--- a/brain/platform/db/alembic/versions/0060_storage_policies.py
+++ b/brain/platform/db/alembic/versions/0060_storage_policies.py
@@ -51,7 +51,6 @@ def upgrade() -> None:
             sa.Column(
                 "automatic_reclamation_allowed",
                 sa.Boolean(),
-                server_default=sa.text("FALSE"),
                 nullable=False,
             ),
             sa.Column("rationale", sa.Text(), nullable=False),

--- a/brain/platform/db/models/__init__.py
+++ b/brain/platform/db/models/__init__.py
@@ -20,6 +20,7 @@ from brain.platform.db.models.scratchpad import *  # noqa
 from brain.platform.db.models.browser import *  # noqa
 from brain.platform.db.models.scheduler import *  # noqa
 from brain.platform.db.models.resource_pool import *  # noqa
+from brain.platform.db.models.storage_policy import *  # noqa
 from brain.platform.db.models.retrieval import *  # noqa
 from brain.platform.db.models.routing import *  # noqa
 from brain.platform.db.models.chat import *  # noqa

--- a/brain/platform/db/models/storage_policy.py
+++ b/brain/platform/db/models/storage_policy.py
@@ -75,8 +75,6 @@ class StoragePolicy(Base, CreatedAtMixin):
     automatic_reclamation_allowed: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
-        server_default=text("FALSE"),
-        default=False,
     )
     rationale: Mapped[str] = mapped_column(Text, nullable=False)
     source_type: Mapped[str] = mapped_column(

--- a/brain/platform/db/models/storage_policy.py
+++ b/brain/platform/db/models/storage_policy.py
@@ -1,0 +1,99 @@
+"""Runtime-editable storage and retention policy revisions."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from brain.platform.db.base import Base, CreatedAtMixin
+
+__all__ = ["StoragePolicy"]
+
+
+class StoragePolicy(Base, CreatedAtMixin):
+    """Versioned policy values with exactly one active revision."""
+
+    __tablename__ = "storage_policies"
+    __table_args__ = (
+        CheckConstraint(
+            "finished_workspace_retention_hours > 0",
+            name="ck_storage_policies_finished_workspace_retention_positive",
+        ),
+        CheckConstraint(
+            "project_draft_retention_hours > 0",
+            name="ck_storage_policies_project_draft_retention_positive",
+        ),
+        CheckConstraint(
+            "canvas_quiet_hours > 0",
+            name="ck_storage_policies_canvas_quiet_positive",
+        ),
+        CheckConstraint(
+            "capacity_warn_percent >= 1 AND capacity_warn_percent <= 99",
+            name="ck_storage_policies_warn_percent",
+        ),
+        CheckConstraint(
+            "capacity_critical_percent >= 2 AND capacity_critical_percent <= 100",
+            name="ck_storage_policies_critical_percent",
+        ),
+        CheckConstraint(
+            "capacity_warn_percent < capacity_critical_percent",
+            name="ck_storage_policies_threshold_order",
+        ),
+        Index(
+            "uq_storage_policies_one_active",
+            "is_active",
+            unique=True,
+            postgresql_where=text("is_active"),
+            sqlite_where=text("is_active = 1"),
+        ),
+        Index("ix_storage_policies_created", "created_at", "id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    finished_workspace_retention_hours: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+    project_draft_retention_hours: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+    canvas_quiet_hours: Mapped[int] = mapped_column(Integer, nullable=False)
+    capacity_warn_percent: Mapped[int] = mapped_column(Integer, nullable=False)
+    capacity_critical_percent: Mapped[int] = mapped_column(Integer, nullable=False)
+    automatic_reclamation_allowed: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("FALSE"),
+        default=False,
+    )
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    source_type: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        server_default="system",
+        default="system",
+    )
+    source_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    reverted_from_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("storage_policies.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("TRUE"),
+        default=True,
+    )

--- a/brain/systems/cortex/project_context/draft_lifecycle.py
+++ b/brain/systems/cortex/project_context/draft_lifecycle.py
@@ -15,10 +15,10 @@ from brain.platform.db.models.idea import Idea
 from brain.systems.cortex.project_context.drafts import plan_draft_publish
 from brain.systems.cortex.project_context.repo_publish import repo_draft_status
 from brain.systems.cortex.project_context.workspace_manifest import PROJECT_CONTEXT_DIR
+from brain.systems.storage_policy import async_get_storage_policy
 
 
 PROJECT_DRAFT_CLEANUP_METADATA_KEY = "project_draft_cleanup"
-PROJECT_DRAFT_UNPUBLISHED_RETENTION = timedelta(days=7)
 PROJECT_DRAFT_CLEANUP_SCHEMA_VERSION = 1
 
 
@@ -50,6 +50,7 @@ class ProjectDraftCleanupPath:
 class ProjectDraftCleanupResult:
     status: str
     archived_at: str | None
+    retention_seconds: int
     cleanup_after: str | None = None
     deleted_count: int = 0
     retained_count: int = 0
@@ -72,7 +73,7 @@ class ProjectDraftCleanupResult:
             "has_unpublished_changes": self.has_unpublished_changes,
             "retention": {
                 "clean": "immediate",
-                "unpublished_seconds": int(PROJECT_DRAFT_UNPUBLISHED_RETENTION.total_seconds()),
+                "unpublished_seconds": self.retention_seconds,
             },
             "paths": [path.to_dict() for path in self.paths],
         }
@@ -328,6 +329,7 @@ def _project_context_dir_dirty_state(run: Any, project_context_dir: Path) -> tup
 def cleanup_project_draft_for_run(
     run: Any,
     *,
+    workspace_retention: timedelta,
     archived_at: datetime | None = None,
     now: datetime | None = None,
     force_expired: bool = False,
@@ -336,7 +338,10 @@ def cleanup_project_draft_for_run(
 
     now = _ensure_aware(now or _utc_now())
     archived_at = _ensure_aware(archived_at or now)
-    cleanup_after_dt = archived_at + PROJECT_DRAFT_UNPUBLISHED_RETENTION
+    retention_seconds = int(workspace_retention.total_seconds())
+    if retention_seconds <= 0:
+        raise ValueError("workspace_retention must be positive")
+    cleanup_after_dt = archived_at + workspace_retention
     cleanup_after = _iso_timestamp(cleanup_after_dt)
     paths: list[ProjectDraftCleanupPath] = []
     deleted_count = 0
@@ -348,6 +353,7 @@ def cleanup_project_draft_for_run(
         result = ProjectDraftCleanupResult(
             status="no_project_draft",
             archived_at=_iso_timestamp(archived_at),
+            retention_seconds=retention_seconds,
             skipped_count=1,
         )
         _set_run_cleanup_metadata(run, result)
@@ -401,6 +407,7 @@ def cleanup_project_draft_for_run(
     result = ProjectDraftCleanupResult(
         status=status,
         archived_at=_iso_timestamp(archived_at),
+        retention_seconds=retention_seconds,
         cleanup_after=cleanup_after if retained_count else None,
         deleted_count=deleted_count,
         retained_count=retained_count,
@@ -440,10 +447,17 @@ async def apply_project_draft_cleanup_for_thread(
 ) -> dict[str, Any]:
     """Delete clean archived-thread Project drafts and retain dirty drafts with a grace deadline."""
 
+    policy = await async_get_storage_policy(session)
+    workspace_retention = timedelta(hours=policy.project_draft_retention_hours)
     stmt = select(AgentRunRow).where(AgentRunRow.thread_id == str(thread_id))
     runs = (await session.scalars(stmt)).all()
     results = [
-        cleanup_project_draft_for_run(run, archived_at=archived_at, now=now)
+        cleanup_project_draft_for_run(
+            run,
+            workspace_retention=workspace_retention,
+            archived_at=archived_at,
+            now=now,
+        )
         for run in runs
     ]
     await session.flush()
@@ -459,6 +473,8 @@ async def cleanup_expired_project_draft_workspaces(
     """Delete retained Project drafts whose archived-thread grace period has expired."""
 
     now = _ensure_aware(now or _utc_now())
+    policy = await async_get_storage_policy(session)
+    workspace_retention = timedelta(hours=policy.project_draft_retention_hours)
     stmt = (
         select(AgentRunRow)
         .join(Idea, AgentRunRow.thread_id == Idea.id)
@@ -478,6 +494,7 @@ async def cleanup_expired_project_draft_workspaces(
         archived_at = _parse_timestamp(cleanup.get("archived_at")) or now
         results.append(cleanup_project_draft_for_run(
             run,
+            workspace_retention=workspace_retention,
             archived_at=archived_at,
             now=now,
             force_expired=True,
@@ -489,7 +506,6 @@ async def cleanup_expired_project_draft_workspaces(
 
 __all__ = [
     "PROJECT_DRAFT_CLEANUP_METADATA_KEY",
-    "PROJECT_DRAFT_UNPUBLISHED_RETENTION",
     "apply_project_draft_cleanup_for_thread",
     "cleanup_expired_project_draft_workspaces",
     "cleanup_project_draft_for_run",

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -394,11 +394,25 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "runtime_self_context",
         "name": "Runtime and Self Context",
         "category": "agent_runtime",
-        "summary": "Illo can inspect its runtime settings, capability registry, and verified source/install context, and can persist supported durable workspace preferences.",
-        "aliases": ("runtime", "self context", "who are you", "where are you installed", "models", "preferences", "timezone"),
+        "summary": (
+            "Illo can inspect its runtime settings, capability registry, verified "
+            "source/install context, and durable storage policy."
+        ),
+        "aliases": (
+            "runtime",
+            "self context",
+            "who are you",
+            "where are you installed",
+            "models",
+            "preferences",
+            "timezone",
+            "storage policy",
+            "retention",
+        ),
         "tools": (
             "runtime_settings",
             "manage_runtime_preferences",
+            "manage_storage_policy",
             "read_self_context",
             "read_capabilities",
         ),

--- a/brain/systems/runs/tool_catalog/definitions/runtime_management.py
+++ b/brain/systems/runs/tool_catalog/definitions/runtime_management.py
@@ -98,6 +98,68 @@ RUNTIME_PREFERENCE_TOOLS = [
             },
         },
     },
+    {
+        "name": "manage_storage_policy",
+        "description": (
+            "Read or revise the installation-wide storage policy without a deploy. "
+            "Use get for the active retention windows, capacity thresholds, and automatic "
+            "reclamation permission; history for the audit trail; update with a rationale "
+            "to append a new active revision; and revert with a prior policy_id and rationale."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["get", "update", "history", "revert"],
+                    "default": "get",
+                },
+                "policy_id": {
+                    "type": "integer",
+                    "description": "Prior policy revision id required for revert.",
+                },
+                "finished_workspace_retention_hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Retention window for finished agent workspaces.",
+                },
+                "project_draft_retention_hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Retention window for unpublished Project drafts.",
+                },
+                "canvas_quiet_hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Quiet window before emerged canvas thoughts are archived.",
+                },
+                "capacity_warn_percent": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 99,
+                    "description": "Storage-use percentage that starts a warning state.",
+                },
+                "capacity_critical_percent": {
+                    "type": "integer",
+                    "minimum": 2,
+                    "maximum": 100,
+                    "description": "Storage-use percentage that starts a critical state.",
+                },
+                "automatic_reclamation_allowed": {"type": "boolean"},
+                "rationale": {
+                    "type": "string",
+                    "description": "Required reason for update and revert actions.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 50,
+                    "description": "Maximum revisions returned by history.",
+                },
+            },
+        },
+    },
 ]
 
 WORKSPACE_TOOL_TOOLS = [

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -264,9 +264,43 @@ def _get_tool_handlers(
                 )
         return result
 
+    async def _manage_storage_policy(
+        action="get",
+        policy_id=None,
+        finished_workspace_retention_hours=None,
+        project_draft_retention_hours=None,
+        canvas_quiet_hours=None,
+        capacity_warn_percent=None,
+        capacity_critical_percent=None,
+        automatic_reclamation_allowed=None,
+        rationale=None,
+        limit=50,
+    ):
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+        from brain.systems.storage_policy import async_manage_storage_policy
+
+        actor_id = _current_run_id() or _current_agent_value("user_id")
+        async with UnitOfWork() as uow:
+            return await async_manage_storage_policy(
+                uow.session,
+                action=action,
+                policy_id=policy_id,
+                finished_workspace_retention_hours=finished_workspace_retention_hours,
+                project_draft_retention_hours=project_draft_retention_hours,
+                canvas_quiet_hours=canvas_quiet_hours,
+                capacity_warn_percent=capacity_warn_percent,
+                capacity_critical_percent=capacity_critical_percent,
+                automatic_reclamation_allowed=automatic_reclamation_allowed,
+                rationale=rationale,
+                source_type="agent",
+                source_id=str(actor_id) if actor_id is not None else None,
+                limit=limit,
+            )
+
     _manage_deployment._illo_run_on_event_loop = True
     _manage_runtime_services._illo_run_on_event_loop = True
     _manage_runtime_preferences._illo_run_on_event_loop = True
+    _manage_storage_policy._illo_run_on_event_loop = True
 
     handlers = {
         # Brain tools (workspace-independent — always hit shared DB)
@@ -322,6 +356,7 @@ def _get_tool_handlers(
             )
         ),
         "manage_runtime_preferences": _manage_runtime_preferences,
+        "manage_storage_policy": _manage_storage_policy,
         "read_self_context": _handle_read_self_context,
         "read_capabilities": _handle_read_capabilities,
         "manage_deployment": _manage_deployment,

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -223,6 +223,14 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "inspect or persist a supported workspace preference",
     },
+    "manage_storage_policy": {
+        "permission": "manage_runtime",
+        "risk_class": "medium",
+        "side_effect_class": "runtime_configuration",
+        "reversibility": "reversible",
+        "action_manifest": True,
+        "expected_effect": "inspect or revise the installation-wide storage policy",
+    },
     "read_self_context": {
         "permission": "read_runtime",
         "side_effect_class": "read_only",
@@ -1153,6 +1161,14 @@ def action_policy_for_tool(
         0,
         "get",
     ) == "get":
+        return None
+    if tool_name == "manage_storage_policy" and _arg_at(
+        args_tuple,
+        kwargs_dict,
+        "action",
+        0,
+        "get",
+    ) in {"get", "history"}:
         return None
     if tool_name == "manage_domain" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "query_records", "get_record", "events"}:
         return None

--- a/brain/systems/storage_policy.py
+++ b/brain/systems/storage_policy.py
@@ -1,0 +1,306 @@
+"""Read and revise the installation-wide storage policy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.storage_policy import StoragePolicy
+
+__all__ = [
+    "async_get_storage_policy",
+    "async_list_storage_policy_history",
+    "async_manage_storage_policy",
+    "async_revert_storage_policy",
+    "async_update_storage_policy",
+    "serialize_storage_policy",
+]
+
+
+def _positive_hours(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be a positive integer")
+    normalized = value
+    if normalized <= 0:
+        raise ValueError(f"{field} must be a positive integer")
+    return normalized
+
+
+def _percent(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer from 1 to 100")
+    normalized = value
+    if normalized < 1 or normalized > 100:
+        raise ValueError(f"{field} must be an integer from 1 to 100")
+    return normalized
+
+
+def _required_text(value: object, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field} is required")
+    return normalized
+
+
+def serialize_storage_policy(row: StoragePolicy) -> dict[str, Any]:
+    """Return the stable runtime policy payload exposed to Illo."""
+
+    created_at = getattr(row, "created_at", None)
+    return {
+        "id": row.id,
+        "finished_workspace_retention_hours": row.finished_workspace_retention_hours,
+        "project_draft_retention_hours": row.project_draft_retention_hours,
+        "canvas_quiet_hours": row.canvas_quiet_hours,
+        "capacity_warn_percent": row.capacity_warn_percent,
+        "capacity_critical_percent": row.capacity_critical_percent,
+        "automatic_reclamation_allowed": row.automatic_reclamation_allowed,
+        "rationale": row.rationale,
+        "source_type": row.source_type,
+        "source_id": row.source_id,
+        "reverted_from_id": row.reverted_from_id,
+        "is_active": row.is_active,
+        "created_at": created_at.isoformat() if created_at is not None else None,
+    }
+
+
+async def async_get_storage_policy(
+    session: AsyncSession,
+    *,
+    for_update: bool = False,
+) -> StoragePolicy:
+    """Return the one active policy or fail closed when migration state is invalid."""
+
+    statement = (
+        select(StoragePolicy)
+        .where(StoragePolicy.is_active.is_(True))
+        .order_by(StoragePolicy.id.desc())
+        .limit(1)
+    )
+    if for_update:
+        statement = statement.with_for_update()
+    row = await session.scalar(statement)
+    if row is None:
+        raise RuntimeError("No active storage policy is configured")
+    return row
+
+
+async def async_list_storage_policy_history(
+    session: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[StoragePolicy]:
+    """Return newest-first immutable policy revisions."""
+
+    normalized_limit = max(1, min(int(limit), 200))
+    rows = await session.scalars(
+        select(StoragePolicy)
+        .order_by(StoragePolicy.created_at.desc(), StoragePolicy.id.desc())
+        .limit(normalized_limit)
+    )
+    return list(rows.all())
+
+
+async def _append_storage_policy(
+    session: AsyncSession,
+    *,
+    current: StoragePolicy,
+    finished_workspace_retention_hours: object,
+    project_draft_retention_hours: object,
+    canvas_quiet_hours: object,
+    capacity_warn_percent: object,
+    capacity_critical_percent: object,
+    automatic_reclamation_allowed: object,
+    rationale: object,
+    source_type: object,
+    source_id: object,
+    reverted_from_id: int | None = None,
+) -> StoragePolicy:
+    finished_workspace_hours = _positive_hours(
+        finished_workspace_retention_hours,
+        "finished_workspace_retention_hours",
+    )
+    project_draft_hours = _positive_hours(
+        project_draft_retention_hours,
+        "project_draft_retention_hours",
+    )
+    canvas_hours = _positive_hours(canvas_quiet_hours, "canvas_quiet_hours")
+    warn_percent = _percent(capacity_warn_percent, "capacity_warn_percent")
+    critical_percent = _percent(
+        capacity_critical_percent,
+        "capacity_critical_percent",
+    )
+    if warn_percent >= critical_percent:
+        raise ValueError(
+            "capacity_warn_percent must be less than capacity_critical_percent"
+        )
+    if not isinstance(automatic_reclamation_allowed, bool):
+        raise ValueError("automatic_reclamation_allowed must be a boolean")
+
+    row = StoragePolicy(
+        finished_workspace_retention_hours=finished_workspace_hours,
+        project_draft_retention_hours=project_draft_hours,
+        canvas_quiet_hours=canvas_hours,
+        capacity_warn_percent=warn_percent,
+        capacity_critical_percent=critical_percent,
+        automatic_reclamation_allowed=automatic_reclamation_allowed,
+        rationale=_required_text(rationale, "rationale"),
+        source_type=_required_text(source_type, "source_type"),
+        source_id=str(source_id).strip() if source_id is not None else None,
+        reverted_from_id=reverted_from_id,
+        is_active=True,
+    )
+    current.is_active = False
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def async_update_storage_policy(
+    session: AsyncSession,
+    *,
+    rationale: str,
+    source_type: str,
+    source_id: str | None,
+    finished_workspace_retention_hours: int | None = None,
+    project_draft_retention_hours: int | None = None,
+    canvas_quiet_hours: int | None = None,
+    capacity_warn_percent: int | None = None,
+    capacity_critical_percent: int | None = None,
+    automatic_reclamation_allowed: bool | None = None,
+) -> StoragePolicy:
+    """Append one audited revision and make it the active policy."""
+
+    current = await async_get_storage_policy(session, for_update=True)
+    return await _append_storage_policy(
+        session,
+        current=current,
+        finished_workspace_retention_hours=(
+            current.finished_workspace_retention_hours
+            if finished_workspace_retention_hours is None
+            else finished_workspace_retention_hours
+        ),
+        project_draft_retention_hours=(
+            current.project_draft_retention_hours
+            if project_draft_retention_hours is None
+            else project_draft_retention_hours
+        ),
+        canvas_quiet_hours=(
+            current.canvas_quiet_hours
+            if canvas_quiet_hours is None
+            else canvas_quiet_hours
+        ),
+        capacity_warn_percent=(
+            current.capacity_warn_percent
+            if capacity_warn_percent is None
+            else capacity_warn_percent
+        ),
+        capacity_critical_percent=(
+            current.capacity_critical_percent
+            if capacity_critical_percent is None
+            else capacity_critical_percent
+        ),
+        automatic_reclamation_allowed=(
+            current.automatic_reclamation_allowed
+            if automatic_reclamation_allowed is None
+            else automatic_reclamation_allowed
+        ),
+        rationale=rationale,
+        source_type=source_type,
+        source_id=source_id,
+    )
+
+
+async def async_revert_storage_policy(
+    session: AsyncSession,
+    *,
+    policy_id: int,
+    rationale: str,
+    source_type: str,
+    source_id: str | None,
+) -> StoragePolicy:
+    """Append a new active revision with values copied from an older revision."""
+
+    current = await async_get_storage_policy(session, for_update=True)
+    target = await session.get(StoragePolicy, int(policy_id))
+    if target is None:
+        raise ValueError(f"Storage policy {policy_id} not found")
+    return await _append_storage_policy(
+        session,
+        current=current,
+        finished_workspace_retention_hours=target.finished_workspace_retention_hours,
+        project_draft_retention_hours=target.project_draft_retention_hours,
+        canvas_quiet_hours=target.canvas_quiet_hours,
+        capacity_warn_percent=target.capacity_warn_percent,
+        capacity_critical_percent=target.capacity_critical_percent,
+        automatic_reclamation_allowed=target.automatic_reclamation_allowed,
+        rationale=rationale,
+        source_type=source_type,
+        source_id=source_id,
+        reverted_from_id=target.id,
+    )
+
+
+async def async_manage_storage_policy(
+    session: AsyncSession,
+    *,
+    action: str = "get",
+    rationale: str | None = None,
+    source_type: str = "agent",
+    source_id: str | None = None,
+    policy_id: int | None = None,
+    finished_workspace_retention_hours: int | None = None,
+    project_draft_retention_hours: int | None = None,
+    canvas_quiet_hours: int | None = None,
+    capacity_warn_percent: int | None = None,
+    capacity_critical_percent: int | None = None,
+    automatic_reclamation_allowed: bool | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Agent-facing read, update, history, and revert actions."""
+
+    normalized_action = str(action or "get").strip().lower()
+    if normalized_action == "get":
+        return {"policy": serialize_storage_policy(await async_get_storage_policy(session))}
+    if normalized_action == "history":
+        rows = await async_list_storage_policy_history(session, limit=limit)
+        return {"policies": [serialize_storage_policy(row) for row in rows]}
+    if normalized_action == "update":
+        if all(
+            value is None
+            for value in (
+                finished_workspace_retention_hours,
+                project_draft_retention_hours,
+                canvas_quiet_hours,
+                capacity_warn_percent,
+                capacity_critical_percent,
+                automatic_reclamation_allowed,
+            )
+        ):
+            raise ValueError("update requires at least one policy field")
+        row = await async_update_storage_policy(
+            session,
+            rationale=_required_text(rationale, "rationale"),
+            source_type=source_type,
+            source_id=source_id,
+            finished_workspace_retention_hours=finished_workspace_retention_hours,
+            project_draft_retention_hours=project_draft_retention_hours,
+            canvas_quiet_hours=canvas_quiet_hours,
+            capacity_warn_percent=capacity_warn_percent,
+            capacity_critical_percent=capacity_critical_percent,
+            automatic_reclamation_allowed=automatic_reclamation_allowed,
+        )
+        return {"updated": serialize_storage_policy(row)}
+    if normalized_action == "revert":
+        if policy_id is None:
+            raise ValueError("policy_id is required")
+        row = await async_revert_storage_policy(
+            session,
+            policy_id=policy_id,
+            rationale=_required_text(rationale, "rationale"),
+            source_type=source_type,
+            source_id=source_id,
+        )
+        return {"reverted": serialize_storage_policy(row)}
+    raise ValueError("manage_storage_policy action must be get, update, history, or revert")

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -59,6 +59,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0054_scheduler_alert_latches.py",
     # Downgrade removes only the behavior-change audit table introduced here.
     "0059_behavior_change_audits.py",
+    # Downgrade removes only the storage-policy table introduced here.
+    "0060_storage_policies.py",
 }
 
 

--- a/tests/test_cycle_context_admission_gate.py
+++ b/tests/test_cycle_context_admission_gate.py
@@ -12,7 +12,7 @@ def test_enabled_cycle_fixture_gate_passes_with_healthy_catalog(monkeypatch):
     assert report["ok"] is True
     assert {item["cycle_id"] for item in report["results"]} == {2, 8, 9}
     assert all(item["status"] == "passed" for item in report["results"])
-    assert all(item["tools"] == 91 for item in report["results"])
+    assert all(item["tools"] == 92 for item in report["results"])
 
 
 def test_enabled_cycle_fixture_gate_names_cycles_killed_by_128k_regression(monkeypatch):
@@ -31,7 +31,7 @@ def test_enabled_cycle_fixture_gate_names_cycles_killed_by_128k_regression(monke
     assert all("floor=" in item["diagnostic"] for item in failures.values())
     assert "ceiling=50486" in failures[2]["diagnostic"]
     assert "ceiling=57859" in failures[9]["diagnostic"]
-    assert all("tools=91" in item["diagnostic"] for item in failures.values())
+    assert all("tools=92" in item["diagnostic"] for item in failures.values())
 
 
 def test_compose_upgrade_runs_live_cycle_gate_after_doctor():

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -117,6 +117,7 @@ EXPECTED_TABLES = {
     "skill_run_evidence",
     "skill_versions",
     "skills",
+    "storage_policies",
     "target_registry",
     "thread_context_submissions",
     "thread_discussion_comments",

--- a/tests/test_project_context_draft_lifecycle.py
+++ b/tests/test_project_context_draft_lifecycle.py
@@ -62,6 +62,7 @@ def test_archived_clean_project_draft_is_deleted_immediately(tmp_path):
 
     result = cleanup_project_draft_for_run(
         run,
+        workspace_retention=timedelta(hours=36),
         archived_at=datetime(2026, 5, 21, tzinfo=timezone.utc),
     )
 
@@ -84,7 +85,11 @@ def test_archived_unpublished_project_draft_is_retained_with_grace_deadline(tmp_
     run = _run_with_local_project_draft(source_dir, draft_dir)
     archived_at = datetime(2026, 5, 21, tzinfo=timezone.utc)
 
-    result = cleanup_project_draft_for_run(run, archived_at=archived_at)
+    result = cleanup_project_draft_for_run(
+        run,
+        workspace_retention=timedelta(hours=36),
+        archived_at=archived_at,
+    )
 
     assert result.status == "retained_unpublished"
     assert result.deleted_count == 0
@@ -92,7 +97,8 @@ def test_archived_unpublished_project_draft_is_retained_with_grace_deadline(tmp_
     assert (tmp_path / "thread" / ".illo-project-context").exists()
     cleanup = run.metadata_["project_draft_cleanup"]
     assert cleanup["has_unpublished_changes"] is True
-    assert cleanup["cleanup_after"] == (archived_at + timedelta(days=7)).isoformat()
+    assert cleanup["cleanup_after"] == (archived_at + timedelta(hours=36)).isoformat()
+    assert cleanup["retention"]["unpublished_seconds"] == 36 * 60 * 60
 
 
 def test_expired_unpublished_project_draft_is_deleted_after_grace_period(tmp_path):
@@ -107,10 +113,15 @@ def test_expired_unpublished_project_draft_is_deleted_after_grace_period(tmp_pat
     (draft_dir / "brief.md").write_text("Unpublished draft\n")
     run = _run_with_local_project_draft(source_dir, draft_dir)
     archived_at = datetime(2026, 5, 21, tzinfo=timezone.utc)
-    cleanup_project_draft_for_run(run, archived_at=archived_at)
+    cleanup_project_draft_for_run(
+        run,
+        workspace_retention=timedelta(hours=36),
+        archived_at=archived_at,
+    )
 
     result = cleanup_project_draft_for_run(
         run,
+        workspace_retention=timedelta(hours=36),
         archived_at=archived_at,
         now=archived_at + timedelta(days=8),
         force_expired=True,
@@ -137,6 +148,9 @@ async def test_thread_cleanup_updates_all_project_runs(tmp_path):
     result = MagicMock()
     result.all.return_value = [run]
     session = MagicMock()
+    session.scalar = AsyncMock(
+        return_value=SimpleNamespace(project_draft_retention_hours=36)
+    )
     session.scalars = AsyncMock(return_value=result)
     session.flush = AsyncMock()
 
@@ -150,6 +164,44 @@ async def test_thread_cleanup_updates_all_project_runs(tmp_path):
     assert payload["deleted_count"] == 1
     assert run.metadata_["project_draft_cleanup"]["status"] == "deleted"
     session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_thread_cleanup_reads_runtime_workspace_retention(tmp_path):
+    from brain.systems.cortex.project_context.draft_lifecycle import (
+        apply_project_draft_cleanup_for_thread,
+    )
+    from brain.systems.cortex.project_context.drafts import sync_draft_from_root
+
+    source_dir = tmp_path / "root"
+    source_dir.mkdir()
+    (source_dir / "brief.md").write_text("Published\n")
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "reports"
+    sync_draft_from_root(source_dir, draft_dir)
+    (draft_dir / "brief.md").write_text("Unpublished draft\n")
+    run = _run_with_local_project_draft(source_dir, draft_dir)
+    archived_at = datetime(2026, 5, 21, tzinfo=timezone.utc)
+
+    result = MagicMock()
+    result.all.return_value = [run]
+    session = MagicMock()
+    session.scalar = AsyncMock(
+        return_value=SimpleNamespace(project_draft_retention_hours=60)
+    )
+    session.scalars = AsyncMock(return_value=result)
+    session.flush = AsyncMock()
+
+    await apply_project_draft_cleanup_for_thread(
+        session,
+        "idea-1",
+        archived_at=archived_at,
+    )
+
+    cleanup = run.metadata_["project_draft_cleanup"]
+    assert cleanup["cleanup_after"] == (
+        archived_at + timedelta(hours=60)
+    ).isoformat()
+    assert cleanup["retention"]["unpublished_seconds"] == 60 * 60 * 60
 
 
 @pytest.mark.asyncio
@@ -168,11 +220,18 @@ async def test_expired_cleanup_reaps_retained_unpublished_project_drafts(tmp_pat
     (draft_dir / "brief.md").write_text("Unpublished draft\n")
     run = _run_with_local_project_draft(source_dir, draft_dir)
     archived_at = datetime(2026, 5, 21, tzinfo=timezone.utc)
-    cleanup_project_draft_for_run(run, archived_at=archived_at)
+    cleanup_project_draft_for_run(
+        run,
+        workspace_retention=timedelta(hours=36),
+        archived_at=archived_at,
+    )
 
     result = MagicMock()
     result.all.return_value = [run]
     session = MagicMock()
+    session.scalar = AsyncMock(
+        return_value=SimpleNamespace(project_draft_retention_hours=36)
+    )
     session.scalars = AsyncMock(return_value=result)
     session.flush = AsyncMock()
 

--- a/tests/test_repo_ideas.py
+++ b/tests/test_repo_ideas.py
@@ -12,6 +12,7 @@ from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler, SQLiteDDLCompile
 from brain.platform.db.base import Base
 from brain.platform.db.models.idea import Idea, IdeaConnection, IdeaStateLog, IdeaThread
 from brain.platform.db.models.org import Org, User
+from brain.platform.db.models.storage_policy import StoragePolicy
 from brain.platform.db.repositories.ideas import (
     IdeaConnectionRepository,
     IdeaRepository,
@@ -73,6 +74,7 @@ async def session(async_sqlite_session_factory):
             IdeaStateLog.__table__,
             IdeaConnection.__table__,
             IdeaThread.__table__,
+            StoragePolicy.__table__,
         ],
         connect_listener=_register_sqlite_functions,
     )
@@ -81,6 +83,19 @@ async def session(async_sqlite_session_factory):
     s.add(org)
     user = User(id=USER_1, org_id=ORG_1, name="Alex", email="alex@test.com")
     s.add(user)
+    s.add(
+        StoragePolicy(
+            finished_workspace_retention_hours=48,
+            project_draft_retention_hours=168,
+            canvas_quiet_hours=24,
+            capacity_warn_percent=80,
+            capacity_critical_percent=90,
+            automatic_reclamation_allowed=False,
+            rationale="Test policy",
+            source_type="test",
+            is_active=True,
+        )
+    )
     await s.flush()
     return s
 
@@ -181,6 +196,23 @@ class TestIdeaRepository:
         assert (log.from_state, log.to_state, log.trigger) == (
             "emerged", "archived", ARCHIVE_TRIGGER
         )
+
+    async def test_canvas_occupancy_reads_runtime_quiet_window(self, session):
+        policy = await session.scalar(
+            select(StoragePolicy).where(StoragePolicy.is_active.is_(True))
+        )
+        policy.canvas_quiet_hours = 48
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        retained = await _make_idea(
+            session,
+            status="emerged",
+            updated_at=now - timedelta(hours=25),
+        )
+
+        archived = await archive_dormant_emerged(session, now=now)
+
+        assert archived == 0
+        assert retained.status == "emerged"
 
     async def test_list_by_org(self, repo, session):
         await _make_idea(session, org_id=ORG_1)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -354,8 +354,9 @@ async def test_workspace_gc_catalog_config(session):
     assert job.max_concurrency == 1
     assert job.retry_policy == {"max_attempts": 2, "backoff_seconds": 300}
     assert job.task_contract["success_criteria"] == [
-        "Headless-worker workspaces older than 48 hours are reclaimed only when "
-        "the parent run is terminal or absent from the database"
+        "Headless-worker workspaces past the active storage-policy retention "
+        "window are reclaimed only when the parent run is terminal or absent "
+        "from the database"
     ]
     assert build_scheduler_step_plan(job) == [
         {

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -20,7 +20,7 @@ from brain.app.scheduler.programs import (
 
 _SCHEDULED_FOR = datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc)
 _PINNED_PROJECTION_HASHES = {
-    "workspace_gc": "eb924b58441b1c94b2390f7f97f70f60da5d80d8001c8a9f245b97897a328891",
+    "workspace_gc": "5fe6bd75b4e972cfa14822deb90e23d8c55def2ed90a19b9a37f32ff95db308c",
     "cortex_canvas_occupancy": "43cf7e0667228c054968df730d69c75a72ad7d30c1e2aaf66a4a5032f15453ba",
     "knowledge_index_sync": "7b180172f289f6769ef024b425a8978ee4f4c14c78e57fe98e94e7c151c7d4c6",
     "nightly_sleep": "0cb9173b9e0b71a094063bb867d644304f4c8b996fec6c9d1656b31dde060ee0",
@@ -82,8 +82,8 @@ def test_aws_health_scan_declares_detached_agent_run_completion():
 
 def test_workspace_gc_description_states_complete_deletion_policy():
     assert SINGLE_COMMAND_PROGRAM_REGISTRY["workspace_gc"].description == (
-        "Reclaim headless-worker workspaces older than 48 hours when parent runs are "
-        "terminal or absent from the database"
+        "Reclaim headless-worker workspaces past the active storage-policy retention "
+        "window when parent runs are terminal or absent from the database"
     )
 
 

--- a/tests/test_storage_policy.py
+++ b/tests/test_storage_policy.py
@@ -1,0 +1,134 @@
+"""Tests for the runtime-editable storage policy."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from brain.platform.db.models.storage_policy import StoragePolicy
+from brain.systems.storage_policy import (
+    async_get_storage_policy,
+    async_manage_storage_policy,
+)
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    session = await async_sqlite_session_factory([StoragePolicy.__table__])
+    connection = await session.connection()
+    for index in StoragePolicy.__table__.indexes:
+        await connection.run_sync(
+            lambda sync_connection, policy_index=index: policy_index.create(
+                sync_connection,
+                checkfirst=True,
+            )
+        )
+    session.add(
+        StoragePolicy(
+            finished_workspace_retention_hours=48,
+            project_draft_retention_hours=168,
+            canvas_quiet_hours=24,
+            capacity_warn_percent=80,
+            capacity_critical_percent=90,
+            automatic_reclamation_allowed=False,
+            rationale="Initial migrated behavior",
+            source_type="system",
+            is_active=True,
+        )
+    )
+    await session.flush()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_update_appends_audited_active_revision(session):
+    original = await async_get_storage_policy(session)
+
+    result = await async_manage_storage_policy(
+        session,
+        action="update",
+        finished_workspace_retention_hours=72,
+        project_draft_retention_hours=120,
+        capacity_warn_percent=75,
+        capacity_critical_percent=88,
+        automatic_reclamation_allowed=True,
+        rationale="Capacity is tight after the new workspace rollout",
+        source_type="agent",
+        source_id="run-779",
+    )
+
+    current = await async_get_storage_policy(session)
+    assert current.id != original.id
+    assert original.is_active is False
+    assert current.finished_workspace_retention_hours == 72
+    assert current.project_draft_retention_hours == 120
+    assert current.canvas_quiet_hours == 24
+    assert current.capacity_warn_percent == 75
+    assert current.capacity_critical_percent == 88
+    assert current.automatic_reclamation_allowed is True
+    assert current.rationale == "Capacity is tight after the new workspace rollout"
+    assert current.source_type == "agent"
+    assert current.source_id == "run-779"
+    assert result["updated"]["id"] == current.id
+
+
+@pytest.mark.asyncio
+async def test_revert_appends_revision_copied_from_history(session):
+    original = await async_get_storage_policy(session)
+    await async_manage_storage_policy(
+        session,
+        action="update",
+        finished_workspace_retention_hours=24,
+        project_draft_retention_hours=48,
+        canvas_quiet_hours=12,
+        rationale="Shorten both retention windows",
+        source_id="run-1",
+    )
+
+    result = await async_manage_storage_policy(
+        session,
+        action="revert",
+        policy_id=original.id,
+        rationale="Restore the previous safety window",
+        source_id="run-2",
+    )
+
+    current = await async_get_storage_policy(session)
+    history = list(
+        (
+            await session.scalars(
+                select(StoragePolicy).order_by(StoragePolicy.id)
+            )
+        ).all()
+    )
+    assert len(history) == 3
+    assert sum(row.is_active for row in history) == 1
+    assert current.id == result["reverted"]["id"]
+    assert current.id != original.id
+    assert current.reverted_from_id == original.id
+    assert (
+        current.finished_workspace_retention_hours
+        == original.finished_workspace_retention_hours
+    )
+    assert current.project_draft_retention_hours == original.project_draft_retention_hours
+    assert current.canvas_quiet_hours == original.canvas_quiet_hours
+    assert current.rationale == "Restore the previous safety window"
+
+
+@pytest.mark.asyncio
+async def test_update_requires_rationale_and_ordered_thresholds(session):
+    with pytest.raises(ValueError, match="rationale is required"):
+        await async_manage_storage_policy(
+            session,
+            action="update",
+            finished_workspace_retention_hours=24,
+        )
+
+    with pytest.raises(ValueError, match="must be less than"):
+        await async_manage_storage_policy(
+            session,
+            action="update",
+            capacity_warn_percent=95,
+            capacity_critical_percent=90,
+            rationale="Invalid threshold experiment",
+        )

--- a/tests/test_storage_policy.py
+++ b/tests/test_storage_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.schema import CreateIndex
 
 from brain.platform.db.models.storage_policy import StoragePolicy
 from brain.systems.storage_policy import (
@@ -17,12 +18,7 @@ async def session(async_sqlite_session_factory):
     session = await async_sqlite_session_factory([StoragePolicy.__table__])
     connection = await session.connection()
     for index in StoragePolicy.__table__.indexes:
-        await connection.run_sync(
-            lambda sync_connection, policy_index=index: policy_index.create(
-                sync_connection,
-                checkfirst=True,
-            )
-        )
+        await connection.execute(CreateIndex(index, if_not_exists=True))
     session.add(
         StoragePolicy(
             finished_workspace_retention_hours=48,

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -369,6 +369,39 @@ def test_manage_runtime_preferences_tool_is_registered_and_audited():
     assert registration.action_manifest is True
 
 
+def test_manage_storage_policy_tool_is_registered_and_audited():
+    import inspect
+
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "manage_storage_policy"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name not in _names(WORKER_TOOLS)
+    handler = _get_tool_handlers()[name]
+    assert set(inspect.signature(handler).parameters) == {
+        "action",
+        "policy_id",
+        "finished_workspace_retention_hours",
+        "project_draft_retention_hours",
+        "canvas_quiet_hours",
+        "capacity_warn_percent",
+        "capacity_critical_percent",
+        "automatic_reclamation_allowed",
+        "rationale",
+        "limit",
+    }
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert [role.value for role in registration.availability] == ["coordinator"]
+    assert registration.permission == "manage_runtime"
+    assert registration.side_effect_class == "runtime_configuration"
+    assert registration.reversibility == "reversible"
+    assert registration.action_manifest is True
+
+
 def test_manage_workspace_tools_tool_is_coordinator_only_and_registered():
     from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_handlers import _get_tool_handlers
@@ -634,6 +667,10 @@ def test_action_policy_comes_from_registry_metadata():
         "manage_runtime_preferences",
         kwargs={"action": "get"},
     ) is None
+    assert action_policy_for_tool(
+        "manage_storage_policy",
+        kwargs={"action": "history"},
+    ) is None
 
     policy = action_policy_for_tool("manage_cycle", kwargs={"action": "create"})
     assert policy == {
@@ -653,6 +690,14 @@ def test_action_policy_comes_from_registry_metadata():
         "risk": "medium",
         "reversibility": "reversible",
         "expected_effect": "inspect or persist a supported workspace preference",
+    }
+    assert action_policy_for_tool(
+        "manage_storage_policy",
+        kwargs={"action": "update"},
+    ) == {
+        "risk": "medium",
+        "reversibility": "reversible",
+        "expected_effect": "inspect or revise the installation-wide storage policy",
     }
 
     assert action_policy_for_tool(

--- a/tests/test_workspace_gc.py
+++ b/tests/test_workspace_gc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 from brain.jobs.pipelines.workspace_gc import reclaim_headless_worker_workspaces
 from brain.systems.runs.headless_worker_identity import (
@@ -24,8 +25,19 @@ class _Rows:
 
 
 class _Session:
-    def __init__(self, statuses: dict[int, str]) -> None:
+    def __init__(
+        self,
+        statuses: dict[int, str],
+        *,
+        retention_hours: int = 48,
+    ) -> None:
         self._statuses = statuses
+        self._retention_hours = retention_hours
+
+    async def scalar(self, _statement):
+        return SimpleNamespace(
+            finished_workspace_retention_hours=self._retention_hours
+        )
 
     async def execute(self, _statement) -> _Rows:
         return _Rows(self._statuses)
@@ -80,6 +92,21 @@ async def test_terminal_workspace_inside_retention_is_kept(tmp_path):
 
     result = await reclaim_headless_worker_workspaces(
         _Session({102: "completed"}),
+        workspace_root=workspace_root,
+        now=NOW,
+    )
+
+    assert workspace.is_dir()
+    assert result["directories_recent"] == 1
+    assert result["directories_reclaimed"] == 0
+
+
+async def test_runtime_policy_can_extend_finished_workspace_retention(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    workspace = _worker_workspace(workspace_root, 108, age=timedelta(hours=49))
+
+    result = await reclaim_headless_worker_workspaces(
+        _Session({108: "completed"}, retention_hours=72),
         workspace_root=workspace_root,
         now=NOW,
     )


### PR DESCRIPTION
> *This was generated by AI during an autonomous routine run (R3).*

Closes #779

Slice 1 of 3 of #752 — the foundation the capacity sensor (#780) and the reclaim
lever (#781) both read from.

## Stacked on #794 — merge that first

This branch is based on `illo-qa/consolidated-20260810` ([#794](https://github.com/Illospace/illospace/pull/794)),
because its migration `0060` chains off `0059` there. Merge #794, then this.

## What it does

One versioned `storage_policies` row, edited at runtime through an audited
`manage_storage_policy` action with **get / update / history / revert** — a
rationale on every change, and a real rollback. It holds:

| field | seed |
|---|---|
| finished-workspace retention | 48h |
| project-draft retention | 168h |
| canvas quiet window | 24h |
| capacity warn / critical | 80% / 90% |
| automatic reclamation allowed | false |

It is a **purpose-built row, not a widened `vault_config`** — #752 explicitly
forbids quietly adding a second generic key-value store, and these values need
typed constraints, one-active-row enforcement and revision history.

## The rule this had to pass

> "If this ticket ships a fourth hardcoded window, it has failed." — #752

All three previously hardcoded constants now read from the row:
`CANVAS_QUIET_HOURS`, `PROJECT_DRAFT_UNPUBLISHED_RETENTION`, and the workspace-GC
window. A review then audited every remaining literal and found two survivors,
both fixed here:

- the scheduler catalog still *described* the canvas job as "after 24 quiet
  hours", which goes stale the moment anyone edits the policy;
- `automatic_reclamation_allowed=False` was declared three times (migration seed,
  column default, model default), so changing the bootstrap policy in one place
  would have left column-omitting inserts on the old value.

There is no missing-row fallback anywhere — the accessor raises instead of quietly
inventing a default.

## Verification (local — this repo has no CI minutes)

- Fast suite **4890 passed, 11 skipped** at machine load 4.5 (uncontended).
- `alembic heads` → exactly one (`0060_storage_policies`).
- `async_db_debt_metrics.py --target production` → `sync_bridge_helper_refs: 0`.
- Cycle context admission gate: tool catalog is 92 tools, ceilings unchanged at
  50486 / 57859, and only cycles {2, 9} still fail at a 128k window — no third
  Cycle crosses the line.
- No `frontend/**` changes, so no frontend lane applies.

Two guard tests in files this diff never touches caught the first pass — a
`connection.run_sync(...)` in the new test that put back sync-DB debt the repo has
driven to zero, and the hardcoded tool count. Both are fixed properly, neither
test was weakened.

## What to watch after you deploy

1. `manage_storage_policy update` changes the retention window and writes a new
   revision with your rationale; `history` shows both.
2. `revert` restores the previous values and appends a further revision rather
   than mutating the old one.
3. The canvas occupancy job and the workspace GC honour the edited window on their
   next run, with no deploy.

## Known follow-up, filed not folded

[#796](https://github.com/Illospace/illospace/issues/796) — the six fields are
hand-repeated across nine blocks, and the accessor returns the ORM model, so #780
and #781 would each copy the load-and-convert dance. The remedy is a typed
`StoragePolicyValues` / `StoragePolicyPatch`. It rewrites most of a module this PR
only touches in two places, so it is its own ticket and it gates #780/#781.
