### PR TITLE
feat(cycles): behavior editor slice 4 — edit, review diff and explicit apply

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -518,6 +518,74 @@ export interface CyclePolicyHistoryRead {
   };
 }
 
+/** Mirrors the editable fields in the server CyclePolicyProposal schema. */
+export interface CyclePolicyProposal {
+  prompt?: string | null;
+  schedule_expr?: string | null;
+  timezone?: string | null;
+  enabled?: boolean | null;
+  model_override?: string | null;
+  thinking_override?: string | null;
+  guidance?: string[] | null;
+}
+
+export interface CyclePolicyPreviewRequest {
+  proposal: CyclePolicyProposal;
+}
+
+export interface CyclePolicyApplyRequest extends CyclePolicyPreviewRequest {
+  expected_version: number;
+  preview_digest: string;
+  rationale: string;
+}
+
+export interface CyclePolicyRevertApplyRequest {
+  expected_version: number;
+  preview_digest: string;
+  rationale: string;
+}
+
+export interface CyclePolicyDiffEntryRead {
+  field: string;
+  kind: string;
+  before: CyclePolicyJsonValue;
+  after: CyclePolicyJsonValue;
+  added: string[] | null;
+  removed: string[] | null;
+}
+
+export interface CyclePolicyWarningRead {
+  code: string;
+  message: string;
+}
+
+export interface CyclePolicyAffectedRunsRead {
+  admitted_runs: string;
+  future_runs: string;
+}
+
+export interface CyclePolicyPreviewRead {
+  expected_version: number;
+  preview_digest: string;
+  before: CyclePolicySnapshotRead;
+  after: CyclePolicySnapshotRead;
+  changed_fields: string[];
+  diff: CyclePolicyDiffEntryRead[];
+  warnings: CyclePolicyWarningRead[];
+  affected_runs: CyclePolicyAffectedRunsRead;
+  reverted_from_id: number | null;
+}
+
+export interface CyclePolicyApplyRead {
+  effective_policy: EffectiveCyclePolicyRead;
+  change: CyclePolicyChangeRead;
+}
+
+export interface CyclePolicyConflictDetail {
+  reason: string;
+  latest_effective_policy: EffectiveCyclePolicyRead;
+}
+
 export interface DomainFieldRead {
   id: number;
   domain_id: number;
@@ -1534,9 +1602,33 @@ export const api = {
     fetchJson<CycleRunRead>(`/api/cycles/${cycleId}/run`, { method: 'POST' }),
   getCycleBehaviorPolicy: (cycleId: number) =>
     fetchJson<EffectiveCyclePolicyRead>(`/api/cycles/${cycleId}/behavior-policy`),
+  previewCycleBehaviorPolicy: (cycleId: number, data: CyclePolicyPreviewRequest) =>
+    fetchJson<CyclePolicyPreviewRead>(`/api/cycles/${cycleId}/behavior-policy/preview`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  applyCycleBehaviorPolicy: (cycleId: number, data: CyclePolicyApplyRequest) =>
+    fetchJson<CyclePolicyApplyRead>(`/api/cycles/${cycleId}/behavior-policy/apply`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   getCycleBehaviorPolicyHistory: (cycleId: number, limit = 50, offset = 0) =>
     fetchJson<CyclePolicyHistoryRead>(
       withQuery(`/api/cycles/${cycleId}/behavior-policy/history`, { limit, offset }),
+    ),
+  previewCycleBehaviorPolicyRevert: (cycleId: number, changeId: number) =>
+    fetchJson<CyclePolicyPreviewRead>(
+      `/api/cycles/${cycleId}/behavior-policy/history/${changeId}/revert/preview`,
+      { method: 'POST' },
+    ),
+  applyCycleBehaviorPolicyRevert: (
+    cycleId: number,
+    changeId: number,
+    data: CyclePolicyRevertApplyRequest,
+  ) =>
+    fetchJson<CyclePolicyApplyRead>(
+      `/api/cycles/${cycleId}/behavior-policy/history/${changeId}/revert/apply`,
+      { method: 'POST', body: JSON.stringify(data) },
     ),
 
   // Domains

--- a/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
@@ -1,0 +1,427 @@
+<script lang="ts">
+  import type { EffectiveCyclePolicyRead } from '$lib/api/client';
+  import { ConstellationButton, ConstellationPill } from '$lib/components/constellation';
+  import {
+    formatPolicyDateTime,
+    policyConfigurationEntries,
+    policyFieldLabel,
+    policyFieldSource,
+    policySourceLabel,
+    policyValueLabel,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+
+  let {
+    cycleId,
+    policy,
+    displayTimezone,
+    showDetails,
+    showHeader = true,
+    canEdit,
+    compact = false,
+    onEdit,
+  }: {
+    cycleId: number;
+    policy: EffectiveCyclePolicyRead | null;
+    displayTimezone: string;
+    showDetails: boolean;
+    showHeader?: boolean;
+    canEdit: boolean;
+    compact?: boolean;
+    onEdit: () => void;
+  } = $props();
+
+  const configurationEntries = $derived(
+    policy ? policyConfigurationEntries(policy.configuration) : [],
+  );
+  const guidanceSource = $derived(
+    policy ? policyFieldSource(policy.field_sources, 'guidance') : undefined,
+  );
+</script>
+
+{#if showHeader}
+  <header class="active-heading">
+    <div>
+      <span class="section-kicker">Effective behavior</span>
+      <h3>Active now</h3>
+      <p>What Illo will use on the next run.</p>
+    </div>
+    {#if policy}
+      <div class="active-actions">
+        <div class="active-status">
+          <ConstellationPill variant={policy.configuration.enabled ? 'success' : 'muted'} leadingDot>
+            {policy.configuration.enabled ? 'Enabled' : 'Paused'}
+          </ConstellationPill>
+          <span>Version {policy.version}</span>
+        </div>
+        {#if canEdit}
+          <ConstellationButton variant="secondary" size="sm" onclick={onEdit}>
+            Edit behavior
+          </ConstellationButton>
+        {/if}
+      </div>
+    {/if}
+  </header>
+{/if}
+
+{#if policy && showDetails}
+  <div class:compact class="policy-content">
+    <section class="policy-section" aria-labelledby={`cycle-${cycleId}-configuration`}>
+      <div class="policy-section-heading">
+        <h4 id={`cycle-${cycleId}-configuration`}>Mission and settings</h4>
+        <span>{displayTimezone.replaceAll('_', ' ')}</span>
+      </div>
+
+      <dl class="policy-values">
+        {#each configurationEntries as entry (entry.key)}
+          {@const source = policyFieldSource(policy.field_sources, entry.key)}
+          <div class="policy-value" class:prose-value={entry.key === 'prompt'}>
+            <dt>{policyFieldLabel(entry.key)}</dt>
+            <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
+              {policyValueLabel(entry.value)}
+            </dd>
+            <dd class="value-source" title={source?.rationale || undefined}>
+              <span>From {source ? policySourceLabel(source) : policySourceLabel(policy.source)}</span>
+              <time datetime={source?.changed_at || policy.source.changed_at || undefined}>
+                Changed {formatPolicyDateTime(source?.changed_at || policy.source.changed_at, displayTimezone)}
+              </time>
+            </dd>
+          </div>
+        {/each}
+      </dl>
+    </section>
+
+    <section class="policy-section active-guidance" aria-labelledby={`cycle-${cycleId}-guidance`}>
+      <div class="policy-section-heading">
+        <div>
+          <span class="live-marker">Live</span>
+          <h4 id={`cycle-${cycleId}-guidance`}>Active guidance</h4>
+        </div>
+        <span>{policy.guidance.length} active</span>
+      </div>
+
+      {#if policy.guidance.length}
+        <ol class="guidance-list">
+          {#each policy.guidance as guidance}
+            <li>
+              <p>{guidance}</p>
+              <div class="value-source" title={guidanceSource?.rationale || undefined}>
+                <span>From {guidanceSource ? policySourceLabel(guidanceSource) : policySourceLabel(policy.source)}</span>
+                <time datetime={guidanceSource?.changed_at || policy.source.changed_at || undefined}>
+                  Changed {formatPolicyDateTime(guidanceSource?.changed_at || policy.source.changed_at, displayTimezone)}
+                </time>
+              </div>
+            </li>
+          {/each}
+        </ol>
+      {:else}
+        <p class="empty-policy-value">No active guidance.</p>
+      {/if}
+    </section>
+
+    <section class="policy-section" aria-labelledby={`cycle-${cycleId}-outputs`}>
+      <div class="policy-section-heading">
+        <h4 id={`cycle-${cycleId}-outputs`}>Output targets</h4>
+        <ConstellationPill variant="muted">Read only</ConstellationPill>
+      </div>
+
+      {#if policy.output_targets.length}
+        <div class="output-list">
+          {#each policy.output_targets as target (target.id)}
+            <article class="output-target">
+              <div class="output-target-heading">
+                <strong>{target.label || policyFieldLabel(target.target_type)}</strong>
+                <span>{target.target_type}</span>
+              </div>
+              {#if target.target_id}<p>Target {target.target_id}</p>{/if}
+              {#if Object.keys(target.config).length}<pre>{policyValueLabel(target.config)}</pre>{/if}
+              {#if target.rationale}<p>{target.rationale}</p>{/if}
+              <div class="value-source">
+                <span>From {[target.source_type, target.source_id].filter(Boolean).join(' · ')}</span>
+                <time datetime={target.updated_at}>
+                  Changed {formatPolicyDateTime(target.updated_at, displayTimezone)}
+                </time>
+              </div>
+            </article>
+          {/each}
+        </div>
+      {:else}
+        <p class="empty-policy-value">No output targets.</p>
+      {/if}
+    </section>
+  </div>
+{/if}
+
+<style>
+  .active-heading,
+  .policy-section-heading,
+  .output-target-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .active-heading {
+    padding: 14px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-success) 7%, transparent);
+  }
+
+  .active-heading h3,
+  .active-heading p,
+  .policy-section-heading h4,
+  .guidance-list p,
+  .output-target p {
+    margin: 0;
+  }
+
+  .active-heading h3 {
+    margin-top: 3px;
+    font-size: 16px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+  }
+
+  .active-heading p {
+    margin-top: 5px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .section-kicker,
+  .policy-value dt,
+  .live-marker {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .active-status {
+    display: grid;
+    justify-items: end;
+    gap: 6px;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .active-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .policy-content {
+    display: grid;
+  }
+
+  .policy-section {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+    padding: 14px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+  }
+
+  .policy-section-heading {
+    align-items: center;
+  }
+
+  .policy-section-heading > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .policy-section-heading h4 {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .policy-section-heading > span {
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+  }
+
+  .live-marker {
+    padding: 3px 6px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--constellation-color-success) 14%, transparent);
+    color: var(--constellation-color-success);
+  }
+
+  .policy-values {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0;
+    margin: 0;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value:nth-child(odd) {
+    border-right: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-value.prose-value {
+    grid-column: 1 / -1;
+    border-right: 0;
+  }
+
+  .policy-value dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .policy-value.prose-value > dd:not(.value-source) {
+    font-size: 14px;
+  }
+
+  .mono-value,
+  .output-target pre {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .value-source {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px 10px;
+    color: var(--constellation-color-text-muted) !important;
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px !important;
+    line-height: 1.4 !important;
+  }
+
+  .active-guidance {
+    border-left: 3px solid var(--constellation-color-success);
+    background: color-mix(in srgb, var(--constellation-color-success) 3%, transparent);
+  }
+
+  .guidance-list,
+  .output-list {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .guidance-list {
+    counter-reset: active-guidance;
+  }
+
+  .guidance-list li {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 6px 10px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--constellation-section-divider);
+    counter-increment: active-guidance;
+  }
+
+  .guidance-list li::before {
+    content: counter(active-guidance, decimal-leading-zero);
+    color: var(--constellation-color-success);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    line-height: 1.7;
+  }
+
+  .guidance-list li:last-child {
+    border-bottom: 0;
+  }
+
+  .guidance-list .value-source {
+    grid-column: 2;
+  }
+
+  .guidance-list p {
+    font-size: 13px;
+    line-height: 1.55;
+  }
+
+  .output-target {
+    display: grid;
+    gap: 7px;
+    padding: 11px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 7px;
+    background: var(--constellation-surface-nested-background);
+  }
+
+  .output-target-heading strong {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .output-target-heading span,
+  .output-target p,
+  .output-target pre {
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .output-target-heading span {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .output-target pre {
+    max-width: 100%;
+    margin: 0;
+    overflow: auto;
+    white-space: pre-wrap;
+  }
+
+  .empty-policy-value {
+    margin: 0;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .policy-content.compact .policy-values {
+    grid-template-columns: 1fr;
+  }
+
+  .policy-content.compact .policy-value,
+  .policy-content.compact .policy-value:nth-child(odd) {
+    border-right: 0;
+  }
+
+  @media (max-width: 720px) {
+    .policy-values {
+      grid-template-columns: 1fr;
+    }
+
+    .policy-value,
+    .policy-value:nth-child(odd) {
+      border-right: 0;
+    }
+
+    .active-heading,
+    .active-actions {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .active-status {
+      justify-items: start;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/CyclePolicyDraftEditor.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyDraftEditor.svelte
@@ -1,0 +1,432 @@
+<script lang="ts">
+  import {
+    ConstellationButton,
+    ConstellationSelect,
+    ConstellationTextInput,
+    ConstellationTextarea,
+  } from '$lib/components/constellation';
+  import {
+    clonePolicyDraft,
+    POLICY_FIELD_SCHEMA,
+    type CyclePolicyDraft,
+    type CyclePolicyDraftErrors,
+    type CyclePolicyFieldKey,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+  import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
+
+  let {
+    cycleId,
+    draft,
+    errors,
+    error,
+    dirty,
+    reviewing,
+    compact = false,
+    modelCatalog,
+    onDraftChange,
+    onCancel,
+    onReview,
+  }: {
+    cycleId: number;
+    draft: CyclePolicyDraft;
+    errors: CyclePolicyDraftErrors;
+    error?: string;
+    dirty: boolean;
+    reviewing: boolean;
+    compact?: boolean;
+    modelCatalog: readonly RuntimeModelCatalogEntry[];
+    onDraftChange: (draft: CyclePolicyDraft) => void;
+    onCancel: () => void;
+    onReview: () => void;
+  } = $props();
+
+  const modelOptions = $derived([
+    { value: '', label: 'Workspace default', description: 'Use the workspace model' },
+    ...modelCatalog.map((entry) => ({
+      value: entry.id,
+      label: entry.label,
+      description: entry.description,
+    })),
+    ...(draft.model_override && !modelCatalog.some((entry) => entry.id === draft.model_override)
+      ? [{
+          value: draft.model_override,
+          label: draft.model_override,
+          description: 'Current model selection',
+        }]
+      : []),
+  ]);
+
+  function inputValue(event: Event): string {
+    return (event.currentTarget as HTMLInputElement | HTMLTextAreaElement).value;
+  }
+
+  function changeField<Key extends CyclePolicyFieldKey>(
+    key: Key,
+    value: CyclePolicyDraft[Key],
+  ): void {
+    const next = clonePolicyDraft(draft);
+    Object.assign(next, { [key]: value });
+    onDraftChange(next);
+  }
+
+  function addGuidance(): void {
+    changeField('guidance', [...draft.guidance, '']);
+  }
+
+  function updateGuidance(index: number, value: string): void {
+    const guidance = [...draft.guidance];
+    guidance[index] = value;
+    changeField('guidance', guidance);
+  }
+
+  function removeGuidance(index: number): void {
+    changeField('guidance', draft.guidance.filter((_, itemIndex) => itemIndex !== index));
+  }
+</script>
+
+<section class:compact class="policy-editor" aria-label="Edit cycle behavior">
+  <header class="editor-heading">
+    <div>
+      <span class="section-kicker">Draft</span>
+      <h4>Prepare behavior change</h4>
+    </div>
+    <p>Nothing changes until you review and apply.</p>
+  </header>
+
+  {#if error}<p class="editor-error" role="alert">{error}</p>{/if}
+
+  <div class="editor-fields">
+    {#each POLICY_FIELD_SCHEMA as field (field.key)}
+      {#if field.control === 'textarea'}
+        <div class="editor-field" class:editor-field-full={field.fullWidth}>
+          <label for={`cycle-${cycleId}-policy-${field.key}`}>{field.label}</label>
+          <ConstellationTextarea
+            id={`cycle-${cycleId}-policy-${field.key}`}
+            value={draft[field.key]}
+            rows={field.rows}
+            aria-invalid={errors[field.key] ? 'true' : undefined}
+            oninput={(event) => changeField(field.key, inputValue(event))}
+          />
+          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+        </div>
+      {:else if field.control === 'text'}
+        <div class="editor-field">
+          <label for={`cycle-${cycleId}-policy-${field.key}`}>{field.label}</label>
+          <ConstellationTextInput
+            id={`cycle-${cycleId}-policy-${field.key}`}
+            value={draft[field.key]}
+            mono={'mono' in field && field.mono}
+            placeholder={field.placeholder}
+            aria-invalid={errors[field.key] ? 'true' : undefined}
+            oninput={(event) => changeField(field.key, inputValue(event))}
+          />
+          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+        </div>
+      {:else if field.control === 'toggle'}
+        <div class="editor-field">
+          <span class="editor-field-label">{field.label}</span>
+          <button
+            type="button"
+            class="policy-status-toggle"
+            class:is-enabled={draft[field.key]}
+            aria-pressed={draft[field.key]}
+            onclick={() => changeField(field.key, !draft[field.key])}
+          >
+            <span aria-hidden="true"></span>
+            <strong>{draft[field.key] ? 'Enabled' : 'Paused'}</strong>
+          </button>
+        </div>
+      {:else if field.control === 'model'}
+        <div class="editor-field">
+          <span class="editor-field-label">{field.label}</span>
+          <ConstellationSelect
+            value={draft[field.key]}
+            options={modelOptions}
+            ariaLabel={field.label}
+            onValueChange={(value) => changeField(field.key, value)}
+          />
+          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+        </div>
+      {:else if field.control === 'thinking'}
+        <div class="editor-field">
+          <span class="editor-field-label">{field.label}</span>
+          <ConstellationSelect
+            value={draft[field.key]}
+            options={field.options}
+            ariaLabel={field.label}
+            onValueChange={(value) => changeField(field.key, value)}
+          />
+        </div>
+      {:else if field.control === 'guidance'}
+        <section class="guidance-editor editor-field-full" aria-labelledby={`cycle-${cycleId}-guidance-editor`}>
+          <div class="guidance-editor-heading">
+            <div>
+              <span class="editor-field-label" id={`cycle-${cycleId}-guidance-editor`}>{field.label}</span>
+              <small>Changing text retires the old guidance and adds a new entry.</small>
+            </div>
+            <ConstellationButton variant="quiet" size="sm" onclick={addGuidance}>
+              Add guidance
+            </ConstellationButton>
+          </div>
+          {#if draft[field.key].length}
+            <ol class="guidance-editor-list">
+              {#each draft[field.key] as guidance, index}
+                <li>
+                  <ConstellationTextarea
+                    value={guidance}
+                    rows={2}
+                    aria-label={`Guidance ${index + 1}`}
+                    oninput={(event) => updateGuidance(index, inputValue(event))}
+                  />
+                  <ConstellationButton
+                    variant="quiet"
+                    size="sm"
+                    aria-label={`Remove guidance ${index + 1}`}
+                    onclick={() => removeGuidance(index)}
+                  >
+                    Remove
+                  </ConstellationButton>
+                </li>
+              {/each}
+            </ol>
+          {:else}
+            <p class="empty-policy-value">No active guidance.</p>
+          {/if}
+          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+        </section>
+      {/if}
+    {/each}
+  </div>
+
+  <div class="editor-actions">
+    <ConstellationButton variant="quiet" size="sm" onclick={onCancel}>Cancel</ConstellationButton>
+    <ConstellationButton
+      variant="primary"
+      size="sm"
+      loading={reviewing}
+      disabled={!dirty}
+      onclick={onReview}
+    >
+      Review change
+    </ConstellationButton>
+  </div>
+</section>
+
+<style>
+  .policy-editor {
+    display: grid;
+    gap: 16px;
+    min-width: 0;
+    padding: 16px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-info) 3%, transparent);
+  }
+
+  .editor-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .editor-heading h4,
+  .editor-heading p,
+  .guidance-editor-heading small,
+  .editor-error {
+    margin: 0;
+  }
+
+  .section-kicker,
+  .editor-field > label,
+  .editor-field-label {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .section-kicker {
+    letter-spacing: 0.12em;
+  }
+
+  .editor-heading h4 {
+    margin-top: 4px;
+    font-size: 15px;
+    font-weight: 650;
+  }
+
+  .editor-heading p {
+    max-width: 360px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.5;
+    text-align: right;
+  }
+
+  .editor-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .editor-field {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .editor-field-full {
+    grid-column: 1 / -1;
+  }
+
+  .editor-field > label,
+  .editor-field-label {
+    color: var(--constellation-color-text-secondary);
+    letter-spacing: 0.08em;
+  }
+
+  .editor-field :global(.constellation-text-input),
+  .editor-field :global(.constellation-textarea),
+  .editor-field :global(.constellation-select),
+  .guidance-editor-list :global(.constellation-textarea) {
+    width: 100%;
+  }
+
+  .field-error,
+  .editor-error {
+    color: var(--constellation-color-danger);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .policy-status-toggle {
+    appearance: none;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 9px;
+    min-height: 40px;
+    padding: 6px 10px;
+    border: 1px solid var(--constellation-control-field-border);
+    border-radius: 8px;
+    background: var(--constellation-control-field-background);
+    color: var(--constellation-color-text-primary);
+    cursor: pointer;
+  }
+
+  .policy-status-toggle > span {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--constellation-color-text-muted);
+  }
+
+  .policy-status-toggle.is-enabled > span {
+    background: var(--constellation-color-success);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--constellation-color-success) 55%, transparent);
+  }
+
+  .policy-status-toggle strong {
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+  }
+
+  .policy-status-toggle:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .guidance-editor {
+    display: grid;
+    gap: 10px;
+    min-width: 0;
+    padding-top: 2px;
+  }
+
+  .guidance-editor-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .guidance-editor-heading > div {
+    display: grid;
+    gap: 4px;
+  }
+
+  .guidance-editor-heading small {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+    line-height: 1.4;
+  }
+
+  .guidance-editor-list {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .guidance-editor-list li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 8px;
+  }
+
+  .empty-policy-value {
+    margin: 0;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .editor-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-editor.compact .editor-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .policy-editor.compact .editor-heading {
+    flex-direction: column;
+  }
+
+  .policy-editor.compact .editor-heading p {
+    max-width: none;
+    text-align: left;
+  }
+
+  @media (max-width: 720px) {
+    .editor-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .editor-heading p {
+      max-width: none;
+      text-align: left;
+    }
+
+    .editor-fields,
+    .guidance-editor-list li {
+      grid-template-columns: 1fr;
+    }
+
+    .guidance-editor-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import type { CyclePolicyHistoryRead } from '$lib/api/client';
+  import { ConstellationButton } from '$lib/components/constellation';
+  import {
+    formatPolicyDateTime,
+    policyFieldLabel,
+    policySourceLabel,
+    retiredGuidance,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+  import type { CyclePolicyWorkflowState } from '$lib/features/cycles/domain/effectivePolicyWorkflow';
+
+  let {
+    history,
+    displayTimezone,
+    editable,
+    workflowKind,
+    revertingChangeId,
+    historyError,
+    onRevert,
+    onLoadMore,
+  }: {
+    history: CyclePolicyHistoryRead;
+    displayTimezone: string;
+    editable: boolean;
+    workflowKind: CyclePolicyWorkflowState['kind'];
+    revertingChangeId: number | null;
+    historyError?: string;
+    onRevert: (changeId: number) => void;
+    onLoadMore: () => Promise<void>;
+  } = $props();
+
+  let loadingMore = $state(false);
+
+  async function loadMore(): Promise<void> {
+    if (loadingMore) return;
+    loadingMore = true;
+    try {
+      await onLoadMore();
+    } finally {
+      loadingMore = false;
+    }
+  }
+</script>
+
+<details class="history-region">
+  <summary>
+    <span>
+      <strong>History</strong>
+      <small>Prior versions are not active.</small>
+    </span>
+    <span>{history.items.length} changes</span>
+  </summary>
+
+  <div class="history-content">
+    <div class="history-warning">
+      <strong>Historical only</strong>
+      <span>Text below does not guide the next run.</span>
+    </div>
+
+    {#if history.items.length}
+      <ol class="history-list">
+        {#each history.items as change (change.id)}
+          {@const retired = retiredGuidance(change)}
+          <li class="history-change">
+            <header>
+              <div>
+                <strong>Version {change.version}</strong>
+                <time datetime={change.applied_at}>
+                  {formatPolicyDateTime(change.applied_at, displayTimezone)}
+                </time>
+              </div>
+              <div class="history-change-actions">
+                <span>{change.changed_fields.map(policyFieldLabel).join(', ')}</span>
+                {#if editable}
+                  <ConstellationButton
+                    variant="quiet"
+                    size="sm"
+                    loading={workflowKind === 'reverting' && revertingChangeId === change.id}
+                    disabled={workflowKind !== 'view'}
+                    onclick={() => onRevert(change.id)}
+                  >
+                    Revert
+                  </ConstellationButton>
+                {/if}
+              </div>
+            </header>
+            <p>{change.rationale}</p>
+            <div class="history-source">
+              From {policySourceLabel(change)}
+              {#if change.reverted_from_id !== null}
+                · Reverted change {change.reverted_from_id}
+              {/if}
+            </div>
+
+            {#if retired.length}
+              <section class="retired-guidance" aria-label="Retired guidance">
+                <span>Retired guidance · not active</span>
+                {#each retired as guidance}<blockquote>{guidance}</blockquote>{/each}
+              </section>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <p class="empty-policy-value">No policy changes yet.</p>
+    {/if}
+
+    {#if historyError}<p class="history-error" role="alert">{historyError}</p>{/if}
+    {#if history.pagination.has_more}
+      <ConstellationButton variant="quiet" size="sm" loading={loadingMore} onclick={loadMore}>
+        Load older changes
+      </ConstellationButton>
+    {/if}
+  </div>
+</details>
+
+<style>
+  .history-region summary,
+  .history-change header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .history-region summary {
+    align-items: center;
+    min-height: 46px;
+    padding: 0 14px;
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 5%, transparent);
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .history-region summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .history-region summary > span:first-child {
+    display: grid;
+    gap: 2px;
+  }
+
+  .history-region summary strong {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .history-region summary small,
+  .history-region summary > span:last-child,
+  .history-source,
+  .history-change header span,
+  .history-change time {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+  }
+
+  .history-content {
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    border-top: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
+  }
+
+  .history-warning {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 10px;
+    padding: 8px 10px;
+    border: 1px dashed var(--constellation-color-text-muted);
+    border-radius: 6px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+  }
+
+  .history-warning strong,
+  .retired-guidance > span {
+    color: var(--constellation-color-text-primary);
+  }
+
+  .history-list {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .history-change {
+    display: grid;
+    gap: 7px;
+    padding: 11px 0;
+    border-bottom: 1px solid var(--constellation-section-divider);
+    opacity: 0.82;
+  }
+
+  .history-change:last-child {
+    border-bottom: 0;
+  }
+
+  .history-change header > div {
+    display: grid;
+    gap: 3px;
+  }
+
+  .history-change-actions {
+    justify-items: end;
+  }
+
+  .history-change-actions > span {
+    max-width: 50%;
+    text-align: right;
+  }
+
+  .history-change p,
+  .history-change blockquote {
+    margin: 0;
+  }
+
+  .history-change p {
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .history-source {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .retired-guidance {
+    display: grid;
+    gap: 7px;
+    margin-top: 3px;
+    padding: 10px;
+    border: 1px dashed var(--constellation-color-text-muted);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 6%, transparent);
+  }
+
+  .retired-guidance > span {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .retired-guidance blockquote {
+    padding-left: 10px;
+    border-left: 2px solid var(--constellation-color-text-muted);
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+    font-style: italic;
+    line-height: 1.5;
+  }
+
+  .empty-policy-value {
+    margin: 0;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .history-error {
+    color: var(--constellation-color-danger);
+    font-size: 12px;
+  }
+
+  @media (max-width: 720px) {
+    .history-change header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .history-change-actions {
+      justify-items: start;
+    }
+
+    .history-change-actions > span {
+      max-width: none;
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/CyclePolicyReview.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyReview.svelte
@@ -1,0 +1,343 @@
+<script lang="ts">
+  import {
+    ConstellationButton,
+    ConstellationNotice,
+    ConstellationTextarea,
+  } from '$lib/components/constellation';
+  import { presentedPolicyDiff } from '$lib/features/cycles/domain/effectivePolicy';
+  import type { PolicyReviewProps } from '$lib/features/cycles/domain/effectivePolicyWorkflow';
+
+  let {
+    cycleId,
+    review,
+    rationale,
+    applying,
+    applyDisabled,
+    activeRunBoundary,
+    error,
+    compact = false,
+    onRationaleChange,
+    onBack,
+    onApply,
+  }: PolicyReviewProps & {
+    cycleId: number;
+    compact?: boolean;
+    onRationaleChange: (rationale: string) => void;
+    onBack: () => void;
+    onApply: () => void;
+  } = $props();
+
+  const diffEntries = $derived(presentedPolicyDiff(review.preview));
+
+  function inputValue(event: Event): string {
+    return (event.currentTarget as HTMLTextAreaElement).value;
+  }
+</script>
+
+<section class:compact class="policy-review" aria-label="Review cycle behavior change">
+  <header class="editor-heading">
+    <div>
+      <span class="section-kicker">Review</span>
+      <h4>{review.kind === 'revert' ? 'Review revert' : 'Review behavior change'}</h4>
+    </div>
+    <p>{activeRunBoundary}</p>
+  </header>
+
+  {#if review.preview.changed_fields.length}
+    <div class="diff-list">
+      {#each diffEntries as entry (entry.key)}
+        <article class="diff-entry">
+          <h5>{entry.label}</h5>
+          {#if entry.kind === 'schedule'}
+            <div class="diff-columns">
+              <div>
+                <span>Before</span>
+                <strong>{entry.before.schedule_human}</strong>
+                <code>{entry.before.schedule_expr}</code>
+                <small>{entry.before.timezone.replaceAll('_', ' ')}</small>
+              </div>
+              <div>
+                <span>After</span>
+                <strong>{entry.after.schedule_human}</strong>
+                <code>{entry.after.schedule_expr}</code>
+                <small>{entry.after.timezone.replaceAll('_', ' ')}</small>
+              </div>
+            </div>
+          {:else if entry.kind === 'guidance'}
+            <div class="guidance-diff">
+              {#if entry.retired.length}
+                <div class="guidance-retire">
+                  <span>Retire</span>
+                  {#each entry.retired as item}<p>{item}</p>{/each}
+                </div>
+              {/if}
+              {#if entry.added.length}
+                <div class="guidance-add">
+                  <span>Add</span>
+                  {#each entry.added as item}<p>{item}</p>{/each}
+                </div>
+              {/if}
+            </div>
+          {:else}
+            <div class="diff-columns">
+              <div><span>Before</span><p>{entry.before}</p></div>
+              <div><span>After</span><p>{entry.after}</p></div>
+            </div>
+          {/if}
+        </article>
+      {/each}
+    </div>
+  {:else}
+    <ConstellationNotice
+      title="No effective change"
+      description="This draft matches the current behavior. There is nothing to apply."
+      tone="neutral"
+      compact
+    />
+  {/if}
+
+  {#each review.preview.warnings as warning (warning.code)}
+    <p class="review-warning">{warning.message}</p>
+  {/each}
+
+  <div class="editor-field rationale-field">
+    <label for={`cycle-${cycleId}-policy-rationale`}>Rationale <span>Required</span></label>
+    <ConstellationTextarea
+      id={`cycle-${cycleId}-policy-rationale`}
+      value={rationale}
+      rows={3}
+      maxlength={5000}
+      placeholder="Why should this behavior change?"
+      oninput={(event) => onRationaleChange(inputValue(event))}
+    />
+  </div>
+
+  {#if error}<p class="editor-error" role="alert">{error}</p>{/if}
+
+  <div class="editor-actions">
+    <ConstellationButton variant="quiet" size="sm" onclick={onBack}>
+      {review.kind === 'edit' ? 'Back to draft' : 'Cancel'}
+    </ConstellationButton>
+    <ConstellationButton
+      variant="primary"
+      size="sm"
+      loading={applying}
+      disabled={applyDisabled}
+      onclick={onApply}
+    >
+      {review.kind === 'revert' ? 'Apply revert' : 'Apply change'}
+    </ConstellationButton>
+  </div>
+</section>
+
+<style>
+  .policy-review {
+    display: grid;
+    gap: 16px;
+    min-width: 0;
+    padding: 16px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-info) 3%, transparent);
+  }
+
+  .editor-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .editor-heading h4,
+  .editor-heading p,
+  .diff-entry h5,
+  .diff-entry p,
+  .review-warning,
+  .editor-error {
+    margin: 0;
+  }
+
+  .section-kicker,
+  .editor-field > label {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .section-kicker {
+    letter-spacing: 0.12em;
+  }
+
+  .editor-heading h4 {
+    margin-top: 4px;
+    font-size: 15px;
+    font-weight: 650;
+  }
+
+  .editor-heading p {
+    max-width: 360px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.5;
+    text-align: right;
+  }
+
+  .diff-list {
+    display: grid;
+    gap: 10px;
+  }
+
+  .diff-entry {
+    display: grid;
+    gap: 9px;
+    padding: 12px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 7px;
+    background: var(--constellation-surface-nested-background);
+  }
+
+  .diff-entry h5 {
+    font-size: 12px;
+    font-weight: 650;
+  }
+
+  .diff-columns,
+  .guidance-diff {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .diff-columns > div,
+  .guidance-diff > div {
+    display: grid;
+    align-content: start;
+    gap: 6px;
+    min-width: 0;
+    padding: 9px;
+    border-left: 2px solid var(--constellation-color-text-muted);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 4%, transparent);
+  }
+
+  .diff-columns span,
+  .guidance-diff span {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .diff-columns strong,
+  .diff-columns p,
+  .guidance-diff p {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .diff-columns code {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .diff-columns small {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+  }
+
+  .guidance-retire {
+    border-left-color: var(--constellation-color-warning) !important;
+  }
+
+  .guidance-add {
+    border-left-color: var(--constellation-color-success) !important;
+  }
+
+  .review-warning {
+    padding: 8px 10px;
+    border-left: 2px solid var(--constellation-color-info);
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .editor-field {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .editor-field > label {
+    color: var(--constellation-color-text-secondary);
+    letter-spacing: 0.08em;
+  }
+
+  .editor-field > label span {
+    color: var(--constellation-color-warning);
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  .editor-field :global(.constellation-textarea) {
+    width: 100%;
+  }
+
+  .rationale-field {
+    padding-top: 2px;
+  }
+
+  .editor-error {
+    color: var(--constellation-color-danger);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .editor-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .policy-review.compact .diff-columns,
+  .policy-review.compact .guidance-diff {
+    grid-template-columns: 1fr;
+  }
+
+  .policy-review.compact .editor-heading {
+    flex-direction: column;
+  }
+
+  .policy-review.compact .editor-heading p {
+    max-width: none;
+    text-align: left;
+  }
+
+  @media (max-width: 720px) {
+    .editor-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .editor-heading p {
+      max-width: none;
+      text-align: left;
+    }
+
+    .diff-columns,
+    .guidance-diff {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
@@ -1,46 +1,31 @@
 <script lang="ts">
   import { beforeNavigate } from '$app/navigation';
-  import { onDestroy, onMount } from 'svelte';
+  import { getContext, onDestroy, onMount } from 'svelte';
 
   import {
     api,
-    type CyclePolicyChangeRead,
-    type CyclePolicyConflictDetail,
     type CyclePolicyHistoryRead,
     type EffectiveCyclePolicyRead,
   } from '$lib/api/client';
+  import { ConstellationButton, ConstellationNotice } from '$lib/components/constellation';
+  import type { CyclePolicyEditorApi } from '$lib/features/cycles/domain/effectivePolicy';
   import {
-    ConstellationButton,
-    ConstellationNotice,
-    ConstellationPill,
-    ConstellationSelect,
-    ConstellationTextInput,
-    ConstellationTextarea,
-  } from '$lib/components/constellation';
+    EFFECTIVE_POLICY_CLIENT_CONTEXT,
+    type EffectivePolicyClientResolver,
+  } from '$lib/features/cycles/domain/effectivePolicyClientContext';
   import {
-    applyPolicyReview,
-    clonePolicyDraft,
-    formatPolicyDateTime,
-    hydratePolicyDraft,
-    isPolicyDraftDirty,
-    policyConfigurationEntries,
-    policyFieldLabel,
-    policyFieldSource,
-    policySourceLabel,
-    policyValueLabel,
-    presentedPolicyDiff,
-    recoverPolicyDraftAfterConflict,
-    retiredGuidance,
-    reviewPolicyDraft,
-    reviewPolicyRevert,
-    shouldConfirmPolicyDraftDiscard,
-    type CyclePolicyDraft,
-    type CyclePolicyDraftErrors,
-    type CyclePolicyReview,
-  } from '$lib/features/cycles/domain/effectivePolicy';
+    EffectivePolicyWorkflowController,
+    isPolicyWorkflowDirty,
+    policyReviewProps,
+    type CyclePolicyWorkflowState,
+    workflowErrorMessage,
+  } from '$lib/features/cycles/domain/effectivePolicyWorkflow';
   import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
 
-  type EditorStage = 'view' | 'edit' | 'review';
+  import ActiveCyclePolicyView from './ActiveCyclePolicyView.svelte';
+  import CyclePolicyDraftEditor from './CyclePolicyDraftEditor.svelte';
+  import CyclePolicyHistory from './CyclePolicyHistory.svelte';
+  import CyclePolicyReview from './CyclePolicyReview.svelte';
 
   let {
     cycleId,
@@ -64,293 +49,117 @@
     onDirtyChange?: (dirty: boolean) => void;
   } = $props();
 
-  let policy = $state<EffectiveCyclePolicyRead | null>(null);
-  let history = $state<CyclePolicyChangeRead[]>([]);
-  let pagination = $state<CyclePolicyHistoryRead['pagination'] | null>(null);
+  let workflow = $state<CyclePolicyWorkflowState | null>(null);
   let loading = $state(true);
-  let historyLoading = $state(false);
-  let reviewing = $state(false);
-  let applying = $state(false);
-  let revertingChangeId = $state<number | null>(null);
   let error = $state('');
-  let historyError = $state('');
-  let editorError = $state('');
-  let editorNotice = $state('');
-  let stage = $state<EditorStage>('view');
-  let draft = $state<CyclePolicyDraft | null>(null);
-  let draftErrors = $state<CyclePolicyDraftErrors>({});
-  let review = $state<CyclePolicyReview | null>(null);
-  let rationale = $state('');
   let modelCatalog = $state<RuntimeModelCatalogEntry[]>([]);
   let resolvedTimezone = $state(
     Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
   );
+  let controller: EffectivePolicyWorkflowController | null = null;
   let requestSerial = 0;
   let loadedCycleId: number | null = null;
-
-  const configurationEntries = $derived(
-    policy ? policyConfigurationEntries(policy.configuration) : [],
-  );
-  const guidanceSource = $derived(
-    policy ? policyFieldSource(policy.field_sources, 'guidance') : undefined,
-  );
-  const dirty = $derived(isPolicyDraftDirty(draft, policy));
-  const diffEntries = $derived(review ? presentedPolicyDiff(review.preview) : []);
-  const modelOptions = $derived([
-    { value: '', label: 'Workspace default', description: 'Use the workspace model' },
-    ...modelCatalog.map((entry) => ({
-      value: entry.id,
-      label: entry.label,
-      description: entry.description,
-    })),
-    ...(draft?.model_override
-      && !modelCatalog.some((entry) => entry.id === draft?.model_override)
-      ? [{
-          value: draft.model_override,
-          label: draft.model_override,
-          description: 'Current model selection',
-        }]
-      : []),
-  ]);
-  const thinkingOptions = [
-    { value: '', label: 'Workspace default' },
-    { value: 'none', label: 'None' },
-    { value: 'low', label: 'Low' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'xhigh', label: 'xHigh' },
-  ];
-  const applyDisabled = $derived(
-    applying || !review || !review.preview.changed_fields.length || !rationale.trim(),
+  let loadedPolicyVersion: number | null = null;
+  const resolvePolicyClient = getContext<EffectivePolicyClientResolver | undefined>(
+    EFFECTIVE_POLICY_CLIENT_CONTEXT,
   );
 
-  function errorMessage(value: unknown, fallback: string): string {
-    if (value && typeof value === 'object' && 'detail' in value) {
-      const detail = (value as { detail?: unknown }).detail;
-      return typeof detail === 'string' ? detail : fallback;
-    }
-    return value instanceof Error ? value.message : fallback;
-  }
+  const policy = $derived(workflow?.data.policy ?? null);
+  const dirty = $derived(workflow ? isPolicyWorkflowDirty(workflow) : false);
+  const showReadView = $derived(
+    workflow?.kind === 'view'
+    || workflow?.kind === 'reverting'
+    || (workflow?.kind === 'conflicted' && !workflow.draft),
+  );
+  const canEdit = $derived(
+    editable
+    && (workflow?.kind === 'view' || (workflow?.kind === 'conflicted' && !workflow.draft)),
+  );
+  const editorState = $derived(
+    workflow?.kind === 'edit'
+    || workflow?.kind === 'reviewing'
+    || (workflow?.kind === 'conflicted' && workflow.draft)
+      ? workflow
+      : null,
+  );
+  const reviewState = $derived(
+    workflow?.kind === 'review' || workflow?.kind === 'applying' ? workflow : null,
+  );
+  const notice = $derived(
+    workflow?.kind === 'view' || workflow?.kind === 'edit' || workflow?.kind === 'conflicted'
+      ? workflow.notice
+      : undefined,
+  );
 
-  function conflictDetail(value: unknown): CyclePolicyConflictDetail | null {
-    if (!value || typeof value !== 'object') return null;
-    const candidate = value as { status?: unknown; detail?: unknown };
-    if (candidate.status !== 409 || !candidate.detail || typeof candidate.detail !== 'object') return null;
-    const detail = candidate.detail as Partial<CyclePolicyConflictDetail>;
-    if (!detail.latest_effective_policy || typeof detail.reason !== 'string') return null;
-    return detail as CyclePolicyConflictDetail;
-  }
-
-  function resetEditor(nextPolicy: EffectiveCyclePolicyRead, nextStage: EditorStage = 'view') {
-    draft = hydratePolicyDraft(nextPolicy);
-    draftErrors = {};
-    review = null;
-    rationale = '';
-    editorError = '';
-    stage = nextStage;
-  }
-
-  async function loadPolicy(selectedCycleId: number) {
-    if (loadedCycleId !== selectedCycleId) editorNotice = '';
+  function initializeController(
+    selectedCycleId: number,
+    client: CyclePolicyEditorApi,
+    nextPolicy: EffectiveCyclePolicyRead,
+    nextHistory: CyclePolicyHistoryRead,
+    nextModelCatalog: readonly RuntimeModelCatalogEntry[],
+  ): void {
+    controller?.dispose();
     loadedCycleId = selectedCycleId;
+    loadedPolicyVersion = nextPolicy.version;
+    controller = new EffectivePolicyWorkflowController({
+      client,
+      cycleId: selectedCycleId,
+      data: { policy: nextPolicy, history: nextHistory },
+      modelCatalog: nextModelCatalog,
+      onStateChange: (state) => {
+        loadedPolicyVersion = state.data.policy.version;
+        workflow = state;
+      },
+      onPolicyApplied,
+    });
+    workflow = controller.state;
+  }
+
+  async function loadPolicy(selectedCycleId: number, client: CyclePolicyEditorApi): Promise<void> {
     const serial = ++requestSerial;
     loading = true;
     error = '';
-    historyError = '';
-    policy = null;
-    history = [];
-    pagination = null;
+    workflow = null;
+    controller?.dispose();
+    controller = null;
     try {
       const [nextPolicy, nextHistory, runtime] = await Promise.all([
-        api.getCycleBehaviorPolicy(selectedCycleId),
-        api.getCycleBehaviorPolicyHistory(selectedCycleId),
+        client.getCycleBehaviorPolicy(selectedCycleId),
+        client.getCycleBehaviorPolicyHistory(selectedCycleId),
         api.runtimeSettings().catch(() => null),
       ]);
       if (serial !== requestSerial) return;
-      policy = nextPolicy;
-      history = nextHistory.items;
-      pagination = nextHistory.pagination;
       modelCatalog = runtime?.models.catalog ?? [];
       resolvedTimezone = displayTimezone
         || runtime?.display?.display_timezone
         || Intl.DateTimeFormat().resolvedOptions().timeZone
         || 'UTC';
-      resetEditor(nextPolicy);
+      initializeController(selectedCycleId, client, nextPolicy, nextHistory, modelCatalog);
     } catch (loadError) {
       if (serial !== requestSerial) return;
-      error = errorMessage(loadError, 'Effective behavior failed to load.');
+      error = workflowErrorMessage(loadError, 'Effective behavior failed to load.');
     } finally {
       if (serial === requestSerial) loading = false;
     }
   }
 
-  async function loadMoreHistory() {
-    if (!pagination?.has_more || pagination.next_offset === null || historyLoading) return;
-    const selectedCycleId = cycleId;
-    const serial = requestSerial;
-    historyLoading = true;
-    historyError = '';
-    try {
-      const nextHistory = await api.getCycleBehaviorPolicyHistory(
-        selectedCycleId,
-        pagination.limit,
-        pagination.next_offset,
-      );
-      if (serial !== requestSerial || selectedCycleId !== cycleId) return;
-      history = [...history, ...nextHistory.items];
-      pagination = nextHistory.pagination;
-    } catch (loadError) {
-      if (serial !== requestSerial) return;
-      historyError = errorMessage(loadError, 'Older history failed to load.');
-    } finally {
-      if (serial === requestSerial) historyLoading = false;
-    }
+  function cancelEditing(): void {
+    controller?.cancelEditing(() => window.confirm('Discard this behavior draft?'));
   }
 
-  function startEditing() {
-    if (!policy) return;
-    resetEditor(policy, 'edit');
-    editorNotice = '';
-  }
-
-  function cancelEditing() {
-    if (!policy) return;
-    if (
-      shouldConfirmPolicyDraftDiscard(draft, policy)
-      && !window.confirm('Discard this behavior draft?')
-    ) return;
-    resetEditor(policy);
-    editorNotice = '';
-  }
-
-  function addGuidance() {
-    if (!draft) return;
-    draft.guidance.push('');
-    draftErrors = { ...draftErrors, guidance: undefined };
-  }
-
-  function removeGuidance(index: number) {
-    if (!draft) return;
-    draft.guidance.splice(index, 1);
-    draftErrors = { ...draftErrors, guidance: undefined };
-  }
-
-  function toggleDraftEnabled() {
-    if (draft) draft.enabled = !draft.enabled;
-  }
-
-  async function reviewDraft() {
-    if (!draft || !policy) return;
-    reviewing = true;
-    editorError = '';
-    editorNotice = '';
-    try {
-      const result = await reviewPolicyDraft(
-        api,
-        cycleId,
-        clonePolicyDraft(draft),
-        modelCatalog,
-        policy.configuration.model_override,
-      );
-      draftErrors = result.errors;
-      if (!result.review) return;
-      review = result.review;
-      rationale = '';
-      stage = 'review';
-    } catch (reviewError) {
-      editorError = errorMessage(reviewError, 'The change could not be reviewed.');
-    } finally {
-      reviewing = false;
-    }
-  }
-
-  async function beginRevert(changeId: number) {
-    revertingChangeId = changeId;
-    editorError = '';
-    editorNotice = '';
-    try {
-      review = await reviewPolicyRevert(api, cycleId, changeId);
-      rationale = '';
-      stage = 'review';
-    } catch (revertError) {
-      historyError = errorMessage(revertError, 'The revert could not be reviewed.');
-    } finally {
-      revertingChangeId = null;
-    }
-  }
-
-  function leaveReview() {
-    const reviewKind = review?.kind;
-    review = null;
-    rationale = '';
-    editorError = '';
-    stage = reviewKind === 'edit' ? 'edit' : 'view';
-  }
-
-  async function handleConflict(detail: CyclePolicyConflictDetail) {
-    if (draft && review?.kind === 'edit') {
-      const recovered = recoverPolicyDraftAfterConflict(draft, detail.latest_effective_policy);
-      draft = recovered.draft;
-      policy = recovered.policy;
-      stage = 'edit';
-      editorNotice = 'Another person changed this Cycle. Your draft is safe. Review it against the latest version and try again.';
-    } else {
-      policy = detail.latest_effective_policy;
-      resetEditor(detail.latest_effective_policy);
-      editorNotice = 'Another person changed this Cycle. Review the latest version before you try again.';
-    }
-    review = null;
-    try {
-      const nextHistory = await api.getCycleBehaviorPolicyHistory(cycleId);
-      history = nextHistory.items;
-      pagination = nextHistory.pagination;
-    } catch {
-      historyError = 'History could not be refreshed after the conflict.';
-    }
-  }
-
-  async function applyReviewedChange() {
-    if (applyDisabled) return;
-    const reviewKind = review?.kind;
-    applying = true;
-    editorError = '';
-    editorNotice = '';
-    try {
-      const result = await applyPolicyReview(
-        api,
-        cycleId,
-        review,
-        rationale,
-        () => window.confirm('Apply this revert as a new behavior version?'),
-      );
-      if (!result) return;
-      policy = result.policy;
-      history = result.history.items;
-      pagination = result.history.pagination;
-      resetEditor(result.policy);
-      editorNotice = reviewKind === 'revert'
-        ? 'Revert applied as a new behavior version.'
-        : 'Behavior applied for future runs.';
-      await onPolicyApplied?.(result.policy);
-    } catch (applyError) {
-      const conflict = conflictDetail(applyError);
-      if (conflict) await handleConflict(conflict);
-      else editorError = errorMessage(applyError, 'The change could not be applied.');
-    } finally {
-      applying = false;
-    }
+  function applyReviewedChange(): void {
+    void controller?.applyReviewedChange(
+      () => window.confirm('Apply this revert as a new behavior version?'),
+    );
   }
 
   beforeNavigate(({ cancel }) => {
-    if (
-      shouldConfirmPolicyDraftDiscard(draft, policy)
-      && !window.confirm('Leave this page and discard the behavior draft?')
-    ) cancel();
+    if (dirty && !window.confirm('Leave this page and discard the behavior draft?')) cancel();
   });
 
   onMount(() => {
     const warnBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!shouldConfirmPolicyDraftDiscard(draft, policy)) return;
+      if (!workflow || !isPolicyWorkflowDirty(workflow)) return;
       event.preventDefault();
       event.returnValue = '';
     };
@@ -367,59 +176,58 @@
     refreshSerial;
     const suppliedPolicy = previewPolicy;
     const suppliedHistory = previewHistory;
+    const suppliedClient = suppliedPolicy ? (resolvePolicyClient?.(selectedCycleId) ?? api) : api;
     if (displayTimezone) resolvedTimezone = displayTimezone;
     if (suppliedPolicy) {
-      if (loadedCycleId !== selectedCycleId) editorNotice = '';
-      loadedCycleId = selectedCycleId;
       requestSerial += 1;
-      policy = suppliedPolicy;
-      history = suppliedHistory?.items ?? [];
-      pagination = suppliedHistory?.pagination ?? null;
       loading = false;
       error = '';
-      historyError = '';
-      resetEditor(suppliedPolicy);
+      if (
+        loadedCycleId !== selectedCycleId
+        || loadedPolicyVersion !== suppliedPolicy.version
+        || !controller
+      ) {
+        modelCatalog = [];
+        initializeController(
+          selectedCycleId,
+          suppliedClient,
+          suppliedPolicy,
+          suppliedHistory ?? {
+            items: [],
+            pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
+          },
+          modelCatalog,
+        );
+      }
       return;
     }
-    void loadPolicy(selectedCycleId);
+    void loadPolicy(selectedCycleId, suppliedClient);
   });
 
   onDestroy(() => {
     requestSerial += 1;
+    controller?.dispose();
     onDirtyChange?.(false);
   });
 </script>
 
-<section class="effective-policy" class:compact aria-label="Effective cycle behavior">
-  <header class="active-heading">
-    <div>
-      <span class="section-kicker">Effective behavior</span>
-      <h3>Active now</h3>
-      <p>What Illo will use on the next run.</p>
-    </div>
-    {#if policy}
-      <div class="active-actions">
-        <div class="active-status">
-          <ConstellationPill variant={policy.configuration.enabled ? 'success' : 'muted'} leadingDot>
-            {policy.configuration.enabled ? 'Enabled' : 'Paused'}
-          </ConstellationPill>
-          <span>Version {policy.version}</span>
-        </div>
-        {#if editable && stage === 'view'}
-          <ConstellationButton variant="secondary" size="sm" onclick={startEditing}>
-            Edit behavior
-          </ConstellationButton>
-        {/if}
-      </div>
-    {/if}
-  </header>
+<section class:compact class="effective-policy" aria-label="Effective cycle behavior">
+  <ActiveCyclePolicyView
+    {cycleId}
+    {policy}
+    displayTimezone={resolvedTimezone}
+    showDetails={false}
+    {canEdit}
+    {compact}
+    onEdit={() => controller?.startEditing()}
+  />
 
-  {#if editorNotice}
+  {#if notice}
     <div class="editor-message">
       <ConstellationNotice
-        title={stage === 'edit' ? 'Draft preserved' : 'Behavior updated'}
-        description={editorNotice}
-        tone={stage === 'edit' ? 'warning' : 'success'}
+        title={workflow?.kind === 'conflicted' || workflow?.kind === 'edit' ? 'Draft preserved' : 'Behavior updated'}
+        description={notice}
+        tone={workflow?.kind === 'conflicted' || workflow?.kind === 'edit' ? 'warning' : 'success'}
         compact
       />
     </div>
@@ -427,418 +235,62 @@
 
   {#if loading}
     <div class="policy-loading" aria-label="Loading effective behavior">
-      <span></span>
-      <span></span>
-      <span></span>
+      <span></span><span></span><span></span>
     </div>
   {:else if error}
     <div class="policy-error" role="alert">
       <span>{error}</span>
-      <ConstellationButton variant="secondary" size="sm" onclick={() => loadPolicy(cycleId)}>
+      <ConstellationButton variant="secondary" size="sm" onclick={() => loadPolicy(cycleId, api)}>
         Retry
       </ConstellationButton>
     </div>
-  {:else if policy}
-    {#if stage === 'edit' && draft}
-      <section class="policy-editor" aria-label="Edit cycle behavior">
-        <header class="editor-heading">
-          <div>
-            <span class="section-kicker">Draft</span>
-            <h4>Prepare behavior change</h4>
-          </div>
-          <p>Nothing changes until you review and apply.</p>
-        </header>
-
-        {#if editorError}
-          <p class="editor-error" role="alert">{editorError}</p>
-        {/if}
-
-        <div class="editor-fields">
-          <div class="editor-field editor-field-full">
-            <label for={`cycle-${cycleId}-policy-prompt`}>Mission prompt</label>
-            <ConstellationTextarea
-              id={`cycle-${cycleId}-policy-prompt`}
-              bind:value={draft.prompt}
-              rows={7}
-              aria-invalid={draftErrors.prompt ? 'true' : undefined}
-            />
-            {#if draftErrors.prompt}<small class="field-error">{draftErrors.prompt}</small>{/if}
-          </div>
-
-          <div class="editor-field">
-            <label for={`cycle-${cycleId}-policy-schedule`}>Stored schedule</label>
-            <ConstellationTextInput
-              id={`cycle-${cycleId}-policy-schedule`}
-              bind:value={draft.schedule_expr}
-              mono
-              placeholder="0 9 * * *"
-              aria-invalid={draftErrors.schedule_expr ? 'true' : undefined}
-            />
-            {#if draftErrors.schedule_expr}<small class="field-error">{draftErrors.schedule_expr}</small>{/if}
-          </div>
-
-          <div class="editor-field">
-            <label for={`cycle-${cycleId}-policy-timezone`}>Timezone</label>
-            <ConstellationTextInput
-              id={`cycle-${cycleId}-policy-timezone`}
-              bind:value={draft.timezone}
-              placeholder="America/Toronto"
-              aria-invalid={draftErrors.timezone ? 'true' : undefined}
-            />
-            {#if draftErrors.timezone}<small class="field-error">{draftErrors.timezone}</small>{/if}
-          </div>
-
-          <div class="editor-field">
-            <span class="editor-field-label">Status</span>
-            <button
-              type="button"
-              class="policy-status-toggle"
-              class:is-enabled={draft.enabled}
-              aria-pressed={draft.enabled}
-              onclick={toggleDraftEnabled}
-            >
-              <span aria-hidden="true"></span>
-              <strong>{draft.enabled ? 'Enabled' : 'Paused'}</strong>
-            </button>
-          </div>
-
-          <div class="editor-field">
-            <span class="editor-field-label">Model override</span>
-            <ConstellationSelect
-              bind:value={draft.model_override}
-              options={modelOptions}
-              ariaLabel="Model override"
-            />
-            {#if draftErrors.model_override}<small class="field-error">{draftErrors.model_override}</small>{/if}
-          </div>
-
-          <div class="editor-field">
-            <span class="editor-field-label">Thinking override</span>
-            <ConstellationSelect
-              bind:value={draft.thinking_override}
-              options={thinkingOptions}
-              ariaLabel="Thinking override"
-            />
-            {#if draftErrors.thinking_override}<small class="field-error">{draftErrors.thinking_override}</small>{/if}
-          </div>
-
-          <section class="guidance-editor editor-field-full" aria-labelledby={`cycle-${cycleId}-guidance-editor`}>
-            <div class="guidance-editor-heading">
-              <div>
-                <span class="editor-field-label" id={`cycle-${cycleId}-guidance-editor`}>Active guidance</span>
-                <small>Changing text retires the old guidance and adds a new entry.</small>
-              </div>
-              <ConstellationButton variant="quiet" size="sm" onclick={addGuidance}>
-                Add guidance
-              </ConstellationButton>
-            </div>
-            {#if draft.guidance.length}
-              <ol class="guidance-editor-list">
-                {#each draft.guidance as guidance, index}
-                  <li>
-                    <ConstellationTextarea
-                      bind:value={draft.guidance[index]}
-                      rows={2}
-                      aria-label={`Guidance ${index + 1}`}
-                    />
-                    <ConstellationButton
-                      variant="quiet"
-                      size="sm"
-                      aria-label={`Remove guidance ${index + 1}`}
-                      onclick={() => removeGuidance(index)}
-                    >
-                      Remove
-                    </ConstellationButton>
-                  </li>
-                {/each}
-              </ol>
-            {:else}
-              <p class="empty-policy-value">No active guidance.</p>
-            {/if}
-            {#if draftErrors.guidance}<small class="field-error">{draftErrors.guidance}</small>{/if}
-          </section>
-        </div>
-
-        <div class="editor-actions">
-          <ConstellationButton variant="quiet" size="sm" onclick={cancelEditing}>Cancel</ConstellationButton>
-          <ConstellationButton
-            variant="primary"
-            size="sm"
-            loading={reviewing}
-            disabled={!dirty}
-            onclick={reviewDraft}
-          >
-            Review change
-          </ConstellationButton>
-        </div>
-      </section>
-    {:else if stage === 'review' && review}
-      <section class="policy-review" aria-label="Review cycle behavior change">
-        <header class="editor-heading">
-          <div>
-            <span class="section-kicker">Review</span>
-            <h4>{review.kind === 'revert' ? 'Review revert' : 'Review behavior change'}</h4>
-          </div>
-          <p>Active runs are unchanged. Future runs use this policy only after apply.</p>
-        </header>
-
-        {#if review.preview.changed_fields.length}
-          <div class="diff-list">
-            {#each diffEntries as entry (entry.key)}
-              <article class="diff-entry">
-                <h5>{entry.label}</h5>
-                {#if entry.kind === 'schedule'}
-                  <div class="diff-columns">
-                    <div>
-                      <span>Before</span>
-                      <strong>{entry.before.schedule_human}</strong>
-                      <code>{entry.before.schedule_expr}</code>
-                      <small>{entry.before.timezone.replaceAll('_', ' ')}</small>
-                    </div>
-                    <div>
-                      <span>After</span>
-                      <strong>{entry.after.schedule_human}</strong>
-                      <code>{entry.after.schedule_expr}</code>
-                      <small>{entry.after.timezone.replaceAll('_', ' ')}</small>
-                    </div>
-                  </div>
-                {:else if entry.kind === 'guidance'}
-                  <div class="guidance-diff">
-                    {#if entry.retired.length}
-                      <div class="guidance-retire">
-                        <span>Retire</span>
-                        {#each entry.retired as item}<p>{item}</p>{/each}
-                      </div>
-                    {/if}
-                    {#if entry.added.length}
-                      <div class="guidance-add">
-                        <span>Add</span>
-                        {#each entry.added as item}<p>{item}</p>{/each}
-                      </div>
-                    {/if}
-                  </div>
-                {:else}
-                  <div class="diff-columns">
-                    <div><span>Before</span><p>{entry.before}</p></div>
-                    <div><span>After</span><p>{entry.after}</p></div>
-                  </div>
-                {/if}
-              </article>
-            {/each}
-          </div>
-        {:else}
-          <ConstellationNotice
-            title="No effective change"
-            description="This draft matches the current behavior. There is nothing to apply."
-            tone="neutral"
-            compact
-          />
-        {/if}
-
-        {#each review.preview.warnings as warning (warning.code)}
-          <p class="review-warning">{warning.message}</p>
-        {/each}
-
-        <div class="editor-field editor-field-full rationale-field">
-          <label for={`cycle-${cycleId}-policy-rationale`}>Rationale <span>Required</span></label>
-          <ConstellationTextarea
-            id={`cycle-${cycleId}-policy-rationale`}
-            bind:value={rationale}
-            rows={3}
-            maxlength={5000}
-            placeholder="Why should this behavior change?"
-          />
-        </div>
-
-        {#if editorError}<p class="editor-error" role="alert">{editorError}</p>{/if}
-
-        <div class="editor-actions">
-          <ConstellationButton variant="quiet" size="sm" onclick={leaveReview}>
-            {review.kind === 'edit' ? 'Back to draft' : 'Cancel'}
-          </ConstellationButton>
-          <ConstellationButton
-            variant="primary"
-            size="sm"
-            loading={applying}
-            disabled={applyDisabled}
-            onclick={applyReviewedChange}
-          >
-            {review.kind === 'revert' ? 'Apply revert' : 'Apply change'}
-          </ConstellationButton>
-        </div>
-      </section>
-    {:else}
-      <div class="policy-content">
-      <section class="policy-section" aria-labelledby={`cycle-${cycleId}-configuration`}>
-        <div class="policy-section-heading">
-          <h4 id={`cycle-${cycleId}-configuration`}>Mission and settings</h4>
-          <span>{resolvedTimezone.replaceAll('_', ' ')}</span>
-        </div>
-
-        <dl class="policy-values">
-          {#each configurationEntries as entry (entry.key)}
-            {@const source = policyFieldSource(policy.field_sources, entry.key)}
-            <div class="policy-value" class:prose-value={entry.key === 'prompt'}>
-              <dt>{policyFieldLabel(entry.key)}</dt>
-              <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
-                {policyValueLabel(entry.value)}
-              </dd>
-              <dd class="value-source" title={source?.rationale || undefined}>
-                <span>From {source ? policySourceLabel(source) : policySourceLabel(policy.source)}</span>
-                <time datetime={source?.changed_at || policy.source.changed_at || undefined}>
-                  Changed {formatPolicyDateTime(source?.changed_at || policy.source.changed_at, resolvedTimezone)}
-                </time>
-              </dd>
-            </div>
-          {/each}
-        </dl>
-      </section>
-
-      <section class="policy-section active-guidance" aria-labelledby={`cycle-${cycleId}-guidance`}>
-        <div class="policy-section-heading">
-          <div>
-            <span class="live-marker">Live</span>
-            <h4 id={`cycle-${cycleId}-guidance`}>Active guidance</h4>
-          </div>
-          <span>{policy.guidance.length} active</span>
-        </div>
-
-        {#if policy.guidance.length}
-          <ol class="guidance-list">
-            {#each policy.guidance as guidance}
-              <li>
-                <p>{guidance}</p>
-                <div class="value-source" title={guidanceSource?.rationale || undefined}>
-                  <span>From {guidanceSource ? policySourceLabel(guidanceSource) : policySourceLabel(policy.source)}</span>
-                  <time datetime={guidanceSource?.changed_at || policy.source.changed_at || undefined}>
-                    Changed {formatPolicyDateTime(guidanceSource?.changed_at || policy.source.changed_at, resolvedTimezone)}
-                  </time>
-                </div>
-              </li>
-            {/each}
-          </ol>
-        {:else}
-          <p class="empty-policy-value">No active guidance.</p>
-        {/if}
-      </section>
-
-      <section class="policy-section" aria-labelledby={`cycle-${cycleId}-outputs`}>
-        <div class="policy-section-heading">
-          <h4 id={`cycle-${cycleId}-outputs`}>Output targets</h4>
-          <ConstellationPill variant="muted">Read only</ConstellationPill>
-        </div>
-
-        {#if policy.output_targets.length}
-          <div class="output-list">
-            {#each policy.output_targets as target (target.id)}
-              <article class="output-target">
-                <div class="output-target-heading">
-                  <strong>{target.label || policyFieldLabel(target.target_type)}</strong>
-                  <span>{target.target_type}</span>
-                </div>
-                {#if target.target_id}<p>Target {target.target_id}</p>{/if}
-                {#if Object.keys(target.config).length}
-                  <pre>{policyValueLabel(target.config)}</pre>
-                {/if}
-                {#if target.rationale}<p>{target.rationale}</p>{/if}
-                <div class="value-source">
-                  <span>From {[target.source_type, target.source_id].filter(Boolean).join(' · ')}</span>
-                  <time datetime={target.updated_at}>
-                    Changed {formatPolicyDateTime(target.updated_at, resolvedTimezone)}
-                  </time>
-                </div>
-              </article>
-            {/each}
-          </div>
-        {:else}
-          <p class="empty-policy-value">No output targets.</p>
-        {/if}
-      </section>
-      </div>
+  {:else if workflow && policy}
+    {#if editorState && editorState.draft}
+      <CyclePolicyDraftEditor
+        {cycleId}
+        draft={editorState.draft}
+        errors={editorState.kind === 'edit' ? editorState.errors : {}}
+        error={editorState.kind === 'edit' ? editorState.error : undefined}
+        dirty={isPolicyWorkflowDirty(editorState)}
+        reviewing={editorState.kind === 'reviewing'}
+        {compact}
+        {modelCatalog}
+        onDraftChange={(draft) => controller?.updateDraft(draft)}
+        onCancel={cancelEditing}
+        onReview={() => void controller?.reviewDraft()}
+      />
+    {:else if reviewState}
+      <CyclePolicyReview
+        {cycleId}
+        {...policyReviewProps(reviewState)}
+        {compact}
+        onRationaleChange={(rationale) => controller?.setRationale(rationale)}
+        onBack={() => controller?.leaveReview()}
+        onApply={applyReviewedChange}
+      />
+    {:else if showReadView}
+      <ActiveCyclePolicyView
+        {cycleId}
+        {policy}
+        displayTimezone={resolvedTimezone}
+        showHeader={false}
+        showDetails
+        canEdit={false}
+        {compact}
+        onEdit={() => {}}
+      />
     {/if}
-  {/if}
 
-  {#if !loading && !error}
-    <details class="history-region">
-      <summary>
-        <span>
-          <strong>History</strong>
-          <small>Prior versions are not active.</small>
-        </span>
-        <span>{history.length} changes</span>
-      </summary>
-
-      <div class="history-content">
-        <div class="history-warning">
-          <strong>Historical only</strong>
-          <span>Text below does not guide the next run.</span>
-        </div>
-
-        {#if history.length}
-          <ol class="history-list">
-            {#each history as change (change.id)}
-              {@const retired = retiredGuidance(change)}
-              <li class="history-change">
-                <header>
-                  <div>
-                    <strong>Version {change.version}</strong>
-                    <time datetime={change.applied_at}>
-                      {formatPolicyDateTime(change.applied_at, resolvedTimezone)}
-                    </time>
-                  </div>
-                  <div class="history-change-actions">
-                    <span>{change.changed_fields.map(policyFieldLabel).join(', ')}</span>
-                    {#if editable}
-                      <ConstellationButton
-                        variant="quiet"
-                        size="sm"
-                        loading={revertingChangeId === change.id}
-                        disabled={stage !== 'view'}
-                        onclick={() => beginRevert(change.id)}
-                      >
-                        Revert
-                      </ConstellationButton>
-                    {/if}
-                  </div>
-                </header>
-                <p>{change.rationale}</p>
-                <div class="history-source">
-                  From {policySourceLabel(change)}
-                  {#if change.reverted_from_id !== null}
-                    · Reverted change {change.reverted_from_id}
-                  {/if}
-                </div>
-
-                {#if retired.length}
-                  <section class="retired-guidance" aria-label="Retired guidance">
-                    <span>Retired guidance · not active</span>
-                    {#each retired as guidance}
-                      <blockquote>{guidance}</blockquote>
-                    {/each}
-                  </section>
-                {/if}
-              </li>
-            {/each}
-          </ol>
-        {:else}
-          <p class="empty-policy-value">No policy changes yet.</p>
-        {/if}
-
-        {#if historyError}
-          <p class="history-error" role="alert">{historyError}</p>
-        {/if}
-        {#if pagination?.has_more}
-          <ConstellationButton
-            variant="quiet"
-            size="sm"
-            loading={historyLoading}
-            onclick={loadMoreHistory}
-          >
-            Load older changes
-          </ConstellationButton>
-        {/if}
-      </div>
-    </details>
+    <CyclePolicyHistory
+      history={workflow.data.history}
+      displayTimezone={resolvedTimezone}
+      {editable}
+      workflowKind={workflow.kind}
+      revertingChangeId={workflow.kind === 'reverting' ? workflow.changeId : null}
+      historyError={workflow.historyError}
+      onRevert={(changeId) => void controller?.beginRevert(changeId)}
+      onLoadMore={() => controller?.loadMoreHistory() ?? Promise.resolve()}
+    />
   {/if}
 </section>
 
@@ -853,647 +305,18 @@
     color: var(--constellation-color-text-primary);
   }
 
-  .active-heading,
-  .policy-section-heading,
-  .output-target-heading,
-  .history-change header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 16px;
-  }
-
-  .active-heading {
-    padding: 14px;
-    border-bottom: 1px solid var(--constellation-surface-panel-separator);
-    background: color-mix(in srgb, var(--constellation-color-success) 7%, transparent);
-  }
-
-  .active-heading h3,
-  .active-heading p,
-  .policy-section-heading h4,
-  .guidance-list p,
-  .output-target p,
-  .history-change p,
-  .history-change blockquote {
-    margin: 0;
-  }
-
-  .active-heading h3 {
-    margin-top: 3px;
-    font-size: 16px;
-    font-weight: 650;
-    letter-spacing: -0.01em;
-  }
-
-  .active-heading p {
-    margin-top: 5px;
-    color: var(--constellation-color-text-secondary);
-    font-size: 12px;
-  }
-
-  .section-kicker,
-  .policy-value dt,
-  .live-marker,
-  .retired-guidance > span {
-    color: var(--constellation-color-text-muted);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px;
-    font-weight: 650;
-    letter-spacing: 0.12em;
-    line-height: 1.2;
-    text-transform: uppercase;
-  }
-
-  .active-status {
-    display: grid;
-    justify-items: end;
-    gap: 6px;
-    color: var(--constellation-color-text-secondary);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px;
-  }
-
-  .active-actions {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
   .editor-message {
     padding: 12px 14px 0;
   }
 
-  .policy-editor,
-  .policy-review {
-    display: grid;
-    gap: 16px;
-    min-width: 0;
-    padding: 16px;
-    border-bottom: 1px solid var(--constellation-surface-panel-separator);
-    background: color-mix(in srgb, var(--constellation-color-info) 3%, transparent);
-  }
-
-  .editor-heading {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 16px;
-  }
-
-  .editor-heading h4,
-  .editor-heading p,
-  .diff-entry h5,
-  .diff-entry p,
-  .guidance-editor-heading small,
-  .review-warning,
-  .editor-error {
-    margin: 0;
-  }
-
-  .editor-heading h4 {
-    margin-top: 4px;
-    font-size: 15px;
-    font-weight: 650;
-  }
-
-  .editor-heading p {
-    max-width: 360px;
-    color: var(--constellation-color-text-secondary);
-    font-size: 11px;
-    line-height: 1.5;
-    text-align: right;
-  }
-
-  .editor-fields {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 14px;
-  }
-
-  .editor-field {
-    display: grid;
-    align-content: start;
-    gap: 7px;
-    min-width: 0;
-  }
-
-  .editor-field-full {
-    grid-column: 1 / -1;
-  }
-
-  .editor-field > label,
-  .editor-field-label {
-    color: var(--constellation-color-text-secondary);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px;
-    font-weight: 650;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .editor-field > label span {
-    color: var(--constellation-color-warning);
-    letter-spacing: 0;
-    text-transform: none;
-  }
-
-  .editor-field :global(.constellation-text-input),
-  .editor-field :global(.constellation-textarea),
-  .editor-field :global(.constellation-select),
-  .guidance-editor-list :global(.constellation-textarea) {
-    width: 100%;
-  }
-
-  .field-error,
-  .editor-error {
-    color: var(--constellation-color-danger);
-    font-size: 11px;
-    line-height: 1.4;
-  }
-
-  .policy-status-toggle {
-    appearance: none;
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: center;
-    gap: 9px;
-    min-height: 40px;
-    padding: 6px 10px;
-    border: 1px solid var(--constellation-control-field-border);
-    border-radius: 8px;
-    background: var(--constellation-control-field-background);
-    color: var(--constellation-color-text-primary);
-    cursor: pointer;
-  }
-
-  .policy-status-toggle > span {
-    width: 10px;
-    height: 10px;
-    border-radius: 999px;
-    background: var(--constellation-color-text-muted);
-  }
-
-  .policy-status-toggle.is-enabled > span {
-    background: var(--constellation-color-success);
-    box-shadow: 0 0 10px color-mix(in srgb, var(--constellation-color-success) 55%, transparent);
-  }
-
-  .policy-status-toggle strong {
-    font-size: 12px;
-    font-weight: 600;
-    text-align: left;
-  }
-
-  .policy-status-toggle:focus-visible {
-    outline: 2px solid var(--constellation-control-focus-ring);
-    outline-offset: 2px;
-  }
-
-  .guidance-editor {
-    display: grid;
-    gap: 10px;
-    min-width: 0;
-    padding-top: 2px;
-  }
-
-  .guidance-editor-heading {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-  }
-
-  .guidance-editor-heading > div {
-    display: grid;
-    gap: 4px;
-  }
-
-  .guidance-editor-heading small {
-    color: var(--constellation-color-text-muted);
-    font-size: 10px;
-    line-height: 1.4;
-  }
-
-  .guidance-editor-list {
-    display: grid;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .guidance-editor-list li {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: start;
-    gap: 8px;
-  }
-
-  .editor-actions {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 8px;
-    padding-top: 12px;
-    border-top: 1px solid var(--constellation-section-divider);
-  }
-
-  .diff-list {
-    display: grid;
-    gap: 10px;
-  }
-
-  .diff-entry {
-    display: grid;
-    gap: 9px;
-    padding: 12px;
-    border: 1px solid var(--constellation-surface-nested-border);
-    border-radius: 7px;
-    background: var(--constellation-surface-nested-background);
-  }
-
-  .diff-entry h5 {
-    font-size: 12px;
-    font-weight: 650;
-  }
-
-  .diff-columns,
-  .guidance-diff {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
-  }
-
-  .diff-columns > div,
-  .guidance-diff > div {
-    display: grid;
-    align-content: start;
-    gap: 6px;
-    min-width: 0;
-    padding: 9px;
-    border-left: 2px solid var(--constellation-color-text-muted);
-    background: color-mix(in srgb, var(--constellation-color-text-muted) 4%, transparent);
-  }
-
-  .diff-columns span,
-  .guidance-diff span {
-    color: var(--constellation-color-text-muted);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 9px;
-    font-weight: 650;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-  }
-
-  .diff-columns strong,
-  .diff-columns p,
-  .guidance-diff p {
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-primary);
-    font-size: 12px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-  }
-
-  .diff-columns code {
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-secondary);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px;
-  }
-
-  .diff-columns small {
-    color: var(--constellation-color-text-muted);
-    font-size: 10px;
-  }
-
-  .guidance-retire {
-    border-left-color: var(--constellation-color-warning) !important;
-  }
-
-  .guidance-add {
-    border-left-color: var(--constellation-color-success) !important;
-  }
-
-  .review-warning {
-    padding: 8px 10px;
-    border-left: 2px solid var(--constellation-color-info);
-    color: var(--constellation-color-text-secondary);
-    font-size: 11px;
-    line-height: 1.45;
-  }
-
-  .rationale-field {
-    padding-top: 2px;
-  }
-
-  .policy-content {
-    display: grid;
-  }
-
-  .policy-section {
-    display: grid;
-    gap: 12px;
-    min-width: 0;
-    padding: 14px;
-    border-bottom: 1px solid var(--constellation-surface-panel-separator);
-  }
-
-  .policy-section-heading {
-    align-items: center;
-  }
-
-  .policy-section-heading > div {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .policy-section-heading h4 {
-    font-size: 13px;
-    font-weight: 600;
-  }
-
-  .policy-section-heading > span {
-    color: var(--constellation-color-text-secondary);
-    font-size: 11px;
-  }
-
-  .live-marker {
-    padding: 3px 6px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--constellation-color-success) 14%, transparent);
-    color: var(--constellation-color-success);
-  }
-
-  .policy-values {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0;
-    margin: 0;
-    border-top: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value {
-    display: grid;
-    align-content: start;
-    gap: 7px;
-    min-width: 0;
-    padding: 12px 10px;
-    border-bottom: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value:nth-child(odd) {
-    border-right: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value.prose-value {
-    grid-column: 1 / -1;
-    border-right: 0;
-  }
-
-  .policy-value dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-primary);
-    font-size: 13px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-  }
-
-  .policy-value.prose-value > dd:not(.value-source) {
-    font-size: 14px;
-  }
-
-  .mono-value,
-  .output-target pre {
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-  }
-
-  .value-source {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 3px 10px;
-    color: var(--constellation-color-text-muted) !important;
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px !important;
-    line-height: 1.4 !important;
-  }
-
-  .active-guidance {
-    border-left: 3px solid var(--constellation-color-success);
-    background: color-mix(in srgb, var(--constellation-color-success) 3%, transparent);
-  }
-
-  .guidance-list,
-  .output-list,
-  .history-list {
-    display: grid;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .guidance-list {
-    counter-reset: active-guidance;
-  }
-
-  .guidance-list li {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    gap: 6px 10px;
-    padding: 10px 0;
-    border-bottom: 1px solid var(--constellation-section-divider);
-    counter-increment: active-guidance;
-  }
-
-  .guidance-list li::before {
-    content: counter(active-guidance, decimal-leading-zero);
-    color: var(--constellation-color-success);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px;
-    line-height: 1.7;
-  }
-
-  .guidance-list li:last-child {
-    border-bottom: 0;
-  }
-
-  .guidance-list .value-source {
-    grid-column: 2;
-  }
-
-  .guidance-list p {
-    font-size: 13px;
-    line-height: 1.55;
-  }
-
-  .output-target {
-    display: grid;
-    gap: 7px;
-    padding: 11px;
-    border: 1px solid var(--constellation-surface-nested-border);
-    border-radius: 7px;
-    background: var(--constellation-surface-nested-background);
-  }
-
-  .output-target-heading strong {
-    font-size: 13px;
-    font-weight: 600;
-  }
-
-  .output-target-heading span,
-  .output-target p,
-  .output-target pre {
-    color: var(--constellation-color-text-secondary);
-    font-size: 11px;
-    line-height: 1.45;
-  }
-
-  .output-target-heading span {
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-  }
-
-  .output-target pre {
-    max-width: 100%;
-    margin: 0;
-    overflow: auto;
-    white-space: pre-wrap;
-  }
-
-  .empty-policy-value {
-    margin: 0;
-    color: var(--constellation-color-text-secondary);
-    font-size: 12px;
-  }
-
-  .history-region summary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    min-height: 46px;
-    padding: 0 14px;
-    background: color-mix(in srgb, var(--constellation-color-text-muted) 5%, transparent);
-    cursor: pointer;
-    list-style: none;
-  }
-
-  .history-region summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .history-region summary > span:first-child {
-    display: grid;
-    gap: 2px;
-  }
-
-  .history-region summary strong {
-    font-size: 13px;
-    font-weight: 600;
-  }
-
-  .history-region summary small,
-  .history-region summary > span:last-child,
-  .history-source,
-  .history-change header span,
-  .history-change time {
-    color: var(--constellation-color-text-muted);
-    font-size: 10px;
-  }
-
-  .history-content {
-    display: grid;
-    gap: 12px;
-    padding: 14px;
-    border-top: 1px solid var(--constellation-surface-panel-separator);
-    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
-  }
-
-  .history-warning {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px 10px;
-    padding: 8px 10px;
-    border: 1px dashed var(--constellation-color-text-muted);
-    border-radius: 6px;
-    color: var(--constellation-color-text-secondary);
-    font-size: 11px;
-  }
-
-  .history-warning strong,
-  .retired-guidance > span {
-    color: var(--constellation-color-text-primary);
-  }
-
-  .history-change {
-    display: grid;
-    gap: 7px;
-    padding: 11px 0;
-    border-bottom: 1px solid var(--constellation-section-divider);
-    opacity: 0.82;
-  }
-
-  .history-change:last-child {
-    border-bottom: 0;
-  }
-
-  .history-change header > div {
-    display: grid;
-    gap: 3px;
-  }
-
-  .history-change-actions {
-    justify-items: end;
-  }
-
-  .history-change-actions > span {
-    max-width: 50%;
-    text-align: right;
-  }
-
-  .history-change p {
-    color: var(--constellation-color-text-secondary);
-    font-size: 12px;
-  }
-
-  .history-source {
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-  }
-
-  .retired-guidance {
-    display: grid;
-    gap: 7px;
-    margin-top: 3px;
-    padding: 10px;
-    border: 1px dashed var(--constellation-color-text-muted);
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--constellation-color-text-muted) 6%, transparent);
-  }
-
-  .retired-guidance blockquote {
-    padding-left: 10px;
-    border-left: 2px solid var(--constellation-color-text-muted);
-    color: var(--constellation-color-text-secondary);
-    font-size: 12px;
-    font-style: italic;
-    line-height: 1.5;
-  }
-
-  .history-error,
-  .policy-error {
-    color: var(--constellation-color-danger);
-    font-size: 12px;
-  }
-
   .policy-error {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
     padding: 14px;
+    color: var(--constellation-color-danger);
+    font-size: 12px;
   }
 
   .policy-loading {
@@ -1512,85 +335,8 @@
     animation: policy-pulse 1.4s ease-in-out infinite;
   }
 
-  .effective-policy.compact .policy-values {
-    grid-template-columns: 1fr;
-  }
-
-  .effective-policy.compact .editor-fields,
-  .effective-policy.compact .diff-columns,
-  .effective-policy.compact .guidance-diff {
-    grid-template-columns: 1fr;
-  }
-
-  .effective-policy.compact .editor-heading {
-    flex-direction: column;
-  }
-
-  .effective-policy.compact .editor-heading p {
-    max-width: none;
-    text-align: left;
-  }
-
-  .effective-policy.compact .policy-value,
-  .effective-policy.compact .policy-value:nth-child(odd) {
-    border-right: 0;
-  }
-
   @keyframes policy-pulse {
     from { background-position: 200% 0; }
     to { background-position: -200% 0; }
-  }
-
-  @media (max-width: 720px) {
-    .policy-values {
-      grid-template-columns: 1fr;
-    }
-
-    .policy-value,
-    .policy-value:nth-child(odd) {
-      border-right: 0;
-    }
-
-    .active-heading,
-    .active-actions,
-    .editor-heading,
-    .history-change header {
-      align-items: flex-start;
-      flex-direction: column;
-    }
-
-    .active-status {
-      justify-items: start;
-    }
-
-    .editor-heading p {
-      max-width: none;
-      text-align: left;
-    }
-
-    .editor-fields,
-    .diff-columns,
-    .guidance-diff {
-      grid-template-columns: 1fr;
-    }
-
-    .guidance-editor-heading,
-    .guidance-editor-list li {
-      grid-template-columns: 1fr;
-    }
-
-    .guidance-editor-heading {
-      align-items: flex-start;
-      flex-direction: column;
-    }
-
-    .history-change-actions {
-      justify-items: start;
-    }
-
-    .history-change-actions > span {
-      max-width: none;
-      text-align: left;
-    }
   }
 </style>

--- a/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
@@ -1,25 +1,46 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { beforeNavigate } from '$app/navigation';
+  import { onDestroy, onMount } from 'svelte';
 
   import {
     api,
     type CyclePolicyChangeRead,
+    type CyclePolicyConflictDetail,
     type CyclePolicyHistoryRead,
     type EffectiveCyclePolicyRead,
   } from '$lib/api/client';
   import {
     ConstellationButton,
+    ConstellationNotice,
     ConstellationPill,
+    ConstellationSelect,
+    ConstellationTextInput,
+    ConstellationTextarea,
   } from '$lib/components/constellation';
   import {
+    applyPolicyReview,
+    clonePolicyDraft,
     formatPolicyDateTime,
+    hydratePolicyDraft,
+    isPolicyDraftDirty,
     policyConfigurationEntries,
     policyFieldLabel,
     policyFieldSource,
     policySourceLabel,
     policyValueLabel,
+    presentedPolicyDiff,
+    recoverPolicyDraftAfterConflict,
     retiredGuidance,
+    reviewPolicyDraft,
+    reviewPolicyRevert,
+    shouldConfirmPolicyDraftDiscard,
+    type CyclePolicyDraft,
+    type CyclePolicyDraftErrors,
+    type CyclePolicyReview,
   } from '$lib/features/cycles/domain/effectivePolicy';
+  import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
+
+  type EditorStage = 'view' | 'edit' | 'review';
 
   let {
     cycleId,
@@ -27,14 +48,20 @@
     previewHistory = null,
     displayTimezone = null,
     compact = false,
+    editable = false,
     refreshSerial = 0,
+    onPolicyApplied,
+    onDirtyChange,
   }: {
     cycleId: number;
     previewPolicy?: EffectiveCyclePolicyRead | null;
     previewHistory?: CyclePolicyHistoryRead | null;
     displayTimezone?: string | null;
     compact?: boolean;
+    editable?: boolean;
     refreshSerial?: number;
+    onPolicyApplied?: (policy: EffectiveCyclePolicyRead) => void | Promise<void>;
+    onDirtyChange?: (dirty: boolean) => void;
   } = $props();
 
   let policy = $state<EffectiveCyclePolicyRead | null>(null);
@@ -42,12 +69,24 @@
   let pagination = $state<CyclePolicyHistoryRead['pagination'] | null>(null);
   let loading = $state(true);
   let historyLoading = $state(false);
+  let reviewing = $state(false);
+  let applying = $state(false);
+  let revertingChangeId = $state<number | null>(null);
   let error = $state('');
   let historyError = $state('');
+  let editorError = $state('');
+  let editorNotice = $state('');
+  let stage = $state<EditorStage>('view');
+  let draft = $state<CyclePolicyDraft | null>(null);
+  let draftErrors = $state<CyclePolicyDraftErrors>({});
+  let review = $state<CyclePolicyReview | null>(null);
+  let rationale = $state('');
+  let modelCatalog = $state<RuntimeModelCatalogEntry[]>([]);
   let resolvedTimezone = $state(
     Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
   );
   let requestSerial = 0;
+  let loadedCycleId: number | null = null;
 
   const configurationEntries = $derived(
     policy ? policyConfigurationEntries(policy.configuration) : [],
@@ -55,15 +94,65 @@
   const guidanceSource = $derived(
     policy ? policyFieldSource(policy.field_sources, 'guidance') : undefined,
   );
+  const dirty = $derived(isPolicyDraftDirty(draft, policy));
+  const diffEntries = $derived(review ? presentedPolicyDiff(review.preview) : []);
+  const modelOptions = $derived([
+    { value: '', label: 'Workspace default', description: 'Use the workspace model' },
+    ...modelCatalog.map((entry) => ({
+      value: entry.id,
+      label: entry.label,
+      description: entry.description,
+    })),
+    ...(draft?.model_override
+      && !modelCatalog.some((entry) => entry.id === draft?.model_override)
+      ? [{
+          value: draft.model_override,
+          label: draft.model_override,
+          description: 'Current model selection',
+        }]
+      : []),
+  ]);
+  const thinkingOptions = [
+    { value: '', label: 'Workspace default' },
+    { value: 'none', label: 'None' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'xHigh' },
+  ];
+  const applyDisabled = $derived(
+    applying || !review || !review.preview.changed_fields.length || !rationale.trim(),
+  );
 
   function errorMessage(value: unknown, fallback: string): string {
     if (value && typeof value === 'object' && 'detail' in value) {
-      return String((value as { detail?: unknown }).detail || fallback);
+      const detail = (value as { detail?: unknown }).detail;
+      return typeof detail === 'string' ? detail : fallback;
     }
-    return fallback;
+    return value instanceof Error ? value.message : fallback;
+  }
+
+  function conflictDetail(value: unknown): CyclePolicyConflictDetail | null {
+    if (!value || typeof value !== 'object') return null;
+    const candidate = value as { status?: unknown; detail?: unknown };
+    if (candidate.status !== 409 || !candidate.detail || typeof candidate.detail !== 'object') return null;
+    const detail = candidate.detail as Partial<CyclePolicyConflictDetail>;
+    if (!detail.latest_effective_policy || typeof detail.reason !== 'string') return null;
+    return detail as CyclePolicyConflictDetail;
+  }
+
+  function resetEditor(nextPolicy: EffectiveCyclePolicyRead, nextStage: EditorStage = 'view') {
+    draft = hydratePolicyDraft(nextPolicy);
+    draftErrors = {};
+    review = null;
+    rationale = '';
+    editorError = '';
+    stage = nextStage;
   }
 
   async function loadPolicy(selectedCycleId: number) {
+    if (loadedCycleId !== selectedCycleId) editorNotice = '';
+    loadedCycleId = selectedCycleId;
     const serial = ++requestSerial;
     loading = true;
     error = '';
@@ -75,18 +164,18 @@
       const [nextPolicy, nextHistory, runtime] = await Promise.all([
         api.getCycleBehaviorPolicy(selectedCycleId),
         api.getCycleBehaviorPolicyHistory(selectedCycleId),
-        displayTimezone
-          ? Promise.resolve(null)
-          : api.runtimeSettings().catch(() => null),
+        api.runtimeSettings().catch(() => null),
       ]);
       if (serial !== requestSerial) return;
       policy = nextPolicy;
       history = nextHistory.items;
       pagination = nextHistory.pagination;
+      modelCatalog = runtime?.models.catalog ?? [];
       resolvedTimezone = displayTimezone
         || runtime?.display?.display_timezone
         || Intl.DateTimeFormat().resolvedOptions().timeZone
         || 'UTC';
+      resetEditor(nextPolicy);
     } catch (loadError) {
       if (serial !== requestSerial) return;
       error = errorMessage(loadError, 'Effective behavior failed to load.');
@@ -118,6 +207,161 @@
     }
   }
 
+  function startEditing() {
+    if (!policy) return;
+    resetEditor(policy, 'edit');
+    editorNotice = '';
+  }
+
+  function cancelEditing() {
+    if (!policy) return;
+    if (
+      shouldConfirmPolicyDraftDiscard(draft, policy)
+      && !window.confirm('Discard this behavior draft?')
+    ) return;
+    resetEditor(policy);
+    editorNotice = '';
+  }
+
+  function addGuidance() {
+    if (!draft) return;
+    draft.guidance.push('');
+    draftErrors = { ...draftErrors, guidance: undefined };
+  }
+
+  function removeGuidance(index: number) {
+    if (!draft) return;
+    draft.guidance.splice(index, 1);
+    draftErrors = { ...draftErrors, guidance: undefined };
+  }
+
+  function toggleDraftEnabled() {
+    if (draft) draft.enabled = !draft.enabled;
+  }
+
+  async function reviewDraft() {
+    if (!draft || !policy) return;
+    reviewing = true;
+    editorError = '';
+    editorNotice = '';
+    try {
+      const result = await reviewPolicyDraft(
+        api,
+        cycleId,
+        clonePolicyDraft(draft),
+        modelCatalog,
+        policy.configuration.model_override,
+      );
+      draftErrors = result.errors;
+      if (!result.review) return;
+      review = result.review;
+      rationale = '';
+      stage = 'review';
+    } catch (reviewError) {
+      editorError = errorMessage(reviewError, 'The change could not be reviewed.');
+    } finally {
+      reviewing = false;
+    }
+  }
+
+  async function beginRevert(changeId: number) {
+    revertingChangeId = changeId;
+    editorError = '';
+    editorNotice = '';
+    try {
+      review = await reviewPolicyRevert(api, cycleId, changeId);
+      rationale = '';
+      stage = 'review';
+    } catch (revertError) {
+      historyError = errorMessage(revertError, 'The revert could not be reviewed.');
+    } finally {
+      revertingChangeId = null;
+    }
+  }
+
+  function leaveReview() {
+    const reviewKind = review?.kind;
+    review = null;
+    rationale = '';
+    editorError = '';
+    stage = reviewKind === 'edit' ? 'edit' : 'view';
+  }
+
+  async function handleConflict(detail: CyclePolicyConflictDetail) {
+    if (draft && review?.kind === 'edit') {
+      const recovered = recoverPolicyDraftAfterConflict(draft, detail.latest_effective_policy);
+      draft = recovered.draft;
+      policy = recovered.policy;
+      stage = 'edit';
+      editorNotice = 'Another person changed this Cycle. Your draft is safe. Review it against the latest version and try again.';
+    } else {
+      policy = detail.latest_effective_policy;
+      resetEditor(detail.latest_effective_policy);
+      editorNotice = 'Another person changed this Cycle. Review the latest version before you try again.';
+    }
+    review = null;
+    try {
+      const nextHistory = await api.getCycleBehaviorPolicyHistory(cycleId);
+      history = nextHistory.items;
+      pagination = nextHistory.pagination;
+    } catch {
+      historyError = 'History could not be refreshed after the conflict.';
+    }
+  }
+
+  async function applyReviewedChange() {
+    if (applyDisabled) return;
+    const reviewKind = review?.kind;
+    applying = true;
+    editorError = '';
+    editorNotice = '';
+    try {
+      const result = await applyPolicyReview(
+        api,
+        cycleId,
+        review,
+        rationale,
+        () => window.confirm('Apply this revert as a new behavior version?'),
+      );
+      if (!result) return;
+      policy = result.policy;
+      history = result.history.items;
+      pagination = result.history.pagination;
+      resetEditor(result.policy);
+      editorNotice = reviewKind === 'revert'
+        ? 'Revert applied as a new behavior version.'
+        : 'Behavior applied for future runs.';
+      await onPolicyApplied?.(result.policy);
+    } catch (applyError) {
+      const conflict = conflictDetail(applyError);
+      if (conflict) await handleConflict(conflict);
+      else editorError = errorMessage(applyError, 'The change could not be applied.');
+    } finally {
+      applying = false;
+    }
+  }
+
+  beforeNavigate(({ cancel }) => {
+    if (
+      shouldConfirmPolicyDraftDiscard(draft, policy)
+      && !window.confirm('Leave this page and discard the behavior draft?')
+    ) cancel();
+  });
+
+  onMount(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!shouldConfirmPolicyDraftDiscard(draft, policy)) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload);
+  });
+
+  $effect(() => {
+    onDirtyChange?.(dirty);
+  });
+
   $effect(() => {
     const selectedCycleId = cycleId;
     refreshSerial;
@@ -125,6 +369,8 @@
     const suppliedHistory = previewHistory;
     if (displayTimezone) resolvedTimezone = displayTimezone;
     if (suppliedPolicy) {
+      if (loadedCycleId !== selectedCycleId) editorNotice = '';
+      loadedCycleId = selectedCycleId;
       requestSerial += 1;
       policy = suppliedPolicy;
       history = suppliedHistory?.items ?? [];
@@ -132,6 +378,7 @@
       loading = false;
       error = '';
       historyError = '';
+      resetEditor(suppliedPolicy);
       return;
     }
     void loadPolicy(selectedCycleId);
@@ -139,6 +386,7 @@
 
   onDestroy(() => {
     requestSerial += 1;
+    onDirtyChange?.(false);
   });
 </script>
 
@@ -150,14 +398,32 @@
       <p>What Illo will use on the next run.</p>
     </div>
     {#if policy}
-      <div class="active-status">
-        <ConstellationPill variant={policy.configuration.enabled ? 'success' : 'muted'} leadingDot>
-          {policy.configuration.enabled ? 'Enabled' : 'Paused'}
-        </ConstellationPill>
-        <span>Version {policy.version}</span>
+      <div class="active-actions">
+        <div class="active-status">
+          <ConstellationPill variant={policy.configuration.enabled ? 'success' : 'muted'} leadingDot>
+            {policy.configuration.enabled ? 'Enabled' : 'Paused'}
+          </ConstellationPill>
+          <span>Version {policy.version}</span>
+        </div>
+        {#if editable && stage === 'view'}
+          <ConstellationButton variant="secondary" size="sm" onclick={startEditing}>
+            Edit behavior
+          </ConstellationButton>
+        {/if}
       </div>
     {/if}
   </header>
+
+  {#if editorNotice}
+    <div class="editor-message">
+      <ConstellationNotice
+        title={stage === 'edit' ? 'Draft preserved' : 'Behavior updated'}
+        description={editorNotice}
+        tone={stage === 'edit' ? 'warning' : 'success'}
+        compact
+      />
+    </div>
+  {/if}
 
   {#if loading}
     <div class="policy-loading" aria-label="Loading effective behavior">
@@ -173,7 +439,236 @@
       </ConstellationButton>
     </div>
   {:else if policy}
-    <div class="policy-content">
+    {#if stage === 'edit' && draft}
+      <section class="policy-editor" aria-label="Edit cycle behavior">
+        <header class="editor-heading">
+          <div>
+            <span class="section-kicker">Draft</span>
+            <h4>Prepare behavior change</h4>
+          </div>
+          <p>Nothing changes until you review and apply.</p>
+        </header>
+
+        {#if editorError}
+          <p class="editor-error" role="alert">{editorError}</p>
+        {/if}
+
+        <div class="editor-fields">
+          <div class="editor-field editor-field-full">
+            <label for={`cycle-${cycleId}-policy-prompt`}>Mission prompt</label>
+            <ConstellationTextarea
+              id={`cycle-${cycleId}-policy-prompt`}
+              bind:value={draft.prompt}
+              rows={7}
+              aria-invalid={draftErrors.prompt ? 'true' : undefined}
+            />
+            {#if draftErrors.prompt}<small class="field-error">{draftErrors.prompt}</small>{/if}
+          </div>
+
+          <div class="editor-field">
+            <label for={`cycle-${cycleId}-policy-schedule`}>Stored schedule</label>
+            <ConstellationTextInput
+              id={`cycle-${cycleId}-policy-schedule`}
+              bind:value={draft.schedule_expr}
+              mono
+              placeholder="0 9 * * *"
+              aria-invalid={draftErrors.schedule_expr ? 'true' : undefined}
+            />
+            {#if draftErrors.schedule_expr}<small class="field-error">{draftErrors.schedule_expr}</small>{/if}
+          </div>
+
+          <div class="editor-field">
+            <label for={`cycle-${cycleId}-policy-timezone`}>Timezone</label>
+            <ConstellationTextInput
+              id={`cycle-${cycleId}-policy-timezone`}
+              bind:value={draft.timezone}
+              placeholder="America/Toronto"
+              aria-invalid={draftErrors.timezone ? 'true' : undefined}
+            />
+            {#if draftErrors.timezone}<small class="field-error">{draftErrors.timezone}</small>{/if}
+          </div>
+
+          <div class="editor-field">
+            <span class="editor-field-label">Status</span>
+            <button
+              type="button"
+              class="policy-status-toggle"
+              class:is-enabled={draft.enabled}
+              aria-pressed={draft.enabled}
+              onclick={toggleDraftEnabled}
+            >
+              <span aria-hidden="true"></span>
+              <strong>{draft.enabled ? 'Enabled' : 'Paused'}</strong>
+            </button>
+          </div>
+
+          <div class="editor-field">
+            <span class="editor-field-label">Model override</span>
+            <ConstellationSelect
+              bind:value={draft.model_override}
+              options={modelOptions}
+              ariaLabel="Model override"
+            />
+            {#if draftErrors.model_override}<small class="field-error">{draftErrors.model_override}</small>{/if}
+          </div>
+
+          <div class="editor-field">
+            <span class="editor-field-label">Thinking override</span>
+            <ConstellationSelect
+              bind:value={draft.thinking_override}
+              options={thinkingOptions}
+              ariaLabel="Thinking override"
+            />
+            {#if draftErrors.thinking_override}<small class="field-error">{draftErrors.thinking_override}</small>{/if}
+          </div>
+
+          <section class="guidance-editor editor-field-full" aria-labelledby={`cycle-${cycleId}-guidance-editor`}>
+            <div class="guidance-editor-heading">
+              <div>
+                <span class="editor-field-label" id={`cycle-${cycleId}-guidance-editor`}>Active guidance</span>
+                <small>Changing text retires the old guidance and adds a new entry.</small>
+              </div>
+              <ConstellationButton variant="quiet" size="sm" onclick={addGuidance}>
+                Add guidance
+              </ConstellationButton>
+            </div>
+            {#if draft.guidance.length}
+              <ol class="guidance-editor-list">
+                {#each draft.guidance as guidance, index}
+                  <li>
+                    <ConstellationTextarea
+                      bind:value={draft.guidance[index]}
+                      rows={2}
+                      aria-label={`Guidance ${index + 1}`}
+                    />
+                    <ConstellationButton
+                      variant="quiet"
+                      size="sm"
+                      aria-label={`Remove guidance ${index + 1}`}
+                      onclick={() => removeGuidance(index)}
+                    >
+                      Remove
+                    </ConstellationButton>
+                  </li>
+                {/each}
+              </ol>
+            {:else}
+              <p class="empty-policy-value">No active guidance.</p>
+            {/if}
+            {#if draftErrors.guidance}<small class="field-error">{draftErrors.guidance}</small>{/if}
+          </section>
+        </div>
+
+        <div class="editor-actions">
+          <ConstellationButton variant="quiet" size="sm" onclick={cancelEditing}>Cancel</ConstellationButton>
+          <ConstellationButton
+            variant="primary"
+            size="sm"
+            loading={reviewing}
+            disabled={!dirty}
+            onclick={reviewDraft}
+          >
+            Review change
+          </ConstellationButton>
+        </div>
+      </section>
+    {:else if stage === 'review' && review}
+      <section class="policy-review" aria-label="Review cycle behavior change">
+        <header class="editor-heading">
+          <div>
+            <span class="section-kicker">Review</span>
+            <h4>{review.kind === 'revert' ? 'Review revert' : 'Review behavior change'}</h4>
+          </div>
+          <p>Active runs are unchanged. Future runs use this policy only after apply.</p>
+        </header>
+
+        {#if review.preview.changed_fields.length}
+          <div class="diff-list">
+            {#each diffEntries as entry (entry.key)}
+              <article class="diff-entry">
+                <h5>{entry.label}</h5>
+                {#if entry.kind === 'schedule'}
+                  <div class="diff-columns">
+                    <div>
+                      <span>Before</span>
+                      <strong>{entry.before.schedule_human}</strong>
+                      <code>{entry.before.schedule_expr}</code>
+                      <small>{entry.before.timezone.replaceAll('_', ' ')}</small>
+                    </div>
+                    <div>
+                      <span>After</span>
+                      <strong>{entry.after.schedule_human}</strong>
+                      <code>{entry.after.schedule_expr}</code>
+                      <small>{entry.after.timezone.replaceAll('_', ' ')}</small>
+                    </div>
+                  </div>
+                {:else if entry.kind === 'guidance'}
+                  <div class="guidance-diff">
+                    {#if entry.retired.length}
+                      <div class="guidance-retire">
+                        <span>Retire</span>
+                        {#each entry.retired as item}<p>{item}</p>{/each}
+                      </div>
+                    {/if}
+                    {#if entry.added.length}
+                      <div class="guidance-add">
+                        <span>Add</span>
+                        {#each entry.added as item}<p>{item}</p>{/each}
+                      </div>
+                    {/if}
+                  </div>
+                {:else}
+                  <div class="diff-columns">
+                    <div><span>Before</span><p>{entry.before}</p></div>
+                    <div><span>After</span><p>{entry.after}</p></div>
+                  </div>
+                {/if}
+              </article>
+            {/each}
+          </div>
+        {:else}
+          <ConstellationNotice
+            title="No effective change"
+            description="This draft matches the current behavior. There is nothing to apply."
+            tone="neutral"
+            compact
+          />
+        {/if}
+
+        {#each review.preview.warnings as warning (warning.code)}
+          <p class="review-warning">{warning.message}</p>
+        {/each}
+
+        <div class="editor-field editor-field-full rationale-field">
+          <label for={`cycle-${cycleId}-policy-rationale`}>Rationale <span>Required</span></label>
+          <ConstellationTextarea
+            id={`cycle-${cycleId}-policy-rationale`}
+            bind:value={rationale}
+            rows={3}
+            maxlength={5000}
+            placeholder="Why should this behavior change?"
+          />
+        </div>
+
+        {#if editorError}<p class="editor-error" role="alert">{editorError}</p>{/if}
+
+        <div class="editor-actions">
+          <ConstellationButton variant="quiet" size="sm" onclick={leaveReview}>
+            {review.kind === 'edit' ? 'Back to draft' : 'Cancel'}
+          </ConstellationButton>
+          <ConstellationButton
+            variant="primary"
+            size="sm"
+            loading={applying}
+            disabled={applyDisabled}
+            onclick={applyReviewedChange}
+          >
+            {review.kind === 'revert' ? 'Apply revert' : 'Apply change'}
+          </ConstellationButton>
+        </div>
+      </section>
+    {:else}
+      <div class="policy-content">
       <section class="policy-section" aria-labelledby={`cycle-${cycleId}-configuration`}>
         <div class="policy-section-heading">
           <h4 id={`cycle-${cycleId}-configuration`}>Mission and settings</h4>
@@ -259,7 +754,8 @@
           <p class="empty-policy-value">No output targets.</p>
         {/if}
       </section>
-    </div>
+      </div>
+    {/if}
   {/if}
 
   {#if !loading && !error}
@@ -290,7 +786,20 @@
                       {formatPolicyDateTime(change.applied_at, resolvedTimezone)}
                     </time>
                   </div>
-                  <span>{change.changed_fields.map(policyFieldLabel).join(', ')}</span>
+                  <div class="history-change-actions">
+                    <span>{change.changed_fields.map(policyFieldLabel).join(', ')}</span>
+                    {#if editable}
+                      <ConstellationButton
+                        variant="quiet"
+                        size="sm"
+                        loading={revertingChangeId === change.id}
+                        disabled={stage !== 'view'}
+                        onclick={() => beginRevert(change.id)}
+                      >
+                        Revert
+                      </ConstellationButton>
+                    {/if}
+                  </div>
                 </header>
                 <p>{change.rationale}</p>
                 <div class="history-source">
@@ -403,6 +912,280 @@
     color: var(--constellation-color-text-secondary);
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
     font-size: 10px;
+  }
+
+  .active-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .editor-message {
+    padding: 12px 14px 0;
+  }
+
+  .policy-editor,
+  .policy-review {
+    display: grid;
+    gap: 16px;
+    min-width: 0;
+    padding: 16px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    background: color-mix(in srgb, var(--constellation-color-info) 3%, transparent);
+  }
+
+  .editor-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .editor-heading h4,
+  .editor-heading p,
+  .diff-entry h5,
+  .diff-entry p,
+  .guidance-editor-heading small,
+  .review-warning,
+  .editor-error {
+    margin: 0;
+  }
+
+  .editor-heading h4 {
+    margin-top: 4px;
+    font-size: 15px;
+    font-weight: 650;
+  }
+
+  .editor-heading p {
+    max-width: 360px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.5;
+    text-align: right;
+  }
+
+  .editor-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .editor-field {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .editor-field-full {
+    grid-column: 1 / -1;
+  }
+
+  .editor-field > label,
+  .editor-field-label {
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .editor-field > label span {
+    color: var(--constellation-color-warning);
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  .editor-field :global(.constellation-text-input),
+  .editor-field :global(.constellation-textarea),
+  .editor-field :global(.constellation-select),
+  .guidance-editor-list :global(.constellation-textarea) {
+    width: 100%;
+  }
+
+  .field-error,
+  .editor-error {
+    color: var(--constellation-color-danger);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .policy-status-toggle {
+    appearance: none;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 9px;
+    min-height: 40px;
+    padding: 6px 10px;
+    border: 1px solid var(--constellation-control-field-border);
+    border-radius: 8px;
+    background: var(--constellation-control-field-background);
+    color: var(--constellation-color-text-primary);
+    cursor: pointer;
+  }
+
+  .policy-status-toggle > span {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--constellation-color-text-muted);
+  }
+
+  .policy-status-toggle.is-enabled > span {
+    background: var(--constellation-color-success);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--constellation-color-success) 55%, transparent);
+  }
+
+  .policy-status-toggle strong {
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+  }
+
+  .policy-status-toggle:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .guidance-editor {
+    display: grid;
+    gap: 10px;
+    min-width: 0;
+    padding-top: 2px;
+  }
+
+  .guidance-editor-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .guidance-editor-heading > div {
+    display: grid;
+    gap: 4px;
+  }
+
+  .guidance-editor-heading small {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+    line-height: 1.4;
+  }
+
+  .guidance-editor-list {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .guidance-editor-list li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 8px;
+  }
+
+  .editor-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .diff-list {
+    display: grid;
+    gap: 10px;
+  }
+
+  .diff-entry {
+    display: grid;
+    gap: 9px;
+    padding: 12px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 7px;
+    background: var(--constellation-surface-nested-background);
+  }
+
+  .diff-entry h5 {
+    font-size: 12px;
+    font-weight: 650;
+  }
+
+  .diff-columns,
+  .guidance-diff {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .diff-columns > div,
+  .guidance-diff > div {
+    display: grid;
+    align-content: start;
+    gap: 6px;
+    min-width: 0;
+    padding: 9px;
+    border-left: 2px solid var(--constellation-color-text-muted);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 4%, transparent);
+  }
+
+  .diff-columns span,
+  .guidance-diff span {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .diff-columns strong,
+  .diff-columns p,
+  .guidance-diff p {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .diff-columns code {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .diff-columns small {
+    color: var(--constellation-color-text-muted);
+    font-size: 10px;
+  }
+
+  .guidance-retire {
+    border-left-color: var(--constellation-color-warning) !important;
+  }
+
+  .guidance-add {
+    border-left-color: var(--constellation-color-success) !important;
+  }
+
+  .review-warning {
+    padding: 8px 10px;
+    border-left: 2px solid var(--constellation-color-info);
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .rationale-field {
+    padding-top: 2px;
   }
 
   .policy-content {
@@ -662,7 +1445,11 @@
     gap: 3px;
   }
 
-  .history-change header > span {
+  .history-change-actions {
+    justify-items: end;
+  }
+
+  .history-change-actions > span {
     max-width: 50%;
     text-align: right;
   }
@@ -729,6 +1516,21 @@
     grid-template-columns: 1fr;
   }
 
+  .effective-policy.compact .editor-fields,
+  .effective-policy.compact .diff-columns,
+  .effective-policy.compact .guidance-diff {
+    grid-template-columns: 1fr;
+  }
+
+  .effective-policy.compact .editor-heading {
+    flex-direction: column;
+  }
+
+  .effective-policy.compact .editor-heading p {
+    max-width: none;
+    text-align: left;
+  }
+
   .effective-policy.compact .policy-value,
   .effective-policy.compact .policy-value:nth-child(odd) {
     border-right: 0;
@@ -750,6 +1552,8 @@
     }
 
     .active-heading,
+    .active-actions,
+    .editor-heading,
     .history-change header {
       align-items: flex-start;
       flex-direction: column;
@@ -759,7 +1563,32 @@
       justify-items: start;
     }
 
-    .history-change header > span {
+    .editor-heading p {
+      max-width: none;
+      text-align: left;
+    }
+
+    .editor-fields,
+    .diff-columns,
+    .guidance-diff {
+      grid-template-columns: 1fr;
+    }
+
+    .guidance-editor-heading,
+    .guidance-editor-list li {
+      grid-template-columns: 1fr;
+    }
+
+    .guidance-editor-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .history-change-actions {
+      justify-items: start;
+    }
+
+    .history-change-actions > span {
       max-width: none;
       text-align: left;
     }

--- a/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
+++ b/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
@@ -74,6 +74,7 @@
   let lastFocusCycleId = $state<number | null>(null);
   let lastRefreshSerial = $state<number | null>(null);
   let behaviorPolicyRefreshSerial = $state(0);
+  let behaviorPolicyDirty = $state(false);
   let unsubscribeCyclesChanged: (() => void) | null = null;
 
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
@@ -180,21 +181,8 @@
     return { ...base, cadence: 'custom' };
   }
 
-  function fillForm(cycle: CycleRead | null) {
-    if (!cycle) {
-      form = emptyForm();
-      return;
-    }
-    const schedule = parseSchedule(cycle);
-    form = {
-      name: cycle.name,
-      prompt: cycle.prompt,
-      ...schedule,
-      enabled: cycle.enabled,
-      modelOverride: cycle.model_override || '',
-      thinkingOverride: (cycle.thinking_override as FormState['thinkingOverride']) || '',
-      targetIdeaId: cycle.target_idea_id || '',
-    };
+  function resetCreateForm() {
+    form = emptyForm();
   }
 
   function scheduleExprFromForm(): string {
@@ -286,7 +274,6 @@
         : selectedCycle ?? nextCycles[0] ?? null;
       selectedCycleId = nextSelected?.id ?? null;
       isDraft = !nextSelected && isDraft;
-      if (nextSelected) fillForm(nextSelected);
       await loadRuns(nextSelected?.id ?? null);
       behaviorPolicyRefreshSerial += 1;
     } catch (err: any) {
@@ -297,22 +284,22 @@
   }
 
   async function selectCycle(cycle: CycleRead) {
+    if (!confirmDiscardBehaviorDraft()) return;
     selectedCycleId = cycle.id;
     isDraft = false;
-    fillForm(cycle);
     await loadRuns(cycle.id);
   }
 
   function newCycle() {
+    if (!confirmDiscardBehaviorDraft()) return;
     selectedCycleId = null;
     isDraft = true;
     runs = [];
-    fillForm(null);
+    resetCreateForm();
   }
 
   async function saveCycle() {
     const scheduleExpr = scheduleExprFromForm();
-    const wasUpdate = Boolean(selectedCycleId);
     const payload = {
       name: form.name.trim(),
       prompt: form.prompt.trim(),
@@ -322,7 +309,7 @@
       model_override: form.modelOverride.trim() || null,
       thinking_override: form.thinkingOverride || null,
       execution_mode: 'reuse_same_idea' as const,
-      target_idea_id: form.targetIdeaId || selectedCycle?.target_idea_id || null,
+      target_idea_id: form.targetIdeaId || null,
       reopen_archived: true,
     };
     if (!payload.name || !payload.prompt || !payload.schedule_expr) {
@@ -331,19 +318,26 @@
     }
     saving = true;
     try {
-      const saved = selectedCycleId
-        ? await api.updateCycle(selectedCycleId, payload)
-        : await api.createCycle(payload);
+      const saved = await api.createCycle(payload);
       selectedCycleId = saved.id;
       isDraft = false;
-      fillForm(saved);
-      ui.toast(wasUpdate ? 'Cycle saved' : 'Cycle created', 'success');
+      resetCreateForm();
+      ui.toast('Cycle created', 'success');
       await loadCycles(saved.id);
     } catch (err: any) {
       ui.toast(err?.detail || 'Failed to save cycle', 'error');
     } finally {
       saving = false;
     }
+  }
+
+  function confirmDiscardBehaviorDraft(): boolean {
+    return !behaviorPolicyDirty || window.confirm('Discard the current behavior draft?');
+  }
+
+  async function handlePolicyApplied() {
+    behaviorPolicyDirty = false;
+    await loadCycles(selectedCycleId);
   }
 
   async function runSelectedNow() {
@@ -373,12 +367,14 @@
 
   $effect(() => {
     if (!focusCycleId || focusCycleId === lastFocusCycleId) return;
+    if (behaviorPolicyDirty) return;
     lastFocusCycleId = focusCycleId;
     void loadCycles(focusCycleId);
   });
 
   $effect(() => {
     if (!refreshSerial || refreshSerial === lastRefreshSerial) return;
+    if (behaviorPolicyDirty) return;
     lastRefreshSerial = refreshSerial;
     void loadCycles(focusCycleId || selectedCycleId);
   });
@@ -386,6 +382,7 @@
   onMount(() => {
     void loadCycles(focusCycleId);
     unsubscribeCyclesChanged = wsClient.on('cycles_changed', (msg) => {
+      if (behaviorPolicyDirty) return;
       const cycleId = Number(msg?.cycle_id || 0) || selectedCycleId;
       void loadCycles(cycleId ?? null);
     });
@@ -437,17 +434,10 @@
     </button>
   {/if}
 
-  {#if isDraft || selectedCycle}
-    {#if selectedCycle}
-      <EffectiveCyclePolicyView
-        cycleId={selectedCycle.id}
-        compact
-        refreshSerial={behaviorPolicyRefreshSerial}
-      />
-    {/if}
+  {#if isDraft}
     <div class="cycle-pane-editor">
       <div class="cycle-pane-editor-head">
-        <span>{isDraft ? 'New cycle' : 'Selected cycle'}</span>
+        <span>New cycle</span>
         <strong>{schedulePreview}</strong>
       </div>
 
@@ -535,32 +525,38 @@
 
       <div class="cycle-pane-actions">
         <ConstellationButton variant="primary" size="sm" loading={saving} onclick={saveCycle}>
-          Save
+          Create
         </ConstellationButton>
-        {#if selectedCycleId}
-          <ConstellationButton variant="quiet" size="sm" onclick={runSelectedNow}>Run now</ConstellationButton>
-          <ConstellationButton variant="destructive" size="sm" onclick={deleteSelected}>Delete</ConstellationButton>
-        {/if}
       </div>
-
-      {#if selectedCycle}
-        <div class="cycle-pane-runs">
-          <span>Recent runs</span>
-          {#if runsLoading}
-            <small>Loading...</small>
-          {:else if runs.length === 0}
-            <small>No runs yet.</small>
-          {:else}
-            {#each runs as run (run.id)}
-              <article>
-                <strong>{formatDateTime(run.scheduled_for)}</strong>
-                <ConstellationPill variant={run.status === 'failed' ? 'danger' : run.status === 'completed' ? 'success' : 'muted'}>
-                  {run.status}
-                </ConstellationPill>
-              </article>
-            {/each}
-          {/if}
-        </div>
+    </div>
+  {:else if selectedCycle}
+    <EffectiveCyclePolicyView
+      cycleId={selectedCycle.id}
+      compact
+      editable
+      refreshSerial={behaviorPolicyRefreshSerial}
+      onPolicyApplied={handlePolicyApplied}
+      onDirtyChange={(dirty) => (behaviorPolicyDirty = dirty)}
+    />
+    <div class="cycle-pane-actions">
+      <ConstellationButton variant="quiet" size="sm" onclick={runSelectedNow}>Run now</ConstellationButton>
+      <ConstellationButton variant="destructive" size="sm" onclick={deleteSelected}>Delete</ConstellationButton>
+    </div>
+    <div class="cycle-pane-runs">
+      <span>Recent runs</span>
+      {#if runsLoading}
+        <small>Loading...</small>
+      {:else if runs.length === 0}
+        <small>No runs yet.</small>
+      {:else}
+        {#each runs as run (run.id)}
+          <article>
+            <strong>{formatDateTime(run.scheduled_for)}</strong>
+            <ConstellationPill variant={run.status === 'failed' ? 'danger' : run.status === 'completed' ? 'success' : 'muted'}>
+              {run.status}
+            </ConstellationPill>
+          </article>
+        {/each}
       {/if}
     </div>
   {/if}

--- a/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
@@ -1,10 +1,99 @@
 import type {
+  CyclePolicyApplyRead,
   CyclePolicyChangeRead,
   CyclePolicyConfigurationRead,
+  CyclePolicyDiffEntryRead,
   CyclePolicyFieldSourceRead,
   CyclePolicyJsonValue,
+  CyclePolicyPreviewRead,
+  CyclePolicyProposal,
+  CyclePolicyHistoryRead,
+  EffectiveCyclePolicyRead,
 } from '$lib/api/client';
+import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
 import { parseServerDate } from '../../../utils/datetime.ts';
+
+export type CyclePolicyDraft = {
+  prompt: string;
+  schedule_expr: string;
+  timezone: string;
+  enabled: boolean;
+  model_override: string;
+  thinking_override: string;
+  guidance: string[];
+};
+
+export type CyclePolicyDraftErrors = Partial<Record<keyof CyclePolicyDraft, string>>;
+
+export type CyclePolicyScheduleDiffValue = {
+  schedule_expr: string;
+  schedule_human: string;
+  timezone: string;
+};
+
+export type PresentedCyclePolicyDiff =
+  | {
+      key: string;
+      kind: 'value';
+      field: string;
+      label: string;
+      before: string;
+      after: string;
+    }
+  | {
+      key: 'schedule';
+      kind: 'schedule';
+      field: 'schedule';
+      label: 'Schedule';
+      before: CyclePolicyScheduleDiffValue;
+      after: CyclePolicyScheduleDiffValue;
+    }
+  | {
+      key: 'guidance';
+      kind: 'guidance';
+      field: 'guidance';
+      label: 'Guidance';
+      added: string[];
+      retired: string[];
+    };
+
+export type CyclePolicyReview =
+  | {
+      kind: 'edit';
+      proposal: CyclePolicyProposal;
+      preview: CyclePolicyPreviewRead;
+    }
+  | {
+      kind: 'revert';
+      changeId: number;
+      preview: CyclePolicyPreviewRead;
+    };
+
+type CyclePolicyEditorApi = Pick<
+  typeof import('$lib/api/client').api,
+  | 'previewCycleBehaviorPolicy'
+  | 'applyCycleBehaviorPolicy'
+  | 'previewCycleBehaviorPolicyRevert'
+  | 'applyCycleBehaviorPolicyRevert'
+  | 'getCycleBehaviorPolicy'
+  | 'getCycleBehaviorPolicyHistory'
+>;
+
+const THINKING_OVERRIDES = new Set(['', 'none', 'low', 'medium', 'high', 'xhigh']);
+const CRON_NAME_RANGES: Record<number, Record<string, number>> = {
+  3: {
+    JAN: 1, FEB: 2, MAR: 3, APR: 4, MAY: 5, JUN: 6,
+    JUL: 7, AUG: 8, SEP: 9, OCT: 10, NOV: 11, DEC: 12,
+  },
+  4: { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 },
+};
+const CRON_RANGES: Array<[number, number]> = [
+  [0, 59],
+  [0, 23],
+  [1, 31],
+  [1, 12],
+  [0, 7],
+];
 
 export type CyclePolicyConfigurationEntry = {
   key: keyof CyclePolicyConfigurationRead & string;
@@ -18,6 +107,269 @@ export function policyConfigurationEntries(
     key: key as CyclePolicyConfigurationEntry['key'],
     value,
   }));
+}
+
+export function hydratePolicyDraft(policy: EffectiveCyclePolicyRead): CyclePolicyDraft {
+  return {
+    prompt: policy.configuration.prompt,
+    schedule_expr: policy.configuration.schedule_expr,
+    timezone: policy.configuration.timezone,
+    enabled: policy.configuration.enabled,
+    model_override: policy.configuration.model_override ?? '',
+    thinking_override: policy.configuration.thinking_override ?? '',
+    guidance: [...policy.guidance],
+  };
+}
+
+export function clonePolicyDraft(draft: CyclePolicyDraft): CyclePolicyDraft {
+  return { ...draft, guidance: [...draft.guidance] };
+}
+
+export function isPolicyDraftDirty(
+  draft: CyclePolicyDraft | null,
+  policy: EffectiveCyclePolicyRead | null,
+): boolean {
+  if (!draft || !policy) return false;
+  const baseline = hydratePolicyDraft(policy);
+  return (
+    draft.prompt !== baseline.prompt
+    || draft.schedule_expr !== baseline.schedule_expr
+    || draft.timezone !== baseline.timezone
+    || draft.enabled !== baseline.enabled
+    || draft.model_override !== baseline.model_override
+    || draft.thinking_override !== baseline.thinking_override
+    || draft.guidance.length !== baseline.guidance.length
+    || draft.guidance.some((value, index) => value !== baseline.guidance[index])
+  );
+}
+
+export function shouldConfirmPolicyDraftDiscard(
+  draft: CyclePolicyDraft | null,
+  policy: EffectiveCyclePolicyRead | null,
+): boolean {
+  return isPolicyDraftDirty(draft, policy);
+}
+
+function cronValue(value: string, fieldIndex: number): number | null {
+  if (/^\d+$/.test(value)) return Number(value);
+  return CRON_NAME_RANGES[fieldIndex]?.[value.toUpperCase()] ?? null;
+}
+
+function validCronAtom(value: string, fieldIndex: number): boolean {
+  const [minimum, maximum] = CRON_RANGES[fieldIndex];
+  const [rangePart, stepPart, ...extra] = value.split('/');
+  if (extra.length || (stepPart !== undefined && (!/^\d+$/.test(stepPart) || Number(stepPart) < 1))) {
+    return false;
+  }
+  if (rangePart === '*') return true;
+  const [startPart, endPart, ...rangeExtra] = rangePart.split('-');
+  if (rangeExtra.length) return false;
+  const start = cronValue(startPart, fieldIndex);
+  if (start === null || start < minimum || start > maximum) return false;
+  if (endPart === undefined) return true;
+  const end = cronValue(endPart, fieldIndex);
+  return end !== null && end >= minimum && end <= maximum && start <= end;
+}
+
+export function isValidPolicySchedule(value: string): boolean {
+  const schedule = value.trim();
+  if (schedule.toLowerCase().startsWith('at:')) {
+    const timestamp = schedule.slice(3).trim();
+    return Boolean(timestamp) && !Number.isNaN(new Date(timestamp).getTime());
+  }
+  const fields = schedule.split(/\s+/);
+  return fields.length === 5 && fields.every((field, fieldIndex) =>
+    field.split(',').every((atom) => Boolean(atom) && validCronAtom(atom, fieldIndex)));
+}
+
+export function isValidPolicyTimezone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en', { timeZone: value.trim() }).format();
+    return Boolean(value.trim());
+  } catch {
+    return false;
+  }
+}
+
+export function validatePolicyDraft(
+  draft: CyclePolicyDraft,
+  modelCatalog: readonly Pick<RuntimeModelCatalogEntry, 'id'>[],
+  currentModel: string | null = null,
+): CyclePolicyDraftErrors {
+  const errors: CyclePolicyDraftErrors = {};
+  const prompt = draft.prompt.trim();
+  const schedule = draft.schedule_expr.trim();
+  const timezone = draft.timezone.trim();
+  const model = draft.model_override.trim();
+  const guidance = draft.guidance.map((value) => value.trim());
+
+  if (!prompt) errors.prompt = 'Mission prompt is required.';
+  else if (prompt.length > 20_000) errors.prompt = 'Mission prompt must be 20,000 characters or fewer.';
+  if (!schedule) errors.schedule_expr = 'Schedule is required.';
+  else if (schedule.length > 100 || !isValidPolicySchedule(schedule)) {
+    errors.schedule_expr = 'Use a valid five-field cron rule or one-time at: timestamp.';
+  }
+  if (!timezone) errors.timezone = 'Timezone is required.';
+  else if (timezone.length > 64 || !isValidPolicyTimezone(timezone)) {
+    errors.timezone = 'Use a valid IANA timezone, such as America/Toronto.';
+  }
+  if (model) {
+    const supportedModels = new Set(modelCatalog.map((entry) => entry.id));
+    if (currentModel) supportedModels.add(currentModel);
+    if (!supportedModels.has(model)) errors.model_override = 'Select a supported model.';
+  }
+  if (!THINKING_OVERRIDES.has(draft.thinking_override)) {
+    errors.thinking_override = 'Select a supported thinking level.';
+  }
+  if (guidance.some((value) => !value)) {
+    errors.guidance = 'Guidance cannot be empty.';
+  } else if (new Set(guidance).size !== guidance.length) {
+    errors.guidance = 'Guidance entries must be unique.';
+  }
+  return errors;
+}
+
+export function policyProposalFromDraft(draft: CyclePolicyDraft): CyclePolicyProposal {
+  return {
+    prompt: draft.prompt.trim(),
+    schedule_expr: draft.schedule_expr.trim(),
+    timezone: draft.timezone.trim(),
+    enabled: draft.enabled,
+    model_override: draft.model_override.trim() || null,
+    thinking_override: draft.thinking_override || null,
+    guidance: draft.guidance.map((value) => value.trim()),
+  };
+}
+
+export async function reviewPolicyDraft(
+  client: CyclePolicyEditorApi,
+  cycleId: number,
+  draft: CyclePolicyDraft,
+  modelCatalog: readonly Pick<RuntimeModelCatalogEntry, 'id'>[],
+  currentModel: string | null = null,
+): Promise<{ review: CyclePolicyReview | null; errors: CyclePolicyDraftErrors }> {
+  const errors = validatePolicyDraft(draft, modelCatalog, currentModel);
+  if (Object.keys(errors).length) return { review: null, errors };
+  const proposal = policyProposalFromDraft(draft);
+  const preview = await client.previewCycleBehaviorPolicy(cycleId, { proposal });
+  return { review: { kind: 'edit', proposal, preview }, errors: {} };
+}
+
+export async function reviewPolicyRevert(
+  client: CyclePolicyEditorApi,
+  cycleId: number,
+  changeId: number,
+): Promise<CyclePolicyReview> {
+  return {
+    kind: 'revert',
+    changeId,
+    preview: await client.previewCycleBehaviorPolicyRevert(cycleId, changeId),
+  };
+}
+
+export async function applyPolicyReview(
+  client: CyclePolicyEditorApi,
+  cycleId: number,
+  review: CyclePolicyReview | null,
+  rationale: string,
+  confirmRevert: () => boolean = () => true,
+): Promise<{
+  applied: CyclePolicyApplyRead;
+  policy: EffectiveCyclePolicyRead;
+  history: CyclePolicyHistoryRead;
+} | null> {
+  if (!review) throw new Error('Review the change before applying it.');
+  const normalizedRationale = rationale.trim();
+  if (!normalizedRationale) throw new Error('Rationale is required.');
+  if (!review.preview.changed_fields.length) throw new Error('There are no changes to apply.');
+  if (review.kind === 'revert' && !confirmRevert()) return null;
+
+  const common = {
+    expected_version: review.preview.expected_version,
+    preview_digest: review.preview.preview_digest,
+    rationale: normalizedRationale,
+  };
+  const applied = review.kind === 'edit'
+    ? await client.applyCycleBehaviorPolicy(cycleId, {
+        proposal: review.proposal,
+        ...common,
+      })
+    : await client.applyCycleBehaviorPolicyRevert(cycleId, review.changeId, common);
+  const [policy, history] = await Promise.all([
+    client.getCycleBehaviorPolicy(cycleId),
+    client.getCycleBehaviorPolicyHistory(cycleId),
+  ]);
+  return { applied, policy, history };
+}
+
+export function recoverPolicyDraftAfterConflict(
+  draft: CyclePolicyDraft,
+  latestPolicy: EffectiveCyclePolicyRead,
+): { draft: CyclePolicyDraft; policy: EffectiveCyclePolicyRead } {
+  return { draft: clonePolicyDraft(draft), policy: latestPolicy };
+}
+
+function scheduleDiffValue(value: CyclePolicyJsonValue): CyclePolicyScheduleDiffValue | null {
+  if (!value || Array.isArray(value) || typeof value !== 'object') return null;
+  const scheduleExpr = value.schedule_expr;
+  const scheduleHuman = value.schedule_human;
+  const timezone = value.timezone;
+  if (typeof scheduleExpr !== 'string' || typeof scheduleHuman !== 'string' || typeof timezone !== 'string') {
+    return null;
+  }
+  return { schedule_expr: scheduleExpr, schedule_human: scheduleHuman, timezone };
+}
+
+export function guidanceDiff(entry: CyclePolicyDiffEntryRead): {
+  added: string[];
+  retired: string[];
+} {
+  return { added: [...(entry.added ?? [])], retired: [...(entry.removed ?? [])] };
+}
+
+export function presentedPolicyDiff(preview: CyclePolicyPreviewRead): PresentedCyclePolicyDiff[] {
+  const presented: PresentedCyclePolicyDiff[] = [];
+  let scheduleAdded = false;
+  for (const entry of preview.diff) {
+    if (entry.kind === 'schedule') {
+      if (scheduleAdded) continue;
+      const before = scheduleDiffValue(entry.before);
+      const after = scheduleDiffValue(entry.after);
+      if (before && after) {
+        presented.push({
+          key: 'schedule',
+          kind: 'schedule',
+          field: 'schedule',
+          label: 'Schedule',
+          before,
+          after,
+        });
+        scheduleAdded = true;
+      }
+      continue;
+    }
+    if (entry.kind === 'collection' && entry.field === 'guidance') {
+      const { added, retired } = guidanceDiff(entry);
+      presented.push({
+        key: 'guidance',
+        kind: 'guidance',
+        field: 'guidance',
+        label: 'Guidance',
+        added,
+        retired,
+      });
+      continue;
+    }
+    presented.push({
+      key: entry.field,
+      kind: 'value',
+      field: entry.field,
+      label: policyFieldLabel(entry.field),
+      before: policyValueLabel(entry.before),
+      after: policyValueLabel(entry.after),
+    });
+  }
+  return presented;
 }
 
 export function policyFieldLabel(field: string): string {

--- a/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
@@ -13,14 +13,80 @@ import type {
 import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
 import { parseServerDate } from '../../../utils/datetime.ts';
 
+export const POLICY_FIELD_SCHEMA = [
+  {
+    key: 'prompt',
+    label: 'Mission prompt',
+    control: 'textarea',
+    fullWidth: true,
+    rows: 7,
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.prompt,
+    proposal: (value: unknown) => String(value).trim(),
+  },
+  {
+    key: 'schedule_expr',
+    label: 'Stored schedule',
+    control: 'text',
+    mono: true,
+    placeholder: '0 9 * * *',
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.schedule_expr,
+    proposal: (value: unknown) => String(value).trim(),
+  },
+  {
+    key: 'timezone',
+    label: 'Timezone',
+    control: 'text',
+    placeholder: 'America/Toronto',
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.timezone,
+    proposal: (value: unknown) => String(value).trim(),
+  },
+  {
+    key: 'enabled',
+    label: 'Status',
+    control: 'toggle',
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.enabled,
+    proposal: (value: unknown) => Boolean(value),
+  },
+  {
+    key: 'model_override',
+    label: 'Model override',
+    control: 'model',
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.model_override ?? '',
+    proposal: (value: unknown) => String(value).trim() || null,
+  },
+  {
+    key: 'thinking_override',
+    label: 'Thinking override',
+    control: 'thinking',
+    options: [
+      { value: '', label: 'Workspace default' },
+      { value: 'none', label: 'None' },
+      { value: 'low', label: 'Low' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'high', label: 'High' },
+      { value: 'xhigh', label: 'xHigh' },
+    ],
+    read: (policy: EffectiveCyclePolicyRead) => policy.configuration.thinking_override ?? '',
+    proposal: (value: unknown) => String(value) || null,
+  },
+  {
+    key: 'guidance',
+    label: 'Active guidance',
+    control: 'guidance',
+    fullWidth: true,
+    read: (policy: EffectiveCyclePolicyRead) => [...policy.guidance],
+    proposal: (value: unknown) => Array.isArray(value)
+      ? value.map((item) => String(item).trim())
+      : [],
+  },
+] as const;
+
+type PolicyFieldDefinition = (typeof POLICY_FIELD_SCHEMA)[number];
+
+export type CyclePolicyFieldKey = PolicyFieldDefinition['key'];
+
 export type CyclePolicyDraft = {
-  prompt: string;
-  schedule_expr: string;
-  timezone: string;
-  enabled: boolean;
-  model_override: string;
-  thinking_override: string;
-  guidance: string[];
+  [Field in PolicyFieldDefinition as Field['key']]: ReturnType<Field['read']>;
 };
 
 export type CyclePolicyDraftErrors = Partial<Record<keyof CyclePolicyDraft, string>>;
@@ -69,7 +135,7 @@ export type CyclePolicyReview =
       preview: CyclePolicyPreviewRead;
     };
 
-type CyclePolicyEditorApi = Pick<
+export type CyclePolicyEditorApi = Pick<
   typeof import('$lib/api/client').api,
   | 'previewCycleBehaviorPolicy'
   | 'applyCycleBehaviorPolicy'
@@ -78,22 +144,6 @@ type CyclePolicyEditorApi = Pick<
   | 'getCycleBehaviorPolicy'
   | 'getCycleBehaviorPolicyHistory'
 >;
-
-const THINKING_OVERRIDES = new Set(['', 'none', 'low', 'medium', 'high', 'xhigh']);
-const CRON_NAME_RANGES: Record<number, Record<string, number>> = {
-  3: {
-    JAN: 1, FEB: 2, MAR: 3, APR: 4, MAY: 5, JUN: 6,
-    JUL: 7, AUG: 8, SEP: 9, OCT: 10, NOV: 11, DEC: 12,
-  },
-  4: { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 },
-};
-const CRON_RANGES: Array<[number, number]> = [
-  [0, 59],
-  [0, 23],
-  [1, 31],
-  [1, 12],
-  [0, 7],
-];
 
 export type CyclePolicyConfigurationEntry = {
   key: keyof CyclePolicyConfigurationRead & string;
@@ -110,15 +160,9 @@ export function policyConfigurationEntries(
 }
 
 export function hydratePolicyDraft(policy: EffectiveCyclePolicyRead): CyclePolicyDraft {
-  return {
-    prompt: policy.configuration.prompt,
-    schedule_expr: policy.configuration.schedule_expr,
-    timezone: policy.configuration.timezone,
-    enabled: policy.configuration.enabled,
-    model_override: policy.configuration.model_override ?? '',
-    thinking_override: policy.configuration.thinking_override ?? '',
-    guidance: [...policy.guidance],
-  };
+  return Object.fromEntries(
+    POLICY_FIELD_SCHEMA.map((field) => [field.key, field.read(policy)]),
+  ) as CyclePolicyDraft;
 }
 
 export function clonePolicyDraft(draft: CyclePolicyDraft): CyclePolicyDraft {
@@ -131,16 +175,15 @@ export function isPolicyDraftDirty(
 ): boolean {
   if (!draft || !policy) return false;
   const baseline = hydratePolicyDraft(policy);
-  return (
-    draft.prompt !== baseline.prompt
-    || draft.schedule_expr !== baseline.schedule_expr
-    || draft.timezone !== baseline.timezone
-    || draft.enabled !== baseline.enabled
-    || draft.model_override !== baseline.model_override
-    || draft.thinking_override !== baseline.thinking_override
-    || draft.guidance.length !== baseline.guidance.length
-    || draft.guidance.some((value, index) => value !== baseline.guidance[index])
-  );
+  return POLICY_FIELD_SCHEMA.some((field) => {
+    const current = draft[field.key];
+    const original = baseline[field.key];
+    if (Array.isArray(current) && Array.isArray(original)) {
+      return current.length !== original.length
+        || current.some((value, index) => value !== original[index]);
+    }
+    return current !== original;
+  });
 }
 
 export function shouldConfirmPolicyDraftDiscard(
@@ -150,27 +193,6 @@ export function shouldConfirmPolicyDraftDiscard(
   return isPolicyDraftDirty(draft, policy);
 }
 
-function cronValue(value: string, fieldIndex: number): number | null {
-  if (/^\d+$/.test(value)) return Number(value);
-  return CRON_NAME_RANGES[fieldIndex]?.[value.toUpperCase()] ?? null;
-}
-
-function validCronAtom(value: string, fieldIndex: number): boolean {
-  const [minimum, maximum] = CRON_RANGES[fieldIndex];
-  const [rangePart, stepPart, ...extra] = value.split('/');
-  if (extra.length || (stepPart !== undefined && (!/^\d+$/.test(stepPart) || Number(stepPart) < 1))) {
-    return false;
-  }
-  if (rangePart === '*') return true;
-  const [startPart, endPart, ...rangeExtra] = rangePart.split('-');
-  if (rangeExtra.length) return false;
-  const start = cronValue(startPart, fieldIndex);
-  if (start === null || start < minimum || start > maximum) return false;
-  if (endPart === undefined) return true;
-  const end = cronValue(endPart, fieldIndex);
-  return end !== null && end >= minimum && end <= maximum && start <= end;
-}
-
 export function isValidPolicySchedule(value: string): boolean {
   const schedule = value.trim();
   if (schedule.toLowerCase().startsWith('at:')) {
@@ -178,17 +200,7 @@ export function isValidPolicySchedule(value: string): boolean {
     return Boolean(timestamp) && !Number.isNaN(new Date(timestamp).getTime());
   }
   const fields = schedule.split(/\s+/);
-  return fields.length === 5 && fields.every((field, fieldIndex) =>
-    field.split(',').every((atom) => Boolean(atom) && validCronAtom(atom, fieldIndex)));
-}
-
-export function isValidPolicyTimezone(value: string): boolean {
-  try {
-    new Intl.DateTimeFormat('en', { timeZone: value.trim() }).format();
-    return Boolean(value.trim());
-  } catch {
-    return false;
-  }
+  return fields.length === 5 && fields.every(Boolean);
 }
 
 export function validatePolicyDraft(
@@ -199,46 +211,28 @@ export function validatePolicyDraft(
   const errors: CyclePolicyDraftErrors = {};
   const prompt = draft.prompt.trim();
   const schedule = draft.schedule_expr.trim();
-  const timezone = draft.timezone.trim();
   const model = draft.model_override.trim();
   const guidance = draft.guidance.map((value) => value.trim());
 
   if (!prompt) errors.prompt = 'Mission prompt is required.';
-  else if (prompt.length > 20_000) errors.prompt = 'Mission prompt must be 20,000 characters or fewer.';
-  if (!schedule) errors.schedule_expr = 'Schedule is required.';
-  else if (schedule.length > 100 || !isValidPolicySchedule(schedule)) {
+  if (!schedule || !isValidPolicySchedule(schedule)) {
     errors.schedule_expr = 'Use a valid five-field cron rule or one-time at: timestamp.';
-  }
-  if (!timezone) errors.timezone = 'Timezone is required.';
-  else if (timezone.length > 64 || !isValidPolicyTimezone(timezone)) {
-    errors.timezone = 'Use a valid IANA timezone, such as America/Toronto.';
   }
   if (model) {
     const supportedModels = new Set(modelCatalog.map((entry) => entry.id));
     if (currentModel) supportedModels.add(currentModel);
     if (!supportedModels.has(model)) errors.model_override = 'Select a supported model.';
   }
-  if (!THINKING_OVERRIDES.has(draft.thinking_override)) {
-    errors.thinking_override = 'Select a supported thinking level.';
-  }
-  if (guidance.some((value) => !value)) {
-    errors.guidance = 'Guidance cannot be empty.';
-  } else if (new Set(guidance).size !== guidance.length) {
+  if (new Set(guidance).size !== guidance.length) {
     errors.guidance = 'Guidance entries must be unique.';
   }
   return errors;
 }
 
 export function policyProposalFromDraft(draft: CyclePolicyDraft): CyclePolicyProposal {
-  return {
-    prompt: draft.prompt.trim(),
-    schedule_expr: draft.schedule_expr.trim(),
-    timezone: draft.timezone.trim(),
-    enabled: draft.enabled,
-    model_override: draft.model_override.trim() || null,
-    thinking_override: draft.thinking_override || null,
-    guidance: draft.guidance.map((value) => value.trim()),
-  };
+  return Object.fromEntries(
+    POLICY_FIELD_SCHEMA.map((field) => [field.key, field.proposal(draft[field.key])]),
+  ) as CyclePolicyProposal;
 }
 
 export async function reviewPolicyDraft(

--- a/frontend/src/lib/features/cycles/domain/effectivePolicyClientContext.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicyClientContext.ts
@@ -1,0 +1,7 @@
+import type { CyclePolicyEditorApi } from './effectivePolicy.ts';
+
+export type EffectivePolicyClientResolver = (
+  cycleId: number,
+) => CyclePolicyEditorApi | undefined;
+
+export const EFFECTIVE_POLICY_CLIENT_CONTEXT = Symbol('effective-policy-client');

--- a/frontend/src/lib/features/cycles/domain/effectivePolicyWorkflow.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicyWorkflow.ts
@@ -1,0 +1,398 @@
+import type {
+  CyclePolicyConflictDetail,
+  CyclePolicyHistoryRead,
+  EffectiveCyclePolicyRead,
+} from '$lib/api/client';
+import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
+
+import {
+  applyPolicyReview,
+  clonePolicyDraft,
+  hydratePolicyDraft,
+  isPolicyDraftDirty,
+  recoverPolicyDraftAfterConflict,
+  reviewPolicyDraft,
+  reviewPolicyRevert,
+  type CyclePolicyDraft,
+  type CyclePolicyDraftErrors,
+  type CyclePolicyEditorApi,
+  type CyclePolicyReview,
+} from './effectivePolicy.ts';
+
+export const POLICY_ACTIVE_RUN_BOUNDARY =
+  'Active runs are unchanged. Future runs use this policy only after apply.';
+
+export type CyclePolicyWorkflowData = {
+  policy: EffectiveCyclePolicyRead;
+  history: CyclePolicyHistoryRead;
+};
+
+export type CyclePolicyWorkflowState =
+  | {
+      kind: 'view';
+      data: CyclePolicyWorkflowData;
+      notice?: string;
+      historyError?: string;
+    }
+  | {
+      kind: 'edit';
+      data: CyclePolicyWorkflowData;
+      draft: CyclePolicyDraft;
+      errors: CyclePolicyDraftErrors;
+      error?: string;
+      notice?: string;
+      historyError?: string;
+    }
+  | {
+      kind: 'reviewing';
+      data: CyclePolicyWorkflowData;
+      draft: CyclePolicyDraft;
+      historyError?: string;
+    }
+  | {
+      kind: 'review';
+      data: CyclePolicyWorkflowData;
+      draft: CyclePolicyDraft | null;
+      review: CyclePolicyReview;
+      rationale: string;
+      error?: string;
+      historyError?: string;
+    }
+  | {
+      kind: 'applying';
+      data: CyclePolicyWorkflowData;
+      draft: CyclePolicyDraft | null;
+      review: CyclePolicyReview;
+      rationale: string;
+      historyError?: string;
+    }
+  | {
+      kind: 'conflicted';
+      data: CyclePolicyWorkflowData;
+      draft: CyclePolicyDraft | null;
+      notice: string;
+      historyError?: string;
+    }
+  | {
+      kind: 'reverting';
+      data: CyclePolicyWorkflowData;
+      changeId: number;
+      historyError?: string;
+    };
+
+export type PolicyReviewProps = {
+  review: CyclePolicyReview;
+  rationale: string;
+  applying: boolean;
+  applyDisabled: boolean;
+  activeRunBoundary: typeof POLICY_ACTIVE_RUN_BOUNDARY;
+  error?: string;
+};
+
+type WorkflowOptions = {
+  client: CyclePolicyEditorApi;
+  cycleId: number;
+  data: CyclePolicyWorkflowData;
+  modelCatalog?: readonly RuntimeModelCatalogEntry[];
+  onStateChange?: (state: CyclePolicyWorkflowState) => void;
+  onPolicyApplied?: (policy: EffectiveCyclePolicyRead) => void | Promise<void>;
+};
+
+export function policyWorkflowDraft(state: CyclePolicyWorkflowState): CyclePolicyDraft | null {
+  if (
+    state.kind === 'edit'
+    || state.kind === 'reviewing'
+    || state.kind === 'review'
+    || state.kind === 'applying'
+    || state.kind === 'conflicted'
+  ) return state.draft;
+  return null;
+}
+
+export function isPolicyWorkflowDirty(state: CyclePolicyWorkflowState): boolean {
+  return isPolicyDraftDirty(policyWorkflowDraft(state), state.data.policy);
+}
+
+export function policyReviewProps(
+  state: Extract<CyclePolicyWorkflowState, { kind: 'review' | 'applying' }>,
+): PolicyReviewProps {
+  return {
+    review: state.review,
+    rationale: state.rationale,
+    applying: state.kind === 'applying',
+    applyDisabled: state.kind === 'applying'
+      || !state.review.preview.changed_fields.length
+      || !state.rationale.trim(),
+    activeRunBoundary: POLICY_ACTIVE_RUN_BOUNDARY,
+    ...(state.kind === 'review' && state.error ? { error: state.error } : {}),
+  };
+}
+
+export function workflowErrorMessage(value: unknown, fallback: string): string {
+  if (value && typeof value === 'object' && 'detail' in value) {
+    const detail = (value as { detail?: unknown }).detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+  return value instanceof Error ? value.message : fallback;
+}
+
+export function policyConflictDetail(value: unknown): CyclePolicyConflictDetail | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as { status?: unknown; detail?: unknown };
+  if (candidate.status !== 409 || !candidate.detail || typeof candidate.detail !== 'object') {
+    return null;
+  }
+  const detail = candidate.detail as Partial<CyclePolicyConflictDetail>;
+  if (!detail.latest_effective_policy || typeof detail.reason !== 'string') return null;
+  return detail as CyclePolicyConflictDetail;
+}
+
+export class EffectivePolicyWorkflowController {
+  private current: CyclePolicyWorkflowState;
+  private operationSerial = 0;
+  private readonly client: CyclePolicyEditorApi;
+  private readonly cycleId: number;
+  private readonly modelCatalog: readonly RuntimeModelCatalogEntry[];
+  private readonly onStateChange?: (state: CyclePolicyWorkflowState) => void;
+  private readonly onPolicyApplied?: (
+    policy: EffectiveCyclePolicyRead,
+  ) => void | Promise<void>;
+
+  constructor(options: WorkflowOptions) {
+    this.client = options.client;
+    this.cycleId = options.cycleId;
+    this.modelCatalog = options.modelCatalog ?? [];
+    this.onStateChange = options.onStateChange;
+    this.onPolicyApplied = options.onPolicyApplied;
+    this.current = { kind: 'view', data: options.data };
+  }
+
+  get state(): CyclePolicyWorkflowState {
+    return this.current;
+  }
+
+  private transition(state: CyclePolicyWorkflowState): void {
+    this.current = state;
+    this.onStateChange?.(state);
+  }
+
+  dispose(): void {
+    this.operationSerial += 1;
+  }
+
+  startEditing(): void {
+    if (
+      this.current.kind !== 'view'
+      && !(this.current.kind === 'conflicted' && !this.current.draft)
+    ) return;
+    this.transition({
+      kind: 'edit',
+      data: this.current.data,
+      draft: hydratePolicyDraft(this.current.data.policy),
+      errors: {},
+    });
+  }
+
+  async loadMoreHistory(): Promise<void> {
+    const { pagination } = this.current.data.history;
+    if (!pagination.has_more || pagination.next_offset === null) return;
+    const version = this.current.data.policy.version;
+    try {
+      const nextHistory = await this.client.getCycleBehaviorPolicyHistory(
+        this.cycleId,
+        pagination.limit,
+        pagination.next_offset,
+      );
+      if (this.current.data.policy.version !== version) return;
+      this.transition({
+        ...this.current,
+        data: {
+          ...this.current.data,
+          history: {
+            items: [...this.current.data.history.items, ...nextHistory.items],
+            pagination: nextHistory.pagination,
+          },
+        },
+        historyError: undefined,
+      });
+    } catch (error) {
+      this.transition({
+        ...this.current,
+        historyError: workflowErrorMessage(error, 'Older history failed to load.'),
+      });
+    }
+  }
+
+  updateDraft(draft: CyclePolicyDraft): void {
+    if (this.current.kind === 'edit') {
+      this.transition({
+        ...this.current,
+        draft: clonePolicyDraft(draft),
+        errors: {},
+        error: undefined,
+      });
+      return;
+    }
+    if (this.current.kind === 'conflicted' && this.current.draft) {
+      this.transition({ ...this.current, draft: clonePolicyDraft(draft) });
+    }
+  }
+
+  cancelEditing(confirmDiscard: () => boolean = () => true): void {
+    const draft = policyWorkflowDraft(this.current);
+    if (!draft) return;
+    if (isPolicyDraftDirty(draft, this.current.data.policy) && !confirmDiscard()) return;
+    this.operationSerial += 1;
+    this.transition({ kind: 'view', data: this.current.data });
+  }
+
+  leaveReview(): void {
+    if (this.current.kind !== 'review') return;
+    if (this.current.review.kind === 'edit' && this.current.draft) {
+      this.transition({
+        kind: 'edit',
+        data: this.current.data,
+        draft: this.current.draft,
+        errors: {},
+      });
+      return;
+    }
+    this.transition({ kind: 'view', data: this.current.data });
+  }
+
+  setRationale(rationale: string): void {
+    if (this.current.kind !== 'review') return;
+    this.transition({ ...this.current, rationale, error: undefined });
+  }
+
+  async reviewDraft(): Promise<void> {
+    if (this.current.kind !== 'edit' && this.current.kind !== 'conflicted') return;
+    const draft = this.current.draft;
+    if (!draft) return;
+    const data = this.current.data;
+    const serial = ++this.operationSerial;
+    this.transition({ kind: 'reviewing', data, draft });
+    try {
+      const result = await reviewPolicyDraft(
+        this.client,
+        this.cycleId,
+        clonePolicyDraft(draft),
+        this.modelCatalog,
+        data.policy.configuration.model_override,
+      );
+      if (serial !== this.operationSerial) return;
+      if (!result.review) {
+        this.transition({ kind: 'edit', data, draft, errors: result.errors });
+        return;
+      }
+      this.transition({
+        kind: 'review',
+        data,
+        draft,
+        review: result.review,
+        rationale: '',
+      });
+    } catch (error) {
+      if (serial !== this.operationSerial) return;
+      this.transition({
+        kind: 'edit',
+        data,
+        draft,
+        errors: {},
+        error: workflowErrorMessage(error, 'The change could not be reviewed.'),
+      });
+    }
+  }
+
+  async beginRevert(changeId: number): Promise<void> {
+    if (this.current.kind !== 'view') return;
+    const data = this.current.data;
+    const serial = ++this.operationSerial;
+    this.transition({ kind: 'reverting', data, changeId });
+    try {
+      const review = await reviewPolicyRevert(this.client, this.cycleId, changeId);
+      if (serial !== this.operationSerial) return;
+      this.transition({ kind: 'review', data, draft: null, review, rationale: '' });
+    } catch (error) {
+      if (serial !== this.operationSerial) return;
+      this.transition({
+        kind: 'view',
+        data,
+        historyError: workflowErrorMessage(error, 'The revert could not be reviewed.'),
+      });
+    }
+  }
+
+  async applyReviewedChange(confirmRevert: () => boolean = () => true): Promise<void> {
+    if (this.current.kind !== 'review' || policyReviewProps(this.current).applyDisabled) return;
+    const { data, draft, review, rationale } = this.current;
+    const serial = ++this.operationSerial;
+    this.transition({ kind: 'applying', data, draft, review, rationale });
+    try {
+      const result = await applyPolicyReview(
+        this.client,
+        this.cycleId,
+        review,
+        rationale,
+        confirmRevert,
+      );
+      if (serial !== this.operationSerial) return;
+      if (!result) {
+        this.transition({ kind: 'review', data, draft, review, rationale });
+        return;
+      }
+      const nextData = { policy: result.policy, history: result.history };
+      this.transition({
+        kind: 'view',
+        data: nextData,
+        notice: review.kind === 'revert'
+          ? 'Revert applied as a new behavior version.'
+          : 'Behavior applied for future runs.',
+      });
+      await this.onPolicyApplied?.(result.policy);
+    } catch (error) {
+      if (serial !== this.operationSerial) return;
+      const conflict = policyConflictDetail(error);
+      if (conflict) {
+        await this.recoverConflict(data, draft, conflict, serial);
+        return;
+      }
+      this.transition({
+        kind: 'review',
+        data,
+        draft,
+        review,
+        rationale,
+        error: workflowErrorMessage(error, 'The change could not be applied.'),
+      });
+    }
+  }
+
+  private async recoverConflict(
+    previousData: CyclePolicyWorkflowData,
+    draft: CyclePolicyDraft | null,
+    detail: CyclePolicyConflictDetail,
+    serial: number,
+  ): Promise<void> {
+    let history = previousData.history;
+    let historyError: string | undefined;
+    try {
+      history = await this.client.getCycleBehaviorPolicyHistory(this.cycleId);
+    } catch {
+      historyError = 'History could not be refreshed after the conflict.';
+    }
+    if (serial !== this.operationSerial) return;
+    const recoveredDraft = draft
+      ? recoverPolicyDraftAfterConflict(draft, detail.latest_effective_policy).draft
+      : null;
+    this.transition({
+      kind: 'conflicted',
+      data: { policy: detail.latest_effective_policy, history },
+      draft: recoveredDraft,
+      notice: recoveredDraft
+        ? 'Another person changed this Cycle. Your draft is safe. Review it against the latest version and try again.'
+        : 'Another person changed this Cycle. Review the latest version before you try again.',
+      ...(historyError ? { historyError } : {}),
+    });
+  }
+}

--- a/frontend/src/lib/utils/behaviorPolicyEditor.test.js
+++ b/frontend/src/lib/utils/behaviorPolicyEditor.test.js
@@ -340,3 +340,40 @@ test('preview client runs semantic edit and revert flows through the production 
   assert.equal(controller.state.data.history.items[0].reverted_from_id, appliedChangeId);
   assert.equal(controller.state.data.history.items[0].rationale, 'Restore the earlier preview behavior.');
 });
+
+test('preview client reviews a semantic diff when policy state is proxied', async () => {
+  const livePolicy = policy();
+  livePolicy.configuration = new Proxy(livePolicy.configuration, {});
+  assert.throws(() => structuredClone(livePolicy.configuration), { name: 'DataCloneError' });
+
+  const previewClient = createPreviewBehaviorPolicyClient({
+    cycleId: 7,
+    getPolicy: () => livePolicy,
+    getHistory: () => history(),
+    commit: () => {},
+    scheduleLabel: (expression, timezone) => `${expression} (${timezone})`,
+  });
+  const controller = new EffectivePolicyWorkflowController({
+    client: previewClient,
+    cycleId: 7,
+    data: { policy: livePolicy, history: history() },
+  });
+
+  controller.startEditing();
+  const draft = hydratePolicyDraft(livePolicy);
+  draft.prompt = 'Review incidents and owners.';
+  controller.updateDraft(draft);
+  await controller.reviewDraft();
+
+  assert.equal(controller.state.error, undefined);
+  assert.equal(controller.state.kind, 'review');
+  assert.deepEqual(controller.state.review.preview.changed_fields, ['prompt']);
+  assert.deepEqual(controller.state.review.preview.diff, [{
+    field: 'prompt',
+    kind: 'value',
+    before: 'Review current priorities.',
+    after: 'Review incidents and owners.',
+    added: null,
+    removed: null,
+  }]);
+});

--- a/frontend/src/lib/utils/behaviorPolicyEditor.test.js
+++ b/frontend/src/lib/utils/behaviorPolicyEditor.test.js
@@ -1,6 +1,5 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 
 import {
   applyPolicyReview,
@@ -8,6 +7,12 @@ import {
   reviewPolicyDraft,
   reviewPolicyRevert,
 } from '../features/cycles/domain/effectivePolicy.ts';
+import {
+  EffectivePolicyWorkflowController,
+  isPolicyWorkflowDirty,
+  policyReviewProps,
+} from '../features/cycles/domain/effectivePolicyWorkflow.ts';
+import { createPreviewBehaviorPolicyClient } from '../../routes/cycles/previewBehaviorPolicy.ts';
 
 function configuration(overrides = {}) {
   return {
@@ -202,30 +207,136 @@ test('revert requires explicit confirmation before it applies a new version', as
   assert.deepEqual(calls.slice(0, 2), [['revert-preview', 41], ['revert-apply', 41]]);
 });
 
-test('the shipped editor keeps apply disabled without rationale and states the active-run boundary', () => {
-  const source = readFileSync(
-    new URL('../features/cycles/components/EffectiveCyclePolicyView.svelte', import.meta.url),
-    'utf8',
+test('review props disable apply until rationale and state the active-run boundary', async () => {
+  const controller = new EffectivePolicyWorkflowController({
+    client: client(),
+    cycleId: 7,
+    data: { policy: policy(), history: history() },
+  });
+  controller.startEditing();
+  const draft = hydratePolicyDraft(policy());
+  draft.prompt = 'Review incidents and owners.';
+  controller.updateDraft(draft);
+  await controller.reviewDraft();
+
+  assert.equal(controller.state.kind, 'review');
+  let props = policyReviewProps(controller.state);
+  assert.equal(props.applyDisabled, true);
+  assert.equal(
+    props.activeRunBoundary,
+    'Active runs are unchanged. Future runs use this policy only after apply.',
   );
 
-  assert.match(source, /disabled=\{applyDisabled\}/);
-  assert.match(source, /Active runs are unchanged\. Future runs use this policy only after apply\./);
-  assert.match(source, /beforeunload/);
-  assert.match(source, /Your draft is safe/);
+  controller.setRationale('Keep incident ownership current.');
+  props = policyReviewProps(controller.state);
+  assert.equal(props.applyDisabled, false);
 });
 
-test('existing Cycle surfaces no longer expose a direct behavior update path', () => {
-  const mainPage = readFileSync(
-    new URL('../../routes/cycles/+page.svelte', import.meta.url),
-    'utf8',
-  );
-  const threadPane = readFileSync(
-    new URL('../features/cycles/components/ThreadCyclesPane.svelte', import.meta.url),
-    'utf8',
-  );
+test('dirty drafts require confirmation before the controller discards them', () => {
+  const controller = new EffectivePolicyWorkflowController({
+    client: client(),
+    cycleId: 7,
+    data: { policy: policy(), history: history() },
+  });
+  controller.startEditing();
+  const draft = hydratePolicyDraft(policy());
+  draft.guidance.push('Name the incident owner.');
+  controller.updateDraft(draft);
+  assert.equal(isPolicyWorkflowDirty(controller.state), true);
 
-  assert.doesNotMatch(mainPage, /api\.updateCycle/);
-  assert.doesNotMatch(threadPane, /api\.updateCycle/);
-  assert.match(mainPage, /editable=\{!isCyclesPreview\}/);
-  assert.match(threadPane, /<EffectiveCyclePolicyView[\s\S]*?editable/);
+  let confirmations = 0;
+  controller.cancelEditing(() => {
+    confirmations += 1;
+    return false;
+  });
+  assert.equal(confirmations, 1);
+  assert.equal(controller.state.kind, 'edit');
+
+  controller.cancelEditing(() => true);
+  assert.equal(controller.state.kind, 'view');
+});
+
+test('a 409 moves the controller to conflicted and preserves the dirty draft', async () => {
+  const latest = policy(2, { configuration: { prompt: 'Another reviewer changed this.' } });
+  const api = client({
+    applyCycleBehaviorPolicy: async () => {
+      throw {
+        status: 409,
+        detail: { reason: 'version_conflict', latest_effective_policy: latest },
+      };
+    },
+  });
+  const controller = new EffectivePolicyWorkflowController({
+    client: api,
+    cycleId: 7,
+    data: { policy: policy(), history: history() },
+  });
+  controller.startEditing();
+  const draft = hydratePolicyDraft(policy());
+  draft.prompt = 'My safe draft.';
+  controller.updateDraft(draft);
+  await controller.reviewDraft();
+  controller.setRationale('Keep my proposed incident workflow.');
+  await controller.applyReviewedChange();
+
+  assert.equal(controller.state.kind, 'conflicted');
+  assert.equal(controller.state.draft.prompt, 'My safe draft.');
+  assert.equal(controller.state.data.policy.version, 2);
+  assert.equal(isPolicyWorkflowDirty(controller.state), true);
+  assert.match(controller.state.notice, /Your draft is safe/);
+});
+
+test('preview client runs semantic edit and revert flows through the production controller', async () => {
+  let livePolicy = policy();
+  let liveHistory = history();
+  const previewClient = createPreviewBehaviorPolicyClient({
+    cycleId: 7,
+    getPolicy: () => livePolicy,
+    getHistory: () => liveHistory,
+    commit: (nextPolicy, nextHistory) => {
+      livePolicy = nextPolicy;
+      liveHistory = nextHistory;
+    },
+    scheduleLabel: (expression, timezone) => `${expression} (${timezone})`,
+    now: () => '2026-08-11T18:00:00Z',
+  });
+  const controller = new EffectivePolicyWorkflowController({
+    client: previewClient,
+    cycleId: 7,
+    data: { policy: livePolicy, history: liveHistory },
+  });
+
+  controller.startEditing();
+  const draft = hydratePolicyDraft(livePolicy);
+  draft.prompt = 'Review incidents and owners.';
+  draft.guidance = ['Keep reports concise', 'Name the incident owner.'];
+  controller.updateDraft(draft);
+  await controller.reviewDraft();
+  assert.equal(controller.state.kind, 'review');
+  assert.deepEqual(controller.state.review.preview.changed_fields, ['prompt', 'guidance']);
+  assert.deepEqual(
+    controller.state.review.preview.diff.map(({ field, kind }) => [field, kind]),
+    [['prompt', 'value'], ['guidance', 'collection']],
+  );
+  controller.setRationale('Keep incident ownership current.');
+  await controller.applyReviewedChange();
+
+  assert.equal(controller.state.kind, 'view');
+  assert.equal(controller.state.data.policy.version, 2);
+  assert.equal(controller.state.data.policy.configuration.prompt, 'Review incidents and owners.');
+  assert.equal(controller.state.data.history.items[0].rationale, 'Keep incident ownership current.');
+  assert.equal(controller.state.data.history.items[0].actor_id, 'preview-user');
+
+  const appliedChangeId = controller.state.data.history.items[0].id;
+  await controller.beginRevert(appliedChangeId);
+  assert.equal(controller.state.kind, 'review');
+  assert.deepEqual(controller.state.review.preview.changed_fields, ['prompt', 'guidance']);
+  controller.setRationale('Restore the earlier preview behavior.');
+  await controller.applyReviewedChange(() => true);
+
+  assert.equal(controller.state.kind, 'view');
+  assert.equal(controller.state.data.policy.version, 3);
+  assert.equal(controller.state.data.policy.configuration.prompt, 'Review current priorities.');
+  assert.equal(controller.state.data.history.items[0].reverted_from_id, appliedChangeId);
+  assert.equal(controller.state.data.history.items[0].rationale, 'Restore the earlier preview behavior.');
 });

--- a/frontend/src/lib/utils/behaviorPolicyEditor.test.js
+++ b/frontend/src/lib/utils/behaviorPolicyEditor.test.js
@@ -1,0 +1,231 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  applyPolicyReview,
+  hydratePolicyDraft,
+  reviewPolicyDraft,
+  reviewPolicyRevert,
+} from '../features/cycles/domain/effectivePolicy.ts';
+
+function configuration(overrides = {}) {
+  return {
+    name: 'Morning review',
+    prompt: 'Review current priorities.',
+    schedule_expr: '0 9 * * *',
+    schedule_human: 'Every day at 9:00 AM (UTC)',
+    timezone: 'UTC',
+    enabled: true,
+    max_concurrency: 1,
+    timeout_seconds: null,
+    retry_policy: {},
+    model_override: null,
+    thinking_override: 'high',
+    execution_policy_key: null,
+    target_idea_id: null,
+    ...overrides,
+  };
+}
+
+function policy(version = 1, overrides = {}) {
+  return {
+    workspace_id: 'workspace-1',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: '7',
+    version,
+    revision_id: 10 + version,
+    configuration: configuration(overrides.configuration),
+    guidance: overrides.guidance ?? ['Keep reports concise'],
+    editable_fields: ['prompt', 'schedule_expr', 'timezone', 'enabled', 'model_override', 'thinking_override', 'guidance'],
+    output_targets: [],
+    output_targets_read_only: true,
+    source: {
+      revision_id: 10 + version,
+      actor_type: 'human',
+      actor_id: 'reviewer',
+      rationale: 'Approved behavior.',
+      source_reference: 'api:/cycles/7/behavior-policy',
+      changed_at: '2026-08-11T13:00:00Z',
+    },
+    field_sources: {},
+    latest_change: null,
+  };
+}
+
+function snapshot(nextPolicy = policy()) {
+  return {
+    configuration: nextPolicy.configuration,
+    guidance: nextPolicy.guidance,
+  };
+}
+
+function preview(overrides = {}) {
+  const beforePolicy = policy(1);
+  const afterPolicy = policy(1, { configuration: { prompt: 'Review incidents and owners.' } });
+  return {
+    expected_version: 1,
+    preview_digest: 'a'.repeat(64),
+    before: snapshot(beforePolicy),
+    after: snapshot(afterPolicy),
+    changed_fields: ['prompt'],
+    diff: [{
+      field: 'prompt',
+      kind: 'value',
+      before: beforePolicy.configuration.prompt,
+      after: afterPolicy.configuration.prompt,
+      added: null,
+      removed: null,
+    }],
+    warnings: [{ code: 'admitted_runs_unchanged', message: 'Active runs are unchanged.' }],
+    affected_runs: { admitted_runs: 'unchanged', future_runs: 'use_proposed_policy_after_apply' },
+    reverted_from_id: null,
+    ...overrides,
+  };
+}
+
+function history(items = []) {
+  return {
+    items,
+    pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
+  };
+}
+
+function client(overrides = {}) {
+  return {
+    previewCycleBehaviorPolicy: async () => preview(),
+    applyCycleBehaviorPolicy: async () => ({ effective_policy: policy(2), change: {} }),
+    previewCycleBehaviorPolicyRevert: async () => preview({ reverted_from_id: 41 }),
+    applyCycleBehaviorPolicyRevert: async () => ({ effective_policy: policy(2), change: {} }),
+    getCycleBehaviorPolicy: async () => policy(2),
+    getCycleBehaviorPolicyHistory: async () => history([{}]),
+    ...overrides,
+  };
+}
+
+test('requires review before apply and refuses apply without a rationale', async () => {
+  let applyCalls = 0;
+  const api = client({
+    applyCycleBehaviorPolicy: async () => {
+      applyCalls += 1;
+      return { effective_policy: policy(2), change: {} };
+    },
+  });
+
+  await assert.rejects(
+    applyPolicyReview(api, 7, null, 'Required reason'),
+    /Review the change before applying it/,
+  );
+  await assert.rejects(
+    applyPolicyReview(api, 7, { kind: 'edit', proposal: {}, preview: preview() }, '   '),
+    /Rationale is required/,
+  );
+  assert.equal(applyCalls, 0);
+});
+
+test('reviews a valid draft before apply and refreshes both effective policy and history after success', async () => {
+  const calls = [];
+  const api = client({
+    previewCycleBehaviorPolicy: async (_cycleId, body) => {
+      calls.push(['preview', body]);
+      return preview();
+    },
+    applyCycleBehaviorPolicy: async (_cycleId, body) => {
+      calls.push(['apply', body]);
+      return { effective_policy: policy(2), change: {} };
+    },
+    getCycleBehaviorPolicy: async () => {
+      calls.push(['refresh-policy']);
+      return policy(2);
+    },
+    getCycleBehaviorPolicyHistory: async () => {
+      calls.push(['refresh-history']);
+      return history([{}]);
+    },
+  });
+  const draft = hydratePolicyDraft(policy());
+  draft.prompt = 'Review incidents and owners.';
+
+  const reviewed = await reviewPolicyDraft(api, 7, draft, [], null);
+  assert.ok(reviewed.review);
+  assert.deepEqual(calls.map(([name]) => name), ['preview']);
+
+  const result = await applyPolicyReview(api, 7, reviewed.review, 'Keep incident ownership current.');
+  assert.equal(result.policy.version, 2);
+  assert.equal(result.history.items.length, 1);
+  assert.deepEqual(calls.map(([name]) => name), [
+    'preview',
+    'apply',
+    'refresh-policy',
+    'refresh-history',
+  ]);
+});
+
+test('client validation stops an invalid draft before the preview or apply API', async () => {
+  let previewCalls = 0;
+  const api = client({
+    previewCycleBehaviorPolicy: async () => {
+      previewCalls += 1;
+      return preview();
+    },
+  });
+  const draft = hydratePolicyDraft(policy());
+  draft.schedule_expr = 'bad cron';
+
+  const reviewed = await reviewPolicyDraft(api, 7, draft, [], null);
+
+  assert.equal(reviewed.review, null);
+  assert.match(reviewed.errors.schedule_expr, /valid five-field cron/);
+  assert.equal(previewCalls, 0);
+});
+
+test('revert requires explicit confirmation before it applies a new version', async () => {
+  const calls = [];
+  const api = client({
+    previewCycleBehaviorPolicyRevert: async (_cycleId, changeId) => {
+      calls.push(['revert-preview', changeId]);
+      return preview({ reverted_from_id: changeId });
+    },
+    applyCycleBehaviorPolicyRevert: async (_cycleId, changeId) => {
+      calls.push(['revert-apply', changeId]);
+      return { effective_policy: policy(2), change: {} };
+    },
+  });
+  const reviewed = await reviewPolicyRevert(api, 7, 41);
+
+  const cancelled = await applyPolicyReview(api, 7, reviewed, 'Restore the known-good behavior.', () => false);
+  assert.equal(cancelled, null);
+  assert.deepEqual(calls, [['revert-preview', 41]]);
+
+  await applyPolicyReview(api, 7, reviewed, 'Restore the known-good behavior.', () => true);
+  assert.deepEqual(calls.slice(0, 2), [['revert-preview', 41], ['revert-apply', 41]]);
+});
+
+test('the shipped editor keeps apply disabled without rationale and states the active-run boundary', () => {
+  const source = readFileSync(
+    new URL('../features/cycles/components/EffectiveCyclePolicyView.svelte', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(source, /disabled=\{applyDisabled\}/);
+  assert.match(source, /Active runs are unchanged\. Future runs use this policy only after apply\./);
+  assert.match(source, /beforeunload/);
+  assert.match(source, /Your draft is safe/);
+});
+
+test('existing Cycle surfaces no longer expose a direct behavior update path', () => {
+  const mainPage = readFileSync(
+    new URL('../../routes/cycles/+page.svelte', import.meta.url),
+    'utf8',
+  );
+  const threadPane = readFileSync(
+    new URL('../features/cycles/components/ThreadCyclesPane.svelte', import.meta.url),
+    'utf8',
+  );
+
+  assert.doesNotMatch(mainPage, /api\.updateCycle/);
+  assert.doesNotMatch(threadPane, /api\.updateCycle/);
+  assert.match(mainPage, /editable=\{!isCyclesPreview\}/);
+  assert.match(threadPane, /<EffectiveCyclePolicyView[\s\S]*?editable/);
+});

--- a/frontend/src/lib/utils/effectivePolicy.test.js
+++ b/frontend/src/lib/utils/effectivePolicy.test.js
@@ -3,10 +3,60 @@ import assert from 'node:assert/strict';
 
 import {
   formatPolicyDateTime,
+  guidanceDiff,
+  hydratePolicyDraft,
+  isPolicyDraftDirty,
   policyConfigurationEntries,
   policyFieldSource,
+  policyProposalFromDraft,
+  presentedPolicyDiff,
+  recoverPolicyDraftAfterConflict,
   retiredGuidance,
+  shouldConfirmPolicyDraftDiscard,
+  validatePolicyDraft,
 } from '../features/cycles/domain/effectivePolicy.ts';
+
+function effectivePolicy(overrides = {}) {
+  const configuration = {
+    name: 'Morning review',
+    prompt: 'Review current priorities.',
+    schedule_expr: '0 9 * * *',
+    schedule_human: 'Every day at 9:00 AM (UTC)',
+    timezone: 'UTC',
+    enabled: true,
+    max_concurrency: 1,
+    timeout_seconds: null,
+    retry_policy: {},
+    model_override: null,
+    thinking_override: 'high',
+    execution_policy_key: null,
+    target_idea_id: null,
+    ...overrides.configuration,
+  };
+  return {
+    workspace_id: 'workspace-1',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: '1',
+    version: overrides.version ?? 1,
+    revision_id: 10,
+    configuration,
+    guidance: overrides.guidance ?? ['Keep reports concise'],
+    editable_fields: ['prompt', 'schedule_expr', 'timezone', 'enabled', 'model_override', 'thinking_override', 'guidance'],
+    output_targets: [],
+    output_targets_read_only: true,
+    source: {
+      revision_id: 10,
+      actor_type: 'human',
+      actor_id: 'reviewer',
+      rationale: 'Initial behavior.',
+      source_reference: 'api:/cycles/1/behavior-policy',
+      changed_at: '2026-08-11T13:00:00Z',
+    },
+    field_sources: {},
+    latest_change: null,
+  };
+}
 
 test('renders every configuration field supplied by the typed policy object', () => {
   const configuration = {
@@ -60,4 +110,127 @@ test('formats UTC API timestamps in the display timezone', () => {
     formatPolicyDateTime('2026-08-11T16:00:00Z', 'America/Toronto', 'en-CA'),
     /12:00 p\.m\./,
   );
+});
+
+test('hydrates an isolated editable draft from the effective policy', () => {
+  const policy = effectivePolicy({
+    configuration: { model_override: 'openai/gpt-5.2', enabled: false },
+    guidance: ['Keep reports concise', 'Name the owner'],
+  });
+  const draft = hydratePolicyDraft(policy);
+
+  assert.deepEqual(draft, {
+    prompt: 'Review current priorities.',
+    schedule_expr: '0 9 * * *',
+    timezone: 'UTC',
+    enabled: false,
+    model_override: 'openai/gpt-5.2',
+    thinking_override: 'high',
+    guidance: ['Keep reports concise', 'Name the owner'],
+  });
+  draft.guidance[0] = 'Changed draft text';
+  assert.equal(policy.guidance[0], 'Keep reports concise');
+  assert.deepEqual(Object.keys(policyProposalFromDraft(draft)), [
+    'prompt',
+    'schedule_expr',
+    'timezone',
+    'enabled',
+    'model_override',
+    'thinking_override',
+    'guidance',
+  ]);
+});
+
+test('presents schedule evidence as stored cron plus human labels and guidance as retire plus add', () => {
+  const preview = {
+    diff: [
+      {
+        field: 'schedule_expr',
+        kind: 'schedule',
+        before: { schedule_expr: '0 9 * * *', schedule_human: 'Daily at 9 AM', timezone: 'UTC' },
+        after: { schedule_expr: '30 10 * * 1', schedule_human: 'Mondays at 10:30 AM', timezone: 'America/Toronto' },
+        added: null,
+        removed: null,
+      },
+      {
+        field: 'timezone',
+        kind: 'schedule',
+        before: { schedule_expr: '0 9 * * *', schedule_human: 'Daily at 9 AM', timezone: 'UTC' },
+        after: { schedule_expr: '30 10 * * 1', schedule_human: 'Mondays at 10:30 AM', timezone: 'America/Toronto' },
+        added: null,
+        removed: null,
+      },
+      {
+        field: 'guidance',
+        kind: 'collection',
+        before: ['Old wording'],
+        after: ['New wording'],
+        added: ['New wording'],
+        removed: ['Old wording'],
+      },
+    ],
+  };
+
+  assert.deepEqual(presentedPolicyDiff(preview), [
+    {
+      key: 'schedule',
+      kind: 'schedule',
+      field: 'schedule',
+      label: 'Schedule',
+      before: { schedule_expr: '0 9 * * *', schedule_human: 'Daily at 9 AM', timezone: 'UTC' },
+      after: { schedule_expr: '30 10 * * 1', schedule_human: 'Mondays at 10:30 AM', timezone: 'America/Toronto' },
+    },
+    {
+      key: 'guidance',
+      kind: 'guidance',
+      field: 'guidance',
+      label: 'Guidance',
+      added: ['New wording'],
+      retired: ['Old wording'],
+    },
+  ]);
+  assert.deepEqual(guidanceDiff(preview.diff[2]), {
+    added: ['New wording'],
+    retired: ['Old wording'],
+  });
+});
+
+test('keeps a dirty draft intact when conflict recovery adopts the latest live policy', () => {
+  const original = effectivePolicy();
+  const latest = effectivePolicy({
+    version: 2,
+    configuration: { prompt: 'Another person changed this.' },
+  });
+  const draft = hydratePolicyDraft(original);
+  draft.prompt = 'My unsubmitted draft.';
+
+  const recovered = recoverPolicyDraftAfterConflict(draft, latest);
+
+  assert.equal(recovered.draft.prompt, 'My unsubmitted draft.');
+  assert.equal(recovered.policy.version, 2);
+  assert.equal(recovered.policy.configuration.prompt, 'Another person changed this.');
+  assert.equal(isPolicyDraftDirty(recovered.draft, recovered.policy), true);
+});
+
+test('asks for dirty-draft protection only after a field changes', () => {
+  const policy = effectivePolicy();
+  const draft = hydratePolicyDraft(policy);
+  assert.equal(shouldConfirmPolicyDraftDiscard(draft, policy), false);
+  draft.guidance.push('New guidance');
+  assert.equal(shouldConfirmPolicyDraftDiscard(draft, policy), true);
+});
+
+test('rejects invalid schedules, empty missions, unsupported models, and duplicate guidance in the client', () => {
+  const draft = hydratePolicyDraft(effectivePolicy());
+  draft.prompt = '   ';
+  draft.schedule_expr = 'not a schedule';
+  draft.model_override = 'openai/not-a-model';
+  draft.guidance = ['Repeat this', ' Repeat this '];
+
+  assert.deepEqual(validatePolicyDraft(draft, [{ id: 'openai/gpt-5.2' }]), {
+    prompt: 'Mission prompt is required.',
+    schedule_expr: 'Use a valid five-field cron rule or one-time at: timestamp.',
+    model_override: 'Select a supported model.',
+    guidance: 'Guidance entries must be unique.',
+  });
 });

--- a/frontend/src/lib/utils/postMessageClone.ts
+++ b/frontend/src/lib/utils/postMessageClone.ts
@@ -25,7 +25,7 @@ function safeJsonValue(value: unknown, seen = new WeakSet<object>()): unknown {
   return output;
 }
 
-export function cloneForPostMessage<T>(value: T): T {
+export function clonePlainData<T>(value: T): T {
   if (!value || typeof value !== 'object') return value;
 
   try {
@@ -35,4 +35,8 @@ export function cloneForPostMessage<T>(value: T): T {
     if (jsonClone !== null) return jsonClone;
     return safeJsonValue(value) as T;
   }
+}
+
+export function cloneForPostMessage<T>(value: T): T {
+  return clonePlainData(value);
 }

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { dev } from '$app/environment';
   import { page } from '$app/stores';
-  import { getContext, onMount } from 'svelte';
+  import { getContext, onMount, setContext } from 'svelte';
 
   import {
     api,
@@ -29,8 +29,11 @@
   } from '$lib/components/constellation/constellationPageFrameContext';
   import AiPromptComposer from '$lib/features/composer/components/AiPromptComposer.svelte';
   import EffectiveCyclePolicyView from '$lib/features/cycles/components/EffectiveCyclePolicyView.svelte';
+  import type { CyclePolicyEditorApi } from '$lib/features/cycles/domain/effectivePolicy';
+  import { EFFECTIVE_POLICY_CLIENT_CONTEXT } from '$lib/features/cycles/domain/effectivePolicyClientContext';
   import { ui } from '$lib/stores/ui.svelte';
   import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
+  import { createPreviewBehaviorPolicyClient } from './previewBehaviorPolicy';
 
   type ThinkingLevel = '' | 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   type ScheduleCadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
@@ -112,8 +115,14 @@
   let previewRuns = $state<Record<number, CycleRunRead[]>>({});
   let previewPolicies = $state<Record<number, EffectiveCyclePolicyRead>>({});
   let previewPolicyHistories = $state<Record<number, CyclePolicyHistoryRead>>({});
+  let previewPolicyClients: Record<number, CyclePolicyEditorApi> = {};
   let behaviorPolicyRefreshSerial = $state(0);
   let behaviorPolicyDirty = $state(false);
+
+  setContext(
+    EFFECTIVE_POLICY_CLIENT_CONTEXT,
+    (cycleId: number) => previewPolicyClients[cycleId],
+  );
 
   const workspacePageModalContext = getContext<ConstellationPageFrameModalContext | undefined>(
     CONSTELLATION_PAGE_FRAME_MODAL_CONTEXT,
@@ -431,6 +440,25 @@
     const { policy, history } = previewBehaviorPolicy(cycle);
     previewPolicies = { ...previewPolicies, [cycle.id]: policy };
     previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: history };
+    previewPolicyClients[cycle.id] = createPreviewBehaviorPolicyClient({
+      cycleId: cycle.id,
+      getPolicy: () => previewPolicies[cycle.id],
+      getHistory: () => previewPolicyHistories[cycle.id],
+      commit: (nextPolicy, nextHistory) => {
+        previewPolicies = { ...previewPolicies, [cycle.id]: nextPolicy };
+        previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: nextHistory };
+      },
+      scheduleLabel: (scheduleExpression, timezone) => {
+        const parsed = parseSchedule(scheduleExpression);
+        if (parsed.cadence === 'custom') return 'Custom schedule';
+        return scheduleLabelForForm({
+          ...emptyForm(),
+          ...parsed,
+          schedule_expr: scheduleExpression,
+          timezone,
+        });
+      },
+    });
   }
 
   function loadPreviewData() {
@@ -847,8 +875,24 @@
     return !behaviorPolicyDirty || window.confirm('Discard the current behavior draft?');
   }
 
-  async function handlePolicyApplied() {
+  async function handlePolicyApplied(policy: EffectiveCyclePolicyRead) {
     behaviorPolicyDirty = false;
+    if (isCyclesPreview) {
+      cycles = cycles.map((cycle) => cycle.id === Number(policy.target_id)
+        ? {
+            ...cycle,
+            prompt: policy.configuration.prompt,
+            schedule_expr: policy.configuration.schedule_expr,
+            schedule_human: policy.configuration.schedule_human,
+            timezone: policy.configuration.timezone,
+            enabled: policy.configuration.enabled,
+            model_override: policy.configuration.model_override,
+            thinking_override: policy.configuration.thinking_override,
+            updated_at: policy.source.changed_at ?? cycle.updated_at,
+          }
+        : cycle);
+      return;
+    }
     await loadCycles(selectedCycleId);
   }
 
@@ -1092,7 +1136,7 @@
                     previewPolicy={isCyclesPreview ? previewPolicies[cycle.id] : null}
                     previewHistory={isCyclesPreview ? previewPolicyHistories[cycle.id] : null}
                     displayTimezone={isCyclesPreview ? localTimezone : null}
-                    editable={!isCyclesPreview}
+                    editable
                     refreshSerial={behaviorPolicyRefreshSerial}
                     onPolicyApplied={handlePolicyApplied}
                     onDirtyChange={(dirty) => (behaviorPolicyDirty = dirty)}

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -113,6 +113,7 @@
   let previewPolicies = $state<Record<number, EffectiveCyclePolicyRead>>({});
   let previewPolicyHistories = $state<Record<number, CyclePolicyHistoryRead>>({});
   let behaviorPolicyRefreshSerial = $state(0);
+  let behaviorPolicyDirty = $state(false);
 
   const workspacePageModalContext = getContext<ConstellationPageFrameModalContext | undefined>(
     CONSTELLATION_PAGE_FRAME_MODAL_CONTEXT,
@@ -161,12 +162,6 @@
       return cycleSearchText(cycle).includes(needle);
     });
   });
-  const selectedRunThreadId = $derived.by(
-    () => runs.find((run) => Boolean(run.idea_id))?.idea_id ?? null,
-  );
-  const selectedThreadId = $derived.by(
-    () => selectedCycle?.target_idea_id || selectedRunThreadId,
-  );
   const schedulePreview = $derived.by(() => scheduleLabelForForm(form));
 
   function toneForStatus(status: string | null | undefined): PillTone {
@@ -494,7 +489,6 @@
     };
     selectedCycleId = previewCycles[0].id;
     selectedRowId = cycleRowId(previewCycles[0]);
-    fillForm(previewCycles[0]);
     runs = previewRuns[previewCycles[0].id] ?? [];
     loading = false;
   }
@@ -742,31 +736,9 @@
     return cycle.target_idea_id ? 'Same thread' : 'Thread after first run';
   }
 
-  function fillForm(cycle: CycleRead | null) {
-    if (!cycle) {
-      form = emptyForm();
-      advancedOpen = false;
-      return;
-    }
-
-    const parsed = parseSchedule(cycle.schedule_expr);
-    form = {
-      name: cycle.name,
-      prompt: cycle.prompt,
-      schedule_expr: cycle.schedule_expr,
-      cadence: parsed.cadence,
-      date: parsed.date,
-      time: parsed.time,
-      weekday: parsed.weekday,
-      monthday: parsed.monthday,
-      custom_schedule: parsed.custom_schedule,
-      timezone: cycle.timezone || localTimezone,
-      enabled: cycle.enabled,
-      model_override: cycle.model_override || '',
-      thinking_override: (cycle.thinking_override as ThinkingLevel) || '',
-      target_idea_id: cycle.target_idea_id || '',
-    };
-    advancedOpen = parsed.cadence === 'custom' || Boolean(cycle.model_override || cycle.thinking_override);
+  function resetCreateForm() {
+    form = emptyForm();
+    advancedOpen = false;
   }
 
   function setCadence(cadence: ScheduleCadence) {
@@ -817,13 +789,12 @@
       if (nextSelectedCycle) {
         selectedCycleId = nextSelectedCycle.id;
         selectedRowId = cycleRowId(nextSelectedCycle);
-        fillForm(nextSelectedCycle);
         await loadRuns(nextSelectedCycle.id);
       } else if (selectedRowId !== 'draft') {
         selectedCycleId = null;
         selectedRowId = null;
         runs = [];
-        fillForm(null);
+        resetCreateForm();
       }
     } catch (err: any) {
       loadError = err.detail || 'Failed to load cycles';
@@ -832,28 +803,30 @@
       runs = [];
       selectedCycleId = null;
       selectedRowId = null;
-      fillForm(null);
+      resetCreateForm();
     } finally {
       loading = false;
     }
   }
 
   function createNewCycle() {
+    if (!confirmDiscardBehaviorDraft()) return;
     selectedCycleId = null;
     selectedRowId = null;
     runs = [];
-    fillForm(null);
+    resetCreateForm();
     showCreateModal = true;
   }
 
   function closeCreateModal() {
     showCreateModal = false;
     if (!selectedCycleId) {
-      fillForm(null);
+      resetCreateForm();
     }
   }
 
   async function selectCycle(cycleId: number) {
+    if (!confirmDiscardBehaviorDraft()) return;
     showCreateModal = false;
     const cycle = cycles.find((item) => item.id === cycleId) ?? null;
     if (!cycle) return;
@@ -862,17 +835,24 @@
       selectedCycleId = null;
       selectedRowId = null;
       runs = [];
-      fillForm(null);
+      resetCreateForm();
       return;
     }
     selectedCycleId = cycleId;
     selectedRowId = rowId;
-    fillForm(cycle);
     await loadRuns(cycleId);
   }
 
+  function confirmDiscardBehaviorDraft(): boolean {
+    return !behaviorPolicyDirty || window.confirm('Discard the current behavior draft?');
+  }
+
+  async function handlePolicyApplied() {
+    behaviorPolicyDirty = false;
+    await loadCycles(selectedCycleId);
+  }
+
   async function saveCycle() {
-    const isCreate = !selectedCycleId;
     const scheduleExpr = scheduleExprFromForm();
     const payload = {
       name: form.name.trim(),
@@ -883,7 +863,7 @@
       model_override: form.model_override.trim() || null,
       thinking_override: form.thinking_override || null,
       execution_mode: 'reuse_same_idea' as const,
-      target_idea_id: form.target_idea_id || selectedRunThreadId || null,
+      target_idea_id: form.target_idea_id || null,
       reopen_archived: true,
     };
 
@@ -896,10 +876,8 @@
     try {
       if (isCyclesPreview) {
         const now = new Date().toISOString();
-        const savedId = selectedCycleId ?? Math.max(900, ...cycles.map((cycle) => cycle.id)) + 1;
-        const existing = cycles.find((cycle) => cycle.id === savedId);
+        const savedId = Math.max(900, ...cycles.map((cycle) => cycle.id)) + 1;
         const saved = previewCycle(savedId, {
-          ...existing,
           name: payload.name,
           prompt: payload.prompt,
           schedule_expr: payload.schedule_expr,
@@ -908,31 +886,27 @@
           enabled: payload.enabled,
           model_override: payload.model_override,
           thinking_override: payload.thinking_override,
-          target_idea_id: payload.target_idea_id ?? existing?.target_idea_id ?? `preview-cycle-${savedId}`,
+          target_idea_id: payload.target_idea_id ?? `preview-cycle-${savedId}`,
           next_run_at: previewNextRunAtForSchedule(payload.schedule_expr, payload.enabled),
-          last_run_at: existing?.last_run_at ?? null,
-          last_status: existing?.last_status ?? 'idle',
+          last_run_at: null,
+          last_status: 'idle',
           last_error: null,
-          created_at: existing?.created_at ?? now,
+          created_at: now,
           updated_at: now,
         });
-        cycles = existing
-          ? cycles.map((cycle) => (cycle.id === savedId ? saved : cycle))
-          : [saved, ...cycles];
+        cycles = [saved, ...cycles];
         setPreviewBehaviorPolicy(saved);
         selectedCycleId = saved.id;
         selectedRowId = cycleRowId(saved);
-        fillForm(saved);
+        resetCreateForm();
         runs = previewRuns[saved.id] ?? [];
-        if (isCreate) showCreateModal = false;
-        ui.toast(existing ? 'Preview cycle updated' : 'Preview cycle created', 'success');
+        showCreateModal = false;
+        ui.toast('Preview cycle created', 'success');
         return;
       }
-      const saved = selectedCycleId
-        ? await api.updateCycle(selectedCycleId, payload)
-        : await api.createCycle(payload);
-      ui.toast(selectedCycleId ? 'Cycle updated' : 'Cycle created', 'success');
-      if (isCreate) showCreateModal = false;
+      const saved = await api.createCycle(payload);
+      ui.toast('Cycle created', 'success');
+      showCreateModal = false;
       await loadCycles(saved.id);
       behaviorPolicyRefreshSerial += 1;
     } catch (err: any) {
@@ -959,7 +933,7 @@
         selectedCycleId = null;
         selectedRowId = null;
         runs = [];
-        fillForm(null);
+        resetCreateForm();
         ui.toast('Preview cycle deleted', 'success');
         return;
       }
@@ -998,36 +972,6 @@
       await loadCycles(cycleId);
     } catch (err: any) {
       ui.toast(err.detail || 'Failed to run cycle', 'error');
-    }
-  }
-
-  async function toggleEnabled(cycle: CycleRead) {
-    const preferredCycleId = selectedCycleId;
-    try {
-      if (isCyclesPreview) {
-        cycles = cycles.map((item) =>
-          item.id === cycle.id
-            ? {
-                ...item,
-                enabled: !item.enabled,
-                next_run_at: !item.enabled ? previewNextRunAtForSchedule(item.schedule_expr, true) : null,
-                updated_at: new Date().toISOString(),
-              }
-            : item,
-        );
-        const updated = cycles.find((item) => item.id === cycle.id);
-        if (updated && preferredCycleId === updated.id) {
-          fillForm(updated);
-          setPreviewBehaviorPolicy(updated);
-        }
-        ui.toast(updated?.enabled ? 'Preview cycle resumed' : 'Preview cycle paused', 'success');
-        return;
-      }
-      await api.updateCycle(cycle.id, { enabled: !cycle.enabled });
-      await loadCycles(preferredCycleId);
-      behaviorPolicyRefreshSerial += 1;
-    } catch (err: any) {
-      ui.toast(err.detail || 'Failed to update cycle', 'error');
     }
   }
 
@@ -1124,12 +1068,6 @@
                       <ConstellationButton variant="quiet" size="sm" onclick={() => runNow(cycle.id)}>
                         Run now
                       </ConstellationButton>
-                      <ConstellationButton variant="quiet" size="sm" onclick={() => toggleEnabled(cycle)}>
-                        {cycle.enabled ? 'Pause' : 'Resume'}
-                      </ConstellationButton>
-                      <ConstellationButton variant="secondary" size="sm" loading={saving} onclick={saveCycle}>
-                        Save
-                      </ConstellationButton>
                       <ConstellationButton
                         variant="destructive"
                         size="sm"
@@ -1154,212 +1092,11 @@
                     previewPolicy={isCyclesPreview ? previewPolicies[cycle.id] : null}
                     previewHistory={isCyclesPreview ? previewPolicyHistories[cycle.id] : null}
                     displayTimezone={isCyclesPreview ? localTimezone : null}
+                    editable={!isCyclesPreview}
                     refreshSerial={behaviorPolicyRefreshSerial}
+                    onPolicyApplied={handlePolicyApplied}
+                    onDirtyChange={(dirty) => (behaviorPolicyDirty = dirty)}
                   />
-
-                  <details class="cycle-region" open>
-                    <summary>
-                      <span>Editor</span>
-                      <small>{schedulePreview}</small>
-                    </summary>
-                    <div class="cycle-form">
-                      <section class="cycle-form-section" aria-labelledby={`cycle-${cycle.id}-basics-heading`}>
-                        <div class="cycle-form-section-heading">
-                          <h3 id={`cycle-${cycle.id}-basics-heading`}>Basics</h3>
-                        </div>
-
-                        <div class="cycle-form-grid">
-                          <label class="cycle-field cycle-field-full">
-                            <span class="cycle-field-label">Name</span>
-                            <input bind:value={form.name} class="cycle-input" placeholder="Morning briefing" />
-                          </label>
-
-                          <label class="cycle-field cycle-field-full">
-                            <span class="cycle-field-label">Prompt</span>
-                            <AiPromptComposer
-                              bind:value={form.prompt}
-                              className="cycle-prompt-composer"
-                              rows={7}
-                              minHeight={176}
-                              maxHeight={320}
-                              slashPlacement="below"
-                              ariaLabel="Cycle prompt"
-                              placeholder="Review my latest priorities and tell me what needs attention."
-                            />
-                          </label>
-                        </div>
-                      </section>
-
-                      <section class="cycle-form-section" aria-labelledby={`cycle-${cycle.id}-schedule-heading`}>
-                        <div class="cycle-form-section-heading">
-                          <h3 id={`cycle-${cycle.id}-schedule-heading`}>When</h3>
-                          <p>{schedulePreview}</p>
-                        </div>
-
-                        <div class="cadence-grid" role="group" aria-label="Schedule frequency">
-                          {#each CADENCE_OPTIONS as option}
-                            <button
-                              type="button"
-                              class="cadence-option"
-                              class:active={form.cadence === option.value}
-                              aria-pressed={form.cadence === option.value}
-                              onclick={() => setCadence(option.value)}
-                            >
-                              <span>{option.label}</span>
-                              <small>{option.description}</small>
-                            </button>
-                          {/each}
-                        </div>
-
-                        {#if form.cadence !== 'custom'}
-                          <div class="schedule-fields">
-                            {#if form.cadence === 'once'}
-                              <label class="cycle-field">
-                                <span class="cycle-field-label">Date</span>
-                                <input bind:value={form.date} class="cycle-input" type="date" />
-                              </label>
-                            {/if}
-
-                            <label class="cycle-field">
-                              <span class="cycle-field-label">Time</span>
-                              <input bind:value={form.time} class="cycle-input" type="time" />
-                            </label>
-
-                            {#if form.cadence === 'weekly'}
-                              <label class="cycle-field">
-                                <span class="cycle-field-label">Day</span>
-                                <select bind:value={form.weekday} class="cycle-select">
-                                  {#each WEEKDAY_OPTIONS as option}
-                                    <option value={option.value}>{option.label}</option>
-                                  {/each}
-                                </select>
-                              </label>
-                            {:else if form.cadence === 'monthly'}
-                              <label class="cycle-field">
-                                <span class="cycle-field-label">Day of month</span>
-                                <select bind:value={form.monthday} class="cycle-select">
-                                  {#each MONTHDAY_OPTIONS as day}
-                                    <option value={day}>{day}</option>
-                                  {/each}
-                                </select>
-                              </label>
-                            {/if}
-                          </div>
-                        {/if}
-
-                        <p class="local-time-note">
-                          Runs in your local time: {friendlyTimezone(localTimezone)}
-                        </p>
-                      </section>
-
-                      <section class="cycle-form-section" aria-labelledby={`cycle-${cycle.id}-thread-heading`}>
-                        <div class="cycle-form-section-heading">
-                          <h3 id={`cycle-${cycle.id}-thread-heading`}>Thread</h3>
-                        </div>
-
-                        <div class="thread-status">
-                          <div>
-                            <strong>
-                              {#if selectedThreadId}
-                                Continues in the same thread
-                              {:else}
-                                Thread will be created on first run
-                              {/if}
-                            </strong>
-                            <p>
-                              {#if selectedThreadId}
-                                Future runs return here, even if the thread gets archived.
-                              {:else}
-                                After the first run, this cycle will keep using that thread automatically.
-                              {/if}
-                            </p>
-                          </div>
-
-                          {#if selectedThreadId}
-                            <a class="cycle-link" href={`/cortex?idea=${selectedThreadId}`}>
-                              Open thread
-                            </a>
-                          {/if}
-                        </div>
-                      </section>
-
-                      <section class="cycle-form-section" aria-labelledby={`cycle-${cycle.id}-status-heading`}>
-                        <div class="cycle-form-section-heading">
-                          <h3 id={`cycle-${cycle.id}-status-heading`}>Status</h3>
-                        </div>
-
-                        <button
-                          type="button"
-                          class="status-switch"
-                          class:active={form.enabled}
-                          aria-pressed={form.enabled}
-                          onclick={() => (form.enabled = !form.enabled)}
-                        >
-                          <span aria-hidden="true"></span>
-                          <strong>{form.enabled ? 'Active' : 'Paused'}</strong>
-                          <small>
-                            {form.enabled
-                              ? 'Runs automatically on the schedule above.'
-                              : 'Kept for later, but will not run automatically.'}
-                          </small>
-                        </button>
-                      </section>
-
-                      <section class="cycle-advanced">
-                        <button
-                          type="button"
-                          class="advanced-toggle"
-                          aria-expanded={advancedOpen}
-                          onclick={() => (advancedOpen = !advancedOpen)}
-                        >
-                          <span>Advanced settings</span>
-                          <span aria-hidden="true">{advancedOpen ? 'Hide' : 'Show'}</span>
-                        </button>
-
-                        {#if advancedOpen}
-                          <div class="advanced-fields">
-                            {#if form.cadence === 'custom'}
-                              <label class="cycle-field cycle-field-full">
-                                <span class="cycle-field-label">Custom schedule</span>
-                                <input
-                                  bind:value={form.custom_schedule}
-                                  class="cycle-input cycle-mono"
-                                  placeholder="0 9 * * *"
-                                />
-                                <span class="cycle-field-hint">
-                                  Use this only when Once, Daily, Weekdays, Weekly, or Monthly does not cover the cycle.
-                                </span>
-                              </label>
-                            {/if}
-
-                            <label class="cycle-field">
-                              <span class="cycle-field-label">Model override</span>
-                              <input
-                                bind:value={form.model_override}
-                                class="cycle-input cycle-mono"
-                                placeholder="Use default"
-                              />
-                            </label>
-
-                            <label class="cycle-field">
-                              <span class="cycle-field-label">Reasoning</span>
-                              <select bind:value={form.thinking_override} class="cycle-select">
-                                {#each THINKING_OPTIONS as option}
-                                  <option value={option.value}>{option.label}</option>
-                                {/each}
-                              </select>
-                            </label>
-                          </div>
-                        {/if}
-                      </section>
-
-                      <div class="cycle-form-actions">
-                        <ConstellationButton variant="primary" loading={saving} onclick={saveCycle}>
-                          Save cycle
-                        </ConstellationButton>
-                      </div>
-                    </div>
-                  </details>
 
                   <details class="cycle-region" open>
                     <summary>
@@ -1794,7 +1531,6 @@
 
   .cycle-region summary span,
   .cycle-form-section-heading h3,
-  .thread-status strong,
   .status-switch strong,
   .advanced-toggle span:first-child,
   .run-row-main strong {
@@ -1985,22 +1721,6 @@
     max-width: 520px;
   }
 
-  .thread-status {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 18px;
-    min-width: 0;
-    padding: 12px;
-    border: 1px solid var(--constellation-surface-panel-separator);
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--constellation-color-text-primary) 2%, transparent);
-  }
-
-  .thread-status p {
-    margin: 5px 0 0;
-  }
-
   .status-switch {
     display: grid;
     grid-template-columns: auto minmax(0, max-content) minmax(0, 1fr);
@@ -2165,8 +1885,7 @@
       max-width: none;
     }
 
-    .cycle-form-section-heading,
-    .thread-status {
+    .cycle-form-section-heading {
       align-items: flex-start;
       flex-direction: column;
     }

--- a/frontend/src/routes/cycles/previewBehaviorPolicy.ts
+++ b/frontend/src/routes/cycles/previewBehaviorPolicy.ts
@@ -9,6 +9,8 @@ import type {
   EffectiveCyclePolicyRead,
 } from '$lib/api/client';
 
+import { clonePlainData } from '../../lib/utils/postMessageClone.ts';
+
 import {
   POLICY_FIELD_SCHEMA,
   type CyclePolicyEditorApi,
@@ -29,13 +31,9 @@ type PendingPreview = {
   revertedFromId: number | null;
 };
 
-function clone<Value>(value: Value): Value {
-  return structuredClone(value);
-}
-
 function snapshot(policy: EffectiveCyclePolicyRead): CyclePolicySnapshotRead {
   return {
-    configuration: clone(policy.configuration),
+    configuration: clonePlainData(policy.configuration),
     guidance: [...policy.guidance],
   };
 }
@@ -114,7 +112,7 @@ function conflict(policy: EffectiveCyclePolicyRead): never {
     status: 409,
     detail: {
       reason: 'version_conflict',
-      latest_effective_policy: clone(policy),
+      latest_effective_policy: clonePlainData(policy),
     },
   };
 }
@@ -163,7 +161,7 @@ export function createPreviewBehaviorPolicyClient(
       expected_version: policy.version,
       preview_digest: nextDigest(),
       before,
-      after: clone(after),
+      after: clonePlainData(after),
       changed_fields: changedFields,
       diff,
       warnings: [{
@@ -177,7 +175,7 @@ export function createPreviewBehaviorPolicyClient(
       reverted_from_id: revertedFromId,
     };
     pending.set(preview.preview_digest, { preview, revertedFromId });
-    return clone(preview);
+    return clonePlainData(preview);
   }
 
   function applyPending(
@@ -202,7 +200,7 @@ export function createPreviewBehaviorPolicyClient(
       actor_id: 'preview-user',
       source_reference: `preview:/cycles/${options.cycleId}/behavior-policy`,
     };
-    const after = clone(pendingPreview.preview.after);
+    const after = clonePlainData(pendingPreview.preview.after);
     const change: CyclePolicyChangeRead = {
       id: changeId,
       version,
@@ -215,7 +213,7 @@ export function createPreviewBehaviorPolicyClient(
       policy_kind: policy.policy_kind,
       target_type: policy.target_type,
       target_id: policy.target_id,
-      before_snapshot: clone(pendingPreview.preview.before),
+      before_snapshot: clonePlainData(pendingPreview.preview.before),
       after_snapshot: after,
       cycle_revision_id: revisionId,
     };
@@ -234,7 +232,7 @@ export function createPreviewBehaviorPolicyClient(
       ...policy,
       version,
       revision_id: revisionId,
-      configuration: clone(after.configuration),
+      configuration: clonePlainData(after.configuration),
       guidance: [...after.guidance],
       source: {
         revision_id: revisionId,
@@ -264,17 +262,17 @@ export function createPreviewBehaviorPolicyClient(
     };
     options.commit(nextPolicy, nextHistory);
     pending.delete(previewDigest);
-    return { effective_policy: clone(nextPolicy), change: clone(change) };
+    return { effective_policy: clonePlainData(nextPolicy), change: clonePlainData(change) };
   }
 
   const client: CyclePolicyEditorApi = {
-    getCycleBehaviorPolicy: async () => clone(options.getPolicy()),
+    getCycleBehaviorPolicy: async () => clonePlainData(options.getPolicy()),
     getCycleBehaviorPolicyHistory: async (_cycleId, limit = 50, offset = 0) => {
       const history = options.getHistory();
       const items = history.items.slice(offset, offset + limit);
       const nextOffset = offset + items.length;
       return {
-        items: clone(items),
+        items: clonePlainData(items),
         pagination: {
           limit,
           offset,
@@ -296,7 +294,7 @@ export function createPreviewBehaviorPolicyClient(
       const policy = options.getPolicy();
       const change = options.getHistory().items.find((item) => item.id === changeId);
       if (!change) throw new Error('The selected history entry is not available.');
-      return createPreview(policy, clone(change.before_snapshot), changeId);
+      return createPreview(policy, clonePlainData(change.before_snapshot), changeId);
     },
     applyCycleBehaviorPolicyRevert: async (_cycleId, _changeId, request) => applyPending(
       request.expected_version,

--- a/frontend/src/routes/cycles/previewBehaviorPolicy.ts
+++ b/frontend/src/routes/cycles/previewBehaviorPolicy.ts
@@ -1,0 +1,308 @@
+import type {
+  CyclePolicyChangeRead,
+  CyclePolicyConfigurationRead,
+  CyclePolicyDiffEntryRead,
+  CyclePolicyHistoryRead,
+  CyclePolicyPreviewRead,
+  CyclePolicyProposal,
+  CyclePolicySnapshotRead,
+  EffectiveCyclePolicyRead,
+} from '$lib/api/client';
+
+import {
+  POLICY_FIELD_SCHEMA,
+  type CyclePolicyEditorApi,
+  type CyclePolicyFieldKey,
+} from '../../lib/features/cycles/domain/effectivePolicy.ts';
+
+type PreviewPolicyClientOptions = {
+  cycleId: number;
+  getPolicy: () => EffectiveCyclePolicyRead;
+  getHistory: () => CyclePolicyHistoryRead;
+  commit: (policy: EffectiveCyclePolicyRead, history: CyclePolicyHistoryRead) => void;
+  scheduleLabel: (scheduleExpression: string, timezone: string) => string;
+  now?: () => string;
+};
+
+type PendingPreview = {
+  preview: CyclePolicyPreviewRead;
+  revertedFromId: number | null;
+};
+
+function clone<Value>(value: Value): Value {
+  return structuredClone(value);
+}
+
+function snapshot(policy: EffectiveCyclePolicyRead): CyclePolicySnapshotRead {
+  return {
+    configuration: clone(policy.configuration),
+    guidance: [...policy.guidance],
+  };
+}
+
+function snapshotField(
+  policySnapshot: CyclePolicySnapshotRead,
+  field: CyclePolicyFieldKey,
+): unknown {
+  if (field === 'guidance') return policySnapshot.guidance;
+  return policySnapshot.configuration[field];
+}
+
+function sameValue(before: unknown, after: unknown): boolean {
+  return JSON.stringify(before) === JSON.stringify(after);
+}
+
+function scheduleDiffValue(configuration: CyclePolicyConfigurationRead) {
+  return {
+    schedule_expr: configuration.schedule_expr,
+    schedule_human: configuration.schedule_human,
+    timezone: configuration.timezone,
+  };
+}
+
+function semanticDiff(
+  before: CyclePolicySnapshotRead,
+  after: CyclePolicySnapshotRead,
+): { changedFields: CyclePolicyFieldKey[]; diff: CyclePolicyDiffEntryRead[] } {
+  const changedFields = POLICY_FIELD_SCHEMA
+    .filter((field) => !sameValue(snapshotField(before, field.key), snapshotField(after, field.key)))
+    .map((field) => field.key);
+  const diff: CyclePolicyDiffEntryRead[] = [];
+
+  if (changedFields.includes('schedule_expr') || changedFields.includes('timezone')) {
+    diff.push({
+      field: 'schedule_expr',
+      kind: 'schedule',
+      before: scheduleDiffValue(before.configuration),
+      after: scheduleDiffValue(after.configuration),
+      added: null,
+      removed: null,
+    });
+  }
+
+  for (const field of changedFields) {
+    if (field === 'schedule_expr' || field === 'timezone') continue;
+    const beforeValue = snapshotField(before, field);
+    const afterValue = snapshotField(after, field);
+    if (field === 'guidance') {
+      const beforeGuidance = before.guidance;
+      const afterGuidance = after.guidance;
+      diff.push({
+        field,
+        kind: 'collection',
+        before: beforeGuidance,
+        after: afterGuidance,
+        added: afterGuidance.filter((item) => !beforeGuidance.includes(item)),
+        removed: beforeGuidance.filter((item) => !afterGuidance.includes(item)),
+      });
+      continue;
+    }
+    diff.push({
+      field,
+      kind: 'value',
+      before: beforeValue as CyclePolicyDiffEntryRead['before'],
+      after: afterValue as CyclePolicyDiffEntryRead['after'],
+      added: null,
+      removed: null,
+    });
+  }
+  return { changedFields, diff };
+}
+
+function conflict(policy: EffectiveCyclePolicyRead): never {
+  throw {
+    status: 409,
+    detail: {
+      reason: 'version_conflict',
+      latest_effective_policy: clone(policy),
+    },
+  };
+}
+
+export function createPreviewBehaviorPolicyClient(
+  options: PreviewPolicyClientOptions,
+): CyclePolicyEditorApi {
+  let previewSerial = 0;
+  const pending = new Map<string, PendingPreview>();
+
+  function nextDigest(): string {
+    previewSerial += 1;
+    return String(previewSerial).padStart(64, '0');
+  }
+
+  function afterProposal(
+    policy: EffectiveCyclePolicyRead,
+    proposal: CyclePolicyProposal,
+  ): CyclePolicySnapshotRead {
+    const after = snapshot(policy);
+    const configuration = after.configuration;
+    const configurationFields = configuration as unknown as Record<string, unknown>;
+    for (const field of POLICY_FIELD_SCHEMA) {
+      if (field.key === 'guidance') {
+        if (proposal.guidance !== undefined) after.guidance = [...(proposal.guidance ?? [])];
+        continue;
+      }
+      const value = proposal[field.key];
+      if (value !== undefined) configurationFields[field.key] = value;
+    }
+    configuration.schedule_human = options.scheduleLabel(
+      configuration.schedule_expr,
+      configuration.timezone,
+    );
+    return after;
+  }
+
+  function createPreview(
+    policy: EffectiveCyclePolicyRead,
+    after: CyclePolicySnapshotRead,
+    revertedFromId: number | null,
+  ): CyclePolicyPreviewRead {
+    const before = snapshot(policy);
+    const { changedFields, diff } = semanticDiff(before, after);
+    const preview: CyclePolicyPreviewRead = {
+      expected_version: policy.version,
+      preview_digest: nextDigest(),
+      before,
+      after: clone(after),
+      changed_fields: changedFields,
+      diff,
+      warnings: [{
+        code: 'admitted_runs_unchanged',
+        message: 'Active runs are unchanged.',
+      }],
+      affected_runs: {
+        admitted_runs: 'unchanged',
+        future_runs: 'use_proposed_policy_after_apply',
+      },
+      reverted_from_id: revertedFromId,
+    };
+    pending.set(preview.preview_digest, { preview, revertedFromId });
+    return clone(preview);
+  }
+
+  function applyPending(
+    expectedVersion: number,
+    previewDigest: string,
+    rationale: string,
+  ) {
+    const policy = options.getPolicy();
+    if (policy.version !== expectedVersion) conflict(policy);
+    const pendingPreview = pending.get(previewDigest);
+    if (!pendingPreview || pendingPreview.preview.expected_version !== expectedVersion) {
+      throw new Error('Review this behavior change again before apply.');
+    }
+
+    const appliedAt = options.now?.() ?? new Date().toISOString();
+    const history = options.getHistory();
+    const version = policy.version + 1;
+    const revisionId = (policy.revision_id ?? 0) + 1;
+    const changeId = Math.max(0, ...history.items.map((change) => change.id)) + 1;
+    const actor = {
+      actor_type: 'human',
+      actor_id: 'preview-user',
+      source_reference: `preview:/cycles/${options.cycleId}/behavior-policy`,
+    };
+    const after = clone(pendingPreview.preview.after);
+    const change: CyclePolicyChangeRead = {
+      id: changeId,
+      version,
+      ...actor,
+      rationale: rationale.trim(),
+      changed_fields: [...pendingPreview.preview.changed_fields],
+      applied_at: appliedAt,
+      reverted_from_id: pendingPreview.revertedFromId,
+      workspace_id: policy.workspace_id,
+      policy_kind: policy.policy_kind,
+      target_type: policy.target_type,
+      target_id: policy.target_id,
+      before_snapshot: clone(pendingPreview.preview.before),
+      after_snapshot: after,
+      cycle_revision_id: revisionId,
+    };
+    const fieldSources = { ...policy.field_sources };
+    for (const field of change.changed_fields) {
+      fieldSources[field] = {
+        version,
+        cycle_revision_id: revisionId,
+        ...actor,
+        rationale: rationale.trim(),
+        changed_at: appliedAt,
+        change_id: changeId,
+      };
+    }
+    const nextPolicy: EffectiveCyclePolicyRead = {
+      ...policy,
+      version,
+      revision_id: revisionId,
+      configuration: clone(after.configuration),
+      guidance: [...after.guidance],
+      source: {
+        revision_id: revisionId,
+        ...actor,
+        rationale: rationale.trim(),
+        changed_at: appliedAt,
+      },
+      field_sources: fieldSources,
+      latest_change: {
+        id: change.id,
+        version,
+        ...actor,
+        rationale: change.rationale,
+        changed_fields: [...change.changed_fields],
+        applied_at: appliedAt,
+        reverted_from_id: change.reverted_from_id,
+      },
+    };
+    const nextHistory: CyclePolicyHistoryRead = {
+      items: [change, ...history.items],
+      pagination: {
+        ...history.pagination,
+        offset: 0,
+        has_more: false,
+        next_offset: null,
+      },
+    };
+    options.commit(nextPolicy, nextHistory);
+    pending.delete(previewDigest);
+    return { effective_policy: clone(nextPolicy), change: clone(change) };
+  }
+
+  const client: CyclePolicyEditorApi = {
+    getCycleBehaviorPolicy: async () => clone(options.getPolicy()),
+    getCycleBehaviorPolicyHistory: async (_cycleId, limit = 50, offset = 0) => {
+      const history = options.getHistory();
+      const items = history.items.slice(offset, offset + limit);
+      const nextOffset = offset + items.length;
+      return {
+        items: clone(items),
+        pagination: {
+          limit,
+          offset,
+          has_more: nextOffset < history.items.length,
+          next_offset: nextOffset < history.items.length ? nextOffset : null,
+        },
+      };
+    },
+    previewCycleBehaviorPolicy: async (_cycleId, { proposal }) => {
+      const policy = options.getPolicy();
+      return createPreview(policy, afterProposal(policy, proposal), null);
+    },
+    applyCycleBehaviorPolicy: async (_cycleId, request) => applyPending(
+      request.expected_version,
+      request.preview_digest,
+      request.rationale,
+    ),
+    previewCycleBehaviorPolicyRevert: async (_cycleId, changeId) => {
+      const policy = options.getPolicy();
+      const change = options.getHistory().items.find((item) => item.id === changeId);
+      if (!change) throw new Error('The selected history entry is not available.');
+      return createPreview(policy, clone(change.before_snapshot), changeId);
+    },
+    applyCycleBehaviorPolicyRevert: async (_cycleId, _changeId, request) => applyPending(
+      request.expected_version,
+      request.preview_digest,
+      request.rationale,
+    ),
+  };
+  return client;
+}


### PR DESCRIPTION
Slice **4 of 6** of the workspace behavior editor ([#738](https://github.com/Illospace/illospace/issues/738)). This is the slice that makes behavior editable — everything before it was reading.

Stacked on [#803](https://github.com/Illospace/illospace/pull/803) (slice 3), because it edits the same Cycles surface. **Merge #803 first**, then this.

Closes #785

## What you can see in 6 clicks — no backend needed

```
cd frontend && npm run dev
```

Open **http://localhost:5173/cycles?preview=1**

1. **Edit behavior** on the first Cycle → the draft editor opens, headed *"Nothing changes until you review and apply."*
2. Change the mission prompt → **Review change** → a restrained **field diff**: `Mission prompt` with BEFORE and AFTER side by side. Not raw JSON.
3. **Apply change is disabled**, and the panel says *"Active runs are unchanged. Future runs use this policy only after apply."*
4. Type a rationale → apply enables → apply → **Version 2 becomes Version 3**, "Active now" shows the new mission, and History goes from 1 change to 2.
5. **Revert** on a history entry → its own BEFORE/AFTER diff, its own required rationale, and **Apply revert**. A rollback is a new audited version; it never erases the incident.
6. Try to leave with an unsaved draft → the browser asks you to confirm.

I drove all six myself in a browser and they behave as written above.

## The bug that only a browser could find

The preview flow threw `Failed to execute 'structuredClone' on 'Window'` the moment you clicked **Review change** — the primary action of this slice, dead on click one, while 267 tests, `svelte-check` and the build were all green.

The cause: the new preview fixture wrote its own `clone()` on top of `structuredClone`, which cannot clone Svelte's reactive `$state` proxies. This repo already had the answer — `cloneForPostMessage`, and a test at `postMessageClone.test.js:21` that asserts this exact `DataCloneError`. The fix extracts a shared `clonePlainData` that both callers now use, plus a regression test confirmed to fail without it.

## Also in here: a maintainability pass

A code-quality review came back BLOCKING on four findings and all four were verified before folding. Slice 4 had first landed as one file growing **767 → 1,596 lines**, with slices 5 and 6 due to land on it next:

- **Split into real components** — `EffectiveCyclePolicyView` (342), `ActiveCyclePolicyView` (427), `CyclePolicyDraftEditor` (432), `CyclePolicyReview` (343), `CyclePolicyHistory` (284), plus an `effectivePolicyWorkflow.ts` controller (398). Slice 5 now has a `CyclePolicyHistory` to build on instead of a monolith to edit.
- **One `CyclePolicyWorkflowState` union** (view / edit / reviewing / review / applying / conflicted / reverting) replaces a `stage` string plus three loose booleans that could express impossible states.
- **One `POLICY_FIELD_SCHEMA`** is now the single source of editable-field truth; the draft shape, dirty check, proposal mapping and editor controls all derive from it instead of restating it six times.
- **Tests no longer read source text.** Two tests did `readFileSync` on the `.svelte` file and regex-matched it — they asserted a string existed, not that the behavior held, and any extraction would have failed them for no reason. They are replaced by behavior tests, including one that proves a 409 conflict preserves the draft.

## Verification

All run by me, serially, with no Codex worker live (load average 3.9):

- `npm test` — **268 passed, 0 failed**
- `npm run check` — **0 errors, 0 warnings** across 6,874 files
- `npm run build` — succeeded

Frontend-only diff, so this is the only CI lane the change selects. Console during the browser walkthrough showed no app errors — only Vite's HMR websocket (environmental) and Chrome blocking the `beforeunload` confirm, which is the dirty-draft guard firing under a scripted navigation.

## Two review notes I deliberately did not fix

Both are real and both are wider than this ticket. Naming them rather than expanding the diff:

1. `routes/cycles/+page.svelte` and `ThreadCyclesPane.svelte` each duplicate the dirty flag, discard confirmation, apply callback and refresh coordination. A future change to the discard rule has to be made twice.
2. `client.ts` types diff `kind` and `field` as plain strings although rendering branches on specific semantic variants. A new diff kind would silently fall through to generic rendering; literal unions with exhaustive handling would catch it at compile time.

## Assumptions

- A configured model stays valid even when it is absent from the latest model catalog.
- One-time schedules use the server-supported `at:` timestamp form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
