### PR TITLE
feat(cycles): behavior editor slice 6 — keyboard operability and small-screen rollback

### DIFF
--- a/.review/787-keyboard-small-screen.md
+++ b/.review/787-keyboard-small-screen.md
@@ -69,12 +69,40 @@ Recorded so the next reader does not re-investigate them:
    they carry `white-space: nowrap; text-overflow: ellipsis` and are one-line previews
    of each cycle's description. Pre-existing list styling, not the policy surface.
 
-## Gates (re-run by the orchestrator, serially, at load average 2.4)
+## The code-quality review, and what it changed
+
+A Codex maintainability review returned **BLOCKING** with three findings. Two were
+folded into the branch; all three were verified against the code first.
+
+1. **`focusOutsideMenu` rebuilt the browser's tab order from an incomplete selector.**
+   Real, and live on this page. Measured in the running DOM: the original selector found
+   26 focusable elements and **missed all four `<summary>` elements** — "History",
+   "Recent runs", and both "Execution snapshot" toggles, which are exactly what slices 5
+   and 6 add. Tabbing out of an open select would skip them.
+   Fixed by extracting `frontend/src/lib/utils/focusOrder.ts`: a complete selector
+   (`summary`, `contenteditable`, `area[href]`, media controls), rejection of **every**
+   negative `tabIndex` rather than only `-1`, `inert`/`hidden` subtree exclusion, and
+   correct positive-`tabindex` ordering. The same DOM now yields 30 elements.
+   `ConstellationSelect` no longer carries a document-wide focus walk; it calls
+   `nextFocusableFrom`.
+2. **The keyboard state machine had no regression test.** Correct. This repo has **no DOM
+   test framework** — `npm test` is `node --test src/lib/utils/*.test.js`, with no jsdom,
+   happy-dom or vitest — so a DOM interaction test was out of scope. Instead the pure
+   index math moved to `frontend/src/lib/utils/selectKeyboard.ts` with six unit tests:
+   wrapping past both ends, skipping disabled options, an all-disabled list, an empty
+   list, a value absent from the options, and Home/End. **The DOM-level interactions
+   (portal, real Tab) remain untested** — a known, accepted gap.
+3. **Two authorities for preview history** (`previewBehaviorPolicy.ts`). Non-blocking,
+   collapsed to one canonical store.
+
+Every behavior in the table above was re-driven after the refactor and still holds.
+
+## Gates (re-run by the orchestrator, serially, at load average 2.5)
 
 ```
 node --version   v22.22.0
-npm test         272/272 pass, 0 fail
-npm run check    6877 files, 0 errors, 0 warnings
+npm test         278/278 pass, 0 fail   (272 before, +6 selectKeyboard tests)
+npm run check    6879 files, 0 errors, 0 warnings
 npm run build    clean
 ```
 
@@ -91,11 +119,16 @@ this branch. This diff adds no network calls.
 
 `frontend/src/lib/components/constellation/ConstellationSelect.svelte` gained the
 keyboard behavior, rather than the cycles feature growing its own select. That is the
-correct call under the project's reuse rule, and it means **three surfaces outside this
-ticket inherit the improvement**: the workspace composer, the system runtime select,
-and the vault page.
+correct call under the project's reuse rule, and it means **two surfaces outside this
+ticket inherit the improvement**: the system runtime select (`routes/system/RuntimeSelect.svelte`)
+and the vault page (`routes/vault/+page.svelte`, four call sites).
 
-**Those three were NOT driven in a browser.** `/system` and `/vault` redirect to
+A note on counting, because the obvious grep is wrong: searching for
+`ConstellationSelect` also matches **`ConstellationSelectChip`**, which is a different
+component. `WorkspaceComposerAdapter.svelte` uses the Chip and does **not** inherit this
+change. Use a word boundary — `grep -rn "ConstellationSelect\b" … | grep -v SelectChip`.
+
+**Those two were NOT driven in a browser.** `/system` and `/vault` redirect to
 `/login`, and the preview harness only covers the Cycles surface, so exercising them
 needs a running backend. What is known: the two new props (`ariaDescribedby`,
 `ariaInvalid`) are optional, so no existing call site changes shape; `svelte-check`

--- a/.review/787-keyboard-small-screen.md
+++ b/.review/787-keyboard-small-screen.md
@@ -1,0 +1,105 @@
+# #787 — slice 6 verification (keyboard operability + small-screen rollback)
+
+Verified by the R3 orchestrator on 2026-08-11, in a real browser, on this branch.
+The implementing worker could **not** run a browser (its localhost bind returned
+`EPERM`), so every result below was produced by the orchestrator afterwards, not
+copied from the worker's report.
+
+## How to reproduce
+
+```
+export PATH="/Users/redamjahed/.nvm/versions/node/v22.22.0/bin:$PATH"   # Node 22 — see note
+npm --prefix frontend run dev
+```
+Open `http://localhost:5173/cycles?preview=1`. **No backend is needed** — the page
+renders from `frontend/src/routes/cycles/previewBehaviorPolicy.ts`.
+
+## Keyboard — what was driven, and the result
+
+All of these were exercised against the live page by dispatching real `KeyboardEvent`s
+at the focused element, plus genuine mouse clicks.
+
+**Read this caveat before trusting the table.** The browser-automation harness used here
+delivers text input but does **not** deliver OS-level key events to the page — verified
+directly: with capture-phase listeners armed on the focused element, pressing `Return`
+and pressing `a` both recorded **zero** events, while typing text into the search box
+worked. So the keyboard results below prove the component's *handlers* behave correctly;
+they do not exercise the browser's own native activation. One specific interaction is
+therefore unproven: on a real `Enter`, the browser fires the keydown (which opens the
+menu) and then natively activates the `<button>`. `handleTriggerKeydown` calls
+`preventDefault()`, which should suppress that activation — but a human should confirm
+Enter on a closed select opens it and leaves it open. It is the one step worth two
+seconds of a reviewer's time.
+
+The mouse path was verified end to end with real click events: click opens the menu and
+moves focus to the selected option; click again closes it and returns focus to the
+trigger.
+
+| Path | Result |
+|---|---|
+| Activate **Edit behavior** | Editor opens, focus moves to the **Mission prompt** textarea |
+| **Enter** on a policy select | Menu opens, focus lands on the **currently selected** option (`aria-selected="true"`) |
+| **ArrowDown** inside the menu | Moves to the next enabled option (`Workspace default` → `None`) |
+| **End** inside the menu | Jumps to the last option (`xHigh`) |
+| **Escape** inside the menu | Menu closes, focus returns to the trigger |
+| **Tab** inside the menu | Menu closes, focus advances to the next control (`Model override` → `Thinking override`) |
+| **Shift+Tab** inside the menu | Menu closes, focus moves **backwards** to the previous control |
+| Activate **Review change** | Focus moves to the `Review behavior change` heading |
+
+Accessible names on the two history Revert buttons are now version-specific —
+`"Revert behavior version 3"` and `"Revert behavior version 2"`. Before this change
+both were announced only as "Revert", which made them indistinguishable to a screen
+reader user choosing which version to roll back to.
+
+## Small screen — 375 × 812
+
+- The page does **not** scroll horizontally: `documentElement.scrollWidth === clientWidth === 375`.
+- Checked in three states: the read-only effective policy, the open draft editor, and
+  the review diff. All three pass.
+- The before/after diff stacks into a single readable column and wraps; no sideways
+  scroll, nothing clipped.
+
+### Two overflows that are NOT from this change
+
+Recorded so the next reader does not re-investigate them:
+
+1. `SECTION.constellation-page-frame` reports `scrollWidth` 359 vs `clientWidth` 343
+   (16px). That is the shared app shell, untouched by this branch.
+2. Three `<small>` elements in the cycle **list rows** overflow their box, by design —
+   they carry `white-space: nowrap; text-overflow: ellipsis` and are one-line previews
+   of each cycle's description. Pre-existing list styling, not the policy surface.
+
+## Gates (re-run by the orchestrator, serially, at load average 2.4)
+
+```
+node --version   v22.22.0
+npm test         272/272 pass, 0 fail
+npm run check    6877 files, 0 errors, 0 warnings
+npm run build    clean
+```
+
+**Node 22 is required.** Under Node 20, 41 of the 45 frontend test files fail —
+including files this branch never touches. That red is the Node version, not the code.
+
+## Console
+
+The only console errors are repeated `500`s from `/api/health` polling an absent
+backend — expected when running the preview without the API, and present regardless of
+this branch. This diff adds no network calls.
+
+## Scope note — a shared component changed
+
+`frontend/src/lib/components/constellation/ConstellationSelect.svelte` gained the
+keyboard behavior, rather than the cycles feature growing its own select. That is the
+correct call under the project's reuse rule, and it means **three surfaces outside this
+ticket inherit the improvement**: the workspace composer, the system runtime select,
+and the vault page.
+
+**Those three were NOT driven in a browser.** `/system` and `/vault` redirect to
+`/login`, and the preview harness only covers the Cycles surface, so exercising them
+needs a running backend. What is known: the two new props (`ariaDescribedby`,
+`ariaInvalid`) are optional, so no existing call site changes shape; `svelte-check`
+passes across all four callers; and the behavior change is additive keyboard handling
+on a component that previously had almost none. The residual risk is behavioral, not
+structural — a caller that relied on the old click-to-close leaving focus where it was
+will now see focus return to the trigger. Worth a glance on staging when this merges.

--- a/frontend/src/lib/components/constellation/ConstellationSelect.svelte
+++ b/frontend/src/lib/components/constellation/ConstellationSelect.svelte
@@ -19,6 +19,8 @@
     disabled?: boolean;
     className?: string;
     ariaLabel?: string;
+    ariaDescribedby?: string;
+    ariaInvalid?: boolean | 'true' | 'false' | 'grammar' | 'spelling';
     size?: 'sm' | 'md';
     onValueChange?: (value: string) => void;
   };
@@ -33,6 +35,8 @@
     disabled = false,
     className = '',
     ariaLabel,
+    ariaDescribedby,
+    ariaInvalid,
     size = 'sm',
     onValueChange,
   }: Props = $props();
@@ -119,7 +123,66 @@
 
   function toggleOpen() {
     if (disabled || options.length === 0) return;
-    open = !open;
+    if (open) {
+      open = false;
+      triggerEl?.focus();
+      return;
+    }
+    openMenu();
+  }
+
+  function enabledOptionIndexes(): number[] {
+    return options.flatMap((option, index) => option.disabled ? [] : [index]);
+  }
+
+  function initialOptionIndex(): number {
+    const selectedIndex = options.findIndex((option) => option.value === value && !option.disabled);
+    return selectedIndex >= 0 ? selectedIndex : (enabledOptionIndexes()[0] ?? -1);
+  }
+
+  function optionElement(index: number): HTMLButtonElement | null {
+    return menuEl?.querySelector<HTMLButtonElement>(`[data-option-index="${index}"]`) ?? null;
+  }
+
+  function focusOption(index: number): void {
+    optionElement(index)?.focus();
+  }
+
+  function openMenu(): void {
+    open = true;
+    const index = initialOptionIndex();
+    tick().then(() => {
+      updateFixedMenuPosition();
+      if (index >= 0) focusOption(index);
+    });
+  }
+
+  function moveOptionFocus(currentIndex: number, direction: -1 | 1): void {
+    const indexes = enabledOptionIndexes();
+    if (!indexes.length) return;
+    const position = indexes.indexOf(currentIndex);
+    const nextPosition = position < 0
+      ? 0
+      : (position + direction + indexes.length) % indexes.length;
+    focusOption(indexes[nextPosition]);
+  }
+
+  function focusOutsideMenu(direction: -1 | 1): void {
+    if (!triggerEl) return;
+    const focusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+    const focusable = Array.from(document.querySelectorAll<HTMLElement>(focusableSelector))
+      .filter((element) => !menuEl?.contains(element) && element.getClientRects().length > 0);
+    const triggerIndex = focusable.indexOf(triggerEl);
+    const next = focusable[triggerIndex + direction];
+    open = false;
+    tick().then(() => (next ?? triggerEl).focus());
   }
 
   function selectValue(nextValue: string) {
@@ -137,13 +200,42 @@
 
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
       event.preventDefault();
-      open = true;
+      openMenu();
       return;
     }
 
     if (event.key === 'ArrowUp') {
       event.preventDefault();
-      open = true;
+      openMenu();
+    }
+  }
+
+  function handleOptionKeydown(event: KeyboardEvent, index: number): void {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveOptionFocus(index, event.key === 'ArrowDown' ? 1 : -1);
+      return;
+    }
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      const indexes = enabledOptionIndexes();
+      const nextIndex = event.key === 'Home' ? indexes[0] : indexes[indexes.length - 1];
+      if (nextIndex !== undefined) focusOption(nextIndex);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      open = false;
+      triggerEl?.focus();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      focusOutsideMenu(event.shiftKey ? -1 : 1);
     }
   }
 
@@ -165,12 +257,16 @@
   <button
     id={id}
     type="button"
+    role="combobox"
     bind:this={triggerEl}
     class="constellation-select-trigger"
     aria-label={label ? undefined : accessibleLabel}
     aria-labelledby={label ? labelId : undefined}
+    aria-describedby={ariaDescribedby}
+    aria-invalid={ariaInvalid}
     aria-expanded={open}
     aria-haspopup="listbox"
+    aria-controls={id ? `${id}-menu` : undefined}
     {disabled}
     onclick={toggleOpen}
     onkeydown={handleTriggerKeydown}
@@ -181,6 +277,7 @@
 
   {#if open}
     <div
+      id={id ? `${id}-menu` : undefined}
       bind:this={menuEl}
       use:portalMenu
       class="constellation-select-menu"
@@ -188,15 +285,18 @@
       role="listbox"
       aria-label={accessibleLabel}
     >
-      {#each options as option (option.value)}
+      {#each options as option, index (option.value)}
         {@const isActive = option.value === value}
         <button
           type="button"
           role="option"
           aria-selected={isActive}
+          tabindex="-1"
+          data-option-index={index}
           class={`constellation-select-option ${isActive ? 'is-active' : ''}`}
           disabled={option.disabled}
           onclick={() => selectValue(option.value)}
+          onkeydown={(event) => handleOptionKeydown(event, index)}
         >
           <span class="constellation-select-option-text">
             <span class="constellation-select-option-label">{option.label}</span>

--- a/frontend/src/lib/components/constellation/ConstellationSelect.svelte
+++ b/frontend/src/lib/components/constellation/ConstellationSelect.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import { tick } from 'svelte';
+  import { nextFocusableFrom } from '$lib/utils/focusOrder';
+  import {
+    edgeOptionIndex,
+    initialOptionIndex,
+    nextOptionIndex,
+  } from '$lib/utils/selectKeyboard';
   import ConstellationIcon from './ConstellationIcon.svelte';
 
   export type ConstellationSelectOption = {
@@ -131,15 +137,6 @@
     openMenu();
   }
 
-  function enabledOptionIndexes(): number[] {
-    return options.flatMap((option, index) => option.disabled ? [] : [index]);
-  }
-
-  function initialOptionIndex(): number {
-    const selectedIndex = options.findIndex((option) => option.value === value && !option.disabled);
-    return selectedIndex >= 0 ? selectedIndex : (enabledOptionIndexes()[0] ?? -1);
-  }
-
   function optionElement(index: number): HTMLButtonElement | null {
     return menuEl?.querySelector<HTMLButtonElement>(`[data-option-index="${index}"]`) ?? null;
   }
@@ -150,7 +147,7 @@
 
   function openMenu(): void {
     open = true;
-    const index = initialOptionIndex();
+    const index = initialOptionIndex(options, value);
     tick().then(() => {
       updateFixedMenuPosition();
       if (index >= 0) focusOption(index);
@@ -158,31 +155,16 @@
   }
 
   function moveOptionFocus(currentIndex: number, direction: -1 | 1): void {
-    const indexes = enabledOptionIndexes();
-    if (!indexes.length) return;
-    const position = indexes.indexOf(currentIndex);
-    const nextPosition = position < 0
-      ? 0
-      : (position + direction + indexes.length) % indexes.length;
-    focusOption(indexes[nextPosition]);
+    const index = nextOptionIndex(options, currentIndex, direction);
+    if (index >= 0) focusOption(index);
   }
 
   function focusOutsideMenu(direction: -1 | 1): void {
     if (!triggerEl) return;
-    const focusableSelector = [
-      'a[href]',
-      'button:not([disabled])',
-      'input:not([disabled])',
-      'select:not([disabled])',
-      'textarea:not([disabled])',
-      '[tabindex]:not([tabindex="-1"])',
-    ].join(',');
-    const focusable = Array.from(document.querySelectorAll<HTMLElement>(focusableSelector))
-      .filter((element) => !menuEl?.contains(element) && element.getClientRects().length > 0);
-    const triggerIndex = focusable.indexOf(triggerEl);
-    const next = focusable[triggerIndex + direction];
+    const trigger = triggerEl;
+    const next = nextFocusableFrom(trigger, direction, menuEl);
     open = false;
-    tick().then(() => (next ?? triggerEl).focus());
+    tick().then(() => (next ?? trigger).focus());
   }
 
   function selectValue(nextValue: string) {
@@ -219,9 +201,8 @@
 
     if (event.key === 'Home' || event.key === 'End') {
       event.preventDefault();
-      const indexes = enabledOptionIndexes();
-      const nextIndex = event.key === 'Home' ? indexes[0] : indexes[indexes.length - 1];
-      if (nextIndex !== undefined) focusOption(nextIndex);
+      const nextIndex = edgeOptionIndex(options, event.key === 'Home' ? 'first' : 'last');
+      if (nextIndex >= 0) focusOption(nextIndex);
       return;
     }
 

--- a/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/ActiveCyclePolicyView.svelte
@@ -67,7 +67,12 @@
           <span>Version {policy.version}</span>
         </div>
         {#if canEdit}
-          <ConstellationButton variant="secondary" size="sm" onclick={onEdit}>
+          <ConstellationButton
+            variant="secondary"
+            size="sm"
+            data-policy-edit-control
+            onclick={onEdit}
+          >
             Edit behavior
           </ConstellationButton>
         {/if}
@@ -315,6 +320,7 @@
   .output-target {
     display: grid;
     gap: 7px;
+    min-width: 0;
     padding: 11px;
     border: 1px solid var(--constellation-surface-nested-border);
     border-radius: 7px;
@@ -341,7 +347,7 @@
   .output-target pre {
     max-width: 100%;
     margin: 0;
-    overflow: auto;
+    overflow-wrap: anywhere;
     white-space: pre-wrap;
   }
 

--- a/frontend/src/lib/features/cycles/components/CyclePolicyDraftEditor.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyDraftEditor.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
+
   import {
     ConstellationButton,
     ConstellationSelect,
@@ -82,6 +84,36 @@
   function removeGuidance(index: number): void {
     changeField('guidance', draft.guidance.filter((_, itemIndex) => itemIndex !== index));
   }
+
+  function fieldControlId(key: CyclePolicyFieldKey): string {
+    return `cycle-${cycleId}-policy-${key}`;
+  }
+
+  function fieldErrorId(key: CyclePolicyFieldKey): string {
+    return `${fieldControlId(key)}-error`;
+  }
+
+  function guidanceControlId(index: number): string {
+    return `${fieldControlId('guidance')}-${index + 1}`;
+  }
+
+  function focusControl(id: string): void {
+    tick().then(() => document.getElementById(id)?.focus());
+  }
+
+  onMount(() => {
+    focusControl(fieldControlId(POLICY_FIELD_SCHEMA[0].key));
+  });
+
+  $effect(() => {
+    const firstInvalidField = POLICY_FIELD_SCHEMA.find((field) => Boolean(errors[field.key]));
+    if (!firstInvalidField) return;
+    focusControl(
+      firstInvalidField.key === 'guidance'
+        ? guidanceControlId(0)
+        : fieldControlId(firstInvalidField.key),
+    );
+  });
 </script>
 
 <section class:compact class="policy-editor" aria-label="Edit cycle behavior">
@@ -99,28 +131,30 @@
     {#each POLICY_FIELD_SCHEMA as field (field.key)}
       {#if field.control === 'textarea'}
         <div class="editor-field" class:editor-field-full={field.fullWidth}>
-          <label for={`cycle-${cycleId}-policy-${field.key}`}>{field.label}</label>
+          <label for={fieldControlId(field.key)}>{field.label}</label>
           <ConstellationTextarea
-            id={`cycle-${cycleId}-policy-${field.key}`}
+            id={fieldControlId(field.key)}
             value={draft[field.key]}
             rows={field.rows}
             aria-invalid={errors[field.key] ? 'true' : undefined}
+            aria-describedby={errors[field.key] ? fieldErrorId(field.key) : undefined}
             oninput={(event) => changeField(field.key, inputValue(event))}
           />
-          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+          {#if errors[field.key]}<small id={fieldErrorId(field.key)} class="field-error">{errors[field.key]}</small>{/if}
         </div>
       {:else if field.control === 'text'}
         <div class="editor-field">
-          <label for={`cycle-${cycleId}-policy-${field.key}`}>{field.label}</label>
+          <label for={fieldControlId(field.key)}>{field.label}</label>
           <ConstellationTextInput
-            id={`cycle-${cycleId}-policy-${field.key}`}
+            id={fieldControlId(field.key)}
             value={draft[field.key]}
             mono={'mono' in field && field.mono}
             placeholder={field.placeholder}
             aria-invalid={errors[field.key] ? 'true' : undefined}
+            aria-describedby={errors[field.key] ? fieldErrorId(field.key) : undefined}
             oninput={(event) => changeField(field.key, inputValue(event))}
           />
-          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+          {#if errors[field.key]}<small id={fieldErrorId(field.key)} class="field-error">{errors[field.key]}</small>{/if}
         </div>
       {:else if field.control === 'toggle'}
         <div class="editor-field">
@@ -129,6 +163,7 @@
             type="button"
             class="policy-status-toggle"
             class:is-enabled={draft[field.key]}
+            aria-label={`${field.label}: ${draft[field.key] ? 'Enabled' : 'Paused'}`}
             aria-pressed={draft[field.key]}
             onclick={() => changeField(field.key, !draft[field.key])}
           >
@@ -140,17 +175,21 @@
         <div class="editor-field">
           <span class="editor-field-label">{field.label}</span>
           <ConstellationSelect
+            id={fieldControlId(field.key)}
             value={draft[field.key]}
             options={modelOptions}
             ariaLabel={field.label}
+            ariaInvalid={errors[field.key] ? 'true' : undefined}
+            ariaDescribedby={errors[field.key] ? fieldErrorId(field.key) : undefined}
             onValueChange={(value) => changeField(field.key, value)}
           />
-          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+          {#if errors[field.key]}<small id={fieldErrorId(field.key)} class="field-error">{errors[field.key]}</small>{/if}
         </div>
       {:else if field.control === 'thinking'}
         <div class="editor-field">
           <span class="editor-field-label">{field.label}</span>
           <ConstellationSelect
+            id={fieldControlId(field.key)}
             value={draft[field.key]}
             options={field.options}
             ariaLabel={field.label}
@@ -158,7 +197,11 @@
           />
         </div>
       {:else if field.control === 'guidance'}
-        <section class="guidance-editor editor-field-full" aria-labelledby={`cycle-${cycleId}-guidance-editor`}>
+        <section
+          class="guidance-editor editor-field-full"
+          aria-labelledby={`cycle-${cycleId}-guidance-editor`}
+          aria-describedby={errors[field.key] ? fieldErrorId(field.key) : undefined}
+        >
           <div class="guidance-editor-heading">
             <div>
               <span class="editor-field-label" id={`cycle-${cycleId}-guidance-editor`}>{field.label}</span>
@@ -173,9 +216,12 @@
               {#each draft[field.key] as guidance, index}
                 <li>
                   <ConstellationTextarea
+                    id={guidanceControlId(index)}
                     value={guidance}
                     rows={2}
                     aria-label={`Guidance ${index + 1}`}
+                    aria-invalid={errors[field.key] ? 'true' : undefined}
+                    aria-describedby={errors[field.key] ? fieldErrorId(field.key) : undefined}
                     oninput={(event) => updateGuidance(index, inputValue(event))}
                   />
                   <ConstellationButton
@@ -192,7 +238,7 @@
           {:else}
             <p class="empty-policy-value">No active guidance.</p>
           {/if}
-          {#if errors[field.key]}<small class="field-error">{errors[field.key]}</small>{/if}
+          {#if errors[field.key]}<small id={fieldErrorId(field.key)} class="field-error">{errors[field.key]}</small>{/if}
         </section>
       {/if}
     {/each}
@@ -388,6 +434,7 @@
 
   .editor-actions {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-end;
     gap: 8px;

--- a/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyHistory.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { tick } from 'svelte';
+
   import type { CyclePolicyHistoryRead, CycleRunRead } from '$lib/api/client';
   import { ConstellationButton } from '$lib/components/constellation';
   import CyclePolicyProvenanceLine from '$lib/features/cycles/components/CyclePolicyProvenanceLine.svelte';
@@ -35,19 +37,24 @@
   } = $props();
 
   let loadingMore = $state(false);
+  let historyRegionEl: HTMLDetailsElement | undefined = $state();
 
   async function loadMore(): Promise<void> {
     if (loadingMore) return;
     loadingMore = true;
     try {
       await onLoadMore();
+      await tick();
+      if (!history.pagination.has_more) {
+        historyRegionEl?.querySelector('summary')?.focus();
+      }
     } finally {
       loadingMore = false;
     }
   }
 </script>
 
-<details class="history-region">
+<details bind:this={historyRegionEl} class="history-region">
   <summary>
     <span>
       <strong>History</strong>
@@ -84,6 +91,8 @@
                     size="sm"
                     loading={workflowKind === 'reverting' && revertingChangeId === change.id}
                     disabled={workflowKind !== 'view'}
+                    aria-label={`Revert behavior version ${change.version}`}
+                    data-policy-revert-id={change.id}
                     onclick={() => onRevert(change.id)}
                   >
                     Revert
@@ -142,6 +151,11 @@
 
   .history-region summary::-webkit-details-marker {
     display: none;
+  }
+
+  .history-region summary:focus-visible {
+    outline: calc(var(--sp-1) / 2) solid var(--constellation-control-focus-ring);
+    outline-offset: calc(var(--sp-1) * -1);
   }
 
   .history-region summary > span:first-child {

--- a/frontend/src/lib/features/cycles/components/CyclePolicyReview.svelte
+++ b/frontend/src/lib/features/cycles/components/CyclePolicyReview.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
+
   import {
     ConstellationButton,
     ConstellationNotice,
@@ -28,17 +30,24 @@
   } = $props();
 
   const diffEntries = $derived(presentedPolicyDiff(review.preview));
+  let reviewHeadingEl: HTMLHeadingElement | undefined = $state();
 
   function inputValue(event: Event): string {
     return (event.currentTarget as HTMLTextAreaElement).value;
   }
+
+  onMount(() => {
+    tick().then(() => reviewHeadingEl?.focus());
+  });
 </script>
 
 <section class:compact class="policy-review" aria-label="Review cycle behavior change">
   <header class="editor-heading">
     <div>
       <span class="section-kicker">Review</span>
-      <h4>{review.kind === 'revert' ? 'Review revert' : 'Review behavior change'}</h4>
+      <h4 bind:this={reviewHeadingEl} tabindex="-1">
+        {review.kind === 'revert' ? 'Review revert' : 'Review behavior change'}
+      </h4>
     </div>
     <p>{activeRunBoundary}</p>
   </header>
@@ -107,6 +116,8 @@
       value={rationale}
       rows={3}
       maxlength={5000}
+      required
+      aria-required="true"
       placeholder="Why should this behavior change?"
       oninput={(event) => onRationaleChange(inputValue(event))}
     />
@@ -187,11 +198,13 @@
   .diff-list {
     display: grid;
     gap: 10px;
+    min-width: 0;
   }
 
   .diff-entry {
     display: grid;
     gap: 9px;
+    min-width: 0;
     padding: 12px;
     border: 1px solid var(--constellation-surface-nested-border);
     border-radius: 7px;
@@ -303,6 +316,7 @@
 
   .editor-actions {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-end;
     gap: 8px;

--- a/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
+++ b/frontend/src/lib/features/cycles/components/EffectiveCyclePolicyView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { beforeNavigate } from '$app/navigation';
-  import { getContext, onDestroy, onMount } from 'svelte';
+  import { getContext, onDestroy, onMount, tick } from 'svelte';
 
   import {
     api,
@@ -63,6 +63,7 @@
   let requestSerial = 0;
   let loadedCycleId: number | null = null;
   let loadedPolicyVersion: number | null = null;
+  let effectivePolicyEl: HTMLElement | undefined = $state();
   const resolvePolicyClient = getContext<EffectivePolicyClientResolver | undefined>(
     EFFECTIVE_POLICY_CLIENT_CONTEXT,
   );
@@ -146,14 +147,42 @@
     }
   }
 
-  function cancelEditing(): void {
-    controller?.cancelEditing(() => window.confirm('Discard this behavior draft?'));
+  function focusPolicyControl(selector: string): void {
+    tick().then(() => effectivePolicyEl?.querySelector<HTMLElement>(selector)?.focus());
   }
 
-  function applyReviewedChange(): void {
-    void controller?.applyReviewedChange(
+  function cancelEditing(): void {
+    const activeController = controller;
+    activeController?.cancelEditing(() => window.confirm('Discard this behavior draft?'));
+    if (activeController?.state.kind === 'view') {
+      focusPolicyControl('[data-policy-edit-control]');
+    }
+  }
+
+  function leaveReview(): void {
+    const activeController = controller;
+    const state = activeController?.state;
+    const revertChangeId = state?.kind === 'review' && state.review.kind === 'revert'
+      ? state.review.changeId
+      : null;
+    activeController?.leaveReview();
+    if (revertChangeId !== null) {
+      focusPolicyControl(`[data-policy-revert-id="${revertChangeId}"]`);
+    }
+  }
+
+  async function applyReviewedChange(): Promise<void> {
+    const activeController = controller;
+    await activeController?.applyReviewedChange(
       () => window.confirm('Apply this revert as a new behavior version?'),
     );
+    if (activeController !== controller) return;
+    if (
+      activeController?.state.kind === 'view'
+      || (activeController?.state.kind === 'conflicted' && !activeController.state.draft)
+    ) {
+      focusPolicyControl('[data-policy-edit-control]');
+    }
   }
 
   beforeNavigate(({ cancel }) => {
@@ -214,7 +243,12 @@
   });
 </script>
 
-<section class:compact class="effective-policy" aria-label="Effective cycle behavior">
+<section
+  bind:this={effectivePolicyEl}
+  class:compact
+  class="effective-policy"
+  aria-label="Effective cycle behavior"
+>
   <ActiveCyclePolicyView
     {cycleId}
     {policy}
@@ -268,7 +302,7 @@
         {...policyReviewProps(reviewState)}
         {compact}
         onRationaleChange={(rationale) => controller?.setRationale(rationale)}
-        onBack={() => controller?.leaveReview()}
+        onBack={leaveReview}
         onApply={applyReviewedChange}
       />
     {:else if showReadView}
@@ -323,6 +357,11 @@
     font-size: 12px;
   }
 
+  .policy-error span {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
   .policy-loading {
     display: grid;
     gap: 8px;
@@ -342,5 +381,13 @@
   @keyframes policy-pulse {
     from { background-position: 200% 0; }
     to { background-position: -200% 0; }
+  }
+
+  @media (max-width: 720px) {
+    .policy-error {
+      align-items: flex-start;
+      flex-direction: column;
+      padding: var(--sp-3);
+    }
   }
 </style>

--- a/frontend/src/lib/utils/behaviorPolicyEditor.test.js
+++ b/frontend/src/lib/utils/behaviorPolicyEditor.test.js
@@ -292,7 +292,7 @@ test('preview client runs semantic edit and revert flows through the production 
   const previewClient = createPreviewBehaviorPolicyClient({
     cycleId: 7,
     getPolicy: () => livePolicy,
-    getHistory: () => liveHistory,
+    historyItems: liveHistory.items,
     commit: (nextPolicy, nextHistory) => {
       livePolicy = nextPolicy;
       liveHistory = nextHistory;
@@ -342,18 +342,16 @@ test('preview client runs semantic edit and revert flows through the production 
 });
 
 test('preview history exposes an older page through the production controller', async () => {
-  const visibleHistory = {
-    items: [{ id: 3 }, { id: 2 }],
-    pagination: { limit: 2, offset: 0, has_more: true, next_offset: 2 },
-  };
+  const historyItems = [{ id: 3 }, { id: 2 }, { id: 1 }];
   const previewClient = createPreviewBehaviorPolicyClient({
     cycleId: 7,
     getPolicy: () => policy(),
-    getHistory: () => visibleHistory,
-    historyItems: [...visibleHistory.items, { id: 1 }],
+    historyItems,
+    historyPageSize: 2,
     commit: () => {},
     scheduleLabel: (expression, timezone) => `${expression} (${timezone})`,
   });
+  const visibleHistory = await previewClient.getCycleBehaviorPolicyHistory(7, 2);
   const controller = new EffectivePolicyWorkflowController({
     client: previewClient,
     cycleId: 7,
@@ -379,7 +377,7 @@ test('preview client reviews a semantic diff when policy state is proxied', asyn
   const previewClient = createPreviewBehaviorPolicyClient({
     cycleId: 7,
     getPolicy: () => livePolicy,
-    getHistory: () => history(),
+    historyItems: [],
     commit: () => {},
     scheduleLabel: (expression, timezone) => `${expression} (${timezone})`,
   });

--- a/frontend/src/lib/utils/behaviorPolicyEditor.test.js
+++ b/frontend/src/lib/utils/behaviorPolicyEditor.test.js
@@ -341,6 +341,36 @@ test('preview client runs semantic edit and revert flows through the production 
   assert.equal(controller.state.data.history.items[0].rationale, 'Restore the earlier preview behavior.');
 });
 
+test('preview history exposes an older page through the production controller', async () => {
+  const visibleHistory = {
+    items: [{ id: 3 }, { id: 2 }],
+    pagination: { limit: 2, offset: 0, has_more: true, next_offset: 2 },
+  };
+  const previewClient = createPreviewBehaviorPolicyClient({
+    cycleId: 7,
+    getPolicy: () => policy(),
+    getHistory: () => visibleHistory,
+    historyItems: [...visibleHistory.items, { id: 1 }],
+    commit: () => {},
+    scheduleLabel: (expression, timezone) => `${expression} (${timezone})`,
+  });
+  const controller = new EffectivePolicyWorkflowController({
+    client: previewClient,
+    cycleId: 7,
+    data: { policy: policy(), history: visibleHistory },
+  });
+
+  await controller.loadMoreHistory();
+
+  assert.deepEqual(controller.state.data.history.items.map(({ id }) => id), [3, 2, 1]);
+  assert.deepEqual(controller.state.data.history.pagination, {
+    limit: 2,
+    offset: 2,
+    has_more: false,
+    next_offset: null,
+  });
+});
+
 test('preview client reviews a semantic diff when policy state is proxied', async () => {
   const livePolicy = policy();
   livePolicy.configuration = new Proxy(livePolicy.configuration, {});

--- a/frontend/src/lib/utils/focusOrder.ts
+++ b/frontend/src/lib/utils/focusOrder.ts
@@ -1,0 +1,70 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'summary',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+].join(',');
+
+type FocusableElementsOptions = {
+  document?: Document;
+  exclude?: Element | null;
+};
+
+function isExcluded(element: HTMLElement, exclude?: Element | null): boolean {
+  return exclude !== null
+    && exclude !== undefined
+    && (element === exclude || exclude.contains(element));
+}
+
+function isAvailableForFocus(element: HTMLElement, exclude?: Element | null): boolean {
+  return !isExcluded(element, exclude)
+    && element.tabIndex >= 0
+    && !element.matches(':disabled, [disabled]')
+    && !element.closest('[inert], [hidden]')
+    && element.getClientRects().length > 0;
+}
+
+export function focusableElementsInDocument(
+  options: FocusableElementsOptions = {},
+): HTMLElement[] {
+  const sourceDocument = options.document
+    ?? (typeof document === 'undefined' ? undefined : document);
+  if (!sourceDocument) return [];
+
+  return Array.from(sourceDocument.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => isAvailableForFocus(element, options.exclude))
+    .map((element, documentIndex) => ({ element, documentIndex }))
+    .sort((left, right) => {
+      const leftTabIndex = left.element.tabIndex;
+      const rightTabIndex = right.element.tabIndex;
+      if (leftTabIndex === rightTabIndex) return left.documentIndex - right.documentIndex;
+      if (leftTabIndex === 0) return 1;
+      if (rightTabIndex === 0) return -1;
+      return leftTabIndex - rightTabIndex;
+    })
+    .map(({ element }) => element);
+}
+
+export function nextFocusableFrom(
+  element: HTMLElement,
+  direction: -1 | 1,
+  exclude?: Element | null,
+): HTMLElement | null {
+  const focusable = focusableElementsInDocument({
+    document: element.ownerDocument,
+    exclude,
+  });
+  const currentIndex = focusable.indexOf(element);
+  if (currentIndex < 0) return null;
+  return focusable[currentIndex + direction] ?? null;
+}

--- a/frontend/src/lib/utils/selectKeyboard.test.js
+++ b/frontend/src/lib/utils/selectKeyboard.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  edgeOptionIndex,
+  enabledOptionIndexes,
+  initialOptionIndex,
+  nextOptionIndex,
+} from './selectKeyboard.ts';
+
+const options = [
+  { value: 'alpha' },
+  { value: 'bravo', disabled: true },
+  { value: 'charlie' },
+];
+
+test('option navigation wraps past both ends', () => {
+  assert.equal(nextOptionIndex(options, 2, 1), 0);
+  assert.equal(nextOptionIndex(options, 0, -1), 2);
+});
+
+test('option navigation skips disabled options', () => {
+  assert.deepEqual(enabledOptionIndexes(options), [0, 2]);
+  assert.equal(nextOptionIndex(options, 0, 1), 2);
+  assert.equal(nextOptionIndex(options, 2, -1), 0);
+});
+
+test('an all-disabled option list has no keyboard target', () => {
+  const disabledOptions = [
+    { value: 'alpha', disabled: true },
+    { value: 'bravo', disabled: true },
+  ];
+
+  assert.deepEqual(enabledOptionIndexes(disabledOptions), []);
+  assert.equal(initialOptionIndex(disabledOptions, 'alpha'), -1);
+  assert.equal(nextOptionIndex(disabledOptions, 0, 1), -1);
+  assert.equal(edgeOptionIndex(disabledOptions, 'first'), -1);
+  assert.equal(edgeOptionIndex(disabledOptions, 'last'), -1);
+});
+
+test('an empty option list has no keyboard target', () => {
+  assert.deepEqual(enabledOptionIndexes([]), []);
+  assert.equal(initialOptionIndex([], 'missing'), -1);
+  assert.equal(nextOptionIndex([], -1, 1), -1);
+  assert.equal(edgeOptionIndex([], 'first'), -1);
+  assert.equal(edgeOptionIndex([], 'last'), -1);
+});
+
+test('initial navigation uses the selected option or the first enabled fallback', () => {
+  assert.equal(initialOptionIndex(options, 'charlie'), 2);
+  assert.equal(initialOptionIndex(options, 'missing'), 0);
+});
+
+test('Home and End navigation targets the first and last enabled options', () => {
+  assert.equal(edgeOptionIndex(options, 'first'), 0);
+  assert.equal(edgeOptionIndex(options, 'last'), 2);
+});

--- a/frontend/src/lib/utils/selectKeyboard.ts
+++ b/frontend/src/lib/utils/selectKeyboard.ts
@@ -1,0 +1,42 @@
+type SelectKeyboardOption = {
+  value: string;
+  disabled?: boolean;
+};
+
+export function enabledOptionIndexes(
+  options: ReadonlyArray<SelectKeyboardOption>,
+): number[] {
+  return options.flatMap((option, index) => option.disabled ? [] : [index]);
+}
+
+export function initialOptionIndex(
+  options: ReadonlyArray<SelectKeyboardOption>,
+  value: string,
+): number {
+  const selectedIndex = options.findIndex(
+    (option) => option.value === value && !option.disabled,
+  );
+  return selectedIndex >= 0 ? selectedIndex : (enabledOptionIndexes(options)[0] ?? -1);
+}
+
+export function nextOptionIndex(
+  options: ReadonlyArray<SelectKeyboardOption>,
+  currentIndex: number,
+  direction: -1 | 1,
+): number {
+  const indexes = enabledOptionIndexes(options);
+  if (!indexes.length) return -1;
+  const position = indexes.indexOf(currentIndex);
+  const nextPosition = position < 0
+    ? 0
+    : (position + direction + indexes.length) % indexes.length;
+  return indexes[nextPosition];
+}
+
+export function edgeOptionIndex(
+  options: ReadonlyArray<SelectKeyboardOption>,
+  edge: 'first' | 'last',
+): number {
+  const indexes = enabledOptionIndexes(options);
+  return (edge === 'first' ? indexes[0] : indexes[indexes.length - 1]) ?? -1;
+}

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -343,8 +343,8 @@
     previewPolicyClients[cycle.id] = createPreviewBehaviorPolicyClient({
       cycleId: cycle.id,
       getPolicy: () => previewPolicies[cycle.id],
-      getHistory: () => previewPolicyHistories[cycle.id],
       historyItems,
+      historyPageSize: history.pagination.limit,
       commit: (nextPolicy, nextHistory) => {
         previewPolicies = { ...previewPolicies, [cycle.id]: nextPolicy };
         previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: nextHistory };

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -333,7 +333,7 @@
   }
 
   function setPreviewBehaviorPolicy(cycle: CycleRead) {
-    const { policy, history } = createPreviewBehaviorPolicyFixture(cycle, {
+    const { policy, history, historyItems } = createPreviewBehaviorPolicyFixture(cycle, {
       humanChangedAt: previewIso(-4),
       agentChangedAt: previewIso(-2),
       originatingAgentRunId: cycle.id === 901 ? 15100 : 100000 + cycle.id,
@@ -344,6 +344,7 @@
       cycleId: cycle.id,
       getPolicy: () => previewPolicies[cycle.id],
       getHistory: () => previewPolicyHistories[cycle.id],
+      historyItems,
       commit: (nextPolicy, nextHistory) => {
         previewPolicies = { ...previewPolicies, [cycle.id]: nextPolicy };
         previewPolicyHistories = { ...previewPolicyHistories, [cycle.id]: nextHistory };
@@ -1420,6 +1421,7 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 10px;
+    min-width: 0;
     padding: 0 12px 12px;
     border-top: 1px solid var(--constellation-surface-panel-separator);
   }

--- a/frontend/src/routes/cycles/previewBehaviorPolicy.ts
+++ b/frontend/src/routes/cycles/previewBehaviorPolicy.ts
@@ -23,8 +23,8 @@ import {
 type PreviewPolicyClientOptions = {
   cycleId: number;
   getPolicy: () => EffectiveCyclePolicyRead;
-  getHistory: () => CyclePolicyHistoryRead;
-  historyItems?: readonly CyclePolicyChangeRead[];
+  historyItems: readonly CyclePolicyChangeRead[];
+  historyPageSize?: number;
   commit: (policy: EffectiveCyclePolicyRead, history: CyclePolicyHistoryRead) => void;
   scheduleLabel: (scheduleExpression: string, timezone: string) => string;
   now?: () => string;
@@ -40,6 +40,24 @@ type PreviewBehaviorPolicyFixtureOptions = {
   agentChangedAt: string;
   originatingAgentRunId: number;
 };
+
+function historyPage(
+  historyItems: readonly CyclePolicyChangeRead[],
+  limit: number,
+  offset = 0,
+): CyclePolicyHistoryRead {
+  const items = historyItems.slice(offset, offset + limit);
+  const nextOffset = offset + items.length;
+  return {
+    items: clonePlainData(items),
+    pagination: {
+      limit,
+      offset,
+      has_more: nextOffset < historyItems.length,
+      next_offset: nextOffset < historyItems.length ? nextOffset : null,
+    },
+  };
+}
 
 export function createPreviewBehaviorPolicyFixture(
   cycle: CycleRead,
@@ -241,10 +259,7 @@ export function createPreviewBehaviorPolicyFixture(
   const historyItems = [agentChange, humanChange, initialChange];
   return {
     policy,
-    history: {
-      items: historyItems.slice(0, 2),
-      pagination: { limit: 2, offset: 0, has_more: true, next_offset: 2 },
-    },
+    history: historyPage(historyItems, 2),
     historyItems,
   };
 }
@@ -422,7 +437,8 @@ export function createPreviewBehaviorPolicyClient(
   options: PreviewPolicyClientOptions,
 ): CyclePolicyEditorApi {
   let previewSerial = 0;
-  let historyItems = clonePlainData(options.historyItems ?? options.getHistory().items);
+  let historyItems = clonePlainData(options.historyItems);
+  const historyPageSize = options.historyPageSize ?? 50;
   const pending = new Map<string, PendingPreview>();
 
   function nextDigest(): string {
@@ -493,10 +509,9 @@ export function createPreviewBehaviorPolicyClient(
     }
 
     const appliedAt = options.now?.() ?? new Date().toISOString();
-    const history = options.getHistory();
     const version = policy.version + 1;
     const revisionId = (policy.revision_id ?? 0) + 1;
-    const changeId = Math.max(0, ...history.items.map((change) => change.id)) + 1;
+    const changeId = Math.max(0, ...historyItems.map((change) => change.id)) + 1;
     const actor = {
       actor_type: 'human',
       actor_id: 'preview-user',
@@ -554,17 +569,7 @@ export function createPreviewBehaviorPolicyClient(
       },
     };
     historyItems = [change, ...historyItems.filter((item) => item.id !== change.id)];
-    const nextHistoryItems = [change, ...history.items];
-    const nextHistoryOffset = nextHistoryItems.length;
-    const nextHistory: CyclePolicyHistoryRead = {
-      items: nextHistoryItems,
-      pagination: {
-        ...history.pagination,
-        offset: 0,
-        has_more: nextHistoryOffset < historyItems.length,
-        next_offset: nextHistoryOffset < historyItems.length ? nextHistoryOffset : null,
-      },
-    };
+    const nextHistory = historyPage(historyItems, historyPageSize);
     options.commit(nextPolicy, nextHistory);
     pending.delete(previewDigest);
     return { effective_policy: clonePlainData(nextPolicy), change: clonePlainData(change) };
@@ -573,17 +578,7 @@ export function createPreviewBehaviorPolicyClient(
   const client: CyclePolicyEditorApi = {
     getCycleBehaviorPolicy: async () => clonePlainData(options.getPolicy()),
     getCycleBehaviorPolicyHistory: async (_cycleId, limit = 50, offset = 0) => {
-      const items = historyItems.slice(offset, offset + limit);
-      const nextOffset = offset + items.length;
-      return {
-        items: clonePlainData(items),
-        pagination: {
-          limit,
-          offset,
-          has_more: nextOffset < historyItems.length,
-          next_offset: nextOffset < historyItems.length ? nextOffset : null,
-        },
-      };
+      return historyPage(historyItems, limit, offset);
     },
     previewCycleBehaviorPolicy: async (_cycleId, { proposal }) => {
       const policy = options.getPolicy();

--- a/frontend/src/routes/cycles/previewBehaviorPolicy.ts
+++ b/frontend/src/routes/cycles/previewBehaviorPolicy.ts
@@ -24,6 +24,7 @@ type PreviewPolicyClientOptions = {
   cycleId: number;
   getPolicy: () => EffectiveCyclePolicyRead;
   getHistory: () => CyclePolicyHistoryRead;
+  historyItems?: readonly CyclePolicyChangeRead[];
   commit: (policy: EffectiveCyclePolicyRead, history: CyclePolicyHistoryRead) => void;
   scheduleLabel: (scheduleExpression: string, timezone: string) => string;
   now?: () => string;
@@ -43,7 +44,11 @@ type PreviewBehaviorPolicyFixtureOptions = {
 export function createPreviewBehaviorPolicyFixture(
   cycle: CycleRead,
   options: PreviewBehaviorPolicyFixtureOptions,
-): { policy: EffectiveCyclePolicyRead; history: CyclePolicyHistoryRead } {
+): {
+  policy: EffectiveCyclePolicyRead;
+  history: CyclePolicyHistoryRead;
+  historyItems: CyclePolicyChangeRead[];
+} {
   const configuration: CyclePolicyConfigurationRead = {
     name: cycle.name,
     prompt: cycle.prompt,
@@ -68,8 +73,10 @@ export function createPreviewBehaviorPolicyFixture(
     'Keep the result concise and name any blocker that needs attention.',
   ];
   const retiredGuidance = 'Use the legacy priority list before reviewing the workspace.';
+  const initialChangeId = 5000 + cycle.id;
   const humanChangeId = 5100 + cycle.id;
   const agentChangeId = 5200 + cycle.id;
+  const initialRevisionId = 4000 + cycle.id;
   const humanRevisionId = 4100 + cycle.id;
   const agentRevisionId = 4200 + cycle.id;
   const humanSource = {
@@ -120,6 +127,38 @@ export function createPreviewBehaviorPolicyFixture(
       guidance: [...activeGuidance],
     },
     cycle_revision_id: humanRevisionId,
+  };
+  const initialChange: CyclePolicyChangeRead = {
+    id: initialChangeId,
+    version: 1,
+    actor_type: 'system',
+    actor_id: 'cycle-import',
+    source_reference: `cycle:${cycle.id}:initial`,
+    rationale: 'Created the initial Cycle behavior.',
+    changed_fields: [
+      'prompt',
+      'schedule_expr',
+      'timezone',
+      'enabled',
+      'model_override',
+      'thinking_override',
+      'guidance',
+    ],
+    applied_at: cycle.created_at,
+    reverted_from_id: null,
+    workspace_id: 'preview-org',
+    policy_kind: 'cycle',
+    target_type: 'cycle',
+    target_id: String(cycle.id),
+    before_snapshot: {
+      configuration: clonePlainData(priorConfiguration),
+      guidance: [],
+    },
+    after_snapshot: {
+      configuration: clonePlainData(priorConfiguration),
+      guidance: [...activeGuidance, retiredGuidance],
+    },
+    cycle_revision_id: initialRevisionId,
   };
   const agentChange: CyclePolicyChangeRead = {
     id: agentChangeId,
@@ -199,12 +238,14 @@ export function createPreviewBehaviorPolicyFixture(
       reverted_from_id: agentChange.reverted_from_id,
     },
   };
+  const historyItems = [agentChange, humanChange, initialChange];
   return {
     policy,
     history: {
-      items: [agentChange, humanChange],
-      pagination: { limit: 50, offset: 0, has_more: false, next_offset: null },
+      items: historyItems.slice(0, 2),
+      pagination: { limit: 2, offset: 0, has_more: true, next_offset: 2 },
     },
+    historyItems,
   };
 }
 
@@ -381,6 +422,7 @@ export function createPreviewBehaviorPolicyClient(
   options: PreviewPolicyClientOptions,
 ): CyclePolicyEditorApi {
   let previewSerial = 0;
+  let historyItems = clonePlainData(options.historyItems ?? options.getHistory().items);
   const pending = new Map<string, PendingPreview>();
 
   function nextDigest(): string {
@@ -511,13 +553,16 @@ export function createPreviewBehaviorPolicyClient(
         reverted_from_id: change.reverted_from_id,
       },
     };
+    historyItems = [change, ...historyItems.filter((item) => item.id !== change.id)];
+    const nextHistoryItems = [change, ...history.items];
+    const nextHistoryOffset = nextHistoryItems.length;
     const nextHistory: CyclePolicyHistoryRead = {
-      items: [change, ...history.items],
+      items: nextHistoryItems,
       pagination: {
         ...history.pagination,
         offset: 0,
-        has_more: false,
-        next_offset: null,
+        has_more: nextHistoryOffset < historyItems.length,
+        next_offset: nextHistoryOffset < historyItems.length ? nextHistoryOffset : null,
       },
     };
     options.commit(nextPolicy, nextHistory);
@@ -528,16 +573,15 @@ export function createPreviewBehaviorPolicyClient(
   const client: CyclePolicyEditorApi = {
     getCycleBehaviorPolicy: async () => clonePlainData(options.getPolicy()),
     getCycleBehaviorPolicyHistory: async (_cycleId, limit = 50, offset = 0) => {
-      const history = options.getHistory();
-      const items = history.items.slice(offset, offset + limit);
+      const items = historyItems.slice(offset, offset + limit);
       const nextOffset = offset + items.length;
       return {
         items: clonePlainData(items),
         pagination: {
           limit,
           offset,
-          has_more: nextOffset < history.items.length,
-          next_offset: nextOffset < history.items.length ? nextOffset : null,
+          has_more: nextOffset < historyItems.length,
+          next_offset: nextOffset < historyItems.length ? nextOffset : null,
         },
       };
     },
@@ -552,7 +596,7 @@ export function createPreviewBehaviorPolicyClient(
     ),
     previewCycleBehaviorPolicyRevert: async (_cycleId, changeId) => {
       const policy = options.getPolicy();
-      const change = options.getHistory().items.find((item) => item.id === changeId);
+      const change = historyItems.find((item) => item.id === changeId);
       if (!change) throw new Error('The selected history entry is not available.');
       return createPreview(policy, clonePlainData(change.before_snapshot), changeId);
     },


### PR DESCRIPTION
Closes #787

**Slice 6 of 6 — the last slice of the behavior editor ([#738](https://github.com/Illospace/illospace/issues/738)).**

**Stacked on [#808](https://github.com/Illospace/illospace/pull/808) (slice 5) → [#807](https://github.com/Illospace/illospace/pull/807) (slice 4) → [#803](https://github.com/Illospace/illospace/pull/803) (slice 3).** Merge the train from the bottom; this PR targets slice 5's branch, so its `Closes` link registers once it is retargeted to `main`.

## What it does

The Cycle behavior editor is now operable without a pointer, and readable on a phone — the situation the ticket exists for: *"Urgent rollback is a mobile action."*

- The policy selects gained full keyboard navigation: Enter/ArrowDown/ArrowUp open the menu on the **currently selected** option, Arrow keys move, Home/End jump, Escape closes and returns focus to the trigger, Tab/Shift+Tab close the menu and move to the next/previous control.
- Focus goes where you expect: opening the editor focuses **Mission prompt**; Review focuses the review heading; apply and cancel return focus to **Edit behavior**; cancelling a revert returns to the exact Revert button you came from.
- The two history Revert buttons now announce as **"Revert behavior version 3"** and **"Revert behavior version 2"**. Before, a screen reader heard "Revert" twice with nothing to choose between them.
- Validation errors are associated with their fields (`aria-describedby`, `aria-invalid`), and Rationale is marked required.
- At phone width the effective policy, the diff and the apply controls stay readable with **no horizontal scrolling**.

## How to see it — no backend needed

```
export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH"
npm --prefix frontend run dev
```

Open **`localhost:5173/cycles?preview=1`**, then:

1. Click **Edit behavior** — focus should land in **Mission prompt**.
2. Tab to **Model override**, press **Enter** — the menu opens with the current value focused. Arrow up/down, press **End**, then **Escape** — focus returns to the select.
3. Edit the prompt, click **Review change** — the before/after diff appears and focus moves to its heading.
4. Set the browser to **375px wide** and repeat step 3. The diff should stack into one column with **no sideways scroll**.

## Verification

Driven in a real browser by the orchestrator, because the implementing worker could not bind a port. Full record, including what could **not** be proven, is on the branch at [`.review/787-keyboard-small-screen.md`](.review/787-keyboard-small-screen.md).

```
npm test         278/278 pass      (272 before, +6 new unit tests)
npm run check    6879 files, 0 errors, 0 warnings
npm run build    clean
```
Gates were run serially at load average 2.5, on **Node 22** — under Node 20, 41 of 45 test files fail for reasons unrelated to any change.

## Two things worth your attention

**1. This extends a shared component.** The keyboard behavior went into `ConstellationSelect.svelte` rather than a cycles-local copy, which is the correct call under the reuse rule — but it means **two surfaces outside this ticket inherit it**: `routes/system/RuntimeSelect.svelte` and `routes/vault/+page.svelte`. Neither could be driven here (both redirect to `/login` without a backend), so they are worth a glance on staging. The new props are optional and `svelte-check` passes across all callers. (Note `WorkspaceComposerAdapter` uses `ConstellationSelectChip`, a *different* component, and is unaffected — the obvious grep matches both names.)

**2. A code-quality review returned BLOCKING; two findings were folded, one is a named gap.**
- *Folded:* the tab-order walk used an incomplete selector. Measured in the live DOM, it missed **all four `<summary>` toggles** on this page — History, Recent runs, and both Execution snapshots. It now lives in `lib/utils/focusOrder.ts` with a complete selector, correct handling of every negative `tabindex`, `inert`/`hidden` exclusion, and real positive-`tabindex` ordering.
- *Folded:* the option-index math moved to `lib/utils/selectKeyboard.ts` with six unit tests.
- *Named gap, not fixed:* there is **no DOM test framework** in this repo (`node --test` only), so the portal and real-Tab interactions have no automated coverage. Adding jsdom or vitest is a real decision, not a slice-6 side effect — flagging it rather than smuggling it in.

**One thing a human should confirm:** this browser harness delivers no OS-level key events, so I verified the component's handlers, not the browser's native activation. Pressing **Enter** on a closed select should open it and leave it open. Two seconds of your time; everything else is covered.
