### PR TITLE
feat(cycles): behavior-policy API routes with 409 conflict semantics (#783)

### DIFF
--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -36,6 +36,7 @@ from brain.systems.cycles.commands import (
 )
 from brain.systems.cycles.behavior_policy import (
     CyclePolicyApplied,
+    CyclePolicyApplyResult,
     CyclePolicyConflict,
     CyclePolicyPatch,
     async_apply_cycle_policy_change as command_apply_cycle_policy,
@@ -43,7 +44,9 @@ from brain.systems.cycles.behavior_policy import (
     async_list_cycle_policy_history as command_list_cycle_policy_history,
     async_preview_cycle_policy_change as command_preview_cycle_policy,
     async_preview_cycle_policy_revert as command_preview_cycle_policy_revert,
-    async_read_effective_cycle_policy as command_read_effective_cycle_policy,
+)
+from brain.systems.cycles.behavior_policy_read_model import (
+    async_read_effective_cycle_policy as query_effective_cycle_policy,
 )
 from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.common import SCHEDULED_DIGEST_RUN_KIND
@@ -102,7 +105,7 @@ async def _latest_effective_policy_payload(
     actor: CycleActor,
     cycle_id: int,
 ) -> dict:
-    latest = await command_read_effective_cycle_policy(
+    latest = await query_effective_cycle_policy(
         db,
         actor=actor,
         cycle_id=cycle_id,
@@ -129,6 +132,41 @@ async def _raise_policy_conflict(
             "latest_effective_policy": latest,
         },
     )
+
+
+async def _finalize_policy_apply_result(
+    db: AsyncSession,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    result: CyclePolicyApplyResult,
+    invalid_result_detail: str,
+) -> dict:
+    try:
+        if isinstance(result, CyclePolicyConflict):
+            await _raise_policy_conflict(
+                db,
+                actor=actor,
+                cycle_id=cycle_id,
+                conflict=result,
+            )
+        if not isinstance(result, CyclePolicyApplied):
+            raise ValueError(invalid_result_detail)
+        effective_policy = await _latest_effective_policy_payload(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    payload = {
+        "effective_policy": effective_policy,
+        "change": serialize_behavior_change_record(result.change),
+    }
+    await db.commit()
+    return payload
 
 
 async def _get_cycle_or_404(db: AsyncSession, cycle_id: int, user: dict[str, Any]) -> Cycle:
@@ -328,30 +366,15 @@ async def apply_cycle_behavior_policy(
             rationale=body.rationale,
             source_reference=_policy_source_reference(cycle_id),
         )
-        if isinstance(result, CyclePolicyConflict):
-            await _raise_policy_conflict(
-                db,
-                actor=actor,
-                cycle_id=cycle_id,
-                conflict=result,
-            )
-        if not isinstance(result, CyclePolicyApplied):
-            raise ValueError("Cycle policy apply returned an invalid result")
-        effective_policy = await _latest_effective_policy_payload(
-            db,
-            actor=actor,
-            cycle_id=cycle_id,
-        )
-    except HTTPException:
-        raise
     except ValueError as exc:
         raise _policy_request_error(exc) from exc
-    payload = {
-        "effective_policy": effective_policy,
-        "change": serialize_behavior_change_record(result.change),
-    }
-    await db.commit()
-    return payload
+    return await _finalize_policy_apply_result(
+        db,
+        actor=actor,
+        cycle_id=cycle_id,
+        result=result,
+        invalid_result_detail="Cycle policy apply returned an invalid result",
+    )
 
 
 @router.get(
@@ -436,30 +459,15 @@ async def apply_cycle_behavior_policy_revert(
             rationale=body.rationale,
             source_reference=_policy_source_reference(cycle_id),
         )
-        if isinstance(result, CyclePolicyConflict):
-            await _raise_policy_conflict(
-                db,
-                actor=actor,
-                cycle_id=cycle_id,
-                conflict=result,
-            )
-        if not isinstance(result, CyclePolicyApplied):
-            raise ValueError("Cycle policy revert returned an invalid result")
-        effective_policy = await _latest_effective_policy_payload(
-            db,
-            actor=actor,
-            cycle_id=cycle_id,
-        )
-    except HTTPException:
-        raise
     except ValueError as exc:
         raise _policy_request_error(exc) from exc
-    payload = {
-        "effective_policy": effective_policy,
-        "change": serialize_behavior_change_record(result.change),
-    }
-    await db.commit()
-    return payload
+    return await _finalize_policy_apply_result(
+        db,
+        actor=actor,
+        cycle_id=cycle_id,
+        result=result,
+        invalid_result_detail="Cycle policy revert returned an invalid result",
+    )
 
 
 @router.delete("/{cycle_id}")

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.api.auth import get_current_user
 from brain.app.api.deps import get_db, rate_limit
-from brain.app.api.schemas.cycles import CycleCreate, CycleRead, CycleRunRead, CycleUpdate
+from brain.app.api.schemas.cycles import (
+    CycleCreate,
+    CyclePolicyApplyRead,
+    CyclePolicyApplyRequest,
+    CyclePolicyHistoryRead,
+    CyclePolicyPreviewRead,
+    CyclePolicyPreviewRequest,
+    CyclePolicyRevertApplyRequest,
+    CycleRead,
+    CycleRunRead,
+    CycleUpdate,
+    EffectiveCyclePolicyRead,
+)
 from brain.systems.cycles.access import (
     CycleActor,
     cycle_scope_conditions,
@@ -22,9 +34,26 @@ from brain.systems.cycles.commands import (
     async_update_cycle as command_update_cycle,
     cycle_change_event,
 )
+from brain.systems.cycles.behavior_policy import (
+    CyclePolicyApplied,
+    CyclePolicyConflict,
+    CyclePolicyPatch,
+    async_apply_cycle_policy_change as command_apply_cycle_policy,
+    async_apply_cycle_policy_revert as command_apply_cycle_policy_revert,
+    async_list_cycle_policy_history as command_list_cycle_policy_history,
+    async_preview_cycle_policy_change as command_preview_cycle_policy,
+    async_preview_cycle_policy_revert as command_preview_cycle_policy_revert,
+    async_read_effective_cycle_policy as command_read_effective_cycle_policy,
+)
 from brain.systems.cycles.events import publish_cycle_change_safe
 from brain.systems.cycles.common import SCHEDULED_DIGEST_RUN_KIND
-from brain.systems.cycles.serializers import serialize_cycle, serialize_cycle_run
+from brain.systems.cycles.serializers import (
+    serialize_behavior_change_record,
+    serialize_cycle,
+    serialize_cycle_policy_preview,
+    serialize_cycle_run,
+    serialize_effective_cycle_policy,
+)
 from brain.systems.cycles.service import async_run_cycle_now
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea
@@ -38,6 +67,68 @@ router = APIRouter(
 
 def _bad_request(exc: ValueError) -> HTTPException:
     return HTTPException(status_code=400, detail=str(exc))
+
+
+def _policy_request_error(exc: ValueError) -> HTTPException:
+    detail = str(exc)
+    if detail in {"Cycle not found", "Behavior change not found"}:
+        return HTTPException(status_code=404, detail=detail)
+    return _bad_request(exc)
+
+
+def _policy_patch(body: CyclePolicyPreviewRequest) -> CyclePolicyPatch:
+    proposal = body.proposal.model_dump(exclude_unset=True)
+    return CyclePolicyPatch(
+        prompt=proposal.get("prompt", UNSET_CYCLE_FIELD),
+        schedule_expr=proposal.get("schedule_expr", UNSET_CYCLE_FIELD),
+        timezone_name=proposal.get("timezone", UNSET_CYCLE_FIELD),
+        enabled=proposal.get("enabled", UNSET_CYCLE_FIELD),
+        model_override=proposal.get("model_override", UNSET_CYCLE_FIELD),
+        thinking_override=proposal.get(
+            "thinking_override",
+            UNSET_CYCLE_FIELD,
+        ),
+        guidance=proposal.get("guidance", UNSET_CYCLE_FIELD),
+    )
+
+
+def _policy_source_reference(cycle_id: int) -> str:
+    return f"api:/cycles/{cycle_id}/behavior-policy"
+
+
+async def _latest_effective_policy_payload(
+    db: AsyncSession,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+) -> dict:
+    latest = await command_read_effective_cycle_policy(
+        db,
+        actor=actor,
+        cycle_id=cycle_id,
+    )
+    return serialize_effective_cycle_policy(latest)
+
+
+async def _raise_policy_conflict(
+    db: AsyncSession,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+    conflict: CyclePolicyConflict,
+) -> None:
+    latest = await _latest_effective_policy_payload(
+        db,
+        actor=actor,
+        cycle_id=cycle_id,
+    )
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "reason": conflict.reason,
+            "latest_effective_policy": latest,
+        },
+    )
 
 
 async def _get_cycle_or_404(db: AsyncSession, cycle_id: int, user: dict[str, Any]) -> Cycle:
@@ -169,6 +260,204 @@ async def update_cycle(
     await db.flush()
     await db.refresh(cycle)
     payload = serialize_cycle(cycle)
+    await db.commit()
+    return payload
+
+
+@router.get(
+    "/{cycle_id}/behavior-policy",
+    response_model=EffectiveCyclePolicyRead,
+)
+async def get_cycle_behavior_policy(
+    cycle_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    actor = CycleActor.from_user_payload(user)
+    try:
+        return await _latest_effective_policy_payload(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+        )
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+
+
+@router.post(
+    "/{cycle_id}/behavior-policy/preview",
+    response_model=CyclePolicyPreviewRead,
+)
+async def preview_cycle_behavior_policy(
+    cycle_id: int,
+    body: CyclePolicyPreviewRequest,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        preview = await command_preview_cycle_policy(
+            db,
+            actor=CycleActor.from_user_payload(user),
+            cycle_id=cycle_id,
+            proposal=_policy_patch(body),
+        )
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    return serialize_cycle_policy_preview(preview)
+
+
+@router.post(
+    "/{cycle_id}/behavior-policy/apply",
+    response_model=CyclePolicyApplyRead,
+)
+async def apply_cycle_behavior_policy(
+    cycle_id: int,
+    body: CyclePolicyApplyRequest,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    actor = CycleActor.from_user_payload(user)
+    try:
+        result = await command_apply_cycle_policy(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+            proposal=_policy_patch(body),
+            expected_version=body.expected_version,
+            preview_digest=body.preview_digest,
+            rationale=body.rationale,
+            source_reference=_policy_source_reference(cycle_id),
+        )
+        if isinstance(result, CyclePolicyConflict):
+            await _raise_policy_conflict(
+                db,
+                actor=actor,
+                cycle_id=cycle_id,
+                conflict=result,
+            )
+        if not isinstance(result, CyclePolicyApplied):
+            raise ValueError("Cycle policy apply returned an invalid result")
+        effective_policy = await _latest_effective_policy_payload(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    payload = {
+        "effective_policy": effective_policy,
+        "change": serialize_behavior_change_record(result.change),
+    }
+    await db.commit()
+    return payload
+
+
+@router.get(
+    "/{cycle_id}/behavior-policy/history",
+    response_model=CyclePolicyHistoryRead,
+)
+async def list_cycle_behavior_policy_history(
+    cycle_id: int,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        changes = await command_list_cycle_policy_history(
+            db,
+            actor=CycleActor.from_user_payload(user),
+            cycle_id=cycle_id,
+            limit=limit + 1,
+            offset=offset,
+        )
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    has_more = len(changes) > limit
+    page = changes[:limit]
+    return {
+        "items": [
+            serialize_behavior_change_record(change)
+            for change in page
+        ],
+        "pagination": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": has_more,
+            "next_offset": offset + len(page) if has_more else None,
+        },
+    }
+
+
+@router.post(
+    "/{cycle_id}/behavior-policy/history/{change_id}/revert/preview",
+    response_model=CyclePolicyPreviewRead,
+)
+async def preview_cycle_behavior_policy_revert(
+    cycle_id: int,
+    change_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        preview = await command_preview_cycle_policy_revert(
+            db,
+            actor=CycleActor.from_user_payload(user),
+            cycle_id=cycle_id,
+            change_id=change_id,
+        )
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    return serialize_cycle_policy_preview(preview)
+
+
+@router.post(
+    "/{cycle_id}/behavior-policy/history/{change_id}/revert/apply",
+    response_model=CyclePolicyApplyRead,
+)
+async def apply_cycle_behavior_policy_revert(
+    cycle_id: int,
+    change_id: int,
+    body: CyclePolicyRevertApplyRequest,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    actor = CycleActor.from_user_payload(user)
+    try:
+        result = await command_apply_cycle_policy_revert(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+            change_id=change_id,
+            expected_version=body.expected_version,
+            preview_digest=body.preview_digest,
+            rationale=body.rationale,
+            source_reference=_policy_source_reference(cycle_id),
+        )
+        if isinstance(result, CyclePolicyConflict):
+            await _raise_policy_conflict(
+                db,
+                actor=actor,
+                cycle_id=cycle_id,
+                conflict=result,
+            )
+        if not isinstance(result, CyclePolicyApplied):
+            raise ValueError("Cycle policy revert returned an invalid result")
+        effective_policy = await _latest_effective_policy_payload(
+            db,
+            actor=actor,
+            cycle_id=cycle_id,
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise _policy_request_error(exc) from exc
+    payload = {
+        "effective_policy": effective_policy,
+        "change": serialize_behavior_change_record(result.change),
+    }
     await db.commit()
     return payload
 

--- a/brain/app/api/schemas/cycles.py
+++ b/brain/app/api/schemas/cycles.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from brain.systems.cycles.common import (
     MAX_CYCLE_TIMEOUT_SECONDS,
@@ -103,3 +104,182 @@ class CycleRunRead(BaseModel):
     context_snapshot: dict = Field(default_factory=dict)
     self_review_summary: str | None = None
     created_at: datetime
+
+
+class CyclePolicyProposal(BaseModel):
+    """The fields the first behavior-editor slice can change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt: str | None = Field(default=None, min_length=1, max_length=20000)
+    schedule_expr: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+    )
+    timezone: str | None = Field(default=None, min_length=1, max_length=64)
+    enabled: bool | None = None
+    model_override: str | None = None
+    thinking_override: str | None = None
+    guidance: list[str] | None = None
+
+
+class CyclePolicyPreviewRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal: CyclePolicyProposal
+
+
+class CyclePolicyApplyRequest(CyclePolicyPreviewRequest):
+    expected_version: int = Field(ge=0, strict=True)
+    preview_digest: str = Field(min_length=1, max_length=128)
+    rationale: str = Field(min_length=1, max_length=5000)
+
+
+class CyclePolicyRevertApplyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_version: int = Field(ge=0, strict=True)
+    preview_digest: str = Field(min_length=1, max_length=128)
+    rationale: str = Field(min_length=1, max_length=5000)
+
+
+class CyclePolicyConfigurationRead(BaseModel):
+    name: str
+    prompt: str
+    schedule_expr: str
+    schedule_human: str
+    timezone: str
+    enabled: bool
+    max_concurrency: int
+    timeout_seconds: int | None = None
+    retry_policy: dict[str, Any]
+    model_override: str | None = None
+    thinking_override: str | None = None
+    execution_policy_key: str | None = None
+    target_idea_id: str | None = None
+
+
+class CyclePolicySnapshotRead(BaseModel):
+    configuration: CyclePolicyConfigurationRead
+    guidance: list[str]
+
+
+class CyclePolicyOutputTargetRead(BaseModel):
+    id: int
+    target_type: str
+    target_id: str | None = None
+    label: str | None = None
+    config: dict[str, Any]
+    source_type: str
+    source_id: str | None = None
+    rationale: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CyclePolicySourceRead(BaseModel):
+    revision_id: int | None = None
+    actor_type: str | None = None
+    actor_id: str | None = None
+    rationale: str | None = None
+    source_reference: str | None = None
+    changed_at: datetime | None = None
+
+
+class CyclePolicyFieldSourceRead(BaseModel):
+    version: int
+    cycle_revision_id: int | None = None
+    actor_type: str | None = None
+    actor_id: str | None = None
+    source_reference: str | None = None
+    rationale: str | None = None
+    changed_at: datetime | None = None
+    change_id: int | None = None
+
+
+class CyclePolicyChangeSummaryRead(BaseModel):
+    id: int
+    version: int
+    actor_type: str
+    actor_id: str
+    source_reference: str
+    rationale: str
+    changed_fields: list[str]
+    applied_at: datetime
+    reverted_from_id: int | None = None
+
+
+class EffectiveCyclePolicyRead(BaseModel):
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    version: int
+    revision_id: int | None = None
+    configuration: CyclePolicyConfigurationRead
+    guidance: list[str]
+    editable_fields: list[str]
+    output_targets: list[CyclePolicyOutputTargetRead]
+    output_targets_read_only: bool
+    source: CyclePolicySourceRead
+    field_sources: dict[str, CyclePolicyFieldSourceRead]
+    latest_change: CyclePolicyChangeSummaryRead | None = None
+
+
+class CyclePolicyDiffEntryRead(BaseModel):
+    field: str
+    kind: str
+    before: Any
+    after: Any
+    added: list[str] | None = None
+    removed: list[str] | None = None
+
+
+class CyclePolicyWarningRead(BaseModel):
+    code: str
+    message: str
+
+
+class CyclePolicyAffectedRunsRead(BaseModel):
+    admitted_runs: str
+    future_runs: str
+
+
+class CyclePolicyPreviewRead(BaseModel):
+    expected_version: int
+    preview_digest: str
+    before: CyclePolicySnapshotRead
+    after: CyclePolicySnapshotRead
+    changed_fields: list[str]
+    diff: list[CyclePolicyDiffEntryRead]
+    warnings: list[CyclePolicyWarningRead]
+    affected_runs: CyclePolicyAffectedRunsRead
+    reverted_from_id: int | None = None
+
+
+class CyclePolicyChangeRead(CyclePolicyChangeSummaryRead):
+    workspace_id: str
+    policy_kind: str
+    target_type: str
+    target_id: str
+    before_snapshot: CyclePolicySnapshotRead
+    after_snapshot: CyclePolicySnapshotRead
+    cycle_revision_id: int
+
+
+class CyclePolicyApplyRead(BaseModel):
+    effective_policy: EffectiveCyclePolicyRead
+    change: CyclePolicyChangeRead
+
+
+class CyclePolicyHistoryPaginationRead(BaseModel):
+    limit: int
+    offset: int
+    has_more: bool
+    next_offset: int | None = None
+
+
+class CyclePolicyHistoryRead(BaseModel):
+    items: list[CyclePolicyChangeRead]
+    pagination: CyclePolicyHistoryPaginationRead

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -29,6 +29,7 @@ from brain.platform.db.models.cycle import (
     BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
+    CycleOutputTarget,
     CycleRevision,
 )
 from brain.platform.db.models.idea import Idea
@@ -61,6 +62,7 @@ __all__ = [
     "CyclePolicyApplied",
     "CyclePolicyApplyResult",
     "CyclePolicyConflict",
+    "CyclePolicyFieldSource",
     "CyclePolicyPatch",
     "CyclePolicyPreview",
     "CyclePolicySnapshot",
@@ -180,6 +182,12 @@ class CyclePolicySnapshot:
             dict[str, JsonValue],
             jsonable(deepcopy(self.retry_policy)),
         )
+        guidance = [
+            validate_nonempty_trimmed(value, "guidance")
+            for value in self.guidance
+        ]
+        if len(guidance) != len(set(guidance)):
+            raise ValueError("guidance entries must be unique")
         return CyclePolicySnapshot(
             name=validate_nonempty_trimmed(self.name, "name"),
             prompt=validate_nonempty_trimmed(self.prompt, "prompt"),
@@ -202,10 +210,7 @@ class CyclePolicySnapshot:
                 if self.target_idea_id is not None
                 else None
             ),
-            guidance=sorted(
-                validate_nonempty_trimmed(value, "guidance")
-                for value in self.guidance
-            ),
+            guidance=sorted(guidance),
         )
 
     def encode(self) -> dict[str, Any]:
@@ -279,6 +284,19 @@ class _CyclePolicyRevert:
 
 
 @dataclass(frozen=True)
+class CyclePolicyFieldSource:
+    field_name: str
+    version: int
+    cycle_revision_id: int | None
+    actor_type: str | None
+    actor_id: str | None
+    source_reference: str | None
+    rationale: str | None
+    changed_at: datetime | None
+    change_id: int | None
+
+
+@dataclass(frozen=True)
 class EffectiveCyclePolicy:
     workspace_id: str
     policy_kind: str
@@ -287,6 +305,10 @@ class EffectiveCyclePolicy:
     version: int
     revision_id: int | None
     snapshot: CyclePolicySnapshot
+    output_targets: tuple[CycleOutputTarget, ...] = ()
+    source_revision: CycleRevision | None = None
+    latest_change: BehaviorChangeRecord | None = None
+    field_sources: tuple[CyclePolicyFieldSource, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -354,7 +376,7 @@ async def async_read_effective_cycle_policy(
     cycle_id: int,
 ) -> EffectiveCyclePolicy:
     cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
-    return await _effective_policy(session, cycle)
+    return await _effective_policy(session, cycle, include_metadata=True)
 
 
 async def async_preview_cycle_policy_change(
@@ -512,10 +534,12 @@ async def async_list_cycle_policy_history(
     actor: CycleActor,
     cycle_id: int,
     limit: int = 100,
+    offset: int = 0,
 ) -> list[BehaviorChangeRecord]:
     cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
     current = await _effective_policy(session, cycle)
     clean_limit = max(1, min(int(limit), 500))
+    clean_offset = max(0, int(offset))
     rows = list(
         (
             await session.scalars(
@@ -523,6 +547,7 @@ async def async_list_cycle_policy_history(
                 .where(*_audit_target_conditions(cycle))
                 .order_by(BehaviorChangeAudit.version.desc())
                 .limit(clean_limit)
+                .offset(clean_offset)
             )
         ).all()
     )
@@ -594,7 +619,12 @@ async def _load_scoped_cycle(
     return cycle
 
 
-async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
+async def _effective_policy(
+    session,
+    cycle: Cycle,
+    *,
+    include_metadata: bool = False,
+) -> EffectiveCyclePolicy:
     guidance_rows = list(
         (
             await session.scalars(
@@ -607,6 +637,7 @@ async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
             )
         ).all()
     )
+    snapshot = CyclePolicySnapshot.from_cycle(cycle, guidance_rows)
     version = int(
         (
             await session.scalar(
@@ -617,20 +648,96 @@ async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
         )
         or 0
     )
-    revision_id = await session.scalar(
-        select(CycleRevision.id)
+    revision_statement = (
+        select(CycleRevision)
         .where(CycleRevision.cycle_id == cycle.id)
         .order_by(CycleRevision.revision_number.desc(), CycleRevision.id.desc())
         .limit(1)
     )
+    source_revision = None
+    revision_id = None
+    output_targets: tuple[CycleOutputTarget, ...] = ()
+    latest_change = None
+    field_sources: tuple[CyclePolicyFieldSource, ...] = ()
+    if include_metadata:
+        source_revision = await session.scalar(revision_statement)
+        output_targets = tuple(
+            (
+                await session.scalars(
+                    select(CycleOutputTarget)
+                    .where(
+                        CycleOutputTarget.cycle_id == cycle.id,
+                        CycleOutputTarget.is_active.is_(True),
+                    )
+                    .order_by(
+                        CycleOutputTarget.created_at.asc(),
+                        CycleOutputTarget.id.asc(),
+                    )
+                )
+            ).all()
+        )
+        change_rows = list(
+            (
+                await session.scalars(
+                    select(BehaviorChangeAudit)
+                    .where(*_audit_target_conditions(cycle))
+                    .order_by(
+                        BehaviorChangeAudit.version.desc(),
+                        BehaviorChangeAudit.id.desc(),
+                    )
+                )
+            ).all()
+        )
+        if change_rows:
+            latest_change = _record(
+                change_rows[0],
+                current_snapshot=snapshot,
+            )
+            first_policy_revision_number = (
+                select(CycleRevision.revision_number)
+                .where(
+                    CycleRevision.id == change_rows[-1].cycle_revision_id,
+                )
+                .scalar_subquery()
+            )
+            baseline_revision = await session.scalar(
+                select(CycleRevision)
+                .where(
+                    CycleRevision.cycle_id == cycle.id,
+                    CycleRevision.revision_number
+                    < first_policy_revision_number,
+                )
+                .order_by(
+                    CycleRevision.revision_number.desc(),
+                    CycleRevision.id.desc(),
+                )
+                .limit(1)
+            )
+        else:
+            baseline_revision = source_revision
+        field_sources = _field_sources(
+            snapshot=snapshot,
+            baseline_revision=baseline_revision,
+            change_rows=change_rows,
+        )
+    else:
+        revision_id = await session.scalar(
+            revision_statement.with_only_columns(CycleRevision.id)
+        )
     return EffectiveCyclePolicy(
         workspace_id=_workspace_id(cycle),
         policy_kind=CYCLE_POLICY_KIND,
         target_type=CYCLE_TARGET_TYPE,
         target_id=str(cycle.id),
         version=version,
-        revision_id=revision_id,
-        snapshot=CyclePolicySnapshot.from_cycle(cycle, guidance_rows),
+        revision_id=(
+            source_revision.id if source_revision is not None else revision_id
+        ),
+        snapshot=snapshot,
+        output_targets=output_targets,
+        source_revision=source_revision,
+        latest_change=latest_change,
+        field_sources=field_sources,
     )
 
 
@@ -915,14 +1022,87 @@ def _preview_digest(
     return hashlib.sha256(canonical).hexdigest()
 
 
+def _field_sources(
+    *,
+    snapshot: CyclePolicySnapshot,
+    baseline_revision: CycleRevision | None,
+    change_rows: list[BehaviorChangeAudit],
+) -> tuple[CyclePolicyFieldSource, ...]:
+    latest_by_field: dict[str, BehaviorChangeAudit] = {}
+    for row in change_rows:
+        for field_name in row.changed_fields or []:
+            latest_by_field.setdefault(str(field_name), row)
+
+    sources = []
+    for snapshot_field in fields(snapshot):
+        row = latest_by_field.get(snapshot_field.name)
+        if row is not None:
+            sources.append(
+                CyclePolicyFieldSource(
+                    field_name=snapshot_field.name,
+                    version=row.version,
+                    cycle_revision_id=row.cycle_revision_id,
+                    actor_type=row.actor_type,
+                    actor_id=row.actor_id,
+                    source_reference=row.source_reference,
+                    rationale=row.rationale,
+                    changed_at=_aware_utc(row.applied_at),
+                    change_id=row.id,
+                )
+            )
+            continue
+        sources.append(
+            CyclePolicyFieldSource(
+                field_name=snapshot_field.name,
+                version=0,
+                cycle_revision_id=(
+                    baseline_revision.id
+                    if baseline_revision is not None
+                    else None
+                ),
+                actor_type=(
+                    baseline_revision.source_type
+                    if baseline_revision is not None
+                    else None
+                ),
+                actor_id=(
+                    str(baseline_revision.source_id)
+                    if baseline_revision is not None
+                    and baseline_revision.source_id is not None
+                    else None
+                ),
+                source_reference=(
+                    f"cycle_revision:{baseline_revision.id}"
+                    if baseline_revision is not None
+                    else None
+                ),
+                rationale=(
+                    baseline_revision.rationale
+                    if baseline_revision is not None
+                    else None
+                ),
+                changed_at=(
+                    _aware_utc(baseline_revision.created_at)
+                    if baseline_revision is not None
+                    else None
+                ),
+                change_id=None,
+            )
+        )
+    return tuple(sources)
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def _record(
     row: BehaviorChangeAudit,
     *,
     current_snapshot: CyclePolicySnapshot,
 ) -> BehaviorChangeRecord:
-    applied_at = row.applied_at
-    if applied_at.tzinfo is None:
-        applied_at = applied_at.replace(tzinfo=timezone.utc)
     return BehaviorChangeRecord(
         id=row.id,
         workspace_id=row.workspace_id,
@@ -944,7 +1124,7 @@ def _record(
         ),
         changed_fields=tuple(row.changed_fields or []),
         cycle_revision_id=row.cycle_revision_id,
-        applied_at=applied_at,
+        applied_at=_aware_utc(row.applied_at),
         reverted_from_id=row.reverted_from_id,
     )
 

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -29,7 +29,6 @@ from brain.platform.db.models.cycle import (
     BehaviorChangeAudit,
     Cycle,
     CycleGuidance,
-    CycleOutputTarget,
     CycleRevision,
 )
 from brain.platform.db.models.idea import Idea
@@ -62,7 +61,6 @@ __all__ = [
     "CyclePolicyApplied",
     "CyclePolicyApplyResult",
     "CyclePolicyConflict",
-    "CyclePolicyFieldSource",
     "CyclePolicyPatch",
     "CyclePolicyPreview",
     "CyclePolicySnapshot",
@@ -73,7 +71,6 @@ __all__ = [
     "async_list_cycle_policy_history",
     "async_preview_cycle_policy_change",
     "async_preview_cycle_policy_revert",
-    "async_read_effective_cycle_policy",
 ]
 
 CYCLE_POLICY_KIND = "cycle"
@@ -284,19 +281,6 @@ class _CyclePolicyRevert:
 
 
 @dataclass(frozen=True)
-class CyclePolicyFieldSource:
-    field_name: str
-    version: int
-    cycle_revision_id: int | None
-    actor_type: str | None
-    actor_id: str | None
-    source_reference: str | None
-    rationale: str | None
-    changed_at: datetime | None
-    change_id: int | None
-
-
-@dataclass(frozen=True)
 class EffectiveCyclePolicy:
     workspace_id: str
     policy_kind: str
@@ -305,10 +289,6 @@ class EffectiveCyclePolicy:
     version: int
     revision_id: int | None
     snapshot: CyclePolicySnapshot
-    output_targets: tuple[CycleOutputTarget, ...] = ()
-    source_revision: CycleRevision | None = None
-    latest_change: BehaviorChangeRecord | None = None
-    field_sources: tuple[CyclePolicyFieldSource, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -367,16 +347,6 @@ class CyclePolicyConflict:
 
 
 CyclePolicyApplyResult = CyclePolicyApplied | CyclePolicyConflict
-
-
-async def async_read_effective_cycle_policy(
-    session,
-    *,
-    actor: CycleActor,
-    cycle_id: int,
-) -> EffectiveCyclePolicy:
-    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
-    return await _effective_policy(session, cycle, include_metadata=True)
 
 
 async def async_preview_cycle_policy_change(
@@ -619,12 +589,7 @@ async def _load_scoped_cycle(
     return cycle
 
 
-async def _effective_policy(
-    session,
-    cycle: Cycle,
-    *,
-    include_metadata: bool = False,
-) -> EffectiveCyclePolicy:
+async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
     guidance_rows = list(
         (
             await session.scalars(
@@ -648,96 +613,20 @@ async def _effective_policy(
         )
         or 0
     )
-    revision_statement = (
-        select(CycleRevision)
+    revision_id = await session.scalar(
+        select(CycleRevision.id)
         .where(CycleRevision.cycle_id == cycle.id)
         .order_by(CycleRevision.revision_number.desc(), CycleRevision.id.desc())
         .limit(1)
     )
-    source_revision = None
-    revision_id = None
-    output_targets: tuple[CycleOutputTarget, ...] = ()
-    latest_change = None
-    field_sources: tuple[CyclePolicyFieldSource, ...] = ()
-    if include_metadata:
-        source_revision = await session.scalar(revision_statement)
-        output_targets = tuple(
-            (
-                await session.scalars(
-                    select(CycleOutputTarget)
-                    .where(
-                        CycleOutputTarget.cycle_id == cycle.id,
-                        CycleOutputTarget.is_active.is_(True),
-                    )
-                    .order_by(
-                        CycleOutputTarget.created_at.asc(),
-                        CycleOutputTarget.id.asc(),
-                    )
-                )
-            ).all()
-        )
-        change_rows = list(
-            (
-                await session.scalars(
-                    select(BehaviorChangeAudit)
-                    .where(*_audit_target_conditions(cycle))
-                    .order_by(
-                        BehaviorChangeAudit.version.desc(),
-                        BehaviorChangeAudit.id.desc(),
-                    )
-                )
-            ).all()
-        )
-        if change_rows:
-            latest_change = _record(
-                change_rows[0],
-                current_snapshot=snapshot,
-            )
-            first_policy_revision_number = (
-                select(CycleRevision.revision_number)
-                .where(
-                    CycleRevision.id == change_rows[-1].cycle_revision_id,
-                )
-                .scalar_subquery()
-            )
-            baseline_revision = await session.scalar(
-                select(CycleRevision)
-                .where(
-                    CycleRevision.cycle_id == cycle.id,
-                    CycleRevision.revision_number
-                    < first_policy_revision_number,
-                )
-                .order_by(
-                    CycleRevision.revision_number.desc(),
-                    CycleRevision.id.desc(),
-                )
-                .limit(1)
-            )
-        else:
-            baseline_revision = source_revision
-        field_sources = _field_sources(
-            snapshot=snapshot,
-            baseline_revision=baseline_revision,
-            change_rows=change_rows,
-        )
-    else:
-        revision_id = await session.scalar(
-            revision_statement.with_only_columns(CycleRevision.id)
-        )
     return EffectiveCyclePolicy(
         workspace_id=_workspace_id(cycle),
         policy_kind=CYCLE_POLICY_KIND,
         target_type=CYCLE_TARGET_TYPE,
         target_id=str(cycle.id),
         version=version,
-        revision_id=(
-            source_revision.id if source_revision is not None else revision_id
-        ),
+        revision_id=revision_id,
         snapshot=snapshot,
-        output_targets=output_targets,
-        source_revision=source_revision,
-        latest_change=latest_change,
-        field_sources=field_sources,
     )
 
 
@@ -1020,76 +909,6 @@ def _preview_digest(
         separators=(",", ":"),
     ).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
-
-
-def _field_sources(
-    *,
-    snapshot: CyclePolicySnapshot,
-    baseline_revision: CycleRevision | None,
-    change_rows: list[BehaviorChangeAudit],
-) -> tuple[CyclePolicyFieldSource, ...]:
-    latest_by_field: dict[str, BehaviorChangeAudit] = {}
-    for row in change_rows:
-        for field_name in row.changed_fields or []:
-            latest_by_field.setdefault(str(field_name), row)
-
-    sources = []
-    for snapshot_field in fields(snapshot):
-        row = latest_by_field.get(snapshot_field.name)
-        if row is not None:
-            sources.append(
-                CyclePolicyFieldSource(
-                    field_name=snapshot_field.name,
-                    version=row.version,
-                    cycle_revision_id=row.cycle_revision_id,
-                    actor_type=row.actor_type,
-                    actor_id=row.actor_id,
-                    source_reference=row.source_reference,
-                    rationale=row.rationale,
-                    changed_at=_aware_utc(row.applied_at),
-                    change_id=row.id,
-                )
-            )
-            continue
-        sources.append(
-            CyclePolicyFieldSource(
-                field_name=snapshot_field.name,
-                version=0,
-                cycle_revision_id=(
-                    baseline_revision.id
-                    if baseline_revision is not None
-                    else None
-                ),
-                actor_type=(
-                    baseline_revision.source_type
-                    if baseline_revision is not None
-                    else None
-                ),
-                actor_id=(
-                    str(baseline_revision.source_id)
-                    if baseline_revision is not None
-                    and baseline_revision.source_id is not None
-                    else None
-                ),
-                source_reference=(
-                    f"cycle_revision:{baseline_revision.id}"
-                    if baseline_revision is not None
-                    else None
-                ),
-                rationale=(
-                    baseline_revision.rationale
-                    if baseline_revision is not None
-                    else None
-                ),
-                changed_at=(
-                    _aware_utc(baseline_revision.created_at)
-                    if baseline_revision is not None
-                    else None
-                ),
-                change_id=None,
-            )
-        )
-    return tuple(sources)
 
 
 def _aware_utc(value: datetime) -> datetime:

--- a/brain/systems/cycles/behavior_policy_read_model.py
+++ b/brain/systems/cycles/behavior_policy_read_model.py
@@ -1,0 +1,213 @@
+"""Rich read model for an effective Cycle behavior policy."""
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from datetime import datetime
+
+from sqlalchemy import select
+
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    CycleOutputTarget,
+    CycleRevision,
+)
+from brain.systems.cycles.access import CycleActor
+from brain.systems.cycles.behavior_policy import (
+    BehaviorChangeRecord,
+    CyclePolicySnapshot,
+    EffectiveCyclePolicy,
+    _audit_target_conditions,
+    _aware_utc,
+    _effective_policy,
+    _load_scoped_cycle,
+    _record,
+)
+
+__all__ = [
+    "CyclePolicyFieldSource",
+    "EffectiveCyclePolicyReadModel",
+    "async_read_effective_cycle_policy",
+]
+
+
+@dataclass(frozen=True)
+class CyclePolicyFieldSource:
+    field_name: str
+    version: int
+    cycle_revision_id: int | None
+    actor_type: str | None
+    actor_id: str | None
+    source_reference: str | None
+    rationale: str | None
+    changed_at: datetime | None
+    change_id: int | None
+
+
+@dataclass(frozen=True)
+class EffectiveCyclePolicyReadModel(EffectiveCyclePolicy):
+    """Effective policy with all metadata required by read adapters."""
+
+    output_targets: tuple[CycleOutputTarget, ...]
+    source_revision: CycleRevision | None
+    latest_change: BehaviorChangeRecord | None
+    field_sources: tuple[CyclePolicyFieldSource, ...]
+
+
+async def async_read_effective_cycle_policy(
+    session,
+    *,
+    actor: CycleActor,
+    cycle_id: int,
+) -> EffectiveCyclePolicyReadModel:
+    cycle = await _load_scoped_cycle(session, actor=actor, cycle_id=cycle_id)
+    effective = await _effective_policy(session, cycle)
+    source_revision = await session.scalar(
+        select(CycleRevision)
+        .where(CycleRevision.cycle_id == cycle.id)
+        .order_by(CycleRevision.revision_number.desc(), CycleRevision.id.desc())
+        .limit(1)
+    )
+    output_targets = tuple(
+        (
+            await session.scalars(
+                select(CycleOutputTarget)
+                .where(
+                    CycleOutputTarget.cycle_id == cycle.id,
+                    CycleOutputTarget.is_active.is_(True),
+                )
+                .order_by(
+                    CycleOutputTarget.created_at.asc(),
+                    CycleOutputTarget.id.asc(),
+                )
+            )
+        ).all()
+    )
+    change_rows = list(
+        (
+            await session.scalars(
+                select(BehaviorChangeAudit)
+                .where(*_audit_target_conditions(cycle))
+                .order_by(
+                    BehaviorChangeAudit.version.desc(),
+                    BehaviorChangeAudit.id.desc(),
+                )
+            )
+        ).all()
+    )
+    latest_change = (
+        _record(change_rows[0], current_snapshot=effective.snapshot)
+        if change_rows
+        else None
+    )
+    if change_rows:
+        first_policy_revision_number = (
+            select(CycleRevision.revision_number)
+            .where(CycleRevision.id == change_rows[-1].cycle_revision_id)
+            .scalar_subquery()
+        )
+        baseline_revision = await session.scalar(
+            select(CycleRevision)
+            .where(
+                CycleRevision.cycle_id == cycle.id,
+                CycleRevision.revision_number < first_policy_revision_number,
+            )
+            .order_by(
+                CycleRevision.revision_number.desc(),
+                CycleRevision.id.desc(),
+            )
+            .limit(1)
+        )
+    else:
+        baseline_revision = source_revision
+    field_sources = _field_sources(
+        snapshot=effective.snapshot,
+        baseline_revision=baseline_revision,
+        change_rows=change_rows,
+    )
+    return EffectiveCyclePolicyReadModel(
+        workspace_id=effective.workspace_id,
+        policy_kind=effective.policy_kind,
+        target_type=effective.target_type,
+        target_id=effective.target_id,
+        version=effective.version,
+        revision_id=(
+            source_revision.id
+            if source_revision is not None
+            else effective.revision_id
+        ),
+        snapshot=effective.snapshot,
+        output_targets=output_targets,
+        source_revision=source_revision,
+        latest_change=latest_change,
+        field_sources=field_sources,
+    )
+
+
+def _field_sources(
+    *,
+    snapshot: CyclePolicySnapshot,
+    baseline_revision: CycleRevision | None,
+    change_rows: list[BehaviorChangeAudit],
+) -> tuple[CyclePolicyFieldSource, ...]:
+    latest_by_field: dict[str, BehaviorChangeAudit] = {}
+    for row in change_rows:
+        for field_name in row.changed_fields or []:
+            latest_by_field.setdefault(str(field_name), row)
+
+    sources = []
+    for snapshot_field in fields(snapshot):
+        row = latest_by_field.get(snapshot_field.name)
+        if row is not None:
+            sources.append(
+                CyclePolicyFieldSource(
+                    field_name=snapshot_field.name,
+                    version=row.version,
+                    cycle_revision_id=row.cycle_revision_id,
+                    actor_type=row.actor_type,
+                    actor_id=row.actor_id,
+                    source_reference=row.source_reference,
+                    rationale=row.rationale,
+                    changed_at=_aware_utc(row.applied_at),
+                    change_id=row.id,
+                )
+            )
+            continue
+        sources.append(
+            CyclePolicyFieldSource(
+                field_name=snapshot_field.name,
+                version=0,
+                cycle_revision_id=(
+                    baseline_revision.id
+                    if baseline_revision is not None
+                    else None
+                ),
+                actor_type=(
+                    baseline_revision.source_type
+                    if baseline_revision is not None
+                    else None
+                ),
+                actor_id=(
+                    str(baseline_revision.source_id)
+                    if baseline_revision is not None
+                    and baseline_revision.source_id is not None
+                    else None
+                ),
+                source_reference=(
+                    f"cycle_revision:{baseline_revision.id}"
+                    if baseline_revision is not None
+                    else None
+                ),
+                rationale=(
+                    baseline_revision.rationale
+                    if baseline_revision is not None
+                    else None
+                ),
+                changed_at=(
+                    _aware_utc(baseline_revision.created_at)
+                    if baseline_revision is not None
+                    else None
+                ),
+                change_id=None,
+            )
+        )
+    return tuple(sources)

--- a/brain/systems/cycles/serializers.py
+++ b/brain/systems/cycles/serializers.py
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
         BehaviorChangeRecord,
         CyclePolicyPreview,
         CyclePolicySnapshot,
-        EffectiveCyclePolicy,
+    )
+    from brain.systems.cycles.behavior_policy_read_model import (
+        EffectiveCyclePolicyReadModel,
     )
 
 
@@ -117,7 +119,9 @@ def serialize_behavior_change_record(change: BehaviorChangeRecord) -> dict:
     }
 
 
-def serialize_effective_cycle_policy(policy: EffectiveCyclePolicy) -> dict:
+def serialize_effective_cycle_policy(
+    policy: EffectiveCyclePolicyReadModel,
+) -> dict:
     revision = policy.source_revision
     latest_change = policy.latest_change
     output_targets = [

--- a/brain/systems/cycles/serializers.py
+++ b/brain/systems/cycles/serializers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import timezone
+from typing import TYPE_CHECKING
 
 from brain.platform.db.models.cycle import (
     BehaviorChangeAudit,
@@ -22,6 +23,266 @@ from brain.systems.cycles.common import (
     string_or_none,
 )
 from brain.systems.cycles.schedules import safe_humanize_schedule
+
+if TYPE_CHECKING:
+    from brain.systems.cycles.behavior_policy import (
+        BehaviorChangeRecord,
+        CyclePolicyPreview,
+        CyclePolicySnapshot,
+        EffectiveCyclePolicy,
+    )
+
+
+BEHAVIOR_POLICY_EDITABLE_FIELDS = (
+    "prompt",
+    "schedule_expr",
+    "timezone",
+    "enabled",
+    "model_override",
+    "thinking_override",
+    "guidance",
+)
+
+
+def _utc_datetime(value):
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def serialize_cycle_policy_configuration(
+    snapshot: CyclePolicySnapshot,
+) -> dict:
+    return {
+        "name": snapshot.name,
+        "prompt": snapshot.prompt,
+        "schedule_expr": snapshot.schedule_expr,
+        "schedule_human": safe_humanize_schedule(
+            snapshot.schedule_expr,
+            snapshot.timezone,
+        ),
+        "timezone": snapshot.timezone,
+        "enabled": snapshot.enabled,
+        "max_concurrency": snapshot.max_concurrency,
+        "timeout_seconds": snapshot.timeout_seconds,
+        "retry_policy": deepcopy(snapshot.retry_policy),
+        "model_override": snapshot.model_override,
+        "thinking_override": snapshot.thinking_override,
+        "execution_policy_key": snapshot.execution_policy_key,
+        "target_idea_id": snapshot.target_idea_id,
+    }
+
+
+def serialize_cycle_policy_snapshot(snapshot: CyclePolicySnapshot) -> dict:
+    return {
+        "configuration": serialize_cycle_policy_configuration(snapshot),
+        "guidance": list(snapshot.guidance),
+    }
+
+
+def serialize_behavior_change_summary(
+    change: BehaviorChangeRecord | None,
+) -> dict | None:
+    if change is None:
+        return None
+    return {
+        "id": change.id,
+        "version": change.version,
+        "actor_type": change.actor_type,
+        "actor_id": change.actor_id,
+        "source_reference": change.source_reference,
+        "rationale": change.rationale,
+        "changed_fields": list(change.changed_fields),
+        "applied_at": _utc_datetime(change.applied_at),
+        "reverted_from_id": change.reverted_from_id,
+    }
+
+
+def serialize_behavior_change_record(change: BehaviorChangeRecord) -> dict:
+    return {
+        **serialize_behavior_change_summary(change),
+        "workspace_id": change.workspace_id,
+        "policy_kind": change.policy_kind,
+        "target_type": change.target_type,
+        "target_id": change.target_id,
+        "before_snapshot": serialize_cycle_policy_snapshot(
+            change.before_snapshot
+        ),
+        "after_snapshot": serialize_cycle_policy_snapshot(
+            change.after_snapshot
+        ),
+        "cycle_revision_id": change.cycle_revision_id,
+    }
+
+
+def serialize_effective_cycle_policy(policy: EffectiveCyclePolicy) -> dict:
+    revision = policy.source_revision
+    latest_change = policy.latest_change
+    output_targets = [
+        {
+            "id": target.id,
+            "target_type": target.target_type,
+            "target_id": string_or_none(target.target_id),
+            "label": target.label,
+            "config": deepcopy(target.config or {}),
+            "source_type": target.source_type,
+            "source_id": string_or_none(target.source_id),
+            "rationale": target.rationale,
+            "created_at": _utc_datetime(target.created_at),
+            "updated_at": _utc_datetime(target.updated_at),
+        }
+        for target in policy.output_targets
+    ]
+    field_sources = {
+        source.field_name: {
+            "version": source.version,
+            "cycle_revision_id": source.cycle_revision_id,
+            "actor_type": source.actor_type,
+            "actor_id": source.actor_id,
+            "source_reference": source.source_reference,
+            "rationale": source.rationale,
+            "changed_at": _utc_datetime(source.changed_at),
+            "change_id": source.change_id,
+        }
+        for source in policy.field_sources
+    }
+    return {
+        "workspace_id": policy.workspace_id,
+        "policy_kind": policy.policy_kind,
+        "target_type": policy.target_type,
+        "target_id": policy.target_id,
+        "version": policy.version,
+        "revision_id": policy.revision_id,
+        "configuration": serialize_cycle_policy_configuration(policy.snapshot),
+        "guidance": list(policy.snapshot.guidance),
+        "editable_fields": list(BEHAVIOR_POLICY_EDITABLE_FIELDS),
+        "output_targets": output_targets,
+        "output_targets_read_only": True,
+        "source": {
+            "revision_id": policy.revision_id,
+            "actor_type": revision.source_type if revision is not None else None,
+            "actor_id": (
+                string_or_none(revision.source_id)
+                if revision is not None
+                else None
+            ),
+            "rationale": revision.rationale if revision is not None else None,
+            "source_reference": (
+                latest_change.source_reference
+                if latest_change is not None
+                else None
+            ),
+            "changed_at": (
+                _utc_datetime(revision.created_at)
+                if revision is not None
+                else None
+            ),
+        },
+        "field_sources": field_sources,
+        "latest_change": serialize_behavior_change_summary(latest_change),
+    }
+
+
+def serialize_cycle_policy_preview(preview: CyclePolicyPreview) -> dict:
+    changed_fields = list(preview.changed_fields)
+    warnings = []
+    if changed_fields:
+        warnings.append(
+            {
+                "code": "admitted_runs_unchanged",
+                "message": (
+                    "CycleRuns admitted before apply keep their existing "
+                    "policy snapshots."
+                ),
+            }
+        )
+    else:
+        warnings.append(
+            {
+                "code": "no_changes",
+                "message": "The proposal does not change the effective policy.",
+            }
+        )
+    if "enabled" in preview.changed_fields and not preview.after_snapshot.enabled:
+        warnings.append(
+            {
+                "code": "future_runs_disabled",
+                "message": "Disabling this Cycle stops new scheduled admissions.",
+            }
+        )
+    if {"schedule_expr", "timezone"}.intersection(preview.changed_fields):
+        warnings.append(
+            {
+                "code": "future_schedule_changed",
+                "message": "The new schedule applies after this policy is applied.",
+            }
+        )
+    return {
+        "expected_version": preview.before.version,
+        "preview_digest": preview.preview_digest,
+        "before": serialize_cycle_policy_snapshot(preview.before.snapshot),
+        "after": serialize_cycle_policy_snapshot(preview.after_snapshot),
+        "changed_fields": changed_fields,
+        "diff": [
+            _serialize_cycle_policy_diff_entry(preview, field_name)
+            for field_name in preview.changed_fields
+        ],
+        "warnings": warnings,
+        "affected_runs": {
+            "admitted_runs": "unchanged",
+            "future_runs": (
+                "use_proposed_policy_after_apply"
+                if changed_fields
+                else "unchanged"
+            ),
+        },
+        "reverted_from_id": preview.reverted_from_id,
+    }
+
+
+def _serialize_cycle_policy_diff_entry(
+    preview: CyclePolicyPreview,
+    field_name: str,
+) -> dict:
+    before = preview.before.snapshot
+    after = preview.after_snapshot
+    before_value = deepcopy(getattr(before, field_name))
+    after_value = deepcopy(getattr(after, field_name))
+    if field_name == "guidance":
+        return {
+            "field": field_name,
+            "kind": "collection",
+            "before": before_value,
+            "after": after_value,
+            "added": [value for value in after_value if value not in before_value],
+            "removed": [value for value in before_value if value not in after_value],
+        }
+    if field_name in {"schedule_expr", "timezone"}:
+        return {
+            "field": field_name,
+            "kind": "schedule",
+            "before": _schedule_diff_value(before),
+            "after": _schedule_diff_value(after),
+        }
+    return {
+        "field": field_name,
+        "kind": "value",
+        "before": before_value,
+        "after": after_value,
+    }
+
+
+def _schedule_diff_value(snapshot: CyclePolicySnapshot) -> dict:
+    return {
+        "schedule_expr": snapshot.schedule_expr,
+        "schedule_human": safe_humanize_schedule(
+            snapshot.schedule_expr,
+            snapshot.timezone,
+        ),
+        "timezone": snapshot.timezone,
+    }
 
 
 def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -30,6 +30,8 @@ from brain.systems.cycles.behavior_policy import (
     async_list_cycle_policy_history,
     async_preview_cycle_policy_change,
     async_preview_cycle_policy_revert,
+)
+from brain.systems.cycles.behavior_policy_read_model import (
     async_read_effective_cycle_policy,
 )
 from brain.systems.cycles.memory import async_prepare_cycle_run_memory_snapshot

--- a/tests/test_cycle_behavior_policy_api.py
+++ b/tests/test_cycle_behavior_policy_api.py
@@ -1,0 +1,634 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, select
+
+from brain.app.api.routers import cycles as cycles_router
+from brain.app.api.schemas.cycles import (
+    CyclePolicyApplyRead,
+    CyclePolicyApplyRequest,
+    CyclePolicyHistoryRead,
+    CyclePolicyPreviewRead,
+    CyclePolicyPreviewRequest,
+    CyclePolicyProposal,
+    CyclePolicyRevertApplyRequest,
+    EffectiveCyclePolicyRead,
+)
+from brain.platform.db.models.cycle import (
+    BehaviorChangeAudit,
+    Cycle,
+    CycleGuidance,
+    CycleOutputTarget,
+    CycleRevision,
+)
+from brain.platform.db.models.org import Org, User
+from brain.systems.cycles import behavior_policy
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _ApiWorkspace:
+    session: object
+    cycle: Cycle
+    owner: dict
+    outsider: dict
+    initial_revision: CycleRevision
+    output_target: CycleOutputTarget
+    published_events: list[dict]
+
+
+@pytest.fixture
+async def api_workspace(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Cycle.__table__,
+            CycleRevision.__table__,
+            CycleGuidance.__table__,
+            CycleOutputTarget.__table__,
+            BehaviorChangeAudit.__table__,
+        ]
+    )
+    org_id = str(uuid4())
+    other_org_id = str(uuid4())
+    owner_id = str(uuid4())
+    outsider_id = str(uuid4())
+    session.add_all(
+        [
+            Org(id=org_id, name="Policy workspace", slug=f"policy-{org_id[:8]}"),
+            Org(
+                id=other_org_id,
+                name="Other workspace",
+                slug=f"other-{other_org_id[:8]}",
+            ),
+            User(
+                id=owner_id,
+                org_id=org_id,
+                name="Owner",
+                email=f"owner-{owner_id[:8]}@example.com",
+            ),
+            User(
+                id=outsider_id,
+                org_id=other_org_id,
+                name="Outsider",
+                email=f"outsider-{outsider_id[:8]}@example.com",
+            ),
+        ]
+    )
+    await session.flush()
+    cycle = Cycle(
+        user_id=owner_id,
+        org_id=org_id,
+        creator_type="human",
+        creator_id=owner_id,
+        maintainer_type="human",
+        maintainer_id=owner_id,
+        name="Morning review",
+        prompt="Review the workspace.",
+        schedule_expr="0 9 * * *",
+        timezone="UTC",
+        enabled=True,
+        max_concurrency=1,
+        retry_policy={},
+        execution_mode="reuse_same_idea",
+        reopen_archived=True,
+    )
+    session.add(cycle)
+    await session.flush()
+    revision = CycleRevision(
+        cycle_id=cycle.id,
+        revision_number=1,
+        source_type="human",
+        source_id=owner_id,
+        rationale="Initial definition.",
+        name=cycle.name,
+        prompt=cycle.prompt,
+        schedule_expr=cycle.schedule_expr,
+        timezone=cycle.timezone,
+        enabled=cycle.enabled,
+        model_override=None,
+        thinking_override=None,
+        execution_policy_key=None,
+        target_idea_id=None,
+        context_policy={"workspace_id": org_id},
+    )
+    session.add(revision)
+    await session.flush()
+    session.add_all(
+        [
+            CycleGuidance(
+                cycle_id=cycle.id,
+                revision_id=revision.id,
+                source_type="human",
+                source_id=owner_id,
+                guidance="Keep reports concise",
+                rationale="Initial definition.",
+                is_active=True,
+            ),
+            CycleGuidance(
+                cycle_id=cycle.id,
+                revision_id=revision.id,
+                source_type="human",
+                source_id=owner_id,
+                guidance="Report blockers",
+                rationale="Initial definition.",
+                is_active=True,
+            ),
+        ]
+    )
+    output_target = CycleOutputTarget(
+        cycle_id=cycle.id,
+        revision_id=revision.id,
+        target_type="cycle_ledger",
+        target_id=str(cycle.id),
+        label="Cycle ledger",
+        config={"format": "summary"},
+        source_type="system",
+        source_id="cycle-defaults",
+        rationale="Keep a durable result.",
+        is_active=True,
+    )
+    session.add(output_target)
+    await session.flush()
+    published_events: list[dict] = []
+    monkeypatch.setattr(
+        behavior_policy,
+        "publish_cycle_change_strict",
+        lambda **payload: published_events.append(payload),
+    )
+    return _ApiWorkspace(
+        session=session,
+        cycle=cycle,
+        owner={
+            "id": owner_id,
+            "org_id": org_id,
+            "principal_type": "human",
+        },
+        outsider={
+            "id": outsider_id,
+            "org_id": other_org_id,
+            "principal_type": "human",
+        },
+        initial_revision=revision,
+        output_target=output_target,
+        published_events=published_events,
+    )
+
+
+def _preview_body(**proposal) -> CyclePolicyPreviewRequest:
+    return CyclePolicyPreviewRequest(
+        proposal=CyclePolicyProposal(**proposal),
+    )
+
+
+async def _preview_and_apply(
+    workspace: _ApiWorkspace,
+    *,
+    rationale: str = "Apply the reviewed policy.",
+    **proposal,
+) -> dict:
+    preview_body = _preview_body(**proposal)
+    preview = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        preview_body,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+    return await cycles_router.apply_cycle_behavior_policy(
+        workspace.cycle.id,
+        CyclePolicyApplyRequest(
+            proposal=preview_body.proposal,
+            expected_version=preview["expected_version"],
+            preview_digest=preview["preview_digest"],
+            rationale=rationale,
+        ),
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+
+async def test_effective_policy_shape_includes_sources_and_read_only_targets(
+    api_workspace,
+):
+    workspace = api_workspace
+
+    payload = await cycles_router.get_cycle_behavior_policy(
+        workspace.cycle.id,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    EffectiveCyclePolicyRead.model_validate(payload)
+    assert payload["version"] == 0
+    assert payload["configuration"]["prompt"] == "Review the workspace."
+    assert payload["configuration"]["schedule_human"]
+    assert payload["guidance"] == [
+        "Keep reports concise",
+        "Report blockers",
+    ]
+    assert payload["output_targets_read_only"] is True
+    assert payload["output_targets"] == [
+        {
+            "id": workspace.output_target.id,
+            "target_type": "cycle_ledger",
+            "target_id": str(workspace.cycle.id),
+            "label": "Cycle ledger",
+            "config": {"format": "summary"},
+            "source_type": "system",
+            "source_id": "cycle-defaults",
+            "rationale": "Keep a durable result.",
+            "created_at": payload["output_targets"][0]["created_at"],
+            "updated_at": payload["output_targets"][0]["updated_at"],
+        }
+    ]
+    assert payload["source"]["revision_id"] == workspace.initial_revision.id
+    assert payload["source"]["actor_type"] == "human"
+    assert payload["source"]["source_reference"] is None
+    assert payload["field_sources"]["prompt"] == {
+        "version": 0,
+        "cycle_revision_id": workspace.initial_revision.id,
+        "actor_type": "human",
+        "actor_id": workspace.owner["id"],
+        "source_reference": f"cycle_revision:{workspace.initial_revision.id}",
+        "rationale": "Initial definition.",
+        "changed_at": payload["field_sources"]["prompt"]["changed_at"],
+        "change_id": None,
+    }
+    assert payload["latest_change"] is None
+    for value in (
+        payload["output_targets"][0]["created_at"],
+        payload["output_targets"][0]["updated_at"],
+        payload["source"]["changed_at"],
+        payload["field_sources"]["prompt"]["changed_at"],
+    ):
+        assert value.tzinfo is not None
+        assert value.utcoffset() == timedelta(0)
+
+
+async def test_preview_returns_normalized_field_aware_diff_without_writing(
+    api_workspace,
+):
+    workspace = api_workspace
+    payload = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        _preview_body(
+            prompt="  Review incidents and owners.  ",
+            schedule_expr="30 10 * * 1",
+            guidance=["New guidance", "Keep reports concise"],
+        ),
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    CyclePolicyPreviewRead.model_validate(payload)
+    assert payload["expected_version"] == 0
+    assert len(payload["preview_digest"]) == 64
+    assert payload["after"]["configuration"]["prompt"] == (
+        "Review incidents and owners."
+    )
+    assert payload["changed_fields"] == [
+        "guidance",
+        "prompt",
+        "schedule_expr",
+    ]
+    diff = {entry["field"]: entry for entry in payload["diff"]}
+    assert diff["guidance"] == {
+        "field": "guidance",
+        "kind": "collection",
+        "before": ["Keep reports concise", "Report blockers"],
+        "after": ["Keep reports concise", "New guidance"],
+        "added": ["New guidance"],
+        "removed": ["Report blockers"],
+    }
+    assert diff["schedule_expr"]["kind"] == "schedule"
+    assert diff["schedule_expr"]["before"]["schedule_human"]
+    assert diff["schedule_expr"]["after"]["schedule_expr"] == "30 10 * * 1"
+    assert payload["affected_runs"] == {
+        "admitted_runs": "unchanged",
+        "future_runs": "use_proposed_policy_after_apply",
+    }
+    assert payload["warnings"][0]["code"] == "admitted_runs_unchanged"
+    assert workspace.cycle.prompt == "Review the workspace."
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0
+
+
+@pytest.mark.parametrize(
+    ("proposal", "error"),
+    [
+        ({"schedule_expr": "not a schedule"}, "schedule"),
+        ({"prompt": "   "}, "prompt is required"),
+        ({"model_override": "openai/not-a-model"}, "Unknown model_override"),
+        (
+            {"guidance": ["Repeated guidance", "Repeated guidance"]},
+            "guidance entries must be unique",
+        ),
+    ],
+)
+async def test_preview_rejects_invalid_policy_before_apply(
+    api_workspace,
+    proposal,
+    error,
+):
+    workspace = api_workspace
+
+    with pytest.raises(HTTPException) as caught:
+        await cycles_router.preview_cycle_behavior_policy(
+            workspace.cycle.id,
+            _preview_body(**proposal),
+            db=workspace.session,
+            user=workspace.owner,
+        )
+
+    assert caught.value.status_code == 400
+    assert error.lower() in str(caught.value.detail).lower()
+    assert workspace.cycle.prompt == "Review the workspace."
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0
+
+
+async def test_apply_updates_policy_audit_event_and_utc_source(api_workspace):
+    workspace = api_workspace
+
+    payload = await _preview_and_apply(
+        workspace,
+        prompt="Review incidents and owners.",
+        guidance=["Keep reports concise", "Name every owner"],
+        rationale="Make incident ownership explicit.",
+    )
+
+    CyclePolicyApplyRead.model_validate(payload)
+    assert payload["effective_policy"]["version"] == 1
+    assert payload["effective_policy"]["configuration"]["prompt"] == (
+        "Review incidents and owners."
+    )
+    assert payload["effective_policy"]["latest_change"]["id"] == (
+        payload["change"]["id"]
+    )
+    assert payload["effective_policy"]["field_sources"]["prompt"]["version"] == 1
+    assert payload["effective_policy"]["field_sources"]["guidance"]["version"] == 1
+    assert payload["effective_policy"]["field_sources"]["name"]["version"] == 0
+    assert payload["change"]["actor_type"] == "human"
+    assert payload["change"]["actor_id"] == workspace.owner["id"]
+    assert payload["change"]["source_reference"] == (
+        f"api:/cycles/{workspace.cycle.id}/behavior-policy"
+    )
+    assert payload["change"]["rationale"] == (
+        "Make incident ownership explicit."
+    )
+    assert payload["change"]["applied_at"].utcoffset() == timedelta(0)
+    assert payload["effective_policy"]["source"]["changed_at"].utcoffset() == (
+        timedelta(0)
+    )
+    assert workspace.published_events == [
+        {
+            "action": "update",
+            "org_id": workspace.cycle.org_id,
+            "user_id": workspace.cycle.user_id,
+            "cycle_id": workspace.cycle.id,
+            "target_idea_id": None,
+        }
+    ]
+    stored = await workspace.session.get(BehaviorChangeAudit, payload["change"]["id"])
+    assert stored is not None
+    assert stored.version == 1
+
+
+async def test_apply_rejects_whitespace_only_rationale(api_workspace):
+    workspace = api_workspace
+    body = _preview_body(prompt="A reviewed draft.")
+    preview = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        body,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await cycles_router.apply_cycle_behavior_policy(
+            workspace.cycle.id,
+            CyclePolicyApplyRequest(
+                proposal=body.proposal,
+                expected_version=preview["expected_version"],
+                preview_digest=preview["preview_digest"],
+                rationale="   ",
+            ),
+            db=workspace.session,
+            user=workspace.owner,
+        )
+
+    assert caught.value.status_code == 400
+    assert caught.value.detail == "rationale is required"
+    assert workspace.cycle.prompt == "Review the workspace."
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0
+
+
+async def test_apply_returns_exact_conflicts_with_latest_effective_policy(
+    api_workspace,
+):
+    workspace = api_workspace
+    first_body = _preview_body(prompt="First editor won.")
+    stale_body = _preview_body(prompt="Second editor draft.")
+    first_preview = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        first_body,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+    stale_preview = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        stale_body,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+    await cycles_router.apply_cycle_behavior_policy(
+        workspace.cycle.id,
+        CyclePolicyApplyRequest(
+            proposal=first_body.proposal,
+            expected_version=first_preview["expected_version"],
+            preview_digest=first_preview["preview_digest"],
+            rationale="Apply the first editor draft.",
+        ),
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    with pytest.raises(HTTPException) as stale_version:
+        await cycles_router.apply_cycle_behavior_policy(
+            workspace.cycle.id,
+            CyclePolicyApplyRequest(
+                proposal=stale_body.proposal,
+                expected_version=stale_preview["expected_version"],
+                preview_digest=stale_preview["preview_digest"],
+                rationale="Try the second editor draft.",
+            ),
+            db=workspace.session,
+            user=workspace.owner,
+        )
+
+    assert stale_version.value.status_code == 409
+    assert set(stale_version.value.detail) == {
+        "reason",
+        "latest_effective_policy",
+    }
+    assert stale_version.value.detail["reason"] == "stale_version"
+    latest = stale_version.value.detail["latest_effective_policy"]
+    EffectiveCyclePolicyRead.model_validate(latest)
+    assert latest["version"] == 1
+    assert latest["configuration"]["prompt"] == "First editor won."
+
+    fresh_preview = await cycles_router.preview_cycle_behavior_policy(
+        workspace.cycle.id,
+        stale_body,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+    with pytest.raises(HTTPException) as stale_digest:
+        await cycles_router.apply_cycle_behavior_policy(
+            workspace.cycle.id,
+            CyclePolicyApplyRequest(
+                proposal=stale_body.proposal,
+                expected_version=fresh_preview["expected_version"],
+                preview_digest="0" * 64,
+                rationale="Use only the reviewed digest.",
+            ),
+            db=workspace.session,
+            user=workspace.owner,
+        )
+
+    assert stale_digest.value.status_code == 409
+    assert stale_digest.value.detail["reason"] == "stale_preview_digest"
+    assert stale_digest.value.detail["latest_effective_policy"]["version"] == 1
+
+
+async def test_history_is_paginated_in_descending_effective_version(api_workspace):
+    workspace = api_workspace
+    for index in range(1, 4):
+        await _preview_and_apply(
+            workspace,
+            prompt=f"Mission version {index}.",
+            rationale=f"Apply version {index}.",
+        )
+
+    first_page = await cycles_router.list_cycle_behavior_policy_history(
+        workspace.cycle.id,
+        limit=2,
+        offset=0,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+    second_page = await cycles_router.list_cycle_behavior_policy_history(
+        workspace.cycle.id,
+        limit=2,
+        offset=2,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    CyclePolicyHistoryRead.model_validate(first_page)
+    CyclePolicyHistoryRead.model_validate(second_page)
+    assert [item["version"] for item in first_page["items"]] == [3, 2]
+    assert first_page["pagination"] == {
+        "limit": 2,
+        "offset": 0,
+        "has_more": True,
+        "next_offset": 2,
+    }
+    assert [item["version"] for item in second_page["items"]] == [1]
+    assert second_page["pagination"]["has_more"] is False
+    assert second_page["pagination"]["next_offset"] is None
+    assert all(
+        item["applied_at"].utcoffset() == timedelta(0)
+        for item in first_page["items"] + second_page["items"]
+    )
+
+
+async def test_revert_previews_and_applies_as_a_new_version(api_workspace):
+    workspace = api_workspace
+    changed = await _preview_and_apply(
+        workspace,
+        prompt="Changed mission.",
+        rationale="Make the first change.",
+    )
+    change_id = changed["change"]["id"]
+
+    preview = await cycles_router.preview_cycle_behavior_policy_revert(
+        workspace.cycle.id,
+        change_id,
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    CyclePolicyPreviewRead.model_validate(preview)
+    assert preview["reverted_from_id"] == change_id
+    assert preview["after"]["configuration"]["prompt"] == (
+        "Review the workspace."
+    )
+    reverted = await cycles_router.apply_cycle_behavior_policy_revert(
+        workspace.cycle.id,
+        change_id,
+        CyclePolicyRevertApplyRequest(
+            expected_version=preview["expected_version"],
+            preview_digest=preview["preview_digest"],
+            rationale="Restore the earlier mission.",
+        ),
+        db=workspace.session,
+        user=workspace.owner,
+    )
+
+    CyclePolicyApplyRead.model_validate(reverted)
+    assert reverted["effective_policy"]["version"] == 2
+    assert reverted["effective_policy"]["configuration"]["prompt"] == (
+        "Review the workspace."
+    )
+    assert reverted["change"]["reverted_from_id"] == change_id
+    assert reverted["change"]["source_reference"] == (
+        f"api:/cycles/{workspace.cycle.id}/behavior-policy"
+    )
+
+
+async def test_cross_workspace_read_and_apply_are_denied(api_workspace):
+    workspace = api_workspace
+
+    with pytest.raises(HTTPException) as read_denied:
+        await cycles_router.get_cycle_behavior_policy(
+            workspace.cycle.id,
+            db=workspace.session,
+            user=workspace.outsider,
+        )
+    with pytest.raises(HTTPException) as apply_denied:
+        await cycles_router.apply_cycle_behavior_policy(
+            workspace.cycle.id,
+            CyclePolicyApplyRequest(
+                proposal=CyclePolicyProposal(prompt="Cross-workspace change."),
+                expected_version=0,
+                preview_digest="not-a-valid-preview",
+                rationale="This must be denied.",
+            ),
+            db=workspace.session,
+            user=workspace.outsider,
+        )
+
+    assert read_denied.value.status_code == 404
+    assert read_denied.value.detail == "Cycle not found"
+    assert apply_denied.value.status_code == 404
+    assert apply_denied.value.detail == "Cycle not found"
+    assert workspace.cycle.prompt == "Review the workspace."
+    assert await workspace.session.scalar(
+        select(func.count(BehaviorChangeAudit.id))
+    ) == 0


### PR DESCRIPTION
> *This was generated by AI during an autonomous routine run (R3).*

Closes #783

Slice 2 of 6 of #738. HTTP routes over the slice-1 behavior-policy command module.

## Stacked on #794 — merge that first

This branch is based on `illo-qa/consolidated-20260810`
([#794](https://github.com/Illospace/illospace/pull/794)), which carries the
slice-1 command module and the typed policy snapshot this builds on. Merge #794,
then this.

## What it does

Five routes — **read effective policy, preview, apply, history, revert** — that
call the command module and never touch a policy table.

**The conflict contract is the part that matters.** Apply returns **409** when the
expected version or the preview digest is stale, and the 409 body carries the
latest effective policy so the client can refresh without losing its draft. Slice
4's conflict recovery is built on that payload shape.

Validation rejects invalid schedules, empty missions, unsupported models and
duplicate guidance *before* apply, so broken policy never becomes active. Reads
and writes are scoped to the current workspace through the existing Cycle
authority; a cross-workspace request gets 404. All datetimes are timezone-aware
UTC. No feature flag, no environment gate, no migration.

## Verification (local — this repo has no CI minutes)

- Fast suite **4895 passed, 11 skipped** at machine load 3.7 (uncontended).
- `alembic heads` → exactly one (`0059_behavior_change_audits`); no migration added.
- No `frontend/**` changes, so no frontend lane applies.

## What the review changed

A cross-family maintainability review found the command module had quietly
absorbed the HTTP read model: 184 of its 194 new lines were effective-policy
hydration, and `EffectiveCyclePolicy` had grown two hidden modes — lean for
preview/apply/conflict, rich for reads — distinguishable only by default-empty
metadata. A future adapter serializing the conflict payload would have silently
dropped output targets, field sources and the latest change; today's router only
dodged that by discarding the value and re-reading.

Folded: the read model moved to `behavior_policy_read_model.py` with an explicit
rich result type, and `behavior_policy.py` gave back 189 lines. Apply and
revert/apply also duplicated the whole finalize path; both now call one
`_finalize_policy_apply_result`. The HTTP contract did not move —
`tests/test_cycle_behavior_policy_api.py` passes unmodified.

The review explicitly cleared two things: the 409 body already uses one shared
effective-policy helper for both GET and conflict responses, and workspace scoping
is uniform through `_load_scoped_cycle()` / `cycle_scope_conditions()`.

## What to watch after you deploy

1. Preview a Cycle policy change — you get a diff, warnings, and a digest, and
   nothing is written.
2. Apply with that digest succeeds; apply again with the **same stale** digest
   returns 409 and the body contains the current policy.
3. Revert goes through the same preview-then-apply path and appends history rather
   than rewriting it.

## Known follow-up, filed not folded

[#795](https://github.com/Illospace/illospace/issues/795) — adding one editable
scalar policy field currently takes **11 synchronized hand edits** across the
command module, the API schemas and the serializers, with nothing checking they
agree. Its remedy includes renaming API fields, which is a contract decision
rather than a mechanical fix, so it is its own ticket. **It gates slice 3
(#784)** — same call you made on #790 before slice 2.
