### PR TITLE
fix(cycles): make the behavior-change audit envelope honestly Cycle-only (#791)

### DIFF
--- a/brain/app/api/schemas/cycles.py
+++ b/brain/app/api/schemas/cycles.py
@@ -227,8 +227,6 @@ class CyclePolicyChangeSummaryRead(BaseModel):
 
 class EffectiveCyclePolicyRead(BaseModel):
     workspace_id: str
-    policy_kind: str
-    target_type: str
     target_id: str
     version: int
     revision_id: int | None = None
@@ -275,8 +273,6 @@ class CyclePolicyPreviewRead(BaseModel):
 
 class CyclePolicyChangeRead(CyclePolicyChangeSummaryRead):
     workspace_id: str
-    policy_kind: str
-    target_type: str
     target_id: str
     before_snapshot: CyclePolicySnapshotRead
     after_snapshot: CyclePolicySnapshotRead

--- a/brain/platform/db/alembic/versions/0062_cycle_behavior_change_audits.py
+++ b/brain/platform/db/alembic/versions/0062_cycle_behavior_change_audits.py
@@ -1,0 +1,150 @@
+"""Make the behavior-change audit envelope explicitly Cycle-only.
+
+Revision ID: 0062_cycle_behavior_change_audits
+Revises: 0061_meetbot_sessions
+Create Date: 2026-08-11
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0062_cycle_behavior_change_audits"
+down_revision = "0061_meetbot_sessions"
+branch_labels = None
+depends_on = None
+
+_OLD_TABLE = "behavior_change_audits"
+_TABLE = "cycle_behavior_change_audits"
+
+_OLD_TARGET_VERSION = "uq_behavior_change_audits_target_version"
+_TARGET_VERSION = "uq_cycle_behavior_change_audits_target_version"
+_OLD_CYCLE_REVISION = "uq_behavior_change_audits_cycle_revision"
+_CYCLE_REVISION = "uq_cycle_behavior_change_audits_cycle_revision"
+_OLD_WORKSPACE_APPLIED = "ix_behavior_change_audits_workspace_applied"
+_WORKSPACE_APPLIED = "ix_cycle_behavior_change_audits_workspace_applied"
+_OLD_TARGET_HISTORY = "ix_behavior_change_audits_target_history"
+_TARGET_HISTORY = "ix_cycle_behavior_change_audits_target_history"
+
+
+def _has_table(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def upgrade() -> None:
+    old_exists = _has_table(_OLD_TABLE)
+    new_exists = _has_table(_TABLE)
+
+    if new_exists:
+        if old_exists:
+            old_row_count = op.get_bind().execute(
+                sa.text(f'SELECT COUNT(*) FROM "{_OLD_TABLE}"')
+            ).scalar_one()
+            if old_row_count:
+                raise RuntimeError(
+                    "both behavior-change audit tables contain schema state; "
+                    "refusing to discard the old table"
+                )
+            # Fresh installs materialize current model metadata in the public
+            # baseline, then 0059 creates this empty historical table.
+            op.drop_table(_OLD_TABLE)
+        return
+
+    if not old_exists:
+        return
+
+    op.execute(f'ALTER TABLE "{_OLD_TABLE}" RENAME TO "{_TABLE}"')
+    op.execute(
+        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
+        f'"{_OLD_TARGET_VERSION}" TO "{_TARGET_VERSION}"'
+    )
+    op.execute(
+        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
+        f'"{_OLD_CYCLE_REVISION}" TO "{_CYCLE_REVISION}"'
+    )
+    op.execute(
+        f'ALTER INDEX "{_OLD_WORKSPACE_APPLIED}" '
+        f'RENAME TO "{_WORKSPACE_APPLIED}"'
+    )
+    op.execute(
+        f'ALTER INDEX "{_OLD_TARGET_HISTORY}" '
+        f'RENAME TO "{_TARGET_HISTORY}"'
+    )
+
+    # These two objects depended on the generic discriminator columns, so keep
+    # their renamed identities while replacing their definitions.
+    op.drop_index(_TARGET_HISTORY, table_name=_TABLE)
+    op.drop_constraint(_TARGET_VERSION, _TABLE, type_="unique")
+    op.execute(f'ALTER TABLE "{_TABLE}" DROP COLUMN "policy_kind"')
+    op.execute(f'ALTER TABLE "{_TABLE}" DROP COLUMN "target_type"')
+    op.create_unique_constraint(
+        _TARGET_VERSION,
+        _TABLE,
+        ["target_id", "version"],
+    )
+    op.create_index(
+        _TARGET_HISTORY,
+        _TABLE,
+        ["target_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    if _has_table(_OLD_TABLE) or not _has_table(_TABLE):
+        return
+
+    op.drop_index(_TARGET_HISTORY, table_name=_TABLE)
+    op.drop_constraint(_TARGET_VERSION, _TABLE, type_="unique")
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "policy_kind",
+            sa.String(length=50),
+            server_default=sa.text("'cycle'"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "target_type",
+            sa.String(length=50),
+            server_default=sa.text("'cycle'"),
+            nullable=False,
+        ),
+    )
+    op.alter_column(
+        _TABLE,
+        "policy_kind",
+        existing_type=sa.String(length=50),
+        existing_nullable=False,
+        server_default=None,
+    )
+    op.alter_column(
+        _TABLE,
+        "target_type",
+        existing_type=sa.String(length=50),
+        existing_nullable=False,
+        server_default=None,
+    )
+    op.create_unique_constraint(
+        _OLD_TARGET_VERSION,
+        _TABLE,
+        ["policy_kind", "target_type", "target_id", "version"],
+    )
+    op.create_index(
+        _OLD_TARGET_HISTORY,
+        _TABLE,
+        ["policy_kind", "target_type", "target_id", "version"],
+    )
+    op.execute(
+        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
+        f'"{_CYCLE_REVISION}" TO "{_OLD_CYCLE_REVISION}"'
+    )
+    op.execute(
+        f'ALTER INDEX "{_WORKSPACE_APPLIED}" '
+        f'RENAME TO "{_OLD_WORKSPACE_APPLIED}"'
+    )
+    op.execute(f'ALTER TABLE "{_TABLE}" RENAME TO "{_OLD_TABLE}"')

--- a/brain/platform/db/alembic/versions/0062_cycle_behavior_change_audits.py
+++ b/brain/platform/db/alembic/versions/0062_cycle_behavior_change_audits.py
@@ -23,14 +23,96 @@ _OLD_TARGET_VERSION = "uq_behavior_change_audits_target_version"
 _TARGET_VERSION = "uq_cycle_behavior_change_audits_target_version"
 _OLD_CYCLE_REVISION = "uq_behavior_change_audits_cycle_revision"
 _CYCLE_REVISION = "uq_cycle_behavior_change_audits_cycle_revision"
+_OLD_PRIMARY_KEY = "behavior_change_audits_pkey"
+_PRIMARY_KEY = "cycle_behavior_change_audits_pkey"
+_OLD_CYCLE_REVISION_FK = "behavior_change_audits_cycle_revision_id_fkey"
+_CYCLE_REVISION_FK = "cycle_behavior_change_audits_cycle_revision_id_fkey"
+_OLD_REVERTED_FROM_FK = "behavior_change_audits_reverted_from_id_fkey"
+_REVERTED_FROM_FK = "cycle_behavior_change_audits_reverted_from_id_fkey"
 _OLD_WORKSPACE_APPLIED = "ix_behavior_change_audits_workspace_applied"
 _WORKSPACE_APPLIED = "ix_cycle_behavior_change_audits_workspace_applied"
 _OLD_TARGET_HISTORY = "ix_behavior_change_audits_target_history"
-_TARGET_HISTORY = "ix_cycle_behavior_change_audits_target_history"
+
+_CONSTRAINT_RENAMES = (
+    (_OLD_PRIMARY_KEY, _PRIMARY_KEY),
+    (_OLD_CYCLE_REVISION_FK, _CYCLE_REVISION_FK),
+    (_OLD_REVERTED_FROM_FK, _REVERTED_FROM_FK),
+    (_OLD_CYCLE_REVISION, _CYCLE_REVISION),
+)
+_INDEX_RENAMES = ((_OLD_WORKSPACE_APPLIED, _WORKSPACE_APPLIED),)
 
 
 def _has_table(table_name: str) -> bool:
     return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_constraint(table_name: str, constraint_name: str) -> bool:
+    return bool(
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint
+                    WHERE conrelid = to_regclass(:table_name)
+                      AND conname = :constraint_name
+                )
+                """
+            ),
+            {
+                "table_name": table_name,
+                "constraint_name": constraint_name,
+            },
+        )
+        .scalar_one()
+    )
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    return bool(
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_class AS index_relation
+                    JOIN pg_index
+                      ON pg_index.indexrelid = index_relation.oid
+                    WHERE pg_index.indrelid = to_regclass(:table_name)
+                      AND index_relation.relname = :index_name
+                )
+                """
+            ),
+            {
+                "table_name": table_name,
+                "index_name": index_name,
+            },
+        )
+        .scalar_one()
+    )
+
+
+def _rename_constraint_if_exists(
+    table_name: str,
+    old_name: str,
+    new_name: str,
+) -> None:
+    if _has_constraint(table_name, old_name):
+        op.execute(
+            f'ALTER TABLE "{table_name}" RENAME CONSTRAINT '
+            f'"{old_name}" TO "{new_name}"'
+        )
+
+
+def _rename_index_if_exists(
+    table_name: str,
+    old_name: str,
+    new_name: str,
+) -> None:
+    if _has_index(table_name, old_name):
+        op.execute(f'ALTER INDEX "{old_name}" RENAME TO "{new_name}"')
 
 
 def upgrade() -> None:
@@ -53,39 +135,26 @@ def upgrade() -> None:
         return
 
     if not old_exists:
-        return
+        raise RuntimeError(
+            "neither behavior-change audit table exists; refusing to mark "
+            "the migration as applied"
+        )
 
     op.execute(f'ALTER TABLE "{_OLD_TABLE}" RENAME TO "{_TABLE}"')
-    op.execute(
-        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
-        f'"{_OLD_TARGET_VERSION}" TO "{_TARGET_VERSION}"'
-    )
-    op.execute(
-        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
-        f'"{_OLD_CYCLE_REVISION}" TO "{_CYCLE_REVISION}"'
-    )
-    op.execute(
-        f'ALTER INDEX "{_OLD_WORKSPACE_APPLIED}" '
-        f'RENAME TO "{_WORKSPACE_APPLIED}"'
-    )
-    op.execute(
-        f'ALTER INDEX "{_OLD_TARGET_HISTORY}" '
-        f'RENAME TO "{_TARGET_HISTORY}"'
-    )
+    for old_name, new_name in _CONSTRAINT_RENAMES:
+        _rename_constraint_if_exists(_TABLE, old_name, new_name)
+    for old_name, new_name in _INDEX_RENAMES:
+        _rename_index_if_exists(_TABLE, old_name, new_name)
 
-    # These two objects depended on the generic discriminator columns, so keep
-    # their renamed identities while replacing their definitions.
-    op.drop_index(_TARGET_HISTORY, table_name=_TABLE)
-    op.drop_constraint(_TARGET_VERSION, _TABLE, type_="unique")
+    # The target-version objects duplicate each other. Keep only the unique
+    # constraint, replacing it because the generic discriminator columns go.
+    if _has_index(_TABLE, _OLD_TARGET_HISTORY):
+        op.drop_index(_OLD_TARGET_HISTORY, table_name=_TABLE)
+    op.drop_constraint(_OLD_TARGET_VERSION, _TABLE, type_="unique")
     op.execute(f'ALTER TABLE "{_TABLE}" DROP COLUMN "policy_kind"')
     op.execute(f'ALTER TABLE "{_TABLE}" DROP COLUMN "target_type"')
     op.create_unique_constraint(
         _TARGET_VERSION,
-        _TABLE,
-        ["target_id", "version"],
-    )
-    op.create_index(
-        _TARGET_HISTORY,
         _TABLE,
         ["target_id", "version"],
     )
@@ -95,7 +164,6 @@ def downgrade() -> None:
     if _has_table(_OLD_TABLE) or not _has_table(_TABLE):
         return
 
-    op.drop_index(_TARGET_HISTORY, table_name=_TABLE)
     op.drop_constraint(_TARGET_VERSION, _TABLE, type_="unique")
     op.add_column(
         _TABLE,
@@ -139,12 +207,8 @@ def downgrade() -> None:
         _TABLE,
         ["policy_kind", "target_type", "target_id", "version"],
     )
-    op.execute(
-        f'ALTER TABLE "{_TABLE}" RENAME CONSTRAINT '
-        f'"{_CYCLE_REVISION}" TO "{_OLD_CYCLE_REVISION}"'
-    )
-    op.execute(
-        f'ALTER INDEX "{_WORKSPACE_APPLIED}" '
-        f'RENAME TO "{_OLD_WORKSPACE_APPLIED}"'
-    )
+    for old_name, new_name in _CONSTRAINT_RENAMES:
+        _rename_constraint_if_exists(_TABLE, new_name, old_name)
+    for old_name, new_name in _INDEX_RENAMES:
+        _rename_index_if_exists(_TABLE, new_name, old_name)
     op.execute(f'ALTER TABLE "{_TABLE}" RENAME TO "{_OLD_TABLE}"')

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -44,11 +44,6 @@ class CycleBehaviorChangeAudit(Base):
             "applied_at",
             "id",
         ),
-        Index(
-            "ix_cycle_behavior_change_audits_target_history",
-            "target_id",
-            "version",
-        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from brain.platform.db.base import Base, CreatedAtMixin, TimestampMixin
 
 __all__ = [
-    "BehaviorChangeAudit",
+    "CycleBehaviorChangeAudit",
     "Cycle",
     "CycleFailureGuardLatch",
     "CycleFailureGuardObservation",
@@ -24,32 +24,28 @@ __all__ = [
 ]
 
 
-class BehaviorChangeAudit(Base):
-    """Append-only, human-readable envelope for one behavior-policy apply."""
+class CycleBehaviorChangeAudit(Base):
+    """Append-only, human-readable envelope for one Cycle policy apply."""
 
-    __tablename__ = "behavior_change_audits"
+    __tablename__ = "cycle_behavior_change_audits"
     __table_args__ = (
         UniqueConstraint(
-            "policy_kind",
-            "target_type",
             "target_id",
             "version",
-            name="uq_behavior_change_audits_target_version",
+            name="uq_cycle_behavior_change_audits_target_version",
         ),
         UniqueConstraint(
             "cycle_revision_id",
-            name="uq_behavior_change_audits_cycle_revision",
+            name="uq_cycle_behavior_change_audits_cycle_revision",
         ),
         Index(
-            "ix_behavior_change_audits_workspace_applied",
+            "ix_cycle_behavior_change_audits_workspace_applied",
             "workspace_id",
             "applied_at",
             "id",
         ),
         Index(
-            "ix_behavior_change_audits_target_history",
-            "policy_kind",
-            "target_type",
+            "ix_cycle_behavior_change_audits_target_history",
             "target_id",
             "version",
         ),
@@ -57,8 +53,6 @@ class BehaviorChangeAudit(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     workspace_id: Mapped[str] = mapped_column(Text, nullable=False)
-    policy_kind: Mapped[str] = mapped_column(String(50), nullable=False)
-    target_type: Mapped[str] = mapped_column(String(50), nullable=False)
     target_id: Mapped[str] = mapped_column(Text, nullable=False)
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     actor_type: Mapped[str] = mapped_column(String(30), nullable=False)
@@ -75,7 +69,7 @@ class BehaviorChangeAudit(Base):
     )
     reverted_from_id: Mapped[Optional[int]] = mapped_column(
         Integer,
-        ForeignKey("behavior_change_audits.id", ondelete="SET NULL"),
+        ForeignKey("cycle_behavior_change_audits.id", ondelete="SET NULL"),
         nullable=True,
     )
     applied_at: Mapped[datetime] = mapped_column(

--- a/brain/systems/cycles/behavior_policy.py
+++ b/brain/systems/cycles/behavior_policy.py
@@ -25,8 +25,8 @@ from sqlalchemy import func, select
 
 from brain.kernel.common.serialization import jsonable
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleRevision,
 )
@@ -60,9 +60,6 @@ __all__ = [
     "async_preview_cycle_policy_change",
     "async_preview_cycle_policy_revert",
 ]
-
-CYCLE_POLICY_KIND = "cycle"
-CYCLE_TARGET_TYPE = "cycle"
 
 CycleGuidanceValues: TypeAlias = list[str] | tuple[str, ...]
 _PatchValueT = TypeVar("_PatchValueT")
@@ -116,8 +113,6 @@ class _CyclePolicyRevert:
 @dataclass(frozen=True)
 class EffectiveCyclePolicy:
     workspace_id: str
-    policy_kind: str
-    target_type: str
     target_id: str
     version: int
     revision_id: int | None
@@ -136,8 +131,6 @@ class CyclePolicyPreview:
 @dataclass(frozen=True)
 class _CyclePolicyPreviewDigestPayload:
     workspace_id: str
-    policy_kind: str
-    target_type: str
     target_id: str
     expected_version: int
     before_snapshot: CyclePolicySnapshot
@@ -150,8 +143,6 @@ class _CyclePolicyPreviewDigestPayload:
 class BehaviorChangeRecord:
     id: int
     workspace_id: str
-    policy_kind: str
-    target_type: str
     target_id: str
     version: int
     actor_type: str
@@ -287,10 +278,8 @@ async def async_apply_cycle_policy_change(
             revision_id=revision.id,
         )
 
-        change = BehaviorChangeAudit(
+        change = CycleBehaviorChangeAudit(
             workspace_id=current.workspace_id,
-            policy_kind=CYCLE_POLICY_KIND,
-            target_type=CYCLE_TARGET_TYPE,
             target_id=str(cycle.id),
             version=current.version + 1,
             actor_type=actor.source_type,
@@ -317,8 +306,6 @@ async def async_apply_cycle_policy_change(
 
         effective = EffectiveCyclePolicy(
             workspace_id=current.workspace_id,
-            policy_kind=CYCLE_POLICY_KIND,
-            target_type=CYCLE_TARGET_TYPE,
             target_id=str(cycle.id),
             version=change.version,
             revision_id=revision.id,
@@ -346,9 +333,9 @@ async def async_list_cycle_policy_history(
     rows = list(
         (
             await session.scalars(
-                select(BehaviorChangeAudit)
+                select(CycleBehaviorChangeAudit)
                 .where(*_audit_target_conditions(cycle))
-                .order_by(BehaviorChangeAudit.version.desc())
+                .order_by(CycleBehaviorChangeAudit.version.desc())
                 .limit(clean_limit)
                 .offset(clean_offset)
             )
@@ -439,7 +426,7 @@ async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
     version = int(
         (
             await session.scalar(
-                select(func.coalesce(func.max(BehaviorChangeAudit.version), 0)).where(
+                select(func.coalesce(func.max(CycleBehaviorChangeAudit.version), 0)).where(
                     *_audit_target_conditions(cycle)
                 )
             )
@@ -454,8 +441,6 @@ async def _effective_policy(session, cycle: Cycle) -> EffectiveCyclePolicy:
     )
     return EffectiveCyclePolicy(
         workspace_id=_workspace_id(cycle),
-        policy_kind=CYCLE_POLICY_KIND,
-        target_type=CYCLE_TARGET_TYPE,
         target_id=str(cycle.id),
         version=version,
         revision_id=revision_id,
@@ -626,10 +611,10 @@ async def _load_revert_source(
     *,
     cycle: Cycle,
     change_id: int,
-) -> BehaviorChangeAudit:
+) -> CycleBehaviorChangeAudit:
     row = await session.scalar(
-        select(BehaviorChangeAudit).where(
-            BehaviorChangeAudit.id == change_id,
+        select(CycleBehaviorChangeAudit).where(
+            CycleBehaviorChangeAudit.id == change_id,
             *_audit_target_conditions(cycle),
         )
     )
@@ -647,8 +632,6 @@ def _preview_digest(
 ) -> str:
     payload = _CyclePolicyPreviewDigestPayload(
         workspace_id=current.workspace_id,
-        policy_kind=current.policy_kind,
-        target_type=current.target_type,
         target_id=current.target_id,
         expected_version=current.version,
         before_snapshot=current.snapshot,
@@ -671,15 +654,13 @@ def _aware_utc(value: datetime) -> datetime:
 
 
 def _record(
-    row: BehaviorChangeAudit,
+    row: CycleBehaviorChangeAudit,
     *,
     current_snapshot: CyclePolicySnapshot,
 ) -> BehaviorChangeRecord:
     return BehaviorChangeRecord(
         id=row.id,
         workspace_id=row.workspace_id,
-        policy_kind=row.policy_kind,
-        target_type=row.target_type,
         target_id=row.target_id,
         version=row.version,
         actor_type=row.actor_type,
@@ -703,9 +684,7 @@ def _record(
 
 def _audit_target_conditions(cycle: Cycle) -> tuple[Any, ...]:
     return (
-        BehaviorChangeAudit.policy_kind == CYCLE_POLICY_KIND,
-        BehaviorChangeAudit.target_type == CYCLE_TARGET_TYPE,
-        BehaviorChangeAudit.target_id == str(cycle.id),
+        CycleBehaviorChangeAudit.target_id == str(cycle.id),
     )
 
 

--- a/brain/systems/cycles/behavior_policy_read_model.py
+++ b/brain/systems/cycles/behavior_policy_read_model.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from sqlalchemy import select
 
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
+    CycleBehaviorChangeAudit,
     CycleOutputTarget,
     CycleRevision,
 )
@@ -85,11 +85,11 @@ async def async_read_effective_cycle_policy(
     change_rows = list(
         (
             await session.scalars(
-                select(BehaviorChangeAudit)
+                select(CycleBehaviorChangeAudit)
                 .where(*_audit_target_conditions(cycle))
                 .order_by(
-                    BehaviorChangeAudit.version.desc(),
-                    BehaviorChangeAudit.id.desc(),
+                    CycleBehaviorChangeAudit.version.desc(),
+                    CycleBehaviorChangeAudit.id.desc(),
                 )
             )
         ).all()
@@ -126,8 +126,6 @@ async def async_read_effective_cycle_policy(
     )
     return EffectiveCyclePolicyReadModel(
         workspace_id=effective.workspace_id,
-        policy_kind=effective.policy_kind,
-        target_type=effective.target_type,
         target_id=effective.target_id,
         version=effective.version,
         revision_id=(
@@ -147,9 +145,9 @@ def _field_sources(
     *,
     snapshot: CyclePolicySnapshot,
     baseline_revision: CycleRevision | None,
-    change_rows: list[BehaviorChangeAudit],
+    change_rows: list[CycleBehaviorChangeAudit],
 ) -> tuple[CyclePolicyFieldSource, ...]:
-    latest_by_field: dict[str, BehaviorChangeAudit] = {}
+    latest_by_field: dict[str, CycleBehaviorChangeAudit] = {}
     for row in change_rows:
         for field_name in row.changed_fields or []:
             latest_by_field.setdefault(str(field_name), row)

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -9,8 +9,8 @@ from sqlalchemy import func, select
 from brain.kernel.common.serialization import jsonable
 from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleOutputTarget,
     CycleRevision,
@@ -216,7 +216,7 @@ def _build_cycle_run_memory_snapshot(
     *,
     run: CycleRun | None = None,
     revision: CycleRevision | None,
-    behavior_change: BehaviorChangeAudit | None = None,
+    behavior_change: CycleBehaviorChangeAudit | None = None,
     guidance_rows: list[CycleGuidance],
     target_rows: list[CycleOutputTarget],
     degradation_tracking: dict | None = None,
@@ -534,12 +534,12 @@ async def _async_latest_cycle_revision(session, cycle_id: int) -> CycleRevision 
 async def _async_behavior_change_for_revision(
     session,
     revision_id: int | None,
-) -> BehaviorChangeAudit | None:
+) -> CycleBehaviorChangeAudit | None:
     if revision_id is None:
         return None
     return await session.scalar(
-        select(BehaviorChangeAudit).where(
-            BehaviorChangeAudit.cycle_revision_id == revision_id
+        select(CycleBehaviorChangeAudit).where(
+            CycleBehaviorChangeAudit.cycle_revision_id == revision_id
         )
     )
 

--- a/brain/systems/cycles/serializers.py
+++ b/brain/systems/cycles/serializers.py
@@ -6,8 +6,8 @@ from datetime import timezone
 from typing import TYPE_CHECKING
 
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleOutputTarget,
     CycleRevision,
@@ -93,8 +93,6 @@ def serialize_behavior_change_record(change: BehaviorChangeRecord) -> dict:
     return {
         **serialize_behavior_change_summary(change),
         "workspace_id": change.workspace_id,
-        "policy_kind": change.policy_kind,
-        "target_type": change.target_type,
         "target_id": change.target_id,
         "before_snapshot": _serialize_cycle_policy_snapshot(change.before_snapshot),
         "after_snapshot": _serialize_cycle_policy_snapshot(change.after_snapshot),
@@ -138,8 +136,6 @@ def serialize_effective_cycle_policy(
     }
     return {
         "workspace_id": policy.workspace_id,
-        "policy_kind": policy.policy_kind,
-        "target_type": policy.target_type,
         "target_id": policy.target_id,
         "version": policy.version,
         "revision_id": policy.revision_id,
@@ -272,7 +268,7 @@ def _schedule_diff_value(snapshot: CyclePolicySnapshot) -> dict:
     }
 
 
-def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
+def serialize_behavior_change(row: CycleBehaviorChangeAudit | None) -> dict | None:
     if row is None:
         return None
     applied_at = row.applied_at
@@ -281,8 +277,6 @@ def serialize_behavior_change(row: BehaviorChangeAudit | None) -> dict | None:
     return {
         "id": row.id,
         "workspace_id": row.workspace_id,
-        "policy_kind": row.policy_kind,
-        "target_type": row.target_type,
         "target_id": row.target_id,
         "version": row.version,
         "actor_type": row.actor_type,

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -63,6 +63,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0060_storage_policies.py",
     # Downgrade removes only the meetbot-session table introduced here.
     "0061_meetbot_sessions.py",
+    # Fresh baseline replay removes the empty historical table created by 0059.
+    "0062_cycle_behavior_change_audits.py",
 }
 
 

--- a/tests/test_cycle_behavior_change_audit_migration.py
+++ b/tests/test_cycle_behavior_change_audit_migration.py
@@ -1,0 +1,120 @@
+"""Migration coverage for the Cycle-only behavior-change audit envelope."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import Mock
+
+import pytest
+
+
+MIGRATION_MODULE = (
+    "brain.platform.db.alembic.versions.0062_cycle_behavior_change_audits"
+)
+
+
+def _migration_with_tables(monkeypatch, *, old_exists: bool, new_exists: bool):
+    migration = importlib.import_module(MIGRATION_MODULE)
+    operations = Mock()
+    monkeypatch.setattr(migration, "op", operations)
+    monkeypatch.setattr(
+        migration,
+        "_has_table",
+        lambda table_name: {
+            migration._OLD_TABLE: old_exists,
+            migration._TABLE: new_exists,
+        }[table_name],
+    )
+    return migration, operations
+
+
+def _executed_sql(operations: Mock) -> list[str]:
+    return [str(call.args[0]) for call in operations.execute.call_args_list]
+
+
+def test_live_upgrade_renames_in_place_and_drops_generic_columns(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=True,
+        new_exists=False,
+    )
+
+    migration.upgrade()
+
+    sql = _executed_sql(operations)
+    assert sql[0] == (
+        'ALTER TABLE "behavior_change_audits" '
+        'RENAME TO "cycle_behavior_change_audits"'
+    )
+    assert (
+        'ALTER TABLE "cycle_behavior_change_audits" '
+        'DROP COLUMN "policy_kind"'
+    ) in sql
+    assert (
+        'ALTER TABLE "cycle_behavior_change_audits" '
+        'DROP COLUMN "target_type"'
+    ) in sql
+    assert len([statement for statement in sql if "RENAME CONSTRAINT" in statement]) == 2
+    assert len([statement for statement in sql if "ALTER INDEX" in statement]) == 2
+    operations.create_table.assert_not_called()
+    operations.drop_table.assert_not_called()
+
+
+def test_fresh_upgrade_removes_only_empty_historical_table(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=True,
+        new_exists=True,
+    )
+    operations.get_bind.return_value.execute.return_value.scalar_one.return_value = 0
+
+    migration.upgrade()
+
+    operations.drop_table.assert_called_once_with("behavior_change_audits")
+    operations.execute.assert_not_called()
+
+
+def test_fresh_upgrade_refuses_to_discard_historical_rows(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=True,
+        new_exists=True,
+    )
+    operations.get_bind.return_value.execute.return_value.scalar_one.return_value = 1
+
+    with pytest.raises(RuntimeError, match="refusing to discard"):
+        migration.upgrade()
+
+    operations.drop_table.assert_not_called()
+
+
+def test_downgrade_restores_historical_shape_and_names(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=False,
+        new_exists=True,
+    )
+
+    migration.downgrade()
+
+    restored_columns = {
+        call.args[1].name: call.args[1]
+        for call in operations.add_column.call_args_list
+    }
+    assert set(restored_columns) == {"policy_kind", "target_type"}
+    assert all(column.nullable is False for column in restored_columns.values())
+    assert all(column.server_default is not None for column in restored_columns.values())
+    assert _executed_sql(operations)[-1] == (
+        'ALTER TABLE "cycle_behavior_change_audits" '
+        'RENAME TO "behavior_change_audits"'
+    )
+    operations.create_unique_constraint.assert_called_once_with(
+        "uq_behavior_change_audits_target_version",
+        "cycle_behavior_change_audits",
+        ["policy_kind", "target_type", "target_id", "version"],
+    )
+    operations.create_index.assert_called_once_with(
+        "ix_behavior_change_audits_target_history",
+        "cycle_behavior_change_audits",
+        ["policy_kind", "target_type", "target_id", "version"],
+    )

--- a/tests/test_cycle_behavior_change_audit_migration.py
+++ b/tests/test_cycle_behavior_change_audit_migration.py
@@ -25,6 +25,8 @@ def _migration_with_tables(monkeypatch, *, old_exists: bool, new_exists: bool):
             migration._TABLE: new_exists,
         }[table_name],
     )
+    monkeypatch.setattr(migration, "_has_constraint", lambda *_args: True)
+    monkeypatch.setattr(migration, "_has_index", lambda *_args: True)
     return migration, operations
 
 
@@ -42,10 +44,24 @@ def test_live_upgrade_renames_in_place_and_drops_generic_columns(monkeypatch):
     migration.upgrade()
 
     sql = _executed_sql(operations)
-    assert sql[0] == (
+    rename_sql = [statement for statement in sql if "RENAME" in statement]
+    assert rename_sql == [
         'ALTER TABLE "behavior_change_audits" '
-        'RENAME TO "cycle_behavior_change_audits"'
-    )
+        'RENAME TO "cycle_behavior_change_audits"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"behavior_change_audits_pkey" TO "cycle_behavior_change_audits_pkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"behavior_change_audits_cycle_revision_id_fkey" TO '
+        '"cycle_behavior_change_audits_cycle_revision_id_fkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"behavior_change_audits_reverted_from_id_fkey" TO '
+        '"cycle_behavior_change_audits_reverted_from_id_fkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"uq_behavior_change_audits_cycle_revision" TO '
+        '"uq_cycle_behavior_change_audits_cycle_revision"',
+        'ALTER INDEX "ix_behavior_change_audits_workspace_applied" '
+        'RENAME TO "ix_cycle_behavior_change_audits_workspace_applied"',
+    ]
     assert (
         'ALTER TABLE "cycle_behavior_change_audits" '
         'DROP COLUMN "policy_kind"'
@@ -54,10 +70,33 @@ def test_live_upgrade_renames_in_place_and_drops_generic_columns(monkeypatch):
         'ALTER TABLE "cycle_behavior_change_audits" '
         'DROP COLUMN "target_type"'
     ) in sql
-    assert len([statement for statement in sql if "RENAME CONSTRAINT" in statement]) == 2
-    assert len([statement for statement in sql if "ALTER INDEX" in statement]) == 2
     operations.create_table.assert_not_called()
     operations.drop_table.assert_not_called()
+    operations.create_index.assert_not_called()
+    operations.drop_index.assert_called_once_with(
+        "ix_behavior_change_audits_target_history",
+        table_name="cycle_behavior_change_audits",
+    )
+
+
+def test_live_upgrade_skips_renames_without_the_old_object_names(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=True,
+        new_exists=False,
+    )
+    monkeypatch.setattr(migration, "_has_constraint", lambda *_args: False)
+    monkeypatch.setattr(migration, "_has_index", lambda *_args: False)
+
+    migration.upgrade()
+
+    rename_sql = [
+        statement for statement in _executed_sql(operations) if "RENAME" in statement
+    ]
+    assert rename_sql == [
+        'ALTER TABLE "behavior_change_audits" '
+        'RENAME TO "cycle_behavior_change_audits"'
+    ]
 
 
 def test_fresh_upgrade_removes_only_empty_historical_table(monkeypatch):
@@ -88,6 +127,19 @@ def test_fresh_upgrade_refuses_to_discard_historical_rows(monkeypatch):
     operations.drop_table.assert_not_called()
 
 
+def test_upgrade_refuses_to_mark_a_missing_table_as_migrated(monkeypatch):
+    migration, operations = _migration_with_tables(
+        monkeypatch,
+        old_exists=False,
+        new_exists=False,
+    )
+
+    with pytest.raises(RuntimeError, match="neither behavior-change audit table exists"):
+        migration.upgrade()
+
+    operations.execute.assert_not_called()
+
+
 def test_downgrade_restores_historical_shape_and_names(monkeypatch):
     migration, operations = _migration_with_tables(
         monkeypatch,
@@ -104,10 +156,26 @@ def test_downgrade_restores_historical_shape_and_names(monkeypatch):
     assert set(restored_columns) == {"policy_kind", "target_type"}
     assert all(column.nullable is False for column in restored_columns.values())
     assert all(column.server_default is not None for column in restored_columns.values())
-    assert _executed_sql(operations)[-1] == (
+    rename_sql = [
+        statement for statement in _executed_sql(operations) if "RENAME" in statement
+    ]
+    assert rename_sql == [
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"cycle_behavior_change_audits_pkey" TO "behavior_change_audits_pkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"cycle_behavior_change_audits_cycle_revision_id_fkey" TO '
+        '"behavior_change_audits_cycle_revision_id_fkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"cycle_behavior_change_audits_reverted_from_id_fkey" TO '
+        '"behavior_change_audits_reverted_from_id_fkey"',
+        'ALTER TABLE "cycle_behavior_change_audits" RENAME CONSTRAINT '
+        '"uq_cycle_behavior_change_audits_cycle_revision" TO '
+        '"uq_behavior_change_audits_cycle_revision"',
+        'ALTER INDEX "ix_cycle_behavior_change_audits_workspace_applied" '
+        'RENAME TO "ix_behavior_change_audits_workspace_applied"',
         'ALTER TABLE "cycle_behavior_change_audits" '
-        'RENAME TO "behavior_change_audits"'
-    )
+        'RENAME TO "behavior_change_audits"',
+    ]
     operations.create_unique_constraint.assert_called_once_with(
         "uq_behavior_change_audits_target_version",
         "cycle_behavior_change_audits",

--- a/tests/test_cycle_behavior_policy.py
+++ b/tests/test_cycle_behavior_policy.py
@@ -8,8 +8,8 @@ import pytest
 from sqlalchemy import func, select
 
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleOutputTarget,
     CycleRevision,
@@ -66,7 +66,7 @@ async def policy_workspace(
             CycleGuidance.__table__,
             CycleOutputTarget.__table__,
             CycleRun.__table__,
-            BehaviorChangeAudit.__table__,
+            CycleBehaviorChangeAudit.__table__,
         ]
     )
     org_id = str(uuid4())
@@ -301,8 +301,8 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     assert len(history) == 1
     change = history[0]
     assert change.workspace_id == str(workspace.cycle.org_id)
-    assert change.policy_kind == "cycle"
-    assert change.target_type == "cycle"
+    assert not hasattr(change, "policy_kind")
+    assert not hasattr(change, "target_type")
     assert change.target_id == str(workspace.cycle.id)
     assert change.version == 1
     assert change.actor_type == "user"
@@ -313,7 +313,7 @@ async def test_read_preview_apply_history_and_human_audit_envelope(policy_worksp
     assert isinstance(change.after_snapshot, CyclePolicySnapshot)
     assert change.before_snapshot == preview.before.snapshot
     assert change.after_snapshot == preview.after_snapshot
-    stored_change = await workspace.session.get(BehaviorChangeAudit, change.id)
+    stored_change = await workspace.session.get(CycleBehaviorChangeAudit, change.id)
     assert stored_change.before_snapshot["snapshot_version"] == 1
     assert stored_change.after_snapshot["snapshot_version"] == 1
     assert change.changed_fields == preview.changed_fields
@@ -387,7 +387,7 @@ async def test_stale_version_and_stale_digest_return_latest_policy(policy_worksp
     assert stale_digest.reason == "stale_preview_digest"
     assert stale_digest.latest_effective_policy.version == 1
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 1
 
 
@@ -501,7 +501,7 @@ async def test_apply_failure_rolls_back_the_entire_policy_write_set(
         )
     ) == 1
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 0
 
 
@@ -551,7 +551,7 @@ async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_works
         workspace,
         CyclePolicyPatch(name="Changed policy"),
     )
-    stored_change = await workspace.session.get(BehaviorChangeAudit, first.change.id)
+    stored_change = await workspace.session.get(CycleBehaviorChangeAudit, first.change.id)
     stored_before = dict(stored_change.before_snapshot)
     stored_before.pop("max_concurrency")
     stored_before["retired_policy_field"] = "legacy value"
@@ -590,7 +590,7 @@ async def test_revert_decodes_stored_snapshot_across_schema_changes(policy_works
     assert reverted.effective_policy.version == 2
     assert isinstance(reverted.effective_policy.snapshot, CyclePolicySnapshot)
     new_stored_change = await workspace.session.get(
-        BehaviorChangeAudit,
+        CycleBehaviorChangeAudit,
         reverted.change.id,
     )
     assert new_stored_change.before_snapshot["snapshot_version"] == 1
@@ -603,7 +603,7 @@ async def test_revert_decodes_snapshot_written_before_versioning(policy_workspac
         workspace,
         CyclePolicyPatch(name="Changed policy"),
     )
-    stored_change = await workspace.session.get(BehaviorChangeAudit, first.change.id)
+    stored_change = await workspace.session.get(CycleBehaviorChangeAudit, first.change.id)
     stored_before = dict(stored_change.before_snapshot)
     stored_before.pop("snapshot_version")
     stored_change.before_snapshot = stored_before
@@ -707,6 +707,8 @@ async def test_admitted_run_keeps_snapshot_and_next_run_gets_new_policy(policy_w
     ]
     assert second_run.context_snapshot["revision"]["id"] == applied.revision.id
     assert second_run.context_snapshot["behavior_change"]["id"] == applied.change.id
+    assert "policy_kind" not in second_run.context_snapshot["behavior_change"]
+    assert "target_type" not in second_run.context_snapshot["behavior_change"]
 
 
 async def test_workspace_authorization_and_delegated_agent_attribution(policy_workspace):

--- a/tests/test_cycle_behavior_policy_api.py
+++ b/tests/test_cycle_behavior_policy_api.py
@@ -24,8 +24,8 @@ from brain.app.api.schemas.cycles import (
     EffectiveCyclePolicyRead,
 )
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleOutputTarget,
     CycleRevision,
@@ -62,7 +62,7 @@ async def api_workspace(
             CycleRevision.__table__,
             CycleGuidance.__table__,
             CycleOutputTarget.__table__,
-            BehaviorChangeAudit.__table__,
+            CycleBehaviorChangeAudit.__table__,
         ]
     )
     org_id = str(uuid4())
@@ -235,6 +235,8 @@ async def test_effective_policy_shape_includes_sources_and_read_only_targets(
     )
 
     EffectiveCyclePolicyRead.model_validate(payload)
+    assert "policy_kind" not in payload
+    assert "target_type" not in payload
     assert payload["version"] == 0
     assert payload["configuration"]["prompt"] == "Review the workspace."
     assert payload["configuration"]["schedule_human"]
@@ -478,7 +480,7 @@ async def test_preview_returns_normalized_field_aware_diff_without_writing(
     assert payload["warnings"][0]["code"] == "admitted_runs_unchanged"
     assert workspace.cycle.prompt == "Review the workspace."
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 0
 
 
@@ -513,7 +515,7 @@ async def test_preview_rejects_invalid_policy_before_apply(
     assert error.lower() in str(caught.value.detail).lower()
     assert workspace.cycle.prompt == "Review the workspace."
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 0
 
 
@@ -528,6 +530,10 @@ async def test_apply_updates_policy_audit_event_and_utc_source(api_workspace):
     )
 
     CyclePolicyApplyRead.model_validate(payload)
+    assert "policy_kind" not in payload["effective_policy"]
+    assert "target_type" not in payload["effective_policy"]
+    assert "policy_kind" not in payload["change"]
+    assert "target_type" not in payload["change"]
     assert payload["effective_policy"]["version"] == 1
     assert payload["effective_policy"]["configuration"]["prompt"] == (
         "Review incidents and owners."
@@ -559,7 +565,7 @@ async def test_apply_updates_policy_audit_event_and_utc_source(api_workspace):
             "target_idea_id": None,
         }
     ]
-    stored = await workspace.session.get(BehaviorChangeAudit, payload["change"]["id"])
+    stored = await workspace.session.get(CycleBehaviorChangeAudit, payload["change"]["id"])
     assert stored is not None
     assert stored.version == 1
 
@@ -591,7 +597,7 @@ async def test_apply_rejects_whitespace_only_rationale(api_workspace):
     assert caught.value.detail == "rationale is required"
     assert workspace.cycle.prompt == "Review the workspace."
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 0
 
 
@@ -787,5 +793,5 @@ async def test_cross_workspace_read_and_apply_are_denied(api_workspace):
     assert apply_denied.value.detail == "Cycle not found"
     assert workspace.cycle.prompt == "Review the workspace."
     assert await workspace.session.scalar(
-        select(func.count(BehaviorChangeAudit.id))
+        select(func.count(CycleBehaviorChangeAudit.id))
     ) == 0

--- a/tests/test_cycle_behavior_policy_concurrency.py
+++ b/tests/test_cycle_behavior_policy_concurrency.py
@@ -12,8 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.schema import CreateTable
 
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleGuidance,
     CycleRevision,
 )
@@ -125,7 +125,7 @@ async def postgres_policy_workspace(monkeypatch):
                 Cycle.__table__,
                 CycleRevision.__table__,
                 CycleGuidance.__table__,
-                BehaviorChangeAudit.__table__,
+                CycleBehaviorChangeAudit.__table__,
             ):
                 await connection.execute(CreateTable(table))
 
@@ -254,8 +254,8 @@ async def test_two_reviewed_editors_serialize_and_second_gets_latest_conflict(
         changes = list(
             (
                 await session.scalars(
-                    select(BehaviorChangeAudit).order_by(
-                        BehaviorChangeAudit.version.asc()
+                    select(CycleBehaviorChangeAudit).order_by(
+                        CycleBehaviorChangeAudit.version.asc()
                     )
                 )
             ).all()

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -34,8 +34,8 @@ from brain.systems.cycles.promotion_readiness import (
 )
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import (
-    BehaviorChangeAudit,
     Cycle,
+    CycleBehaviorChangeAudit,
     CycleFailureGuardLatch,
     CycleFailureGuardObservation,
     CycleFailureGuardTriggerState,
@@ -344,12 +344,12 @@ class _RouterCycleSession:
 
     async def scalar(self, statement):
         sql = str(statement)
-        if "max(behavior_change_audits.version)" in sql:
+        if "max(cycle_behavior_change_audits.version)" in sql:
             return max(
                 (
                     row.version
                     for row in self.added
-                    if isinstance(row, BehaviorChangeAudit)
+                    if isinstance(row, CycleBehaviorChangeAudit)
                 ),
                 default=0,
             )
@@ -1172,7 +1172,7 @@ async def test_cycle_update_persists_and_serializes_max_concurrency():
 
     assert cycle.max_concurrency == 4
     assert response["max_concurrency"] == 4
-    audit = next(row for row in db.added if isinstance(row, BehaviorChangeAudit))
+    audit = next(row for row in db.added if isinstance(row, CycleBehaviorChangeAudit))
     assert audit.before_snapshot["max_concurrency"] == 1
     assert audit.after_snapshot["max_concurrency"] == 4
     assert audit.cycle_revision_id == next(

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -11,7 +11,7 @@ EXPECTED_TABLES = {
     "agent_run_events",
     "agent_runs",
     "agent_sessions",
-    "behavior_change_audits",
+    "cycle_behavior_change_audits",
     "browser_pool_entries",
     "browser_sessions",
     "chat_conversation_members",
@@ -141,6 +141,23 @@ EXPECTED_TABLES = {
     "workspace_tool_installations",
     "workspace_tool_user_configs",
 }
+
+
+def test_cycle_behavior_change_audit_schema_is_cycle_only():
+    table = Base.metadata.tables["cycle_behavior_change_audits"]
+
+    assert "behavior_change_audits" not in Base.metadata.tables
+    assert "policy_kind" not in table.c
+    assert "target_type" not in table.c
+    assert table.c.cycle_revision_id.nullable is False
+    assert {constraint.name for constraint in table.constraints} >= {
+        "uq_cycle_behavior_change_audits_target_version",
+        "uq_cycle_behavior_change_audits_cycle_revision",
+    }
+    assert {index.name for index in table.indexes} == {
+        "ix_cycle_behavior_change_audits_workspace_applied",
+        "ix_cycle_behavior_change_audits_target_history",
+    }
 
 
 def _modeled_tables() -> set[str]:

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -156,7 +156,6 @@ def test_cycle_behavior_change_audit_schema_is_cycle_only():
     }
     assert {index.name for index in table.indexes} == {
         "ix_cycle_behavior_change_audits_workspace_applied",
-        "ix_cycle_behavior_change_audits_target_history",
     }
 
 


### PR DESCRIPTION
> *Autonomous routine run (R3).*

You answered this on 2026-08-11: **option 1**, make it honest rather than adapter-neutral. No second policy kind is planned, so neutrality would have been speculative.

Closes #791

## What was wrong

The audit envelope advertised itself as generic — it carried `policy_kind`, `target_type` and `target_id` — while `cycle_revision_id` was NOT NULL with a foreign key to `cycle_revisions`. A non-Cycle policy could never have written a row. The columns described a capability the schema does not have.

## What changed

`behavior_change_audits` → `cycle_behavior_change_audits`, `BehaviorChangeAudit` → `CycleBehaviorChangeAudit`, and the two discriminator columns are gone. The unique key is now `(target_id, version)`.

## The migration is the risky part, so here is exactly what it does

The table is **already live** — illo-dev is at `0061` and holds this table — so `0059` is untouched and migration `0062` renames in place off `0061_meetbot_sessions`. One alembic head.

It handles both paths: a fresh install, where the public baseline already created the new name (it drops the empty historical table, and **refuses** if that table has rows), and the deployed database, where the old name holds data and everything is renamed rather than copied.

**The review caught the thing I would have missed.** `ALTER TABLE ... RENAME TO` does not rename implicitly-named constraints. I checked `pg_constraint` on illo-dev and found the three the first cut left behind:

```
behavior_change_audits_pkey
behavior_change_audits_cycle_revision_id_fkey
behavior_change_audits_reverted_from_id_fkey
```

Without the fix, an upgraded database and a fresh install stop converging, and a later migration referencing a constraint by name would have to know which history the database came from. All three are now renamed on upgrade and reversed on downgrade, each guarded by an existence check so replay and fresh installs stay safe.

Also folded from the review: the neither-table state now raises instead of silently marking the migration applied, and a redundant index that duplicated the unique constraint's backing index is gone.

The migration tests now assert the **emitted SQL** rather than mock calls — a mock happily accepts a rename that never happens. They failed 7 of 10 against the unfixed migration.

## Left for a follow-up, on purpose

The exported `BehaviorChangeRecord` dataclass and its serializer helpers keep generic names, so the Cycle-only vocabulary is not yet consistent end to end. That is a separate rename with its own blast radius. Say the word and I will file it.

## Evidence

- Full backend lane on this branch: **4922 passed, 11 skipped, 0 failed** in 99s, run serially at load 3.8 with no Codex worker on this repo.
- `alembic heads`: exactly one, `0062_cycle_behavior_change_audits`.

## What to exercise after merge

The table has no writer yet — slice 3 (#803) is read-only and apply lands in slice 4 — so the check is the deploy itself: confirm the migration runs clean on staging and that `\d cycle_behavior_change_audits` shows every constraint and index under the new name.