### PR TITLE
refactor(meetbot): extract a caption controller from the browser lifecycle (#645)

### DIFF
--- a/meetbot/browser_control.py
+++ b/meetbot/browser_control.py
@@ -1,0 +1,23 @@
+"""Shared low-level browser controls for Google Meet workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def _click_first_visible(page: Any, selectors: tuple[str, ...]) -> bool:
+    locator = await _first_visible(page, selectors)
+    if locator is None:
+        return False
+    await locator.click()
+    return True
+
+
+async def _first_visible(page: Any, selectors: tuple[str, ...]) -> Any | None:
+    for selector in selectors:
+        locator = page.locator(selector)
+        for index in range(await locator.count()):
+            candidate = locator.nth(index)
+            if await candidate.is_visible():
+                return candidate
+    return None

--- a/meetbot/browser_control.py
+++ b/meetbot/browser_control.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 
-async def _click_first_visible(page: Any, selectors: tuple[str, ...]) -> bool:
-    locator = await _first_visible(page, selectors)
+async def click_first_match(page: Any, selectors: tuple[str, ...]) -> bool:
+    locator = await first_visible(page, selectors)
     if locator is None:
         return False
     await locator.click()
     return True
 
 
-async def _first_visible(page: Any, selectors: tuple[str, ...]) -> Any | None:
+async def first_visible(page: Any, selectors: tuple[str, ...]) -> Any | None:
     for selector in selectors:
         locator = page.locator(selector)
         for index in range(await locator.count()):

--- a/meetbot/caption_control.py
+++ b/meetbot/caption_control.py
@@ -7,12 +7,12 @@ import logging
 import re
 from typing import Any
 
-from meetbot.browser_control import _click_first_visible, _first_visible
+from meetbot.browser_control import click_first_match, first_visible
 from meetbot.browser_diagnostics import capture_failure_evidence
 from meetbot.config import MeetbotConfig
 from meetbot.models import SessionEvents
 
-logger = logging.getLogger("meetbot.engine")
+logger = logging.getLogger(__name__)
 
 _CAPTION_LANGUAGE_MENU_LABELS = {
     "fr-fr": "French",
@@ -157,6 +157,10 @@ class CaptionController:
     def __init__(self, config: MeetbotConfig) -> None:
         self._config = config
 
+    async def start(self, page: Any, events: SessionEvents, session_id: str) -> None:
+        await self._attach_caption_observer(page, events)
+        await self._enable_captions(page, events, session_id)
+
     async def _attach_caption_observer(self, page: Any, events: SessionEvents) -> None:
         async def on_caption(payload: object) -> None:
             if not isinstance(payload, dict):
@@ -178,7 +182,7 @@ class CaptionController:
     ) -> None:
         await page.keyboard.press("c")
         await asyncio.sleep(1.0)
-        enabled = await _first_visible(
+        enabled = await first_visible(
             page,
             (
                 'button[aria-label*="Turn off captions" i]',
@@ -186,7 +190,7 @@ class CaptionController:
             ),
         )
         if enabled is None:
-            clicked = await _click_first_visible(
+            clicked = await click_first_match(
                 page,
                 (
                     'button[aria-label*="Turn on captions" i]',
@@ -254,7 +258,7 @@ class CaptionController:
         return await _choose_caption_language(page, control, self._config.caption_language)
 
     async def _set_via_caption_settings_control(self, page: Any) -> bool:
-        opened = await _click_first_visible(
+        opened = await click_first_match(
             page,
             (
                 'button[aria-label*="Caption settings" i]',
@@ -269,7 +273,7 @@ class CaptionController:
         return await self._set_visible_caption_language(page)
 
     async def _set_via_meet_settings(self, page: Any) -> bool:
-        more_opened = await _click_first_visible(
+        more_opened = await click_first_match(
             page,
             (
                 'button[aria-label="More options" i]',
@@ -279,7 +283,7 @@ class CaptionController:
         if not more_opened:
             return False
         await asyncio.sleep(0.25)
-        settings_opened = await _click_first_visible(
+        settings_opened = await click_first_match(
             page,
             (
                 '[role="menuitem"]:has-text("Settings")',
@@ -290,7 +294,7 @@ class CaptionController:
         if not settings_opened:
             return False
         await asyncio.sleep(0.25)
-        captions_opened = await _click_first_visible(
+        captions_opened = await click_first_match(
             page,
             (
                 '[role="tab"]:has-text("Captions")',
@@ -306,7 +310,7 @@ class CaptionController:
 
 
 async def _caption_language_control(page: Any) -> Any | None:
-    control = await _first_visible(
+    control = await first_visible(
         page,
         (
             'select[aria-label*="Language of the meeting" i]',
@@ -330,7 +334,7 @@ async def _caption_language_control(page: Any) -> Any | None:
         if not await label.is_visible():
             continue
         parent = label.locator("xpath=..")
-        control = await _first_visible(
+        control = await first_visible(
             parent,
             (
                 "select",

--- a/meetbot/caption_control.py
+++ b/meetbot/caption_control.py
@@ -1,0 +1,418 @@
+"""Browser-side caption controls for Google Meet."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from meetbot.browser_control import _click_first_visible, _first_visible
+from meetbot.browser_diagnostics import capture_failure_evidence
+from meetbot.config import MeetbotConfig
+from meetbot.models import SessionEvents
+
+logger = logging.getLogger("meetbot.engine")
+
+_CAPTION_LANGUAGE_MENU_LABELS = {
+    "fr-fr": "French",
+    "en-us": "English",
+}
+
+
+def caption_language_menu_labels(language_tag: str) -> tuple[str, ...]:
+    """Return Meet's known label followed by the BCP-47 subtag fallback."""
+
+    normalized = _normalize_language_tag(language_tag)
+    if not normalized:
+        return ()
+    subtag = normalized.partition("-")[0]
+    known_label = _CAPTION_LANGUAGE_MENU_LABELS.get(normalized)
+    return (known_label, subtag) if known_label else (subtag,)
+
+
+def caption_option_matches(option_text: str, language_tag: str) -> bool:
+    """Match a Meet menu option by known label, tag, or standalone language subtag."""
+
+    text = " ".join(str(option_text or "").split())
+    if not text:
+        return False
+    normalized_text = text.casefold().replace("_", "-")
+    normalized_tag = _normalize_language_tag(language_tag)
+    labels = caption_language_menu_labels(language_tag)
+    if not normalized_tag or not labels:
+        return False
+    known_label = _CAPTION_LANGUAGE_MENU_LABELS.get(normalized_tag)
+    if known_label and normalized_text in {
+        known_label.casefold(),
+        f"{known_label.casefold()} (beta)",
+    }:
+        return True
+    if re.search(rf"(?<![a-z]){re.escape(normalized_tag)}(?![a-z])", normalized_text):
+        return True
+    subtag = labels[-1].casefold()
+    return bool(re.search(rf"(?<![a-z]){re.escape(subtag)}(?![a-z])", normalized_text))
+
+
+def _normalize_language_tag(language_tag: str) -> str:
+    return str(language_tag or "").strip().replace("_", "-").casefold()
+
+
+_CAPTION_OBSERVER_SCRIPT = r"""
+(() => {
+  if (window.__illoMeetbotCaptionObserver) return;
+
+  const nodeIds = new WeakMap();
+  const lastValues = new Map();
+  let nextNodeId = 1;
+  const captionSelector = [
+    '[role="region"][aria-label*="aption" i]',
+    '[data-caption-id]',
+    '[jsname="YSxPC"]',
+    '[jsname="tgaKEf"]',
+    '.a4cQT'
+  ].join(',');
+  const rowSelector = [
+    '[data-caption-row]',
+    '[jsname="dsyhDe"]',
+    '.CNusmb',
+    '.TBMuR',
+    '.nMcdL'
+  ].join(',');
+  const speakerSelector = [
+    '[data-speaker-name]',
+    '.KcIKyf',
+    '.zs7s8d',
+    '.NWpY1d',
+    '.xoMHSc',
+    'span[jsname="YSxPC"]'
+  ].join(',');
+  const textSelector = [
+    '[data-caption-text]',
+    '.bh44bd',
+    '.iTTPOb',
+    'span[jsname="tgaKEf"]'
+  ].join(',');
+
+  const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+  const identity = (node) => {
+    if (!nodeIds.has(node)) nodeIds.set(node, nextNodeId++);
+    return `caption-${nodeIds.get(node)}`;
+  };
+  const emit = (row) => {
+    if (!(row instanceof Element)) return;
+    const speakerNode = row.querySelector(speakerSelector);
+    const textNodes = Array.from(row.querySelectorAll(textSelector));
+    let speaker = clean(speakerNode && speakerNode.textContent);
+    let text = clean(textNodes.map((node) => node.textContent).join(' '));
+    if (!text) {
+      const lines = String(row.innerText || '').split('\n').map(clean).filter(Boolean);
+      if (!speaker && lines.length > 1) speaker = lines.shift() || '';
+      text = clean(lines.filter((line) => line !== speaker).join(' '));
+    }
+    if (!text) return;
+    const lineId = identity(row);
+    const fingerprint = `${speaker}\n${text}`;
+    if (lastValues.get(lineId) === fingerprint) return;
+    lastValues.set(lineId, fingerprint);
+    window.__illoMeetbotCaption({line_id: lineId, speaker, text});
+  };
+  const scan = (container) => {
+    const rows = Array.from(container.querySelectorAll(rowSelector));
+    if (rows.length) {
+      rows.forEach(emit);
+      return;
+    }
+    emit(container);
+  };
+  const scanFrom = (target) => {
+    const element = target instanceof Element ? target : target.parentElement;
+    if (!element) return;
+    const row = element.closest(rowSelector);
+    if (row) {
+      emit(row);
+      return;
+    }
+    const closestCaption = element.closest(captionSelector);
+    if (closestCaption) scan(closestCaption);
+    element.querySelectorAll(captionSelector).forEach(scan);
+  };
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      scanFrom(mutation.target);
+      for (const node of mutation.addedNodes) scanFrom(node);
+    }
+  });
+  observer.observe(document.body, {subtree: true, childList: true, characterData: true});
+  document.querySelectorAll(captionSelector).forEach(scan);
+  window.__illoMeetbotCaptionObserver = observer;
+})();
+"""
+
+
+class CaptionController:
+    """Observe captions and drive Google Meet caption controls."""
+
+    def __init__(self, config: MeetbotConfig) -> None:
+        self._config = config
+
+    async def _attach_caption_observer(self, page: Any, events: SessionEvents) -> None:
+        async def on_caption(payload: object) -> None:
+            if not isinstance(payload, dict):
+                return
+            speaker = str(payload.get("speaker") or "Unknown speaker")
+            text = str(payload.get("text") or "").strip()
+            line_id = str(payload.get("line_id") or "").strip() or None
+            if text:
+                await events.caption(speaker, text, line_id)
+
+        await page.expose_function("__illoMeetbotCaption", on_caption)
+        await page.evaluate(_CAPTION_OBSERVER_SCRIPT)
+
+    async def _enable_captions(
+        self,
+        page: Any,
+        events: SessionEvents,
+        session_id: str,
+    ) -> None:
+        await page.keyboard.press("c")
+        await asyncio.sleep(1.0)
+        enabled = await _first_visible(
+            page,
+            (
+                'button[aria-label*="Turn off captions" i]',
+                '[role="button"][data-tooltip*="Turn off captions" i]',
+            ),
+        )
+        if enabled is None:
+            clicked = await _click_first_visible(
+                page,
+                (
+                    'button[aria-label*="Turn on captions" i]',
+                    'button[aria-label*="Show captions" i]',
+                    '[role="button"][data-tooltip*="Turn on captions" i]',
+                ),
+            )
+            if not clicked:
+                logger.warning("Meetbot could not verify or click the Google Meet captions control")
+
+        strategy = await self._set_caption_language(page, session_id)
+        if strategy:
+            logger.info(
+                "Meetbot confirmed caption language %s with selector strategy %s",
+                self._config.caption_language,
+                strategy,
+            )
+            return
+        warning = (
+            f"Could not confirm the caption language is {self._config.caption_language}; "
+            "the transcript may be translated or empty."
+        )
+        logger.warning("%s", warning)
+        logger.info(
+            "Meetbot caption-language diagnostic evidence for session %s is under %s",
+            session_id,
+            self._config.debug_dir,
+        )
+        await events.warning(warning)
+
+    async def _set_caption_language(self, page: Any, session_id: str) -> str | None:
+        strategies = (
+            ("visible-language-control", self._set_visible_caption_language),
+            ("caption-settings-control", self._set_via_caption_settings_control),
+            ("more-options-settings-captions", self._set_via_meet_settings),
+        )
+        for name, strategy in strategies:
+            try:
+                if await strategy(page):
+                    return name
+            except Exception:
+                logger.debug(
+                    "Meet caption-language selector strategy %s failed",
+                    name,
+                    exc_info=True,
+                )
+            # Meet closes the menu on Escape, so live selector evidence must be
+            # recorded while the failed strategy's last overlay is still open.
+            await capture_failure_evidence(
+                page,
+                session_id,
+                name,
+                debug_dir=self._config.debug_dir,
+            )
+            try:
+                await page.keyboard.press("Escape")
+            except Exception:
+                logger.debug("Meetbot could not close a caption settings overlay", exc_info=True)
+        return None
+
+    async def _set_visible_caption_language(self, page: Any) -> bool:
+        control = await _caption_language_control(page)
+        if control is None:
+            return False
+        return await _choose_caption_language(page, control, self._config.caption_language)
+
+    async def _set_via_caption_settings_control(self, page: Any) -> bool:
+        opened = await _click_first_visible(
+            page,
+            (
+                'button[aria-label*="Caption settings" i]',
+                'button[aria-label*="Caption language" i]',
+                '[role="button"][data-tooltip*="Caption settings" i]',
+                '[role="button"][aria-haspopup][aria-label*="caption" i]',
+            ),
+        )
+        if not opened:
+            return False
+        await asyncio.sleep(0.25)
+        return await self._set_visible_caption_language(page)
+
+    async def _set_via_meet_settings(self, page: Any) -> bool:
+        more_opened = await _click_first_visible(
+            page,
+            (
+                'button[aria-label="More options" i]',
+                '[role="button"][data-tooltip="More options" i]',
+            ),
+        )
+        if not more_opened:
+            return False
+        await asyncio.sleep(0.25)
+        settings_opened = await _click_first_visible(
+            page,
+            (
+                '[role="menuitem"]:has-text("Settings")',
+                '[role="button"]:has-text("Settings")',
+                'button:has-text("Settings")',
+            ),
+        )
+        if not settings_opened:
+            return False
+        await asyncio.sleep(0.25)
+        captions_opened = await _click_first_visible(
+            page,
+            (
+                '[role="tab"]:has-text("Captions")',
+                '[role="menuitem"]:has-text("Captions")',
+                '[role="button"][aria-label="Captions" i]',
+                'button:has-text("Captions")',
+            ),
+        )
+        if not captions_opened:
+            return False
+        await asyncio.sleep(0.25)
+        return await self._set_visible_caption_language(page)
+
+
+async def _caption_language_control(page: Any) -> Any | None:
+    control = await _first_visible(
+        page,
+        (
+            'select[aria-label*="Language of the meeting" i]',
+            'select[aria-label*="caption language" i]',
+            '[role="combobox"][aria-label*="Language of the meeting" i]',
+            '[role="combobox"][aria-label*="caption language" i]',
+            'button[aria-label*="Language of the meeting" i]',
+            'button[aria-label*="caption language" i]',
+            '[aria-haspopup="listbox"][aria-label*="Language of the meeting" i]',
+            '[aria-haspopup="listbox"][aria-label*="caption language" i]',
+        ),
+    )
+    if control is not None:
+        return control
+
+    labels = page.get_by_text(
+        re.compile(r"^(Language of the meeting|Caption language)$", re.IGNORECASE)
+    )
+    for index in range(await labels.count()):
+        label = labels.nth(index)
+        if not await label.is_visible():
+            continue
+        parent = label.locator("xpath=..")
+        control = await _first_visible(
+            parent,
+            (
+                "select",
+                '[role="combobox"]',
+                'button[aria-haspopup="listbox"]',
+            ),
+        )
+        if control is not None:
+            return control
+    return None
+
+
+async def _choose_caption_language(page: Any, control: Any, language_tag: str) -> bool:
+    tag_name = str(await control.evaluate("node => node.tagName || ''")).casefold()
+    if tag_name == "select":
+        return await _select_native_caption_language(control, language_tag)
+
+    await control.click()
+    await asyncio.sleep(0.2)
+    options = page.locator(
+        '[role="option"], [role="menuitemradio"], [role="menuitem"]'
+    )
+    for index in range(await options.count()):
+        option = options.nth(index)
+        if not await option.is_visible():
+            continue
+        if not caption_option_matches(await option.inner_text(), language_tag):
+            continue
+        await option.click()
+        await asyncio.sleep(0.2)
+        if await _locator_matches_caption_language(control, language_tag):
+            return True
+        selected = page.locator(
+            '[role="option"][aria-selected="true"], '
+            '[role="menuitemradio"][aria-checked="true"]'
+        )
+        for selected_index in range(await selected.count()):
+            if await _locator_matches_caption_language(
+                selected.nth(selected_index),
+                language_tag,
+            ):
+                return True
+        return False
+    return False
+
+
+async def _select_native_caption_language(control: Any, language_tag: str) -> bool:
+    normalized_tag = _normalize_language_tag(language_tag)
+    options = control.locator("option")
+    for index in range(await options.count()):
+        option = options.nth(index)
+        value = str(await option.get_attribute("value") or "")
+        text = str(await option.inner_text() or "")
+        if _normalize_language_tag(value) != normalized_tag and not caption_option_matches(
+            text,
+            language_tag,
+        ):
+            continue
+        if value:
+            await control.select_option(value=value)
+        else:
+            await control.select_option(label=text)
+        selected = control.locator("option:checked")
+        return bool(
+            await selected.count()
+            and await _locator_matches_caption_language(selected.first, language_tag)
+        )
+    return False
+
+
+async def _locator_matches_caption_language(locator: Any, language_tag: str) -> bool:
+    values = [
+        await locator.get_attribute("value"),
+        await locator.get_attribute("data-value"),
+        await locator.get_attribute("aria-label"),
+        await locator.text_content(),
+    ]
+    normalized_tag = _normalize_language_tag(language_tag)
+    for raw_value in values:
+        value = str(raw_value or "")
+        if _normalize_language_tag(value) == normalized_tag:
+            return True
+        if caption_option_matches(value, language_tag):
+            return True
+    return False

--- a/meetbot/engine.py
+++ b/meetbot/engine.py
@@ -8,54 +8,17 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from meetbot.browser_control import _click_first_visible, _first_visible
 from meetbot.browser_diagnostics import capture_failure_evidence
+from meetbot.caption_control import (
+    CaptionController,
+    caption_language_menu_labels,
+    caption_option_matches,
+)
 from meetbot.config import MeetbotConfig
 from meetbot.models import EngineResult, MeetbotSessionOutcome, SessionEvents
 
 logger = logging.getLogger(__name__)
-
-_CAPTION_LANGUAGE_MENU_LABELS = {
-    "fr-fr": "French",
-    "en-us": "English",
-}
-
-
-def caption_language_menu_labels(language_tag: str) -> tuple[str, ...]:
-    """Return Meet's known label followed by the BCP-47 subtag fallback."""
-
-    normalized = _normalize_language_tag(language_tag)
-    if not normalized:
-        return ()
-    subtag = normalized.partition("-")[0]
-    known_label = _CAPTION_LANGUAGE_MENU_LABELS.get(normalized)
-    return (known_label, subtag) if known_label else (subtag,)
-
-
-def caption_option_matches(option_text: str, language_tag: str) -> bool:
-    """Match a Meet menu option by known label, tag, or standalone language subtag."""
-
-    text = " ".join(str(option_text or "").split())
-    if not text:
-        return False
-    normalized_text = text.casefold().replace("_", "-")
-    normalized_tag = _normalize_language_tag(language_tag)
-    labels = caption_language_menu_labels(language_tag)
-    if not normalized_tag or not labels:
-        return False
-    known_label = _CAPTION_LANGUAGE_MENU_LABELS.get(normalized_tag)
-    if known_label and normalized_text in {
-        known_label.casefold(),
-        f"{known_label.casefold()} (beta)",
-    }:
-        return True
-    if re.search(rf"(?<![a-z]){re.escape(normalized_tag)}(?![a-z])", normalized_text):
-        return True
-    subtag = labels[-1].casefold()
-    return bool(re.search(rf"(?<![a-z]){re.escape(subtag)}(?![a-z])", normalized_text))
-
-
-def _normalize_language_tag(language_tag: str) -> str:
-    return str(language_tag or "").strip().replace("_", "-").casefold()
 
 
 def _lobby_timeout_error(timeout_seconds: int) -> str:
@@ -70,99 +33,6 @@ def _lobby_timeout_error(timeout_seconds: int) -> str:
     )
 
 
-_CAPTION_OBSERVER_SCRIPT = r"""
-(() => {
-  if (window.__illoMeetbotCaptionObserver) return;
-
-  const nodeIds = new WeakMap();
-  const lastValues = new Map();
-  let nextNodeId = 1;
-  const captionSelector = [
-    '[role="region"][aria-label*="aption" i]',
-    '[data-caption-id]',
-    '[jsname="YSxPC"]',
-    '[jsname="tgaKEf"]',
-    '.a4cQT'
-  ].join(',');
-  const rowSelector = [
-    '[data-caption-row]',
-    '[jsname="dsyhDe"]',
-    '.CNusmb',
-    '.TBMuR',
-    '.nMcdL'
-  ].join(',');
-  const speakerSelector = [
-    '[data-speaker-name]',
-    '.KcIKyf',
-    '.zs7s8d',
-    '.NWpY1d',
-    '.xoMHSc',
-    'span[jsname="YSxPC"]'
-  ].join(',');
-  const textSelector = [
-    '[data-caption-text]',
-    '.bh44bd',
-    '.iTTPOb',
-    'span[jsname="tgaKEf"]'
-  ].join(',');
-
-  const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
-  const identity = (node) => {
-    if (!nodeIds.has(node)) nodeIds.set(node, nextNodeId++);
-    return `caption-${nodeIds.get(node)}`;
-  };
-  const emit = (row) => {
-    if (!(row instanceof Element)) return;
-    const speakerNode = row.querySelector(speakerSelector);
-    const textNodes = Array.from(row.querySelectorAll(textSelector));
-    let speaker = clean(speakerNode && speakerNode.textContent);
-    let text = clean(textNodes.map((node) => node.textContent).join(' '));
-    if (!text) {
-      const lines = String(row.innerText || '').split('\n').map(clean).filter(Boolean);
-      if (!speaker && lines.length > 1) speaker = lines.shift() || '';
-      text = clean(lines.filter((line) => line !== speaker).join(' '));
-    }
-    if (!text) return;
-    const lineId = identity(row);
-    const fingerprint = `${speaker}\n${text}`;
-    if (lastValues.get(lineId) === fingerprint) return;
-    lastValues.set(lineId, fingerprint);
-    window.__illoMeetbotCaption({line_id: lineId, speaker, text});
-  };
-  const scan = (container) => {
-    const rows = Array.from(container.querySelectorAll(rowSelector));
-    if (rows.length) {
-      rows.forEach(emit);
-      return;
-    }
-    emit(container);
-  };
-  const scanFrom = (target) => {
-    const element = target instanceof Element ? target : target.parentElement;
-    if (!element) return;
-    const row = element.closest(rowSelector);
-    if (row) {
-      emit(row);
-      return;
-    }
-    const closestCaption = element.closest(captionSelector);
-    if (closestCaption) scan(closestCaption);
-    element.querySelectorAll(captionSelector).forEach(scan);
-  };
-
-  const observer = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-      scanFrom(mutation.target);
-      for (const node of mutation.addedNodes) scanFrom(node);
-    }
-  });
-  observer.observe(document.body, {subtree: true, childList: true, characterData: true});
-  document.querySelectorAll(captionSelector).forEach(scan);
-  window.__illoMeetbotCaptionObserver = observer;
-})();
-"""
-
-
 @dataclass(slots=True)
 class _BrowserRuntime:
     page: Any
@@ -174,6 +44,7 @@ class PlaywrightMeetEngine:
 
     def __init__(self, config: MeetbotConfig) -> None:
         self._config = config
+        self._caption_control = CaptionController(config)
         self._runtimes: dict[str, _BrowserRuntime] = {}
 
     async def run(
@@ -250,8 +121,8 @@ class PlaywrightMeetEngine:
                 if admission_result is not None:
                     return admission_result
                 await events.status("admitted")
-                await self._attach_caption_observer(page, events)
-                await self._enable_captions(page, events, session_id)
+                await self._caption_control._attach_caption_observer(page, events)
+                await self._caption_control._enable_captions(page, events, session_id)
                 return await self._monitor_call(page, runtime.leave_requested, events)
             except Exception:
                 await capture_failure_evidence(
@@ -432,153 +303,6 @@ class PlaywrightMeetEngine:
                 )
             await asyncio.sleep(0.5)
 
-    async def _attach_caption_observer(self, page: Any, events: SessionEvents) -> None:
-        async def on_caption(payload: object) -> None:
-            if not isinstance(payload, dict):
-                return
-            speaker = str(payload.get("speaker") or "Unknown speaker")
-            text = str(payload.get("text") or "").strip()
-            line_id = str(payload.get("line_id") or "").strip() or None
-            if text:
-                await events.caption(speaker, text, line_id)
-
-        await page.expose_function("__illoMeetbotCaption", on_caption)
-        await page.evaluate(_CAPTION_OBSERVER_SCRIPT)
-
-    async def _enable_captions(
-        self,
-        page: Any,
-        events: SessionEvents,
-        session_id: str,
-    ) -> None:
-        await page.keyboard.press("c")
-        await asyncio.sleep(1.0)
-        enabled = await _first_visible(
-            page,
-            (
-                'button[aria-label*="Turn off captions" i]',
-                '[role="button"][data-tooltip*="Turn off captions" i]',
-            ),
-        )
-        if enabled is None:
-            clicked = await _click_first_visible(
-                page,
-                (
-                    'button[aria-label*="Turn on captions" i]',
-                    'button[aria-label*="Show captions" i]',
-                    '[role="button"][data-tooltip*="Turn on captions" i]',
-                ),
-            )
-            if not clicked:
-                logger.warning("Meetbot could not verify or click the Google Meet captions control")
-
-        strategy = await self._set_caption_language(page, session_id)
-        if strategy:
-            logger.info(
-                "Meetbot confirmed caption language %s with selector strategy %s",
-                self._config.caption_language,
-                strategy,
-            )
-            return
-        warning = (
-            f"Could not confirm the caption language is {self._config.caption_language}; "
-            "the transcript may be translated or empty."
-        )
-        logger.warning("%s", warning)
-        logger.info(
-            "Meetbot caption-language diagnostic evidence for session %s is under %s",
-            session_id,
-            self._config.debug_dir,
-        )
-        await events.warning(warning)
-
-    async def _set_caption_language(self, page: Any, session_id: str) -> str | None:
-        strategies = (
-            ("visible-language-control", self._set_visible_caption_language),
-            ("caption-settings-control", self._set_via_caption_settings_control),
-            ("more-options-settings-captions", self._set_via_meet_settings),
-        )
-        for name, strategy in strategies:
-            try:
-                if await strategy(page):
-                    return name
-            except Exception:
-                logger.debug(
-                    "Meet caption-language selector strategy %s failed",
-                    name,
-                    exc_info=True,
-                )
-            # Meet closes the menu on Escape, so live selector evidence must be
-            # recorded while the failed strategy's last overlay is still open.
-            await capture_failure_evidence(
-                page,
-                session_id,
-                name,
-                debug_dir=self._config.debug_dir,
-            )
-            try:
-                await page.keyboard.press("Escape")
-            except Exception:
-                logger.debug("Meetbot could not close a caption settings overlay", exc_info=True)
-        return None
-
-    async def _set_visible_caption_language(self, page: Any) -> bool:
-        control = await _caption_language_control(page)
-        if control is None:
-            return False
-        return await _choose_caption_language(page, control, self._config.caption_language)
-
-    async def _set_via_caption_settings_control(self, page: Any) -> bool:
-        opened = await _click_first_visible(
-            page,
-            (
-                'button[aria-label*="Caption settings" i]',
-                'button[aria-label*="Caption language" i]',
-                '[role="button"][data-tooltip*="Caption settings" i]',
-                '[role="button"][aria-haspopup][aria-label*="caption" i]',
-            ),
-        )
-        if not opened:
-            return False
-        await asyncio.sleep(0.25)
-        return await self._set_visible_caption_language(page)
-
-    async def _set_via_meet_settings(self, page: Any) -> bool:
-        more_opened = await _click_first_visible(
-            page,
-            (
-                'button[aria-label="More options" i]',
-                '[role="button"][data-tooltip="More options" i]',
-            ),
-        )
-        if not more_opened:
-            return False
-        await asyncio.sleep(0.25)
-        settings_opened = await _click_first_visible(
-            page,
-            (
-                '[role="menuitem"]:has-text("Settings")',
-                '[role="button"]:has-text("Settings")',
-                'button:has-text("Settings")',
-            ),
-        )
-        if not settings_opened:
-            return False
-        await asyncio.sleep(0.25)
-        captions_opened = await _click_first_visible(
-            page,
-            (
-                '[role="tab"]:has-text("Captions")',
-                '[role="menuitem"]:has-text("Captions")',
-                '[role="button"][aria-label="Captions" i]',
-                'button:has-text("Captions")',
-            ),
-        )
-        if not captions_opened:
-            return False
-        await asyncio.sleep(0.25)
-        return await self._set_visible_caption_language(page)
-
     async def _monitor_call(
         self,
         page: Any,
@@ -729,134 +453,3 @@ async def _participant_snapshot(page: Any) -> tuple[int | None, list[str]]:
     raw_names = result.get("names")
     names = [str(name) for name in raw_names] if isinstance(raw_names, list) else []
     return count, names
-
-
-async def _caption_language_control(page: Any) -> Any | None:
-    control = await _first_visible(
-        page,
-        (
-            'select[aria-label*="Language of the meeting" i]',
-            'select[aria-label*="caption language" i]',
-            '[role="combobox"][aria-label*="Language of the meeting" i]',
-            '[role="combobox"][aria-label*="caption language" i]',
-            'button[aria-label*="Language of the meeting" i]',
-            'button[aria-label*="caption language" i]',
-            '[aria-haspopup="listbox"][aria-label*="Language of the meeting" i]',
-            '[aria-haspopup="listbox"][aria-label*="caption language" i]',
-        ),
-    )
-    if control is not None:
-        return control
-
-    labels = page.get_by_text(
-        re.compile(r"^(Language of the meeting|Caption language)$", re.IGNORECASE)
-    )
-    for index in range(await labels.count()):
-        label = labels.nth(index)
-        if not await label.is_visible():
-            continue
-        parent = label.locator("xpath=..")
-        control = await _first_visible(
-            parent,
-            (
-                "select",
-                '[role="combobox"]',
-                'button[aria-haspopup="listbox"]',
-            ),
-        )
-        if control is not None:
-            return control
-    return None
-
-
-async def _choose_caption_language(page: Any, control: Any, language_tag: str) -> bool:
-    tag_name = str(await control.evaluate("node => node.tagName || ''")).casefold()
-    if tag_name == "select":
-        return await _select_native_caption_language(control, language_tag)
-
-    await control.click()
-    await asyncio.sleep(0.2)
-    options = page.locator(
-        '[role="option"], [role="menuitemradio"], [role="menuitem"]'
-    )
-    for index in range(await options.count()):
-        option = options.nth(index)
-        if not await option.is_visible():
-            continue
-        if not caption_option_matches(await option.inner_text(), language_tag):
-            continue
-        await option.click()
-        await asyncio.sleep(0.2)
-        if await _locator_matches_caption_language(control, language_tag):
-            return True
-        selected = page.locator(
-            '[role="option"][aria-selected="true"], '
-            '[role="menuitemradio"][aria-checked="true"]'
-        )
-        for selected_index in range(await selected.count()):
-            if await _locator_matches_caption_language(
-                selected.nth(selected_index),
-                language_tag,
-            ):
-                return True
-        return False
-    return False
-
-
-async def _select_native_caption_language(control: Any, language_tag: str) -> bool:
-    normalized_tag = _normalize_language_tag(language_tag)
-    options = control.locator("option")
-    for index in range(await options.count()):
-        option = options.nth(index)
-        value = str(await option.get_attribute("value") or "")
-        text = str(await option.inner_text() or "")
-        if _normalize_language_tag(value) != normalized_tag and not caption_option_matches(
-            text,
-            language_tag,
-        ):
-            continue
-        if value:
-            await control.select_option(value=value)
-        else:
-            await control.select_option(label=text)
-        selected = control.locator("option:checked")
-        return bool(
-            await selected.count()
-            and await _locator_matches_caption_language(selected.first, language_tag)
-        )
-    return False
-
-
-async def _locator_matches_caption_language(locator: Any, language_tag: str) -> bool:
-    values = [
-        await locator.get_attribute("value"),
-        await locator.get_attribute("data-value"),
-        await locator.get_attribute("aria-label"),
-        await locator.text_content(),
-    ]
-    normalized_tag = _normalize_language_tag(language_tag)
-    for raw_value in values:
-        value = str(raw_value or "")
-        if _normalize_language_tag(value) == normalized_tag:
-            return True
-        if caption_option_matches(value, language_tag):
-            return True
-    return False
-
-
-async def _click_first_visible(page: Any, selectors: tuple[str, ...]) -> bool:
-    locator = await _first_visible(page, selectors)
-    if locator is None:
-        return False
-    await locator.click()
-    return True
-
-
-async def _first_visible(page: Any, selectors: tuple[str, ...]) -> Any | None:
-    for selector in selectors:
-        locator = page.locator(selector)
-        for index in range(await locator.count()):
-            candidate = locator.nth(index)
-            if await candidate.is_visible():
-                return candidate
-    return None

--- a/meetbot/engine.py
+++ b/meetbot/engine.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from meetbot.browser_control import _click_first_visible, _first_visible
+from meetbot.browser_control import click_first_match, first_visible
 from meetbot.browser_diagnostics import capture_failure_evidence
 from meetbot.caption_control import (
     CaptionController,
@@ -121,8 +121,7 @@ class PlaywrightMeetEngine:
                 if admission_result is not None:
                     return admission_result
                 await events.status("admitted")
-                await self._caption_control._attach_caption_observer(page, events)
-                await self._caption_control._enable_captions(page, events, session_id)
+                await self._caption_control.start(page, events, session_id)
                 return await self._monitor_call(page, runtime.leave_requested, events)
             except Exception:
                 await capture_failure_evidence(
@@ -147,7 +146,7 @@ class PlaywrightMeetEngine:
         if not runtime:
             raise RuntimeError("The meeting browser is not active.")
         page = runtime.page
-        opened = await _click_first_visible(
+        opened = await click_first_match(
             page,
             (
                 'button[aria-label*="Chat with everyone" i]',
@@ -156,7 +155,7 @@ class PlaywrightMeetEngine:
         )
         if not opened:
             raise RuntimeError("Google Meet chat is not available.")
-        editor = await _first_visible(
+        editor = await first_visible(
             page,
             (
                 'textarea[aria-label*="Send a message" i]',
@@ -178,7 +177,7 @@ class PlaywrightMeetEngine:
         """
 
         for _ in range(10):
-            clicked = await _click_first_visible(
+            clicked = await click_first_match(
                 page,
                 (
                     'button:has-text("Continue without microphone and camera")',
@@ -187,7 +186,7 @@ class PlaywrightMeetEngine:
             )
             if clicked:
                 return
-            if await _first_visible(
+            if await first_visible(
                 page,
                 (
                     'input[aria-label*="Your name" i]',
@@ -228,7 +227,7 @@ class PlaywrightMeetEngine:
         # The prejoin UI renders progressively; poll briefly before concluding
         # the field is absent, and distinguish "blocked" from "not rendered".
         for _ in range(20):
-            field = await _first_visible(
+            field = await first_visible(
                 page,
                 (
                     'input[aria-label*="Your name" i]',
@@ -254,7 +253,7 @@ class PlaywrightMeetEngine:
             if await candidate.is_visible():
                 await candidate.click()
                 return True
-        return await _click_first_visible(
+        return await click_first_match(
             page,
             ('button:has-text("Ask to join")', 'button:has-text("Join now")'),
         )
@@ -344,7 +343,7 @@ class PlaywrightMeetEngine:
 
 
 async def _click_leave(page: Any) -> None:
-    await _click_first_visible(
+    await click_first_match(
         page,
         (
             'button[aria-label*="Leave call" i]',
@@ -393,12 +392,12 @@ async def _ensure_media_muted(
     join failed here when this raised).
     """
 
-    if await _first_visible(page, on_selectors) is not None:
+    if await first_visible(page, on_selectors) is not None:
         return
-    if not await _click_first_visible(page, off_selectors):
+    if not await click_first_match(page, off_selectors):
         logger.info("Google Meet shows no %s control; nothing to mute.", device)
         return
-    if await _first_visible(page, on_selectors) is None:
+    if await first_visible(page, on_selectors) is None:
         logger.warning("Google Meet did not confirm the %s toggled off.", device)
 
 

--- a/meetbot/tests/test_engine.py
+++ b/meetbot/tests/test_engine.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from meetbot.browser_diagnostics import capture_failure_evidence
+from meetbot.caption_control import CaptionController
 from meetbot.config import MeetbotConfig
 from meetbot.engine import (
     PlaywrightMeetEngine,
@@ -104,13 +105,13 @@ async def test_caption_language_failure_emits_transcript_risk_warning(
     async def no_sleep(_: float) -> None:
         return None
 
-    monkeypatch.setattr("meetbot.engine.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("meetbot.caption_control.asyncio.sleep", no_sleep)
     events = _WarningEvents()
-    engine = PlaywrightMeetEngine(
+    caption_control = CaptionController(
         MeetbotConfig(caption_language="fr-FR", private_root=tmp_path)
     )
 
-    await engine._enable_captions(_NeverAdmittedPage(), events, "session-1")
+    await caption_control._enable_captions(_NeverAdmittedPage(), events, "session-1")
 
     assert events.messages == [
         "Could not confirm the caption language is fr-FR; "
@@ -157,13 +158,13 @@ async def test_caption_failure_capture_precedes_each_strategy_escape(
         assert debug_dir == tmp_path / "debug"
         captures.append((label, page.overlay_open))
 
-    engine = PlaywrightMeetEngine(MeetbotConfig(private_root=tmp_path))
-    monkeypatch.setattr(engine, "_set_visible_caption_language", failed_strategy)
-    monkeypatch.setattr(engine, "_set_via_caption_settings_control", failed_strategy)
-    monkeypatch.setattr(engine, "_set_via_meet_settings", failed_strategy)
-    monkeypatch.setattr("meetbot.engine.capture_failure_evidence", capture)
+    caption_control = CaptionController(MeetbotConfig(private_root=tmp_path))
+    monkeypatch.setattr(caption_control, "_set_visible_caption_language", failed_strategy)
+    monkeypatch.setattr(caption_control, "_set_via_caption_settings_control", failed_strategy)
+    monkeypatch.setattr(caption_control, "_set_via_meet_settings", failed_strategy)
+    monkeypatch.setattr("meetbot.caption_control.capture_failure_evidence", capture)
 
-    result = await engine._set_caption_language(_RecordingPage(), "session-1")
+    result = await caption_control._set_caption_language(_RecordingPage(), "session-1")
 
     assert result is None
     assert all(overlay_open for _, overlay_open in captures)
@@ -262,14 +263,14 @@ async def test_capture_errors_do_not_interrupt_caption_warning(
     async def no_sleep(_: float) -> None:
         return None
 
-    monkeypatch.setattr("meetbot.engine.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("meetbot.caption_control.asyncio.sleep", no_sleep)
     page = _BrokenCapturePage()
     events = _WarningEvents()
-    engine = PlaywrightMeetEngine(
+    caption_control = CaptionController(
         MeetbotConfig(caption_language="fr-FR", private_root=tmp_path)
     )
 
-    await engine._enable_captions(page, events, "session-1")
+    await caption_control._enable_captions(page, events, "session-1")
 
     assert page.escape_count == 3
     assert page.screenshot_count == 3


### PR DESCRIPTION
Closes #645

## What changed

`meetbot/engine.py` was 862 lines owning browser startup, admission detection, caption observation, caption-language menu driving, participant discovery, chat and end detection side by side. Google Meet churns its DOM constantly, so every churn meant editing one module where unrelated selector groups sat next to each other.

- **`meetbot/caption_control.py` (new)** — `CaptionController`: the injected MutationObserver script, caption enable, and the three caption-language strategies with their helpers. One public `start()` owns the sequence.
- **`meetbot/browser_control.py` (new, 23 lines)** — the two low-level locator helpers both sides need, with one owner instead of a copy each.
- **`meetbot/engine.py` — 862 → 455 lines**, keeping browser and session lifecycle only.

Note this is distinct from the existing `meetbot/captions.py`, which is the in-memory `RollingCaptionBuffer`. This new module is the browser-side controller.

## This is a pure move — no behaviour change

Not one selector, label, timeout or strategy order changed. Proven mechanically rather than by eye: every string literal in the old `engine.py` was compared against the new modules. **Zero lost**, and the only four additions are three docstrings and one module name.

The caption-**language** strategies are known broken in live use and are tracked separately. They moved unchanged on purpose — this PR deliberately does not try to fix them.

## Verification

| gate | result |
|---|---|
| `pytest meetbot/tests -q` | 45 passed |
| the repo fast lane (`-m "not requires_db and not requires_browser and not live_provider"`) | **4960 passed, 11 skipped, 0 failed** |
| boundary probe — no cross-module private access | clean |

Both gates were run serially at load ~2. A worker run under contention reported 1 failure and 5 errors; those are localhost socket-bind permission artifacts and did not reproduce in either clean serial run.

`meetbot/tests` changed only where a test reaches a private that moved. No assertion was weakened — a maintainability reviewer checked this specifically.

## Review notes

A cross-family maintainability review returned BLOCKING on two findings; both are folded into the second commit:

1. The controller had no public API — the engine called `_attach_caption_observer` and `_enable_captions`, so the seam existed in file layout only. There is now one public `start()`.
2. `browser_control.py` is shared but exported underscore-private names. Its helpers are now public.

**Left open deliberately:** the reviewer flagged that `caption_control.py` and `captions.py` read as confusingly similar and suggested renaming both (`caption_controller.py` / `caption_buffer.py`). Renaming `captions.py` is outside this ticket, so both names are untouched. Worth a follow-up if the pairing bothers you.

## What to check

This is a structural change with no user-visible surface, so there is nothing to click. Two things worth your eye:

1. **Is the seam where you would have put it?** Captions on one side, browser/session lifecycle on the other.
2. **Is a 23-line `browser_control.py` worth having?** The reviewer judged it justified — two consumers, and the alternative is either duplication or `caption_control` importing from `engine`. Your call if you disagree.

## Why now

The ticket says "do this AFTER the first successful live meeting capture, so the refactor diffs against selectors known to work." That capture happened on 2026-08-03 (session `1eebef49`, English transcribed fine), so the gate is met. A previous automated run had narrowed the gate to "caption-language selectors confirmed working in a live French meeting" — a condition the ticket never states, and one nothing can currently satisfy, since no meeting join has been requested since 2026-08-05 (#777). That held the ticket for nine days, so I took it.