### PR TITLE
feat(cycles): read-only effective-policy view in the Cycles workspace (#784)

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -406,6 +406,118 @@ export interface CycleRunRead {
   created_at: string;
 }
 
+export type CyclePolicyJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | CyclePolicyJsonValue[]
+  | { [key: string]: CyclePolicyJsonValue };
+
+/** Mirrors CyclePolicySnapshot configuration plus its derived schedule label. */
+export interface CyclePolicyConfigurationRead {
+  name: string;
+  prompt: string;
+  schedule_expr: string;
+  schedule_human: string;
+  timezone: string;
+  enabled: boolean;
+  max_concurrency: number;
+  timeout_seconds: number | null;
+  retry_policy: Record<string, CyclePolicyJsonValue>;
+  model_override: string | null;
+  thinking_override: string | null;
+  execution_policy_key: string | null;
+  target_idea_id: string | null;
+}
+
+export interface CyclePolicySnapshotRead {
+  configuration: CyclePolicyConfigurationRead;
+  guidance: string[];
+}
+
+export interface CyclePolicyOutputTargetRead {
+  id: number;
+  target_type: string;
+  target_id: string | null;
+  label: string | null;
+  config: Record<string, CyclePolicyJsonValue>;
+  source_type: string;
+  source_id: string | null;
+  rationale: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CyclePolicySourceRead {
+  revision_id: number | null;
+  actor_type: string | null;
+  actor_id: string | null;
+  rationale: string | null;
+  source_reference: string | null;
+  changed_at: string | null;
+}
+
+export interface CyclePolicyFieldSourceRead {
+  version: number;
+  cycle_revision_id: number | null;
+  actor_type: string | null;
+  actor_id: string | null;
+  source_reference: string | null;
+  rationale: string | null;
+  changed_at: string | null;
+  change_id: number | null;
+}
+
+export interface CyclePolicyChangeSummaryRead {
+  id: number;
+  version: number;
+  actor_type: string;
+  actor_id: string;
+  source_reference: string;
+  rationale: string;
+  changed_fields: string[];
+  applied_at: string;
+  reverted_from_id: number | null;
+}
+
+export interface EffectiveCyclePolicyRead {
+  workspace_id: string;
+  policy_kind: string;
+  target_type: string;
+  target_id: string;
+  version: number;
+  revision_id: number | null;
+  configuration: CyclePolicyConfigurationRead;
+  guidance: string[];
+  editable_fields: string[];
+  output_targets: CyclePolicyOutputTargetRead[];
+  output_targets_read_only: boolean;
+  source: CyclePolicySourceRead;
+  field_sources: Record<string, CyclePolicyFieldSourceRead>;
+  latest_change: CyclePolicyChangeSummaryRead | null;
+}
+
+export interface CyclePolicyChangeRead extends CyclePolicyChangeSummaryRead {
+  workspace_id: string;
+  policy_kind: string;
+  target_type: string;
+  target_id: string;
+  before_snapshot: CyclePolicySnapshotRead;
+  after_snapshot: CyclePolicySnapshotRead;
+  cycle_revision_id: number;
+}
+
+export interface CyclePolicyHistoryRead {
+  items: CyclePolicyChangeRead[];
+  pagination: {
+    limit: number;
+    offset: number;
+    has_more: boolean;
+    next_offset: number | null;
+  };
+}
+
 export interface DomainFieldRead {
   id: number;
   domain_id: number;
@@ -1420,6 +1532,12 @@ export const api = {
     fetchJson<CycleRunRead[]>(withQuery(`/api/cycles/${cycleId}/runs`, { limit })),
   runCycle: (cycleId: number) =>
     fetchJson<CycleRunRead>(`/api/cycles/${cycleId}/run`, { method: 'POST' }),
+  getCycleBehaviorPolicy: (cycleId: number) =>
+    fetchJson<EffectiveCyclePolicyRead>(`/api/cycles/${cycleId}/behavior-policy`),
+  getCycleBehaviorPolicyHistory: (cycleId: number, limit = 50, offset = 0) =>
+    fetchJson<CyclePolicyHistoryRead>(
+      withQuery(`/api/cycles/${cycleId}/behavior-policy/history`, { limit, offset }),
+    ),
 
   // Domains
   listDomains: () => fetchJson<DomainSummaryRead[]>('/api/domains/'),

--- a/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
@@ -1,0 +1,767 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  import {
+    api,
+    type CyclePolicyChangeRead,
+    type CyclePolicyHistoryRead,
+    type EffectiveCyclePolicyRead,
+  } from '$lib/api/client';
+  import {
+    ConstellationButton,
+    ConstellationPill,
+  } from '$lib/components/constellation';
+  import {
+    formatPolicyDateTime,
+    policyConfigurationEntries,
+    policyFieldLabel,
+    policyFieldSource,
+    policySourceLabel,
+    policyValueLabel,
+    retiredGuidance,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+
+  let {
+    cycleId,
+    previewPolicy = null,
+    previewHistory = null,
+    displayTimezone = null,
+    compact = false,
+    refreshSerial = 0,
+  }: {
+    cycleId: number;
+    previewPolicy?: EffectiveCyclePolicyRead | null;
+    previewHistory?: CyclePolicyHistoryRead | null;
+    displayTimezone?: string | null;
+    compact?: boolean;
+    refreshSerial?: number;
+  } = $props();
+
+  let policy = $state<EffectiveCyclePolicyRead | null>(null);
+  let history = $state<CyclePolicyChangeRead[]>([]);
+  let pagination = $state<CyclePolicyHistoryRead['pagination'] | null>(null);
+  let loading = $state(true);
+  let historyLoading = $state(false);
+  let error = $state('');
+  let historyError = $state('');
+  let resolvedTimezone = $state(
+    Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+  );
+  let requestSerial = 0;
+
+  const configurationEntries = $derived(
+    policy ? policyConfigurationEntries(policy.configuration) : [],
+  );
+  const guidanceSource = $derived(
+    policy ? policyFieldSource(policy.field_sources, 'guidance') : undefined,
+  );
+
+  function errorMessage(value: unknown, fallback: string): string {
+    if (value && typeof value === 'object' && 'detail' in value) {
+      return String((value as { detail?: unknown }).detail || fallback);
+    }
+    return fallback;
+  }
+
+  async function loadPolicy(selectedCycleId: number) {
+    const serial = ++requestSerial;
+    loading = true;
+    error = '';
+    historyError = '';
+    policy = null;
+    history = [];
+    pagination = null;
+    try {
+      const [nextPolicy, nextHistory, runtime] = await Promise.all([
+        api.getCycleBehaviorPolicy(selectedCycleId),
+        api.getCycleBehaviorPolicyHistory(selectedCycleId),
+        displayTimezone
+          ? Promise.resolve(null)
+          : api.runtimeSettings().catch(() => null),
+      ]);
+      if (serial !== requestSerial) return;
+      policy = nextPolicy;
+      history = nextHistory.items;
+      pagination = nextHistory.pagination;
+      resolvedTimezone = displayTimezone
+        || runtime?.display?.display_timezone
+        || Intl.DateTimeFormat().resolvedOptions().timeZone
+        || 'UTC';
+    } catch (loadError) {
+      if (serial !== requestSerial) return;
+      error = errorMessage(loadError, 'Effective behavior failed to load.');
+    } finally {
+      if (serial === requestSerial) loading = false;
+    }
+  }
+
+  async function loadMoreHistory() {
+    if (!pagination?.has_more || pagination.next_offset === null || historyLoading) return;
+    const selectedCycleId = cycleId;
+    const serial = requestSerial;
+    historyLoading = true;
+    historyError = '';
+    try {
+      const nextHistory = await api.getCycleBehaviorPolicyHistory(
+        selectedCycleId,
+        pagination.limit,
+        pagination.next_offset,
+      );
+      if (serial !== requestSerial || selectedCycleId !== cycleId) return;
+      history = [...history, ...nextHistory.items];
+      pagination = nextHistory.pagination;
+    } catch (loadError) {
+      if (serial !== requestSerial) return;
+      historyError = errorMessage(loadError, 'Older history failed to load.');
+    } finally {
+      if (serial === requestSerial) historyLoading = false;
+    }
+  }
+
+  $effect(() => {
+    const selectedCycleId = cycleId;
+    refreshSerial;
+    const suppliedPolicy = previewPolicy;
+    const suppliedHistory = previewHistory;
+    if (displayTimezone) resolvedTimezone = displayTimezone;
+    if (suppliedPolicy) {
+      requestSerial += 1;
+      policy = suppliedPolicy;
+      history = suppliedHistory?.items ?? [];
+      pagination = suppliedHistory?.pagination ?? null;
+      loading = false;
+      error = '';
+      historyError = '';
+      return;
+    }
+    void loadPolicy(selectedCycleId);
+  });
+
+  onDestroy(() => {
+    requestSerial += 1;
+  });
+</script>
+
+<section class="effective-policy" class:compact aria-label="Effective cycle behavior">
+  <header class="active-heading">
+    <div>
+      <span class="section-kicker">Effective behavior</span>
+      <h3>Active now</h3>
+      <p>What Illo will use on the next run.</p>
+    </div>
+    {#if policy}
+      <div class="active-status">
+        <ConstellationPill variant={policy.configuration.enabled ? 'success' : 'muted'} leadingDot>
+          {policy.configuration.enabled ? 'Enabled' : 'Paused'}
+        </ConstellationPill>
+        <span>Version {policy.version}</span>
+      </div>
+    {/if}
+  </header>
+
+  {#if loading}
+    <div class="policy-loading" aria-label="Loading effective behavior">
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+  {:else if error}
+    <div class="policy-error" role="alert">
+      <span>{error}</span>
+      <ConstellationButton variant="secondary" size="sm" onclick={() => loadPolicy(cycleId)}>
+        Retry
+      </ConstellationButton>
+    </div>
+  {:else if policy}
+    <div class="policy-content">
+      <section class="policy-section" aria-labelledby={`cycle-${cycleId}-configuration`}>
+        <div class="policy-section-heading">
+          <h4 id={`cycle-${cycleId}-configuration`}>Mission and settings</h4>
+          <span>{resolvedTimezone.replaceAll('_', ' ')}</span>
+        </div>
+
+        <dl class="policy-values">
+          {#each configurationEntries as entry (entry.key)}
+            {@const source = policyFieldSource(policy.field_sources, entry.key)}
+            <div class="policy-value" class:prose-value={entry.key === 'prompt'}>
+              <dt>{policyFieldLabel(entry.key)}</dt>
+              <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
+                {policyValueLabel(entry.value)}
+              </dd>
+              <dd class="value-source" title={source?.rationale || undefined}>
+                <span>From {source ? policySourceLabel(source) : policySourceLabel(policy.source)}</span>
+                <time datetime={source?.changed_at || policy.source.changed_at || undefined}>
+                  Changed {formatPolicyDateTime(source?.changed_at || policy.source.changed_at, resolvedTimezone)}
+                </time>
+              </dd>
+            </div>
+          {/each}
+        </dl>
+      </section>
+
+      <section class="policy-section active-guidance" aria-labelledby={`cycle-${cycleId}-guidance`}>
+        <div class="policy-section-heading">
+          <div>
+            <span class="live-marker">Live</span>
+            <h4 id={`cycle-${cycleId}-guidance`}>Active guidance</h4>
+          </div>
+          <span>{policy.guidance.length} active</span>
+        </div>
+
+        {#if policy.guidance.length}
+          <ol class="guidance-list">
+            {#each policy.guidance as guidance}
+              <li>
+                <p>{guidance}</p>
+                <div class="value-source" title={guidanceSource?.rationale || undefined}>
+                  <span>From {guidanceSource ? policySourceLabel(guidanceSource) : policySourceLabel(policy.source)}</span>
+                  <time datetime={guidanceSource?.changed_at || policy.source.changed_at || undefined}>
+                    Changed {formatPolicyDateTime(guidanceSource?.changed_at || policy.source.changed_at, resolvedTimezone)}
+                  </time>
+                </div>
+              </li>
+            {/each}
+          </ol>
+        {:else}
+          <p class="empty-policy-value">No active guidance.</p>
+        {/if}
+      </section>
+
+      <section class="policy-section" aria-labelledby={`cycle-${cycleId}-outputs`}>
+        <div class="policy-section-heading">
+          <h4 id={`cycle-${cycleId}-outputs`}>Output targets</h4>
+          <ConstellationPill variant="muted">Read only</ConstellationPill>
+        </div>
+
+        {#if policy.output_targets.length}
+          <div class="output-list">
+            {#each policy.output_targets as target (target.id)}
+              <article class="output-target">
+                <div class="output-target-heading">
+                  <strong>{target.label || policyFieldLabel(target.target_type)}</strong>
+                  <span>{target.target_type}</span>
+                </div>
+                {#if target.target_id}<p>Target {target.target_id}</p>{/if}
+                {#if Object.keys(target.config).length}
+                  <pre>{policyValueLabel(target.config)}</pre>
+                {/if}
+                {#if target.rationale}<p>{target.rationale}</p>{/if}
+                <div class="value-source">
+                  <span>From {[target.source_type, target.source_id].filter(Boolean).join(' · ')}</span>
+                  <time datetime={target.updated_at}>
+                    Changed {formatPolicyDateTime(target.updated_at, resolvedTimezone)}
+                  </time>
+                </div>
+              </article>
+            {/each}
+          </div>
+        {:else}
+          <p class="empty-policy-value">No output targets.</p>
+        {/if}
+      </section>
+    </div>
+  {/if}
+
+  {#if !loading && !error}
+    <details class="history-region">
+      <summary>
+        <span>
+          <strong>History</strong>
+          <small>Prior versions are not active.</small>
+        </span>
+        <span>{history.length} changes</span>
+      </summary>
+
+      <div class="history-content">
+        <div class="history-warning">
+          <strong>Historical only</strong>
+          <span>Text below does not guide the next run.</span>
+        </div>
+
+        {#if history.length}
+          <ol class="history-list">
+            {#each history as change (change.id)}
+              {@const retired = retiredGuidance(change)}
+              <li class="history-change">
+                <header>
+                  <div>
+                    <strong>Version {change.version}</strong>
+                    <time datetime={change.applied_at}>
+                      {formatPolicyDateTime(change.applied_at, resolvedTimezone)}
+                    </time>
+                  </div>
+                  <span>{change.changed_fields.map(policyFieldLabel).join(', ')}</span>
+                </header>
+                <p>{change.rationale}</p>
+                <div class="history-source">
+                  From {policySourceLabel(change)}
+                  {#if change.reverted_from_id !== null}
+                    · Reverted change {change.reverted_from_id}
+                  {/if}
+                </div>
+
+                {#if retired.length}
+                  <section class="retired-guidance" aria-label="Retired guidance">
+                    <span>Retired guidance · not active</span>
+                    {#each retired as guidance}
+                      <blockquote>{guidance}</blockquote>
+                    {/each}
+                  </section>
+                {/if}
+              </li>
+            {/each}
+          </ol>
+        {:else}
+          <p class="empty-policy-value">No policy changes yet.</p>
+        {/if}
+
+        {#if historyError}
+          <p class="history-error" role="alert">{historyError}</p>
+        {/if}
+        {#if pagination?.has_more}
+          <ConstellationButton
+            variant="quiet"
+            size="sm"
+            loading={historyLoading}
+            onclick={loadMoreHistory}
+          >
+            Load older changes
+          </ConstellationButton>
+        {/if}
+      </div>
+    </details>
+  {/if}
+</section>
+
+<style>
+  .effective-policy {
+    display: grid;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--constellation-surface-panel-separator);
+    border-radius: 8px;
+    background: var(--constellation-surface-panel-background);
+    color: var(--constellation-color-text-primary);
+  }
+
+  .active-heading,
+  .policy-section-heading,
+  .output-target-heading,
+  .history-change header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .active-heading {
+    padding: 14px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-success) 7%, transparent);
+  }
+
+  .active-heading h3,
+  .active-heading p,
+  .policy-section-heading h4,
+  .guidance-list p,
+  .output-target p,
+  .history-change p,
+  .history-change blockquote {
+    margin: 0;
+  }
+
+  .active-heading h3 {
+    margin-top: 3px;
+    font-size: 16px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+  }
+
+  .active-heading p {
+    margin-top: 5px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .section-kicker,
+  .policy-value dt,
+  .live-marker,
+  .retired-guidance > span {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .active-status {
+    display: grid;
+    justify-items: end;
+    gap: 6px;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .policy-content {
+    display: grid;
+  }
+
+  .policy-section {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+    padding: 14px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+  }
+
+  .policy-section-heading {
+    align-items: center;
+  }
+
+  .policy-section-heading > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .policy-section-heading h4 {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .policy-section-heading > span {
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+  }
+
+  .live-marker {
+    padding: 3px 6px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--constellation-color-success) 14%, transparent);
+    color: var(--constellation-color-success);
+  }
+
+  .policy-values {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0;
+    margin: 0;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value:nth-child(odd) {
+    border-right: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value.prose-value {
+    grid-column: 1 / -1;
+    border-right: 0;
+  }
+
+  .policy-value dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .policy-value.prose-value > dd:not(.value-source) {
+    font-size: 14px;
+  }
+
+  .mono-value,
+  .output-target pre {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .value-source {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px 10px;
+    color: var(--constellation-color-text-muted) !important;
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px !important;
+    line-height: 1.4 !important;
+  }
+
+  .active-guidance {
+    border-left: 3px solid var(--constellation-color-success);
+    background: color-mix(in srgb, var(--constellation-color-success) 3%, transparent);
+  }
+
+  .guidance-list,
+  .output-list,
+  .history-list {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .guidance-list {
+    counter-reset: active-guidance;
+  }
+
+  .guidance-list li {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 6px 10px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--constellation-section-divider);
+    counter-increment: active-guidance;
+  }
+
+  .guidance-list li::before {
+    content: counter(active-guidance, decimal-leading-zero);
+    color: var(--constellation-color-success);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    line-height: 1.7;
+  }
+
+  .guidance-list li:last-child {
+    border-bottom: 0;
+  }
+
+  .guidance-list .value-source {
+    grid-column: 2;
+  }
+
+  .guidance-list p {
+    font-size: 13px;
+    line-height: 1.55;
+  }
+
+  .output-target {
+    display: grid;
+    gap: 7px;
+    padding: 11px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 7px;
+    background: var(--constellation-surface-nested-background);
+  }
+
+  .output-target-heading strong {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .output-target-heading span,
+  .output-target p,
+  .output-target pre {
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .output-target-heading span {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .output-target pre {
+    max-width: 100%;
+    margin: 0;
+    overflow: auto;
+    white-space: pre-wrap;
+  }
+
+  .empty-policy-value {
+    margin: 0;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .history-region summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 46px;
+    padding: 0 14px;
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 5%, transparent);
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .history-region summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .history-region summary > span:first-child {
+    display: grid;
+    gap: 2px;
+  }
+
+  .history-region summary strong {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .history-region summary small,
+  .history-region summary > span:last-child,
+  .history-source,
+  .history-change header span,
+  .history-change time {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+  }
+
+  .history-content {
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    border-top: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
+  }
+
+  .history-warning {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 10px;
+    padding: 8px 10px;
+    border: 1px dashed var(--constellation-color-text-muted);
+    border-radius: 6px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+  }
+
+  .history-warning strong,
+  .retired-guidance > span {
+    color: var(--constellation-color-text-primary);
+  }
+
+  .history-change {
+    display: grid;
+    gap: 7px;
+    padding: 11px 0;
+    border-bottom: 1px solid var(--constellation-section-divider);
+    opacity: 0.82;
+  }
+
+  .history-change:last-child {
+    border-bottom: 0;
+  }
+
+  .history-change header > div {
+    display: grid;
+    gap: 3px;
+  }
+
+  .history-change header > span {
+    max-width: 50%;
+    text-align: right;
+  }
+
+  .history-change p {
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .history-source {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .retired-guidance {
+    display: grid;
+    gap: 7px;
+    margin-top: 3px;
+    padding: 10px;
+    border: 1px dashed var(--constellation-color-text-muted);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 6%, transparent);
+  }
+
+  .retired-guidance blockquote {
+    padding-left: 10px;
+    border-left: 2px solid var(--constellation-color-text-muted);
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+    font-style: italic;
+    line-height: 1.5;
+  }
+
+  .history-error,
+  .policy-error {
+    color: var(--constellation-color-danger);
+    font-size: 12px;
+  }
+
+  .policy-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  .policy-loading {
+    display: grid;
+    gap: 8px;
+    padding: 14px;
+  }
+
+  .policy-loading span {
+    height: 48px;
+    border-radius: 6px;
+    background:
+      linear-gradient(90deg, transparent, var(--constellation-skeleton-row-shimmer), transparent),
+      var(--constellation-skeleton-row-background);
+    background-size: 200% 100%;
+    animation: policy-pulse 1.4s ease-in-out infinite;
+  }
+
+  .effective-policy.compact .policy-values {
+    grid-template-columns: 1fr;
+  }
+
+  .effective-policy.compact .policy-value,
+  .effective-policy.compact .policy-value:nth-child(odd) {
+    border-right: 0;
+  }
+
+  @keyframes policy-pulse {
+    from { background-position: 200% 0; }
+    to { background-position: -200% 0; }
+  }
+
+  @media (max-width: 720px) {
+    .policy-values {
+      grid-template-columns: 1fr;
+    }
+
+    .policy-value,
+    .policy-value:nth-child(odd) {
+      border-right: 0;
+    }
+
+    .active-heading,
+    .history-change header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .active-status {
+      justify-items: start;
+    }
+
+    .history-change header > span {
+      max-width: none;
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
+++ b/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
@@ -9,6 +9,7 @@
   } from '$lib/components/constellation';
   import { ui } from '$lib/stores/ui.svelte';
   import { wsClient } from '$lib/stores/ws.svelte';
+  import EffectiveCyclePolicyView from './EffectiveCyclePolicyView.svelte';
 
   type Cadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
   type FormState = {
@@ -72,6 +73,7 @@
   let isDraft = $state(false);
   let lastFocusCycleId = $state<number | null>(null);
   let lastRefreshSerial = $state<number | null>(null);
+  let behaviorPolicyRefreshSerial = $state(0);
   let unsubscribeCyclesChanged: (() => void) | null = null;
 
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
@@ -286,6 +288,7 @@
       isDraft = !nextSelected && isDraft;
       if (nextSelected) fillForm(nextSelected);
       await loadRuns(nextSelected?.id ?? null);
+      behaviorPolicyRefreshSerial += 1;
     } catch (err: any) {
       ui.toast(err?.detail || 'Failed to load cycles', 'error');
     } finally {
@@ -435,6 +438,13 @@
   {/if}
 
   {#if isDraft || selectedCycle}
+    {#if selectedCycle}
+      <EffectiveCyclePolicyView
+        cycleId={selectedCycle.id}
+        compact
+        refreshSerial={behaviorPolicyRefreshSerial}
+      />
+    {/if}
     <div class="cycle-pane-editor">
       <div class="cycle-pane-editor-head">
         <span>{isDraft ? 'New cycle' : 'Selected cycle'}</span>

--- a/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
@@ -1,0 +1,83 @@
+import type {
+  CyclePolicyChangeRead,
+  CyclePolicyConfigurationRead,
+  CyclePolicyFieldSourceRead,
+  CyclePolicyJsonValue,
+} from '$lib/api/client';
+import { parseServerDate } from '../../../utils/datetime.ts';
+
+export type CyclePolicyConfigurationEntry = {
+  key: keyof CyclePolicyConfigurationRead & string;
+  value: CyclePolicyConfigurationRead[keyof CyclePolicyConfigurationRead];
+};
+
+export function policyConfigurationEntries(
+  configuration: CyclePolicyConfigurationRead,
+): CyclePolicyConfigurationEntry[] {
+  return Object.entries(configuration).map(([key, value]) => ({
+    key: key as CyclePolicyConfigurationEntry['key'],
+    value,
+  }));
+}
+
+export function policyFieldLabel(field: string): string {
+  if (field === 'prompt') return 'Mission prompt';
+  if (field === 'schedule_expr') return 'Schedule rule';
+  return field
+    .replaceAll('_', ' ')
+    .replace(/^./, (first) => first.toUpperCase());
+}
+
+export function policyValueLabel(
+  value: CyclePolicyConfigurationEntry['value'] | CyclePolicyJsonValue,
+): string {
+  if (value === null || value === undefined || value === '') return 'Not set';
+  if (typeof value === 'boolean') return value ? 'Enabled' : 'Disabled';
+  if (typeof value === 'object') return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+export function policyFieldSource(
+  fieldSources: Record<string, CyclePolicyFieldSourceRead>,
+  field: string,
+): CyclePolicyFieldSourceRead | undefined {
+  if (field === 'schedule_human') return fieldSources.schedule_expr;
+  return fieldSources[field];
+}
+
+export function policySourceLabel(source: {
+  actor_type?: string | null;
+  actor_id?: string | null;
+  source_reference?: string | null;
+}): string {
+  if (source.source_reference) return source.source_reference;
+  const actor = [source.actor_type, source.actor_id].filter(Boolean).join(' · ');
+  return actor || 'Initial cycle definition';
+}
+
+export function formatPolicyDateTime(
+  timestamp: string | null | undefined,
+  displayTimezone: string,
+  locale?: string,
+): string {
+  const date = parseServerDate(timestamp);
+  if (!date) return 'Time not recorded';
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: displayTimezone,
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    }).format(date);
+  }
+}
+
+export function retiredGuidance(change: CyclePolicyChangeRead): string[] {
+  const activeAfter = new Set(change.after_snapshot.guidance);
+  return change.before_snapshot.guidance.filter((guidance) => !activeAfter.has(guidance));
+}

--- a/frontend/src/lib/utils/effectivePolicy.test.js
+++ b/frontend/src/lib/utils/effectivePolicy.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatPolicyDateTime,
+  policyConfigurationEntries,
+  policyFieldSource,
+  retiredGuidance,
+} from '../features/cycles/domain/effectivePolicy.ts';
+
+test('renders every configuration field supplied by the typed policy object', () => {
+  const configuration = {
+    name: 'Morning review',
+    prompt: 'Review current priorities.',
+    schedule_expr: '0 9 * * *',
+    schedule_human: 'Every day at 9:00 AM',
+    timezone: 'UTC',
+    enabled: true,
+    max_concurrency: 1,
+    timeout_seconds: null,
+    retry_policy: {},
+    model_override: null,
+    thinking_override: 'high',
+    execution_policy_key: null,
+    target_idea_id: null,
+  };
+
+  assert.deepEqual(
+    policyConfigurationEntries(configuration).map(({ key }) => key),
+    Object.keys(configuration),
+  );
+});
+
+test('uses the schedule rule provenance for its derived human label', () => {
+  const scheduleSource = {
+    version: 2,
+    cycle_revision_id: 10,
+    actor_type: 'human',
+    actor_id: 'reviewer',
+    source_reference: 'api:/cycles/1/behavior-policy',
+    rationale: 'Move the morning review.',
+    changed_at: '2026-08-11T13:00:00Z',
+    change_id: 9,
+  };
+
+  assert.equal(policyFieldSource({ schedule_expr: scheduleSource }, 'schedule_human'), scheduleSource);
+});
+
+test('keeps removed guidance in history without treating unchanged guidance as retired', () => {
+  const change = {
+    before_snapshot: { guidance: ['Stay concise', 'Use old CRM copy'] },
+    after_snapshot: { guidance: ['Stay concise', 'Use approved CRM copy'] },
+  };
+
+  assert.deepEqual(retiredGuidance(change), ['Use old CRM copy']);
+});
+
+test('formats UTC API timestamps in the display timezone', () => {
+  assert.match(
+    formatPolicyDateTime('2026-08-11T16:00:00Z', 'America/Toronto', 'en-CA'),
+    /12:00 p\.m\./,
+  );
+});

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -3,7 +3,15 @@
   import { page } from '$app/stores';
   import { getContext, onMount } from 'svelte';
 
-  import { api, type CycleRead, type CycleRunRead } from '$lib/api/client';
+  import {
+    api,
+    type CyclePolicyConfigurationRead,
+    type CyclePolicyFieldSourceRead,
+    type CyclePolicyHistoryRead,
+    type CycleRead,
+    type CycleRunRead,
+    type EffectiveCyclePolicyRead,
+  } from '$lib/api/client';
   import {
     ConstellationButton,
     ConstellationEmptyState,
@@ -20,6 +28,7 @@
     type ConstellationPageFrameModalContext,
   } from '$lib/components/constellation/constellationPageFrameContext';
   import AiPromptComposer from '$lib/features/composer/components/AiPromptComposer.svelte';
+  import EffectiveCyclePolicyView from '$lib/features/cycles/components/EffectiveCyclePolicyView.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
 
@@ -101,6 +110,9 @@
   let filterMode = $state<FilterMode>('all');
   let showCreateModal = $state(false);
   let previewRuns = $state<Record<number, CycleRunRead[]>>({});
+  let previewPolicies = $state<Record<number, EffectiveCyclePolicyRead>>({});
+  let previewPolicyHistories = $state<Record<number, CyclePolicyHistoryRead>>({});
+  let behaviorPolicyRefreshSerial = $state(0);
 
   const workspacePageModalContext = getContext<ConstellationPageFrameModalContext | undefined>(
     CONSTELLATION_PAGE_FRAME_MODAL_CONTEXT,
@@ -298,6 +310,134 @@
     };
   }
 
+  function previewBehaviorPolicy(cycle: CycleRead): {
+    policy: EffectiveCyclePolicyRead;
+    history: CyclePolicyHistoryRead;
+  } {
+    const changedAt = previewIso(-2);
+    const configuration: CyclePolicyConfigurationRead = {
+      name: cycle.name,
+      prompt: cycle.prompt,
+      schedule_expr: cycle.schedule_expr,
+      schedule_human: cycle.schedule_human,
+      timezone: cycle.timezone,
+      enabled: cycle.enabled,
+      max_concurrency: 1,
+      timeout_seconds: null,
+      retry_policy: { max_attempts: 2 },
+      model_override: cycle.model_override,
+      thinking_override: cycle.thinking_override,
+      execution_policy_key: cycle.execution_policy_key,
+      target_idea_id: cycle.target_idea_id,
+    };
+    const activeGuidance = [
+      'Use the current workspace state as the source of truth.',
+      'Keep the result concise and name any blocker that needs attention.',
+    ];
+    const source: CyclePolicyFieldSourceRead = {
+      version: 2,
+      cycle_revision_id: 4100 + cycle.id,
+      actor_type: 'human',
+      actor_id: 'preview-user',
+      source_reference: `api:/cycles/${cycle.id}/behavior-policy`,
+      rationale: 'Approved behavior for the next run.',
+      changed_at: changedAt,
+      change_id: 5100 + cycle.id,
+    };
+    const fieldSources = Object.fromEntries(
+      [...Object.keys(configuration), 'guidance'].map((field) => [field, { ...source }]),
+    ) as Record<string, CyclePolicyFieldSourceRead>;
+    const policy: EffectiveCyclePolicyRead = {
+      workspace_id: 'preview-org',
+      policy_kind: 'cycle',
+      target_type: 'cycle',
+      target_id: String(cycle.id),
+      version: 2,
+      revision_id: source.cycle_revision_id,
+      configuration,
+      guidance: activeGuidance,
+      editable_fields: [
+        'prompt',
+        'schedule_expr',
+        'timezone',
+        'enabled',
+        'model_override',
+        'thinking_override',
+        'guidance',
+      ],
+      output_targets: [
+        {
+          id: 6100 + cycle.id,
+          target_type: 'cycle_ledger',
+          target_id: String(cycle.id),
+          label: 'Cycle ledger',
+          config: { format: 'summary' },
+          source_type: 'system',
+          source_id: 'cycle-defaults',
+          rationale: 'Keep a durable result for later review.',
+          created_at: previewIso(-18),
+          updated_at: changedAt,
+        },
+      ],
+      output_targets_read_only: true,
+      source: {
+        revision_id: source.cycle_revision_id,
+        actor_type: source.actor_type,
+        actor_id: source.actor_id,
+        rationale: source.rationale,
+        source_reference: source.source_reference,
+        changed_at: changedAt,
+      },
+      field_sources: fieldSources,
+      latest_change: {
+        id: source.change_id ?? 0,
+        version: 2,
+        actor_type: 'human',
+        actor_id: 'preview-user',
+        source_reference: source.source_reference ?? '',
+        rationale: source.rationale ?? '',
+        changed_fields: ['guidance'],
+        applied_at: changedAt,
+        reverted_from_id: null,
+      },
+    };
+    return {
+      policy,
+      history: {
+        items: [
+          {
+            id: source.change_id ?? 0,
+            version: 2,
+            actor_type: 'human',
+            actor_id: 'preview-user',
+            source_reference: source.source_reference ?? '',
+            rationale: 'Replace guidance that used an old priority list.',
+            changed_fields: ['guidance'],
+            applied_at: changedAt,
+            reverted_from_id: null,
+            workspace_id: 'preview-org',
+            policy_kind: 'cycle',
+            target_type: 'cycle',
+            target_id: String(cycle.id),
+            before_snapshot: {
+              configuration,
+              guidance: [...activeGuidance, 'Use the legacy priority list before reviewing the workspace.'],
+            },
+            after_snapshot: { configuration, guidance: activeGuidance },
+            cycle_revision_id: source.cycle_revision_id ?? 0,
+          },
+        ],
+        pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
+      },
+    };
+  }
+
+  function setPreviewBehaviorPolicy(cycle: CycleRead) {
+    const { policy, history } = previewBehaviorPolicy(cycle);
+    previewPolicies = { ...previewPolicies, [cycle.id]: policy };
+    previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: history };
+  }
+
   function loadPreviewData() {
     const previewCycles = [
       previewCycle(901, {
@@ -342,6 +482,7 @@
     ];
 
     cycles = previewCycles;
+    for (const cycle of previewCycles) setPreviewBehaviorPolicy(cycle);
     previewRuns = {
       901: [
         previewRun(7101, 901, 'completed', previewCycles[0].prompt, -1),
@@ -778,6 +919,7 @@
         cycles = existing
           ? cycles.map((cycle) => (cycle.id === savedId ? saved : cycle))
           : [saved, ...cycles];
+        setPreviewBehaviorPolicy(saved);
         selectedCycleId = saved.id;
         selectedRowId = cycleRowId(saved);
         fillForm(saved);
@@ -792,6 +934,7 @@
       ui.toast(selectedCycleId ? 'Cycle updated' : 'Cycle created', 'success');
       if (isCreate) showCreateModal = false;
       await loadCycles(saved.id);
+      behaviorPolicyRefreshSerial += 1;
     } catch (err: any) {
       ui.toast(err.detail || 'Failed to save cycle', 'error');
     } finally {
@@ -809,6 +952,10 @@
         cycles = cycles.filter((cycle) => cycle.id !== selectedCycleId);
         const { [selectedCycleId]: _removed, ...nextPreviewRuns } = previewRuns;
         previewRuns = nextPreviewRuns;
+        const { [selectedCycleId]: _removedPolicy, ...nextPreviewPolicies } = previewPolicies;
+        const { [selectedCycleId]: _removedHistory, ...nextPreviewHistories } = previewPolicyHistories;
+        previewPolicies = nextPreviewPolicies;
+        previewPolicyHistories = nextPreviewHistories;
         selectedCycleId = null;
         selectedRowId = null;
         runs = [];
@@ -871,12 +1018,14 @@
         const updated = cycles.find((item) => item.id === cycle.id);
         if (updated && preferredCycleId === updated.id) {
           fillForm(updated);
+          setPreviewBehaviorPolicy(updated);
         }
         ui.toast(updated?.enabled ? 'Preview cycle resumed' : 'Preview cycle paused', 'success');
         return;
       }
       await api.updateCycle(cycle.id, { enabled: !cycle.enabled });
       await loadCycles(preferredCycleId);
+      behaviorPolicyRefreshSerial += 1;
     } catch (err: any) {
       ui.toast(err.detail || 'Failed to update cycle', 'error');
     }
@@ -999,6 +1148,14 @@
                       tone="danger"
                     />
                   {/if}
+
+                  <EffectiveCyclePolicyView
+                    cycleId={cycle.id}
+                    previewPolicy={isCyclesPreview ? previewPolicies[cycle.id] : null}
+                    previewHistory={isCyclesPreview ? previewPolicyHistories[cycle.id] : null}
+                    displayTimezone={isCyclesPreview ? localTimezone : null}
+                    refreshSerial={behaviorPolicyRefreshSerial}
+                  />
 
                   <details class="cycle-region" open>
                     <summary>


### PR DESCRIPTION
> *Autonomous routine run (R3).*

Behavior-editor **slice 3 of 6** of the [#738](https://github.com/Illospace/illospace/issues/738) PRD. Slice 1 (#782), the typed snapshot (#790) and slice 2's API routes (#783) all merged this morning in #799, which unblocked this.

Closes #784

## What you are looking at

An **"Active now"** panel inside the existing Cycle detail — not a new page and not a second editor. It answers "what will Illo do on the next run" before anything becomes editable.

## I verified it in a browser, here is what it shows

- **Mission and settings** — prompt, schedule rule and human schedule, timezone, enabled, concurrency, retry policy, model and thinking overrides. Every value carries its source (`From api:/cycles/901/behavior-policy`) and its last-change time.
- **Active guidance** — marked `LIVE`, with a green rail and an "N active" count.
- **Output targets** — shown with a `READ ONLY` badge, since this slice does not edit.
- **History** — collapsed by default. Opening it shows a `Historical only — Text below does not guide the next run.` banner, and each retired line is labelled `RETIRED GUIDANCE · NOT ACTIVE`.

That last point is the whole reason the PRD exists: retired prose used to sit in the database looking live. It now cannot be mistaken for active guidance.

- All dates render in the user's display timezone; API values stay UTC.
- Policy fields are read through typed client contracts, so a maintainer adding a field does not hand-edit string-keyed maps.

## How to look at it yourself

```
cd frontend && npm ci && npm run dev
```

then open `http://localhost:5173/cycles?preview=1` — the preview route carries sample policy data, so no backend is needed.

## Evidence

- `npm test` — 254 passed, 0 failed.
- `npm run check` (`svelte-check`) — 6,702 files, **0 errors, 0 warnings**.
- `npm run build` — passed.
- Browser check: view rendered, History expanded, **no JavaScript errors**. The console 500s are `/api/me` and `/api/cortex/*` because no brain API runs in the preview; no behavior-policy request fails.

The diff touches `frontend/**` only, so this is the only CI lane it selects.