### PR TITLE
feat(cycles): behavior editor slice 5 — policy history provenance and per-run snapshot inspection

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -394,6 +394,7 @@ export interface CycleRead {
 export interface CycleRunRead {
   id: number;
   cycle_id: number;
+  revision_id: number | null;
   scheduled_for: string;
   started_at: string | null;
   completed_at: string | null;
@@ -403,6 +404,10 @@ export interface CycleRunRead {
   idea_id: string | null;
   run_id: number | null;
   prompt_snapshot: string;
+  guidance_snapshot: Record<string, CyclePolicyJsonValue>[];
+  output_targets_snapshot: Record<string, CyclePolicyJsonValue>[];
+  context_snapshot: Record<string, CyclePolicyJsonValue>;
+  self_review_summary: string | null;
   created_at: string;
 }
 

--- a/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { EffectiveCyclePolicyRead } from '$lib/api/client';
   import { ConstellationButton, ConstellationPill } from '$lib/components/constellation';
+  import CyclePolicyFieldList from '$lib/features/cycles/components/CyclePolicyFieldList.svelte';
   import {
     formatPolicyDateTime,
     policyConfigurationEntries,
@@ -30,9 +31,21 @@
     onEdit: () => void;
   } = $props();
 
-  const configurationEntries = $derived(
-    policy ? policyConfigurationEntries(policy.configuration) : [],
-  );
+  const configurationEntries = $derived(policy
+    ? policyConfigurationEntries(policy.configuration).map((entry) => {
+        const source = policyFieldSource(policy.field_sources, entry.key);
+        const changedAt = source?.changed_at || policy.source.changed_at;
+        return {
+          ...entry,
+          source: {
+            title: source?.rationale || undefined,
+            label: `From ${source ? policySourceLabel(source) : policySourceLabel(policy.source)}`,
+            changedAt,
+            changedLabel: `Changed ${formatPolicyDateTime(changedAt, displayTimezone)}`,
+          },
+        };
+      })
+    : []);
   const guidanceSource = $derived(
     policy ? policyFieldSource(policy.field_sources, 'guidance') : undefined,
   );
@@ -71,23 +84,7 @@
         <span>{displayTimezone.replaceAll('_', ' ')}</span>
       </div>
 
-      <dl class="policy-values">
-        {#each configurationEntries as entry (entry.key)}
-          {@const source = policyFieldSource(policy.field_sources, entry.key)}
-          <div class="policy-value" class:prose-value={entry.key === 'prompt'}>
-            <dt>{policyFieldLabel(entry.key)}</dt>
-            <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
-              {policyValueLabel(entry.value)}
-            </dd>
-            <dd class="value-source" title={source?.rationale || undefined}>
-              <span>From {source ? policySourceLabel(source) : policySourceLabel(policy.source)}</span>
-              <time datetime={source?.changed_at || policy.source.changed_at || undefined}>
-                Changed {formatPolicyDateTime(source?.changed_at || policy.source.changed_at, displayTimezone)}
-              </time>
-            </dd>
-          </div>
-        {/each}
-      </dl>
+      <CyclePolicyFieldList entries={configurationEntries} appearance="active" {compact} />
     </section>
 
     <section class="policy-section active-guidance" aria-labelledby={`cycle-${cycleId}-guidance`}>
@@ -189,7 +186,6 @@
   }
 
   .section-kicker,
-  .policy-value dt,
   .live-marker {
     color: var(--constellation-color-text-muted);
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
@@ -254,46 +250,6 @@
     color: var(--constellation-color-success);
   }
 
-  .policy-values {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0;
-    margin: 0;
-    border-top: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value {
-    display: grid;
-    align-content: start;
-    gap: 7px;
-    min-width: 0;
-    padding: 12px 10px;
-    border-bottom: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value:nth-child(odd) {
-    border-right: 1px solid var(--constellation-section-divider);
-  }
-
-  .policy-value.prose-value {
-    grid-column: 1 / -1;
-    border-right: 0;
-  }
-
-  .policy-value dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-primary);
-    font-size: 13px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-  }
-
-  .policy-value.prose-value > dd:not(.value-source) {
-    font-size: 14px;
-  }
-
-  .mono-value,
   .output-target pre {
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
   }
@@ -395,25 +351,7 @@
     font-size: 12px;
   }
 
-  .policy-content.compact .policy-values {
-    grid-template-columns: 1fr;
-  }
-
-  .policy-content.compact .policy-value,
-  .policy-content.compact .policy-value:nth-child(odd) {
-    border-right: 0;
-  }
-
   @media (max-width: 720px) {
-    .policy-values {
-      grid-template-columns: 1fr;
-    }
-
-    .policy-value,
-    .policy-value:nth-child(odd) {
-      border-right: 0;
-    }
-
     .active-heading,
     .active-actions {
       align-items: flex-start;

--- a/frontend/src/lib/features/cycles/components/CyclePolicyFieldList.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyFieldList.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { CyclePolicyJsonValue } from '$lib/api/client';
+  import {
+    policyFieldLabel,
+    policyValueLabel,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+
+  type PolicyFieldSource = {
+    title?: string;
+    label: string;
+    changedAt: string | null;
+    changedLabel: string;
+  };
+
+  type PolicyFieldEntry = {
+    key: string;
+    value: CyclePolicyJsonValue;
+    source?: PolicyFieldSource;
+  };
+
+  let {
+    entries,
+    appearance,
+    compact = false,
+  }: {
+    entries: readonly PolicyFieldEntry[];
+    appearance: 'active' | 'snapshot';
+    compact?: boolean;
+  } = $props();
+</script>
+
+<dl class="policy-field-list" class:active={appearance === 'active'} class:snapshot={appearance === 'snapshot'} class:compact>
+  {#each entries as entry (entry.key)}
+    <div class="policy-field" class:prose-value={entry.key === 'prompt'}>
+      <dt>{policyFieldLabel(entry.key)}</dt>
+      <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
+        {policyValueLabel(entry.value)}
+      </dd>
+      {#if entry.source}
+        <dd class="value-source" title={entry.source.title}>
+          <span>{entry.source.label}</span>
+          <time datetime={entry.source.changedAt || undefined}>{entry.source.changedLabel}</time>
+        </dd>
+      {/if}
+    </div>
+  {/each}
+</dl>
+
+<style>
+  .policy-field-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 0;
+    border-top: calc(var(--sp-1) / 4) solid var(--constellation-section-divider);
+  }
+
+  .policy-field {
+    display: grid;
+    align-content: start;
+    min-width: 0;
+    border-bottom: calc(var(--sp-1) / 4) solid var(--constellation-section-divider);
+  }
+
+  .policy-field:nth-child(odd) {
+    border-right: calc(var(--sp-1) / 4) solid var(--constellation-section-divider);
+  }
+
+  .policy-field.prose-value {
+    grid-column: 1 / -1;
+    border-right: 0;
+  }
+
+  dt {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    white-space: pre-wrap;
+  }
+
+  .mono-value {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .active .policy-field {
+    gap: var(--sp-2);
+    padding: var(--sp-3);
+  }
+
+  .active dd {
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .active .prose-value > dd:not(.value-source) {
+    font-size: 14px;
+  }
+
+  .value-source {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-1) var(--sp-3);
+    color: var(--constellation-color-text-muted) !important;
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px !important;
+    line-height: 1.4 !important;
+  }
+
+  .snapshot .policy-field {
+    gap: var(--sp-2);
+    padding: var(--sp-3);
+  }
+
+  .snapshot dd {
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  .compact {
+    grid-template-columns: 1fr;
+  }
+
+  .compact .policy-field,
+  .compact .policy-field:nth-child(odd) {
+    border-right: 0;
+  }
+
+  @media (max-width: 720px) {
+    .policy-field-list {
+      grid-template-columns: 1fr;
+    }
+
+    .policy-field,
+    .policy-field:nth-child(odd) {
+      border-right: 0;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { CyclePolicyHistoryRead, CycleRunRead } from '$lib/api/client';
-  import { ConstellationButton, ConstellationPill } from '$lib/components/constellation';
+  import { ConstellationButton } from '$lib/components/constellation';
+  import CyclePolicyProvenanceLine from '$lib/features/cycles/components/CyclePolicyProvenanceLine.svelte';
   import {
     formatPolicyDateTime,
     policyActorPresentation,
@@ -91,22 +92,13 @@
               </div>
             </header>
             <p>{change.rationale}</p>
-            <div class="history-source" class:agent-source={actor.kind === 'agent'}>
-              <ConstellationPill
-                variant={actor.kind === 'agent' ? 'info' : actor.kind === 'human' ? 'muted' : 'warning'}
-                leadingDot
-              >
-                {actor.label}
-              </ConstellationPill>
-              <span><strong>Actor</strong> {actor.identity}</span>
-              {#if originatingRun}
-                <a href={`#cycle-run-${originatingRun.id}`}>Originating Run #{originatingRun.id}</a>
-              {/if}
-              <code>{policySourceLabel(change)}</code>
-              {#if change.reverted_from_id !== null}
-                <span>Reverted change {change.reverted_from_id}</span>
-              {/if}
-            </div>
+            <CyclePolicyProvenanceLine
+              {actor}
+              originatingRunId={originatingRun?.id}
+              sourceLabel={policySourceLabel(change)}
+              appearance="history"
+              revertedFromId={change.reverted_from_id}
+            />
 
             {#if retired.length}
               <section class="retired-guidance" aria-label="Retired guidance">
@@ -164,7 +156,6 @@
 
   .history-region summary small,
   .history-region summary > span:last-child,
-  .history-source,
   .history-change header span,
   .history-change time {
     color: var(--constellation-color-text-muted);
@@ -237,39 +228,6 @@
   .history-change p {
     color: var(--constellation-color-text-secondary);
     font-size: 12px;
-  }
-
-  .history-source {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px 10px;
-    padding: 7px 8px;
-    border-left: 2px solid var(--constellation-color-text-muted);
-    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-  }
-
-  .history-source.agent-source {
-    border-left-color: var(--constellation-control-pill-info-text);
-    background: color-mix(in srgb, var(--constellation-control-pill-info-text) 4%, transparent);
-  }
-
-  .history-source strong {
-    color: var(--constellation-color-text-secondary);
-    font-weight: 650;
-  }
-
-  .history-source a {
-    color: var(--constellation-color-text-secondary);
-    font-weight: 650;
-  }
-
-  .history-source code {
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-muted);
-    font-family: inherit;
-    font-size: inherit;
   }
 
   .retired-guidance {

--- a/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import type { CyclePolicyHistoryRead } from '$lib/api/client';
-  import { ConstellationButton } from '$lib/components/constellation';
+  import type { CyclePolicyHistoryRead, CycleRunRead } from '$lib/api/client';
+  import { ConstellationButton, ConstellationPill } from '$lib/components/constellation';
   import {
     formatPolicyDateTime,
+    policyActorPresentation,
     policyFieldLabel,
+    policyOriginatingRun,
     policySourceLabel,
     retiredGuidance,
   } from '$lib/features/cycles/domain/effectivePolicy';
@@ -11,6 +13,7 @@
 
   let {
     history,
+    runs = [],
     displayTimezone,
     editable,
     workflowKind,
@@ -20,6 +23,7 @@
     onLoadMore,
   }: {
     history: CyclePolicyHistoryRead;
+    runs?: readonly CycleRunRead[];
     displayTimezone: string;
     editable: boolean;
     workflowKind: CyclePolicyWorkflowState['kind'];
@@ -61,6 +65,8 @@
       <ol class="history-list">
         {#each history.items as change (change.id)}
           {@const retired = retiredGuidance(change)}
+          {@const actor = policyActorPresentation(change)}
+          {@const originatingRun = policyOriginatingRun(change, runs)}
           <li class="history-change">
             <header>
               <div>
@@ -85,10 +91,20 @@
               </div>
             </header>
             <p>{change.rationale}</p>
-            <div class="history-source">
-              From {policySourceLabel(change)}
+            <div class="history-source" class:agent-source={actor.kind === 'agent'}>
+              <ConstellationPill
+                variant={actor.kind === 'agent' ? 'info' : actor.kind === 'human' ? 'muted' : 'warning'}
+                leadingDot
+              >
+                {actor.label}
+              </ConstellationPill>
+              <span><strong>Actor</strong> {actor.identity}</span>
+              {#if originatingRun}
+                <a href={`#cycle-run-${originatingRun.id}`}>Originating Run #{originatingRun.id}</a>
+              {/if}
+              <code>{policySourceLabel(change)}</code>
               {#if change.reverted_from_id !== null}
-                · Reverted change {change.reverted_from_id}
+                <span>Reverted change {change.reverted_from_id}</span>
               {/if}
             </div>
 
@@ -224,7 +240,36 @@
   }
 
   .history-source {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 10px;
+    padding: 7px 8px;
+    border-left: 2px solid var(--constellation-color-text-muted);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .history-source.agent-source {
+    border-left-color: var(--constellation-control-pill-info-text);
+    background: color-mix(in srgb, var(--constellation-control-pill-info-text) 4%, transparent);
+  }
+
+  .history-source strong {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  .history-source a {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  .history-source code {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-muted);
+    font-family: inherit;
+    font-size: inherit;
   }
 
   .retired-guidance {

--- a/frontend/src/lib/features/cycles/components/CyclePolicyProvenanceLine.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyProvenanceLine.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import { ConstellationPill } from '$lib/components/constellation';
+  import {
+    cycleRunAnchorId,
+    type CyclePolicyActorPresentation,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+
+  let {
+    actor,
+    originatingRunId = null,
+    sourceLabel,
+    appearance,
+    version = null,
+    appliedAt = null,
+    appliedAtLabel = null,
+    rationaleLabel = null,
+    changedFieldsLabel = null,
+    revertedFromId = null,
+  }: {
+    actor: CyclePolicyActorPresentation;
+    originatingRunId?: number | null;
+    sourceLabel: string;
+    appearance: 'history' | 'snapshot';
+    version?: number | null;
+    appliedAt?: string | null;
+    appliedAtLabel?: string | null;
+    rationaleLabel?: string | null;
+    changedFieldsLabel?: string | null;
+    revertedFromId?: number | null;
+  } = $props();
+</script>
+
+<div
+  class="policy-provenance"
+  class:history={appearance === 'history'}
+  class:snapshot={appearance === 'snapshot'}
+  class:agent-source={actor.kind === 'agent'}
+  class:has-changed-fields={Boolean(changedFieldsLabel)}
+>
+  <div class="actor-pill">
+    <ConstellationPill
+      variant={actor.kind === 'agent' ? 'info' : actor.kind === 'human' ? 'muted' : 'warning'}
+      leadingDot
+    >
+      {actor.label}
+    </ConstellationPill>
+  </div>
+  {#if rationaleLabel}<p class="change-rationale">{rationaleLabel}</p>{/if}
+  <div class="provenance-facts">
+    {#if version !== null}<span>Version {version}</span>{/if}
+    <span><strong>Actor</strong> {actor.identity}</span>
+    {#if appliedAt && appliedAtLabel}
+      <time datetime={appliedAt}>{appliedAtLabel}</time>
+    {/if}
+    {#if originatingRunId !== null}
+      <a href={`#${cycleRunAnchorId(originatingRunId)}`}>Originating Run #{originatingRunId}</a>
+    {/if}
+  </div>
+  {#if changedFieldsLabel}<p class="changed-fields">{changedFieldsLabel}</p>{/if}
+  <code>{sourceLabel}</code>
+  {#if revertedFromId !== null}<span class="reverted-change">Reverted change {revertedFromId}</span>{/if}
+</div>
+
+<style>
+  .policy-provenance {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .history {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--sp-2) var(--sp-3);
+    padding: var(--sp-2);
+    border-left: calc(var(--sp-1) / 2) solid var(--constellation-color-text-muted);
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
+  }
+
+  .history.agent-source {
+    border-left-color: var(--constellation-control-pill-info-text);
+    background: color-mix(in srgb, var(--constellation-control-pill-info-text) 4%, transparent);
+  }
+
+  .history .provenance-facts {
+    display: contents;
+  }
+
+  .snapshot {
+    display: contents;
+  }
+
+  .snapshot .actor-pill {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .snapshot .provenance-facts {
+    display: flex;
+    grid-column: 1 / -1;
+    grid-row: 3;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--sp-3);
+  }
+
+  .snapshot .change-rationale {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .snapshot .changed-fields {
+    grid-column: 1 / -1;
+    grid-row: 4;
+  }
+
+  .snapshot code {
+    grid-column: 1 / -1;
+    grid-row: 4;
+  }
+
+  .snapshot.has-changed-fields code {
+    grid-row: 5;
+  }
+
+  .change-rationale {
+    margin: 0;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .changed-fields {
+    margin: 0;
+    letter-spacing: 0.04em;
+  }
+
+  strong {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  a {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  code {
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-muted);
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  @media (max-width: 720px) {
+    .snapshot .actor-pill {
+      grid-column: 1;
+      grid-row: 2;
+      justify-self: start;
+    }
+
+    .snapshot .change-rationale {
+      grid-row: 3;
+    }
+
+    .snapshot .provenance-facts {
+      grid-row: 4;
+    }
+
+    .snapshot .changed-fields,
+    .snapshot code {
+      grid-row: 5;
+    }
+
+    .snapshot.has-changed-fields code {
+      grid-row: 6;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/CycleRunPolicySnapshot.svelte
+++ b/frontend/src/lib/features/cycles/components/CycleRunPolicySnapshot.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { CycleRunRead } from '$lib/api/client';
   import { ConstellationPill } from '$lib/components/constellation';
+  import CyclePolicyFieldList from '$lib/features/cycles/components/CyclePolicyFieldList.svelte';
+  import CyclePolicyProvenanceLine from '$lib/features/cycles/components/CyclePolicyProvenanceLine.svelte';
   import {
     cycleRunPolicyInspection,
     formatPolicyDateTime,
@@ -8,7 +10,6 @@
     policyFieldLabel,
     policyOriginatingRun,
     policySourceLabel,
-    policyValueLabel,
   } from '$lib/features/cycles/domain/effectivePolicy';
 
   let {
@@ -55,16 +56,7 @@
           <ConstellationPill variant="muted">Read only</ConstellationPill>
         </header>
 
-        <dl class="snapshot-values">
-          {#each inspection.configuration as entry (entry.key)}
-            <div class:wide-value={entry.key === 'prompt'}>
-              <dt>{policyFieldLabel(entry.key)}</dt>
-              <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
-                {policyValueLabel(entry.value)}
-              </dd>
-            </div>
-          {/each}
-        </dl>
+        <CyclePolicyFieldList entries={inspection.configuration} appearance="snapshot" />
 
         <div class="snapshot-guidance">
           <div>
@@ -87,36 +79,24 @@
             <span>Policy provenance</span>
             <h5 id={`run-${run.id}-change-heading`}>Change that produced this snapshot</h5>
           </div>
-          {#if actor}
-            <ConstellationPill
-              variant={actor.kind === 'agent' ? 'info' : actor.kind === 'human' ? 'muted' : 'warning'}
-              leadingDot
-            >
-              {actor.label}
-            </ConstellationPill>
-          {/if}
         </header>
 
         {#if inspection.change}
-          <p class="change-rationale">{inspection.change.rationale || 'No rationale recorded.'}</p>
-          <div class="change-facts">
-            {#if inspection.change.version !== null}<span>Version {inspection.change.version}</span>{/if}
-            {#if actor}<span><strong>Actor</strong> {actor.identity}</span>{/if}
-            {#if inspection.change.applied_at}
-              <time datetime={inspection.change.applied_at}>
-                {formatPolicyDateTime(inspection.change.applied_at, displayTimezone)}
-              </time>
-            {/if}
-            {#if originatingRun}
-              <a href={`#cycle-run-${originatingRun.id}`}>Originating Run #{originatingRun.id}</a>
-            {/if}
-          </div>
-          {#if inspection.change.changed_fields.length}
-            <p class="changed-fields">
-              Changed {inspection.change.changed_fields.map(policyFieldLabel).join(', ')}
-            </p>
+          {#if actor}
+            <CyclePolicyProvenanceLine
+              {actor}
+              originatingRunId={originatingRun?.id}
+              sourceLabel={policySourceLabel(inspection.change)}
+              appearance="snapshot"
+              version={inspection.change.version}
+              appliedAt={inspection.change.applied_at}
+              appliedAtLabel={formatPolicyDateTime(inspection.change.applied_at, displayTimezone)}
+              rationaleLabel={inspection.change.rationale || 'No rationale recorded.'}
+              changedFieldsLabel={inspection.change.changed_fields.length
+                ? `Changed ${inspection.change.changed_fields.map(policyFieldLabel).join(', ')}`
+                : null}
+            />
           {/if}
-          <code>{policySourceLabel(inspection.change)}</code>
         {:else}
           <p class="change-rationale">
             This run used the initial Cycle definition. No producing policy change was recorded.
@@ -133,24 +113,23 @@
   .run-policy-snapshot {
     grid-column: 1 / -1;
     min-width: 0;
-    border: 1px solid var(--constellation-surface-nested-border);
-    border-radius: 8px;
+    border: calc(var(--sp-1) / 4) solid var(--constellation-surface-nested-border);
+    border-radius: var(--radius-md);
     background: var(--constellation-surface-nested-background);
   }
 
   .run-policy-snapshot summary,
   .snapshot-section header,
-  .snapshot-guidance > div,
-  .change-facts {
+  .snapshot-guidance > div {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
+    gap: var(--sp-3);
   }
 
   .run-policy-snapshot summary {
     min-height: 40px;
-    padding: 0 11px;
+    padding: 0 var(--sp-3);
     color: var(--constellation-color-text-primary);
     cursor: pointer;
     list-style: none;
@@ -168,17 +147,14 @@
 
   .run-policy-snapshot summary small,
   .snapshot-section header span,
-  .snapshot-guidance span,
-  .change-facts,
-  .changed-fields,
-  .producing-change code {
+  .snapshot-guidance span {
     color: var(--constellation-color-text-muted);
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
     font-size: 10px;
   }
 
   .run-policy-snapshot[open] summary {
-    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    border-bottom: calc(var(--sp-1) / 4) solid var(--constellation-surface-panel-separator);
   }
 
   .snapshot-content {
@@ -187,10 +163,10 @@
 
   .snapshot-section {
     display: grid;
-    gap: 12px;
+    gap: var(--sp-3);
     min-width: 0;
-    padding: 12px;
-    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    padding: var(--sp-3);
+    border-bottom: calc(var(--sp-1) / 4) solid var(--constellation-surface-panel-separator);
   }
 
   .snapshot-section:last-child {
@@ -203,14 +179,13 @@
 
   .snapshot-section header > div {
     display: grid;
-    gap: 3px;
+    gap: var(--sp-1);
   }
 
   .snapshot-section h5,
   .snapshot-guidance strong,
   .snapshot-guidance p,
-  .change-rationale,
-  .changed-fields {
+  .change-rationale {
     margin: 0;
   }
 
@@ -220,32 +195,6 @@
     text-transform: uppercase;
   }
 
-  .snapshot-values {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    margin: 0;
-    border-top: 1px solid var(--constellation-section-divider);
-  }
-
-  .snapshot-values > div {
-    display: grid;
-    align-content: start;
-    gap: 6px;
-    min-width: 0;
-    padding: 10px;
-    border-bottom: 1px solid var(--constellation-section-divider);
-  }
-
-  .snapshot-values > div:nth-child(odd) {
-    border-right: 1px solid var(--constellation-section-divider);
-  }
-
-  .snapshot-values > .wide-value {
-    grid-column: 1 / -1;
-    border-right: 0;
-  }
-
-  .snapshot-values dt,
   .snapshot-guidance strong {
     color: var(--constellation-color-text-muted);
     font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
@@ -255,33 +204,19 @@
     text-transform: uppercase;
   }
 
-  .snapshot-values dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-    color: var(--constellation-color-text-primary);
-    font-size: 12px;
-    line-height: 1.45;
-    white-space: pre-wrap;
-  }
-
-  .mono-value,
-  .producing-change code {
-    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
-  }
-
   .snapshot-guidance {
     display: grid;
-    gap: 8px;
-    padding: 10px;
-    border-left: 3px solid var(--constellation-color-success);
+    gap: var(--sp-2);
+    padding: var(--sp-3);
+    border-left: calc(var(--sp-1) * 0.75) solid var(--constellation-color-success);
     background: color-mix(in srgb, var(--constellation-color-success) 3%, transparent);
   }
 
   .snapshot-guidance ol {
     display: grid;
-    gap: 7px;
+    gap: var(--sp-2);
     margin: 0;
-    padding-left: 22px;
+    padding-left: var(--sp-5);
     color: var(--constellation-color-text-secondary);
     font-size: 12px;
     line-height: 1.5;
@@ -296,44 +231,27 @@
   }
 
   .producing-change {
+    grid-template-columns: minmax(0, 1fr) auto;
     background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
   }
 
-  .change-facts {
-    justify-content: flex-start;
-    flex-wrap: wrap;
+  .producing-change > header {
+    grid-column: 1;
+    grid-row: 1;
   }
 
-  .change-facts strong {
-    color: var(--constellation-color-text-secondary);
-    font-weight: 650;
-  }
-
-  .change-facts a {
-    color: var(--constellation-color-text-secondary);
-    font-weight: 650;
-  }
-
-  .changed-fields {
-    letter-spacing: 0.04em;
-  }
-
-  .producing-change code {
-    overflow-wrap: anywhere;
+  .producing-change > .change-rationale {
+    grid-column: 1 / -1;
   }
 
   .snapshot-empty {
     margin: 0;
-    padding: 12px;
+    padding: var(--sp-3);
   }
 
   @media (max-width: 720px) {
-    .snapshot-values {
+    .producing-change {
       grid-template-columns: 1fr;
-    }
-
-    .snapshot-values > div:nth-child(odd) {
-      border-right: 0;
     }
 
     .snapshot-section header {

--- a/frontend/src/lib/features/cycles/components/CycleRunPolicySnapshot.svelte
+++ b/frontend/src/lib/features/cycles/components/CycleRunPolicySnapshot.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+  import type { CycleRunRead } from '$lib/api/client';
+  import { ConstellationPill } from '$lib/components/constellation';
+  import {
+    cycleRunPolicyInspection,
+    formatPolicyDateTime,
+    policyActorPresentation,
+    policyFieldLabel,
+    policyOriginatingRun,
+    policySourceLabel,
+    policyValueLabel,
+  } from '$lib/features/cycles/domain/effectivePolicy';
+
+  let {
+    run,
+    runs,
+    displayTimezone,
+  }: {
+    run: CycleRunRead;
+    runs: readonly CycleRunRead[];
+    displayTimezone: string;
+  } = $props();
+
+  const inspection = $derived(cycleRunPolicyInspection(run));
+  const actor = $derived(
+    inspection.change ? policyActorPresentation(inspection.change) : null,
+  );
+  const originatingRun = $derived(
+    inspection.change ? policyOriginatingRun(inspection.change, runs) : null,
+  );
+</script>
+
+<details class="run-policy-snapshot">
+  <summary>
+    <span>Execution snapshot</span>
+    <small>
+      {#if inspection.version !== null}
+        Policy version {inspection.version}
+      {:else if inspection.revisionNumber !== null}
+        Revision {inspection.revisionNumber}
+      {:else}
+        Not recorded
+      {/if}
+    </small>
+  </summary>
+
+  <div class="snapshot-content">
+    {#if inspection.hasSnapshot}
+      <section class="snapshot-section" aria-labelledby={`run-${run.id}-policy-heading`}>
+        <header>
+          <div>
+            <span>Admitted policy</span>
+            <h5 id={`run-${run.id}-policy-heading`}>Policy snapshot</h5>
+          </div>
+          <ConstellationPill variant="muted">Read only</ConstellationPill>
+        </header>
+
+        <dl class="snapshot-values">
+          {#each inspection.configuration as entry (entry.key)}
+            <div class:wide-value={entry.key === 'prompt'}>
+              <dt>{policyFieldLabel(entry.key)}</dt>
+              <dd class:mono-value={entry.key.endsWith('_expr') || typeof entry.value === 'object'}>
+                {policyValueLabel(entry.value)}
+              </dd>
+            </div>
+          {/each}
+        </dl>
+
+        <div class="snapshot-guidance">
+          <div>
+            <strong>Guidance</strong>
+            <span>{inspection.guidance.length} admitted</span>
+          </div>
+          {#if inspection.guidance.length}
+            <ol>
+              {#each inspection.guidance as guidance}<li>{guidance}</li>{/each}
+            </ol>
+          {:else}
+            <p>No guidance was admitted.</p>
+          {/if}
+        </div>
+      </section>
+
+      <section class="snapshot-section producing-change" aria-labelledby={`run-${run.id}-change-heading`}>
+        <header>
+          <div>
+            <span>Policy provenance</span>
+            <h5 id={`run-${run.id}-change-heading`}>Change that produced this snapshot</h5>
+          </div>
+          {#if actor}
+            <ConstellationPill
+              variant={actor.kind === 'agent' ? 'info' : actor.kind === 'human' ? 'muted' : 'warning'}
+              leadingDot
+            >
+              {actor.label}
+            </ConstellationPill>
+          {/if}
+        </header>
+
+        {#if inspection.change}
+          <p class="change-rationale">{inspection.change.rationale || 'No rationale recorded.'}</p>
+          <div class="change-facts">
+            {#if inspection.change.version !== null}<span>Version {inspection.change.version}</span>{/if}
+            {#if actor}<span><strong>Actor</strong> {actor.identity}</span>{/if}
+            {#if inspection.change.applied_at}
+              <time datetime={inspection.change.applied_at}>
+                {formatPolicyDateTime(inspection.change.applied_at, displayTimezone)}
+              </time>
+            {/if}
+            {#if originatingRun}
+              <a href={`#cycle-run-${originatingRun.id}`}>Originating Run #{originatingRun.id}</a>
+            {/if}
+          </div>
+          {#if inspection.change.changed_fields.length}
+            <p class="changed-fields">
+              Changed {inspection.change.changed_fields.map(policyFieldLabel).join(', ')}
+            </p>
+          {/if}
+          <code>{policySourceLabel(inspection.change)}</code>
+        {:else}
+          <p class="change-rationale">
+            This run used the initial Cycle definition. No producing policy change was recorded.
+          </p>
+        {/if}
+      </section>
+    {:else}
+      <p class="snapshot-empty">No admitted policy snapshot was recorded for this run.</p>
+    {/if}
+  </div>
+</details>
+
+<style>
+  .run-policy-snapshot {
+    grid-column: 1 / -1;
+    min-width: 0;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 8px;
+    background: var(--constellation-surface-nested-background);
+  }
+
+  .run-policy-snapshot summary,
+  .snapshot-section header,
+  .snapshot-guidance > div,
+  .change-facts {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .run-policy-snapshot summary {
+    min-height: 40px;
+    padding: 0 11px;
+    color: var(--constellation-color-text-primary);
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .run-policy-snapshot summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .run-policy-snapshot summary span,
+  .snapshot-section h5 {
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .run-policy-snapshot summary small,
+  .snapshot-section header span,
+  .snapshot-guidance span,
+  .change-facts,
+  .changed-fields,
+  .producing-change code {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+  }
+
+  .run-policy-snapshot[open] summary {
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+  }
+
+  .snapshot-content {
+    display: grid;
+  }
+
+  .snapshot-section {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+    padding: 12px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+  }
+
+  .snapshot-section:last-child {
+    border-bottom: 0;
+  }
+
+  .snapshot-section header {
+    align-items: flex-start;
+  }
+
+  .snapshot-section header > div {
+    display: grid;
+    gap: 3px;
+  }
+
+  .snapshot-section h5,
+  .snapshot-guidance strong,
+  .snapshot-guidance p,
+  .change-rationale,
+  .changed-fields {
+    margin: 0;
+  }
+
+  .snapshot-section header span {
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .snapshot-values {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 0;
+    border-top: 1px solid var(--constellation-section-divider);
+  }
+
+  .snapshot-values > div {
+    display: grid;
+    align-content: start;
+    gap: 6px;
+    min-width: 0;
+    padding: 10px;
+    border-bottom: 1px solid var(--constellation-section-divider);
+  }
+
+  .snapshot-values > div:nth-child(odd) {
+    border-right: 1px solid var(--constellation-section-divider);
+  }
+
+  .snapshot-values > .wide-value {
+    grid-column: 1 / -1;
+    border-right: 0;
+  }
+
+  .snapshot-values dt,
+  .snapshot-guidance strong {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .snapshot-values dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--constellation-color-text-primary);
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+  }
+
+  .mono-value,
+  .producing-change code {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .snapshot-guidance {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-left: 3px solid var(--constellation-color-success);
+    background: color-mix(in srgb, var(--constellation-color-success) 3%, transparent);
+  }
+
+  .snapshot-guidance ol {
+    display: grid;
+    gap: 7px;
+    margin: 0;
+    padding-left: 22px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .snapshot-guidance p,
+  .change-rationale,
+  .snapshot-empty {
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .producing-change {
+    background: color-mix(in srgb, var(--constellation-color-text-muted) 3%, transparent);
+  }
+
+  .change-facts {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .change-facts strong {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  .change-facts a {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 650;
+  }
+
+  .changed-fields {
+    letter-spacing: 0.04em;
+  }
+
+  .producing-change code {
+    overflow-wrap: anywhere;
+  }
+
+  .snapshot-empty {
+    margin: 0;
+    padding: 12px;
+  }
+
+  @media (max-width: 720px) {
+    .snapshot-values {
+      grid-template-columns: 1fr;
+    }
+
+    .snapshot-values > div:nth-child(odd) {
+      border-right: 0;
+    }
+
+    .snapshot-section header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
@@ -5,6 +5,7 @@
   import {
     api,
     type CyclePolicyHistoryRead,
+    type CycleRunRead,
     type EffectiveCyclePolicyRead,
   } from '$lib/api/client';
   import { ConstellationButton, ConstellationNotice } from '$lib/components/constellation';
@@ -31,6 +32,7 @@
     cycleId,
     previewPolicy = null,
     previewHistory = null,
+    runs = [],
     displayTimezone = null,
     compact = false,
     editable = false,
@@ -41,6 +43,7 @@
     cycleId: number;
     previewPolicy?: EffectiveCyclePolicyRead | null;
     previewHistory?: CyclePolicyHistoryRead | null;
+    runs?: readonly CycleRunRead[];
     displayTimezone?: string | null;
     compact?: boolean;
     editable?: boolean;
@@ -283,6 +286,7 @@
 
     <CyclePolicyHistory
       history={workflow.data.history}
+      {runs}
       displayTimezone={resolvedTimezone}
       {editable}
       workflowKind={workflow.kind}

--- a/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
+++ b/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
@@ -532,6 +532,7 @@
   {:else if selectedCycle}
     <EffectiveCyclePolicyView
       cycleId={selectedCycle.id}
+      {runs}
       compact
       editable
       refreshSerial={behaviorPolicyRefreshSerial}

--- a/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
@@ -172,25 +172,30 @@ export type CycleRunPolicyInspection = {
   hasSnapshot: boolean;
   revisionNumber: number | null;
   version: number | null;
-  configuration: Array<{ key: string; value: CyclePolicyJsonValue }>;
+  configuration: Array<{ key: CyclePolicySnapshotConfigurationKey; value: CyclePolicyJsonValue }>;
   guidance: string[];
   change: CycleRunPolicyChangeInspection | null;
 };
 
-const CYCLE_POLICY_SNAPSHOT_CONFIGURATION_FIELDS = [
-  'name',
-  'prompt',
-  'schedule_expr',
-  'timezone',
-  'enabled',
-  'max_concurrency',
-  'timeout_seconds',
-  'retry_policy',
-  'model_override',
-  'thinking_override',
-  'execution_policy_key',
-  'target_idea_id',
-] as const;
+export type CyclePolicySnapshotConfigurationKey = Exclude<
+  keyof CyclePolicyConfigurationRead & string,
+  'schedule_human'
+>;
+
+const CYCLE_POLICY_SNAPSHOT_CONFIGURATION_FIELDS = Object.keys({
+  name: true,
+  prompt: true,
+  schedule_expr: true,
+  timezone: true,
+  enabled: true,
+  max_concurrency: true,
+  timeout_seconds: true,
+  retry_policy: true,
+  model_override: true,
+  thinking_override: true,
+  execution_policy_key: true,
+  target_idea_id: true,
+} satisfies Record<CyclePolicySnapshotConfigurationKey, true>) as CyclePolicySnapshotConfigurationKey[];
 
 export function policyConfigurationEntries(
   configuration: CyclePolicyConfigurationRead,
@@ -519,6 +524,10 @@ export function policyOriginatingRun(
   const agentRunId = policySourceRunId(source.source_reference);
   if (agentRunId === null) return null;
   return runs.find((run) => run.run_id === agentRunId) ?? null;
+}
+
+export function cycleRunAnchorId(runId: number): string {
+  return `cycle-run-${runId}`;
 }
 
 export function policySourceLabel(source: {

--- a/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
+++ b/frontend/src/lib/features/cycles/domain/effectivePolicy.ts
@@ -8,6 +8,7 @@ import type {
   CyclePolicyPreviewRead,
   CyclePolicyProposal,
   CyclePolicyHistoryRead,
+  CycleRunRead,
   EffectiveCyclePolicyRead,
 } from '$lib/api/client';
 import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
@@ -150,6 +151,47 @@ export type CyclePolicyConfigurationEntry = {
   value: CyclePolicyConfigurationRead[keyof CyclePolicyConfigurationRead];
 };
 
+export type CyclePolicyActorPresentation = {
+  kind: 'agent' | 'human' | 'system';
+  label: 'Agent' | 'Human' | 'System';
+  identity: string;
+};
+
+export type CycleRunPolicyChangeInspection = {
+  id: number | null;
+  version: number | null;
+  actor_type: string | null;
+  actor_id: string | null;
+  source_reference: string | null;
+  rationale: string | null;
+  changed_fields: string[];
+  applied_at: string | null;
+};
+
+export type CycleRunPolicyInspection = {
+  hasSnapshot: boolean;
+  revisionNumber: number | null;
+  version: number | null;
+  configuration: Array<{ key: string; value: CyclePolicyJsonValue }>;
+  guidance: string[];
+  change: CycleRunPolicyChangeInspection | null;
+};
+
+const CYCLE_POLICY_SNAPSHOT_CONFIGURATION_FIELDS = [
+  'name',
+  'prompt',
+  'schedule_expr',
+  'timezone',
+  'enabled',
+  'max_concurrency',
+  'timeout_seconds',
+  'retry_policy',
+  'model_override',
+  'thinking_override',
+  'execution_policy_key',
+  'target_idea_id',
+] as const;
+
 export function policyConfigurationEntries(
   configuration: CyclePolicyConfigurationRead,
 ): CyclePolicyConfigurationEntry[] {
@@ -157,6 +199,65 @@ export function policyConfigurationEntries(
     key: key as CyclePolicyConfigurationEntry['key'],
     value,
   }));
+}
+
+function policyJsonObject(
+  value: CyclePolicyJsonValue | undefined,
+): Record<string, CyclePolicyJsonValue> | null {
+  if (!value || Array.isArray(value) || typeof value !== 'object') return null;
+  return value;
+}
+
+function policyJsonNumber(value: CyclePolicyJsonValue | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function policyJsonString(value: CyclePolicyJsonValue | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function policyJsonStringList(value: CyclePolicyJsonValue | undefined): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+export function cycleRunPolicyInspection(run: CycleRunRead): CycleRunPolicyInspection {
+  const revision = policyJsonObject(run.context_snapshot?.revision);
+  const rawChange = policyJsonObject(run.context_snapshot?.behavior_change);
+  const afterSnapshot = policyJsonObject(rawChange?.after_snapshot);
+  const snapshot = afterSnapshot ?? revision;
+  const configuration = snapshot
+    ? CYCLE_POLICY_SNAPSHOT_CONFIGURATION_FIELDS.flatMap((key) => (
+        Object.hasOwn(snapshot, key) ? [{ key, value: snapshot[key] }] : []
+      ))
+    : [];
+  const snapshotGuidance = policyJsonStringList(snapshot?.guidance);
+  const guidance = snapshotGuidance ?? run.guidance_snapshot.flatMap((item) => {
+    const value = item.guidance;
+    return typeof value === 'string' ? [value] : [];
+  });
+  const change = rawChange
+    ? {
+        id: policyJsonNumber(rawChange.id),
+        version: policyJsonNumber(rawChange.version),
+        actor_type: policyJsonString(rawChange.actor_type),
+        actor_id: policyJsonString(rawChange.actor_id),
+        source_reference: policyJsonString(rawChange.source_reference),
+        rationale: policyJsonString(rawChange.rationale),
+        changed_fields: policyJsonStringList(rawChange.changed_fields) ?? [],
+        applied_at: policyJsonString(rawChange.applied_at),
+      }
+    : null;
+
+  return {
+    hasSnapshot: Boolean(snapshot || revision || configuration.length || snapshotGuidance),
+    revisionNumber: policyJsonNumber(revision?.revision_number),
+    version: change?.version ?? null,
+    configuration,
+    guidance,
+    change,
+  };
 }
 
 export function hydratePolicyDraft(policy: EffectiveCyclePolicyRead): CyclePolicyDraft {
@@ -389,6 +490,35 @@ export function policyFieldSource(
 ): CyclePolicyFieldSourceRead | undefined {
   if (field === 'schedule_human') return fieldSources.schedule_expr;
   return fieldSources[field];
+}
+
+export function policyActorPresentation(source: {
+  actor_type?: string | null;
+  actor_id?: string | null;
+}): CyclePolicyActorPresentation {
+  const actorType = String(source.actor_type ?? '').trim().toLowerCase();
+  const identity = String(source.actor_id ?? '').trim() || 'Not recorded';
+  if (actorType.includes('agent')) return { kind: 'agent', label: 'Agent', identity };
+  if (actorType === 'human' || actorType === 'user') {
+    return { kind: 'human', label: 'Human', identity };
+  }
+  return { kind: 'system', label: 'System', identity };
+}
+
+export function policySourceRunId(sourceReference: string | null | undefined): number | null {
+  const match = /^(?:agent|agent_run):(\d+)$/.exec(String(sourceReference ?? '').trim());
+  if (!match) return null;
+  const runId = Number(match[1]);
+  return Number.isSafeInteger(runId) && runId > 0 ? runId : null;
+}
+
+export function policyOriginatingRun(
+  source: { source_reference?: string | null },
+  runs: readonly CycleRunRead[],
+): CycleRunRead | null {
+  const agentRunId = policySourceRunId(source.source_reference);
+  if (agentRunId === null) return null;
+  return runs.find((run) => run.run_id === agentRunId) ?? null;
 }
 
 export function policySourceLabel(source: {

--- a/frontend/src/lib/utils/effectivePolicy.test.js
+++ b/frontend/src/lib/utils/effectivePolicy.test.js
@@ -2,13 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  cycleRunPolicyInspection,
   formatPolicyDateTime,
   guidanceDiff,
   hydratePolicyDraft,
   isPolicyDraftDirty,
+  policyActorPresentation,
   policyConfigurationEntries,
   policyFieldSource,
+  policyOriginatingRun,
   policyProposalFromDraft,
+  policySourceRunId,
   presentedPolicyDiff,
   recoverPolicyDraftAfterConflict,
   retiredGuidance,
@@ -103,6 +107,102 @@ test('keeps removed guidance in history without treating unchanged guidance as r
   };
 
   assert.deepEqual(retiredGuidance(change), ['Use old CRM copy']);
+});
+
+test('presents agent and human policy actors as distinct identities', () => {
+  assert.deepEqual(policyActorPresentation({ actor_type: 'agent', actor_id: '15100' }), {
+    kind: 'agent',
+    label: 'Agent',
+    identity: '15100',
+  });
+  assert.deepEqual(policyActorPresentation({ actor_type: 'user', actor_id: 'reviewer-8' }), {
+    kind: 'human',
+    label: 'Human',
+    identity: 'reviewer-8',
+  });
+});
+
+test('resolves an agent policy source to its originating CycleRun when available', () => {
+  const runs = [
+    { id: 7100, run_id: 15100 },
+    { id: 7101, run_id: 15101 },
+  ];
+
+  assert.equal(policySourceRunId('agent:15100'), 15100);
+  assert.equal(policySourceRunId('agent_run:15101'), 15101);
+  assert.equal(policySourceRunId('api:/cycles/901/behavior-policy'), null);
+  assert.equal(policyOriginatingRun({ source_reference: 'agent:15100' }, runs)?.id, 7100);
+  assert.equal(policyOriginatingRun({ source_reference: 'agent:99999' }, runs), null);
+});
+
+test('reads the immutable policy and producing change from a CycleRun context snapshot', () => {
+  const inspection = cycleRunPolicyInspection({
+    id: 7101,
+    cycle_id: 901,
+    revision_id: 4901,
+    scheduled_for: '2026-08-10T13:00:00Z',
+    started_at: '2026-08-10T13:00:00Z',
+    completed_at: '2026-08-10T13:05:00Z',
+    status: 'completed',
+    error: null,
+    skip_reason: null,
+    idea_id: 'preview-run-7101',
+    run_id: 15101,
+    prompt_snapshot: 'Review active Cortex thoughts.',
+    guidance_snapshot: [],
+    output_targets_snapshot: [],
+    context_snapshot: {
+      revision: {
+        id: 4901,
+        revision_number: 3,
+        prompt: 'Review active Cortex thoughts.',
+      },
+      behavior_change: {
+        id: 6001,
+        version: 3,
+        actor_type: 'agent',
+        actor_id: '15100',
+        source_reference: 'agent:15100',
+        rationale: 'Focused the next request.',
+        changed_fields: ['prompt'],
+        applied_at: '2026-08-09T13:00:00Z',
+        after_snapshot: {
+          snapshot_version: 1,
+          name: 'Morning priority sweep',
+          prompt: 'Review active Cortex thoughts.',
+          schedule_expr: '0 9 * * 1-5',
+          timezone: 'America/Toronto',
+          enabled: true,
+          max_concurrency: 1,
+          timeout_seconds: null,
+          retry_policy: { max_attempts: 2 },
+          model_override: null,
+          thinking_override: null,
+          execution_policy_key: null,
+          target_idea_id: 'preview-cycle-901',
+          guidance: ['Use the current workspace state as the source of truth.'],
+        },
+      },
+    },
+    self_review_summary: null,
+    created_at: '2026-08-10T13:00:00Z',
+  });
+
+  assert.equal(inspection.hasSnapshot, true);
+  assert.equal(inspection.version, 3);
+  assert.equal(inspection.revisionNumber, 3);
+  assert.equal(inspection.configuration.find((entry) => entry.key === 'prompt')?.value, 'Review active Cortex thoughts.');
+  assert.deepEqual(inspection.guidance, ['Use the current workspace state as the source of truth.']);
+  assert.deepEqual(inspection.change, {
+    id: 6001,
+    version: 3,
+    actor_type: 'agent',
+    actor_id: '15100',
+    source_reference: 'agent:15100',
+    rationale: 'Focused the next request.',
+    changed_fields: ['prompt'],
+    applied_at: '2026-08-09T13:00:00Z',
+  });
 });
 
 test('formats UTC API timestamps in the display timezone', () => {

--- a/frontend/src/lib/utils/effectivePolicy.test.js
+++ b/frontend/src/lib/utils/effectivePolicy.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  cycleRunAnchorId,
   cycleRunPolicyInspection,
   formatPolicyDateTime,
   guidanceDiff,
@@ -129,6 +130,7 @@ test('resolves an agent policy source to its originating CycleRun when available
   ];
 
   assert.equal(policySourceRunId('agent:15100'), 15100);
+  assert.equal(cycleRunAnchorId(7100), 'cycle-run-7100');
   assert.equal(policySourceRunId('agent_run:15101'), 15101);
   assert.equal(policySourceRunId('api:/cycles/901/behavior-policy'), null);
   assert.equal(policyOriginatingRun({ source_reference: 'agent:15100' }, runs)?.id, 7100);

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -29,7 +29,10 @@
   import AiPromptComposer from '$lib/features/composer/components/AiPromptComposer.svelte';
   import CycleRunPolicySnapshot from '$lib/features/cycles/components/CycleRunPolicySnapshot.svelte';
   import EffectiveCyclePolicyView from '$lib/features/cycles/components/EffectiveCyclePolicyView.svelte';
-  import type { CyclePolicyEditorApi } from '$lib/features/cycles/domain/effectivePolicy';
+  import {
+    cycleRunAnchorId,
+    type CyclePolicyEditorApi,
+  } from '$lib/features/cycles/domain/effectivePolicy';
   import { EFFECTIVE_POLICY_CLIENT_CONTEXT } from '$lib/features/cycles/domain/effectivePolicyClientContext';
   import { ui } from '$lib/stores/ui.svelte';
   import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
@@ -1058,7 +1061,7 @@
                     {:else}
                       <div class="runs-list">
                         {#each runs as run}
-                          <article class="run-row" id={`cycle-run-${run.id}`}>
+                          <article class="run-row" id={cycleRunAnchorId(run.id)}>
                             <div class="run-row-main">
                               <span class="run-row-eyebrow">Run #{run.id}</span>
                               <strong>{formatDateTime(run.scheduled_for)}</strong>

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -5,8 +5,7 @@
 
   import {
     api,
-    type CyclePolicyConfigurationRead,
-    type CyclePolicyFieldSourceRead,
+    type CyclePolicyChangeRead,
     type CyclePolicyHistoryRead,
     type CycleRead,
     type CycleRunRead,
@@ -28,12 +27,17 @@
     type ConstellationPageFrameModalContext,
   } from '$lib/components/constellation/constellationPageFrameContext';
   import AiPromptComposer from '$lib/features/composer/components/AiPromptComposer.svelte';
+  import CycleRunPolicySnapshot from '$lib/features/cycles/components/CycleRunPolicySnapshot.svelte';
   import EffectiveCyclePolicyView from '$lib/features/cycles/components/EffectiveCyclePolicyView.svelte';
   import type { CyclePolicyEditorApi } from '$lib/features/cycles/domain/effectivePolicy';
   import { EFFECTIVE_POLICY_CLIENT_CONTEXT } from '$lib/features/cycles/domain/effectivePolicyClientContext';
   import { ui } from '$lib/stores/ui.svelte';
   import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
-  import { createPreviewBehaviorPolicyClient } from './previewBehaviorPolicy';
+  import {
+    createPreviewBehaviorPolicyClient,
+    createPreviewBehaviorPolicyFixture,
+    createPreviewCycleRunPolicyData,
+  } from './previewBehaviorPolicy';
 
   type ThinkingLevel = '' | 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   type ScheduleCadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
@@ -296,11 +300,22 @@
     status: string,
     prompt: string,
     daysOffset: number,
+    policyChange: CyclePolicyChangeRead | null = null,
   ): CycleRunRead {
     const timestamp = previewIso(daysOffset);
+    const policyData = policyChange
+      ? createPreviewCycleRunPolicyData(id, policyChange)
+      : {
+          revision_id: null,
+          guidance_snapshot: [],
+          output_targets_snapshot: [],
+          context_snapshot: {},
+          self_review_summary: null,
+        };
     return {
       id,
       cycle_id: cycleId,
+      ...policyData,
       scheduled_for: timestamp,
       started_at: timestamp,
       completed_at: status === 'running' ? null : previewIso(daysOffset, 1),
@@ -314,130 +329,12 @@
     };
   }
 
-  function previewBehaviorPolicy(cycle: CycleRead): {
-    policy: EffectiveCyclePolicyRead;
-    history: CyclePolicyHistoryRead;
-  } {
-    const changedAt = previewIso(-2);
-    const configuration: CyclePolicyConfigurationRead = {
-      name: cycle.name,
-      prompt: cycle.prompt,
-      schedule_expr: cycle.schedule_expr,
-      schedule_human: cycle.schedule_human,
-      timezone: cycle.timezone,
-      enabled: cycle.enabled,
-      max_concurrency: 1,
-      timeout_seconds: null,
-      retry_policy: { max_attempts: 2 },
-      model_override: cycle.model_override,
-      thinking_override: cycle.thinking_override,
-      execution_policy_key: cycle.execution_policy_key,
-      target_idea_id: cycle.target_idea_id,
-    };
-    const activeGuidance = [
-      'Use the current workspace state as the source of truth.',
-      'Keep the result concise and name any blocker that needs attention.',
-    ];
-    const source: CyclePolicyFieldSourceRead = {
-      version: 2,
-      cycle_revision_id: 4100 + cycle.id,
-      actor_type: 'human',
-      actor_id: 'preview-user',
-      source_reference: `api:/cycles/${cycle.id}/behavior-policy`,
-      rationale: 'Approved behavior for the next run.',
-      changed_at: changedAt,
-      change_id: 5100 + cycle.id,
-    };
-    const fieldSources = Object.fromEntries(
-      [...Object.keys(configuration), 'guidance'].map((field) => [field, { ...source }]),
-    ) as Record<string, CyclePolicyFieldSourceRead>;
-    const policy: EffectiveCyclePolicyRead = {
-      workspace_id: 'preview-org',
-      policy_kind: 'cycle',
-      target_type: 'cycle',
-      target_id: String(cycle.id),
-      version: 2,
-      revision_id: source.cycle_revision_id,
-      configuration,
-      guidance: activeGuidance,
-      editable_fields: [
-        'prompt',
-        'schedule_expr',
-        'timezone',
-        'enabled',
-        'model_override',
-        'thinking_override',
-        'guidance',
-      ],
-      output_targets: [
-        {
-          id: 6100 + cycle.id,
-          target_type: 'cycle_ledger',
-          target_id: String(cycle.id),
-          label: 'Cycle ledger',
-          config: { format: 'summary' },
-          source_type: 'system',
-          source_id: 'cycle-defaults',
-          rationale: 'Keep a durable result for later review.',
-          created_at: previewIso(-18),
-          updated_at: changedAt,
-        },
-      ],
-      output_targets_read_only: true,
-      source: {
-        revision_id: source.cycle_revision_id,
-        actor_type: source.actor_type,
-        actor_id: source.actor_id,
-        rationale: source.rationale,
-        source_reference: source.source_reference,
-        changed_at: changedAt,
-      },
-      field_sources: fieldSources,
-      latest_change: {
-        id: source.change_id ?? 0,
-        version: 2,
-        actor_type: 'human',
-        actor_id: 'preview-user',
-        source_reference: source.source_reference ?? '',
-        rationale: source.rationale ?? '',
-        changed_fields: ['guidance'],
-        applied_at: changedAt,
-        reverted_from_id: null,
-      },
-    };
-    return {
-      policy,
-      history: {
-        items: [
-          {
-            id: source.change_id ?? 0,
-            version: 2,
-            actor_type: 'human',
-            actor_id: 'preview-user',
-            source_reference: source.source_reference ?? '',
-            rationale: 'Replace guidance that used an old priority list.',
-            changed_fields: ['guidance'],
-            applied_at: changedAt,
-            reverted_from_id: null,
-            workspace_id: 'preview-org',
-            policy_kind: 'cycle',
-            target_type: 'cycle',
-            target_id: String(cycle.id),
-            before_snapshot: {
-              configuration,
-              guidance: [...activeGuidance, 'Use the legacy priority list before reviewing the workspace.'],
-            },
-            after_snapshot: { configuration, guidance: activeGuidance },
-            cycle_revision_id: source.cycle_revision_id ?? 0,
-          },
-        ],
-        pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
-      },
-    };
-  }
-
   function setPreviewBehaviorPolicy(cycle: CycleRead) {
-    const { policy, history } = previewBehaviorPolicy(cycle);
+    const { policy, history } = createPreviewBehaviorPolicyFixture(cycle, {
+      humanChangedAt: previewIso(-4),
+      agentChangedAt: previewIso(-2),
+      originatingAgentRunId: cycle.id === 901 ? 15100 : 100000 + cycle.id,
+    });
     previewPolicies = { ...previewPolicies, [cycle.id]: policy };
     previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: history };
     previewPolicyClients[cycle.id] = createPreviewBehaviorPolicyClient({
@@ -506,10 +403,13 @@
 
     cycles = previewCycles;
     for (const cycle of previewCycles) setPreviewBehaviorPolicy(cycle);
+    const priorityHistory = previewPolicyHistories[901].items;
+    const agentPolicyChange = priorityHistory.find((change) => change.version === 3) ?? null;
+    const humanPolicyChange = priorityHistory.find((change) => change.version === 2) ?? null;
     previewRuns = {
       901: [
-        previewRun(7101, 901, 'completed', previewCycles[0].prompt, -1),
-        previewRun(7100, 901, 'completed', previewCycles[0].prompt, -2),
+        previewRun(7101, 901, 'completed', previewCycles[0].prompt, -1, agentPolicyChange),
+        previewRun(7100, 901, 'completed', previewCycles[0].prompt, -2, humanPolicyChange),
       ],
       902: [previewRun(7201, 902, 'completed', previewCycles[1].prompt, -4)],
       903: [previewRun(7301, 903, 'failed', previewCycles[2].prompt, -2)],
@@ -1135,6 +1035,7 @@
                     cycleId={cycle.id}
                     previewPolicy={isCyclesPreview ? previewPolicies[cycle.id] : null}
                     previewHistory={isCyclesPreview ? previewPolicyHistories[cycle.id] : null}
+                    {runs}
                     displayTimezone={isCyclesPreview ? localTimezone : null}
                     editable
                     refreshSerial={behaviorPolicyRefreshSerial}
@@ -1157,7 +1058,7 @@
                     {:else}
                       <div class="runs-list">
                         {#each runs as run}
-                          <article class="run-row">
+                          <article class="run-row" id={`cycle-run-${run.id}`}>
                             <div class="run-row-main">
                               <span class="run-row-eyebrow">Run #{run.id}</span>
                               <strong>{formatDateTime(run.scheduled_for)}</strong>
@@ -1176,6 +1077,7 @@
                                 <span>{run.skip_reason}</span>
                               {/if}
                             </div>
+                            <CycleRunPolicySnapshot {run} {runs} displayTimezone={localTimezone} />
                           </article>
                         {/each}
                       </div>

--- a/frontend/src/routes/cycles/previewBehaviorPolicy.ts
+++ b/frontend/src/routes/cycles/previewBehaviorPolicy.ts
@@ -2,10 +2,13 @@ import type {
   CyclePolicyChangeRead,
   CyclePolicyConfigurationRead,
   CyclePolicyDiffEntryRead,
+  CyclePolicyFieldSourceRead,
   CyclePolicyHistoryRead,
   CyclePolicyPreviewRead,
   CyclePolicyProposal,
   CyclePolicySnapshotRead,
+  CycleRead,
+  CycleRunRead,
   EffectiveCyclePolicyRead,
 } from '$lib/api/client';
 
@@ -30,6 +33,263 @@ type PendingPreview = {
   preview: CyclePolicyPreviewRead;
   revertedFromId: number | null;
 };
+
+type PreviewBehaviorPolicyFixtureOptions = {
+  humanChangedAt: string;
+  agentChangedAt: string;
+  originatingAgentRunId: number;
+};
+
+export function createPreviewBehaviorPolicyFixture(
+  cycle: CycleRead,
+  options: PreviewBehaviorPolicyFixtureOptions,
+): { policy: EffectiveCyclePolicyRead; history: CyclePolicyHistoryRead } {
+  const configuration: CyclePolicyConfigurationRead = {
+    name: cycle.name,
+    prompt: cycle.prompt,
+    schedule_expr: cycle.schedule_expr,
+    schedule_human: cycle.schedule_human,
+    timezone: cycle.timezone,
+    enabled: cycle.enabled,
+    max_concurrency: 1,
+    timeout_seconds: null,
+    retry_policy: { max_attempts: 2 },
+    model_override: cycle.model_override,
+    thinking_override: cycle.thinking_override,
+    execution_policy_key: cycle.execution_policy_key,
+    target_idea_id: cycle.target_idea_id,
+  };
+  const priorConfiguration = {
+    ...configuration,
+    prompt: 'Review current priorities, summarize the most important items, and continue in the planning thread.',
+  };
+  const activeGuidance = [
+    'Use the current workspace state as the source of truth.',
+    'Keep the result concise and name any blocker that needs attention.',
+  ];
+  const retiredGuidance = 'Use the legacy priority list before reviewing the workspace.';
+  const humanChangeId = 5100 + cycle.id;
+  const agentChangeId = 5200 + cycle.id;
+  const humanRevisionId = 4100 + cycle.id;
+  const agentRevisionId = 4200 + cycle.id;
+  const humanSource = {
+    version: 2,
+    cycle_revision_id: humanRevisionId,
+    actor_type: 'user',
+    actor_id: 'preview-user',
+    source_reference: `api:/cycles/${cycle.id}/behavior-policy`,
+    rationale: 'Replace guidance that used an old priority list.',
+    changed_at: options.humanChangedAt,
+    change_id: humanChangeId,
+  } satisfies CyclePolicyFieldSourceRead;
+  const agentSource = {
+    version: 3,
+    cycle_revision_id: agentRevisionId,
+    actor_type: 'agent',
+    actor_id: String(options.originatingAgentRunId),
+    source_reference: `agent:${options.originatingAgentRunId}`,
+    rationale: 'Focused the request after reviewing the prior Cycle run.',
+    changed_at: options.agentChangedAt,
+    change_id: agentChangeId,
+  } satisfies CyclePolicyFieldSourceRead;
+  const fieldSources = Object.fromEntries(
+    [...Object.keys(configuration), 'guidance'].map((field) => [field, { ...humanSource }]),
+  ) as Record<string, CyclePolicyFieldSourceRead>;
+  fieldSources.prompt = { ...agentSource };
+
+  const humanChange: CyclePolicyChangeRead = {
+    id: humanChangeId,
+    version: 2,
+    actor_type: humanSource.actor_type,
+    actor_id: humanSource.actor_id,
+    source_reference: humanSource.source_reference,
+    rationale: humanSource.rationale,
+    changed_fields: ['guidance'],
+    applied_at: options.humanChangedAt,
+    reverted_from_id: null,
+    workspace_id: 'preview-org',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: String(cycle.id),
+    before_snapshot: {
+      configuration: clonePlainData(priorConfiguration),
+      guidance: [...activeGuidance, retiredGuidance],
+    },
+    after_snapshot: {
+      configuration: clonePlainData(priorConfiguration),
+      guidance: [...activeGuidance],
+    },
+    cycle_revision_id: humanRevisionId,
+  };
+  const agentChange: CyclePolicyChangeRead = {
+    id: agentChangeId,
+    version: 3,
+    actor_type: agentSource.actor_type,
+    actor_id: agentSource.actor_id,
+    source_reference: agentSource.source_reference,
+    rationale: agentSource.rationale,
+    changed_fields: ['prompt'],
+    applied_at: options.agentChangedAt,
+    reverted_from_id: null,
+    workspace_id: 'preview-org',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: String(cycle.id),
+    before_snapshot: {
+      configuration: clonePlainData(priorConfiguration),
+      guidance: [...activeGuidance],
+    },
+    after_snapshot: {
+      configuration: clonePlainData(configuration),
+      guidance: [...activeGuidance],
+    },
+    cycle_revision_id: agentRevisionId,
+  };
+  const policy: EffectiveCyclePolicyRead = {
+    workspace_id: 'preview-org',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: String(cycle.id),
+    version: 3,
+    revision_id: agentRevisionId,
+    configuration,
+    guidance: activeGuidance,
+    editable_fields: [
+      'prompt',
+      'schedule_expr',
+      'timezone',
+      'enabled',
+      'model_override',
+      'thinking_override',
+      'guidance',
+    ],
+    output_targets: [
+      {
+        id: 6100 + cycle.id,
+        target_type: 'cycle_ledger',
+        target_id: String(cycle.id),
+        label: 'Cycle ledger',
+        config: { format: 'summary' },
+        source_type: 'system',
+        source_id: 'cycle-defaults',
+        rationale: 'Keep a durable result for later review.',
+        created_at: cycle.created_at,
+        updated_at: options.agentChangedAt,
+      },
+    ],
+    output_targets_read_only: true,
+    source: {
+      revision_id: agentRevisionId,
+      actor_type: agentSource.actor_type,
+      actor_id: agentSource.actor_id,
+      rationale: agentSource.rationale,
+      source_reference: agentSource.source_reference,
+      changed_at: options.agentChangedAt,
+    },
+    field_sources: fieldSources,
+    latest_change: {
+      id: agentChange.id,
+      version: agentChange.version,
+      actor_type: agentChange.actor_type,
+      actor_id: agentChange.actor_id,
+      source_reference: agentChange.source_reference,
+      rationale: agentChange.rationale,
+      changed_fields: [...agentChange.changed_fields],
+      applied_at: agentChange.applied_at,
+      reverted_from_id: agentChange.reverted_from_id,
+    },
+  };
+  return {
+    policy,
+    history: {
+      items: [agentChange, humanChange],
+      pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
+    },
+  };
+}
+
+function encodedPreviewPolicySnapshot(snapshot: CyclePolicySnapshotRead) {
+  const { schedule_human: _scheduleHuman, ...configuration } = snapshot.configuration;
+  return {
+    snapshot_version: 1,
+    ...clonePlainData(configuration),
+    guidance: [...snapshot.guidance],
+  };
+}
+
+export function createPreviewCycleRunPolicyData(
+  cycleRunId: number,
+  change: CyclePolicyChangeRead,
+): Pick<
+  CycleRunRead,
+  | 'revision_id'
+  | 'guidance_snapshot'
+  | 'output_targets_snapshot'
+  | 'context_snapshot'
+  | 'self_review_summary'
+> {
+  const configuration = change.after_snapshot.configuration;
+  return {
+    revision_id: change.cycle_revision_id,
+    guidance_snapshot: change.after_snapshot.guidance.map((guidance, index) => ({
+      id: cycleRunId * 10 + index,
+      cycle_id: Number(change.target_id),
+      revision_id: change.cycle_revision_id,
+      source_type: change.actor_type,
+      source_id: change.actor_id,
+      guidance,
+      rationale: change.rationale,
+      is_active: true,
+      created_at: change.applied_at,
+    })),
+    output_targets_snapshot: [],
+    context_snapshot: {
+      revision: {
+        id: change.cycle_revision_id,
+        cycle_id: Number(change.target_id),
+        revision_number: change.version,
+        source_type: change.actor_type,
+        source_id: change.actor_id,
+        rationale: change.rationale,
+        name: configuration.name,
+        prompt: configuration.prompt,
+        schedule_expr: configuration.schedule_expr,
+        timezone: configuration.timezone,
+        enabled: configuration.enabled,
+        model_override: configuration.model_override,
+        thinking_override: configuration.thinking_override,
+        execution_policy_key: configuration.execution_policy_key,
+        target_idea_id: configuration.target_idea_id,
+        context_policy: {},
+        created_at: change.applied_at,
+      },
+      behavior_change: {
+        id: change.id,
+        workspace_id: change.workspace_id,
+        policy_kind: change.policy_kind,
+        target_type: change.target_type,
+        target_id: change.target_id,
+        version: change.version,
+        actor_type: change.actor_type,
+        actor_id: change.actor_id,
+        source_reference: change.source_reference,
+        rationale: change.rationale,
+        before_snapshot: encodedPreviewPolicySnapshot(change.before_snapshot),
+        after_snapshot: encodedPreviewPolicySnapshot(change.after_snapshot),
+        changed_fields: [...change.changed_fields],
+        cycle_revision_id: change.cycle_revision_id,
+        applied_at: change.applied_at,
+        reverted_from_id: change.reverted_from_id,
+      },
+      launch_context: {
+        origin: 'cycle_scheduler',
+        source: 'cycle_scheduler',
+        run_kind: 'scheduled_digest',
+      },
+    },
+    self_review_summary: 'Completed the review with the admitted policy unchanged.',
+  };
+}
 
 function snapshot(policy: EffectiveCyclePolicyRead): CyclePolicySnapshotRead {
   return {


### PR DESCRIPTION
Closes #786

Slice **5 of 6** of the Workspace behavior editor ([#738](https://github.com/Illospace/illospace/issues/738)).

**Stacked on [#807](https://github.com/Illospace/illospace/pull/807) (slice 4), which is stacked on [#803](https://github.com/Illospace/illospace/pull/803) (slice 3).** Merge the train from the bottom. This PR targets slice 4's branch, so its `Closes` link only registers once it is retargeted to `main`.

## See it in 30 seconds — no backend needed

```
npm --prefix frontend run dev
```

Open **`http://localhost:5173/cycles?preview=1`**, then on **Morning priority sweep**:

1. Under **Effective behavior**, click **History**.
2. Compare **Version 3** with **Version 2** — one is an agent change, one is a human change.
3. Click **Originating Run #7100** on the version 3 entry. It jumps to that run.
4. Under **Recent runs → Run #7101**, click **Execution snapshot**.

## What it adds

The reviewer's surface: *how behavior got to where it is.*

- **Agent changes are distinguishable at a glance from human ones** — a filled **Agent** pill versus a muted **Human** pill, each naming its actor.
- **The originating run is named and linked** when a change came from a run, so a user who asked Illo to change a Cycle can trace the result back to the request.
- **A past CycleRun shows the exact policy snapshot it executed under**, plus the change that produced it. This is the payoff of the audit design: today, explaining a run's behavior means reading *today's* policy and hoping it did not change.
- Retired guidance stays readable in history.

## Verified by hand in a browser

The build worker could not drive a browser (its sandbox refuses local port binding), so I drove the flow myself at `localhost:5200/cycles?preview=1`, before and after the refactor below.

| acceptance check | result |
|---|---|
| History ordered by effective version, paginates | **Pass** — Version 3 above Version 2 |
| Agent change visibly distinct, originating run named | **Pass** — Agent/Human pills; version 3 links Run #7100, the human change correctly links none |
| Past CycleRun shows its snapshot and the change that produced it | **Pass** — full configuration + "2 admitted" guidance, and provenance naming the agent actor and Run #7100 |
| Retired guidance readable in history | **Pass** |

Both collapsible sections were confirmed to **open on click**, not merely to exist in the DOM. A run with no snapshot renders **"Not recorded"** rather than breaking (seen on the failed run #7301 fixture).

Anchor integrity was checked in the live DOM: every `#cycle-run-*` link on the page resolves to a real element.

## Gates

Run serially with zero other Codex workers live:

- `npm test` → **271 tests, 271 pass, 0 fail**
- `npm run check` → **6712 files, 0 errors, 0 warnings**
- `npm run build` → clean

No Python changed, so no Python lane.

⚠️ **If you run `npm test` under Node 20 you will see 41 failures. Ignore them.** `npm test` is `node --test`, and under Node 20 **41 of the 45 test files fail**, including files this branch never touches (`uuid`, `datetime`, `slashCommand`). The repo's default runtime is Node 22, where it is 271/271. Node 20 is only needed for `npm ci` / `check` / `build`, whose Node 22 wrapper crashes in a macOS security lookup on this machine.

## A maintainability review said BLOCKING — here is what changed

A thermo-nuclear code-quality review (Codex, cross-family) returned **BLOCKING** on the first commit. I verified each finding against the code before folding it, and one of the three was overstated.

**Folded (commit 2edd5b5):**

1. **Duplicate presentation owners.** The new snapshot component had its own copy of the policy-field renderer already in `ActiveCyclePolicyView`, and its own copy of the provenance treatment already in `CyclePolicyHistory`. Extracted two shared components — `CyclePolicyFieldList.svelte` and `CyclePolicyProvenanceLine.svelte` — and pointed all three call sites at them. Net effect: `ActiveCyclePolicyView` −96 lines, `CyclePolicyHistory` −60, `CycleRunPolicySnapshot` −166.
2. **Raw CSS literals.** The new markup used `border-radius: 8px` / `gap: 12px` where the repo has `--radius-*` and `--sp-*` tokens. All three components this branch owns now carry **zero** raw radius/spacing literals.
3. **An unowned DOM contract.** Two components emitted `href="#cycle-run-${id}"` while the matching `id` was written in exactly one place, so any future consumer would silently get dead links. Now a single exported `cycleRunAnchorId()` produces both sides, with a test.

**Corrected:** the review claimed `ThreadCyclesPane.svelte` renders these runs without matching IDs and therefore already has dead links. It does not reference these components at all — no dead link ever shipped. The real problem was the unowned contract above, which is what I fixed.

**Left open (note, not blocking):** the snapshot field list in `effectivePolicy.ts` mirrors the policy configuration schema without a type relationship to the canonical contract, so a newly added field could appear in the active view and silently vanish from historical snapshots. Worth a follow-up ticket rather than widening this PR.

## Separate finding for slice 4, not fixed here

`CyclePolicyHistory.svelte` carries **14 hardcoded spacing/radius values** that arrived with slice 4 and are unchanged by this branch — its sibling `ActiveCyclePolicyView.svelte` on `main` has zero. They belong to [#807](https://github.com/Illospace/illospace/pull/807)'s scope, so I left them rather than widening this diff.

## Assumptions

- Slice 6 ([#787](https://github.com/Illospace/illospace/issues/787)) owns keyboard and small-screen work; this PR does not attempt it.
- The preview fixture gained an agent-authored change and a run carrying a snapshot so the surface is reviewable offline. Fixture only — no production behavior branches on preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
