### PR TITLE
fix(browser): reject non-UUID inbound thread references before they reach asyncpg

### DIFF
--- a/brain/contracts/thread_references.py
+++ b/brain/contracts/thread_references.py
@@ -1,0 +1,76 @@
+"""Shared normalization for AgentRun thread references."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+
+THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
+INBOUND_THREAD_PREFIX = "inbound:"
+
+
+class IdeaThreadReferenceKind(str, Enum):
+    """How an AgentRun thread reference relates to an Idea."""
+
+    IDEA = "idea"
+    INBOUND = "inbound"
+    NOT_IDEA_BACKED = "not_idea_backed"
+
+
+class IdeaBackedThreadRequiredError(ValueError):
+    """Raised when an operation needs an Idea-backed AgentRun thread."""
+
+
+@dataclass(frozen=True)
+class IdeaThreadReference:
+    """The normalized Idea identity, or why the thread has none."""
+
+    kind: IdeaThreadReferenceKind
+    idea_id: str | None = None
+
+    def require_idea_id(self, *, operation: str) -> str:
+        if self.idea_id is not None:
+            return self.idea_id
+        if self.kind is IdeaThreadReferenceKind.INBOUND:
+            raise IdeaBackedThreadRequiredError(
+                f"{operation} need an idea-backed thread; this run is a headless inbound submission"
+            )
+        raise IdeaBackedThreadRequiredError(
+            f"{operation} need an idea-backed thread with a valid UUID idea_id"
+        )
+
+
+def resolve_idea_thread_reference(value: Any) -> IdeaThreadReference:
+    """Resolve a run thread reference without sending invalid UUIDs to storage."""
+
+    text = str(value or "").strip()
+    if text.startswith(THREAD_DISCUSSION_THREAD_PREFIX):
+        text = text.removeprefix(THREAD_DISCUSSION_THREAD_PREFIX).strip()
+    elif text.startswith(INBOUND_THREAD_PREFIX):
+        parts = text.split(":")
+        if len(parts) == 3:
+            try:
+                UUID(parts[1])
+                UUID(parts[2])
+            except (TypeError, ValueError):
+                pass
+            else:
+                return IdeaThreadReference(IdeaThreadReferenceKind.INBOUND)
+
+    try:
+        idea_id = str(UUID(text))
+    except (TypeError, ValueError, AttributeError):
+        return IdeaThreadReference(IdeaThreadReferenceKind.NOT_IDEA_BACKED)
+    return IdeaThreadReference(IdeaThreadReferenceKind.IDEA, idea_id)
+
+
+__all__ = [
+    "IdeaBackedThreadRequiredError",
+    "IdeaThreadReference",
+    "IdeaThreadReferenceKind",
+    "THREAD_DISCUSSION_THREAD_PREFIX",
+    "resolve_idea_thread_reference",
+]

--- a/brain/platform/browser/service.py
+++ b/brain/platform/browser/service.py
@@ -23,6 +23,7 @@ from urllib.parse import unquote, urlparse
 import httpx
 from sqlalchemy import select
 
+from brain.contracts.thread_references import resolve_idea_thread_reference
 from brain.kernel.common.time import utcnow as _shared_utcnow
 
 from brain.platform.events import publish_safe
@@ -44,6 +45,12 @@ WORKSPACE_BROWSER_STATE_DIR = os.environ.get(
 )
 UPLOAD_DIR = BRAIN_ROOT / "uploads"
 HARNESS_RESULT_MARKER = "__ILLO_BROWSER_HARNESS_RESULT__"
+
+
+def _browser_idea_id(thread_reference: Any) -> str:
+    return resolve_idea_thread_reference(thread_reference).require_idea_id(
+        operation="Browser tools"
+    )
 
 
 def _utcnow() -> datetime:
@@ -1548,16 +1555,18 @@ class BrowserSessionService:
                 record.last_error = reason
 
     def get_idea_org_id(self, idea_id: str) -> str | None:
+        idea_id = _browser_idea_id(idea_id)
         for runtime in self._runtimes.values():
-            if runtime.idea_id == str(idea_id) and not runtime._closed:
+            if runtime.idea_id == idea_id and not runtime._closed:
                 return runtime.org_id
         return None
 
     async def get_idea_org_id_async(self, idea_id: str) -> str | None:
+        idea_id = _browser_idea_id(idea_id)
         try:
             async with UnitOfWork() as uow:
                 org_id = await uow.session.scalar(
-                    select(Idea.org_id).where(Idea.id == str(idea_id))
+                    select(Idea.org_id).where(Idea.id == idea_id)
                 )
         except Exception as exc:
             logger.debug("Failed to resolve browser session idea org idea=%s: %s", idea_id, exc)
@@ -1608,8 +1617,9 @@ class BrowserSessionService:
                 return None
             idea_org_id = normalized_org_id
             if idea_org_id is None:
+                idea_id = _browser_idea_id(record.idea_id)
                 idea_org_id = await uow.session.scalar(
-                    select(Idea.org_id).where(Idea.id == str(record.idea_id))
+                    select(Idea.org_id).where(Idea.id == idea_id)
                 )
             setattr(record, "_idea_org_id", str(idea_org_id) if idea_org_id else None)
             return record
@@ -1627,6 +1637,7 @@ class BrowserSessionService:
         allow_downloads: bool = False,
         allow_file_uploads: bool = True,
     ) -> BrowserSessionRuntime:
+        idea_id = _browser_idea_id(idea_id)
         async with self._runtime_lock:
             record = await self.get_active_session_record_async(idea_id)
             org_id = await self.get_idea_org_id_async(idea_id)
@@ -1742,8 +1753,9 @@ class BrowserSessionService:
         async with UnitOfWork() as uow:
             record = await uow.session.get(BrowserSession, session_id)
             if record is not None:
+                idea_id = _browser_idea_id(record.idea_id)
                 org_id = await uow.session.scalar(
-                    select(Idea.org_id).where(Idea.id == str(record.idea_id))
+                    select(Idea.org_id).where(Idea.id == idea_id)
                 )
                 setattr(record, "_idea_org_id", str(org_id) if org_id else None)
         if not record or not record.active:
@@ -1753,14 +1765,16 @@ class BrowserSessionService:
         return runtime
 
     def get_active_session_record(self, idea_id: str) -> BrowserSession | None:
+        idea_id = _browser_idea_id(idea_id)
         for runtime in self._runtimes.values():
-            if runtime.idea_id == str(idea_id) and not runtime._closed:
+            if runtime.idea_id == idea_id and not runtime._closed:
                 record = runtime._record
                 if getattr(record, "active", True):
                     return record
         return None
 
     async def get_active_session_record_async(self, idea_id: str) -> BrowserSession | None:
+        idea_id = _browser_idea_id(idea_id)
         record = self._load_active_session(idea_id)
         if inspect.isawaitable(record):
             return await record
@@ -1861,6 +1875,7 @@ class BrowserSessionService:
             raise
 
     async def _load_active_session(self, idea_id: str) -> BrowserSession | None:
+        idea_id = _browser_idea_id(idea_id)
         async with UnitOfWork() as uow:
             result = await uow.session.scalars(
                 select(BrowserSession)

--- a/brain/systems/cortex/thread_read_model.py
+++ b/brain/systems/cortex/thread_read_model.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
-from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.contracts.thread_references import resolve_idea_thread_reference
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -45,15 +45,7 @@ def _summary_body(summary: dict[str, Any] | None) -> dict[str, Any]:
 
 
 def _idea_id_from_run_thread_id(value: Any) -> str | None:
-    text = str(value or "").strip()
-    if text.startswith("thread-discussion:"):
-        text = text.split(":", 1)[1].strip()
-    if not text:
-        return None
-    try:
-        return str(UUID(text))
-    except (TypeError, ValueError):
-        return None
+    return resolve_idea_thread_reference(value).idea_id
 
 
 def preview_summary_from_handoff(summary: dict[str, Any] | None) -> str | None:

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -19,6 +19,7 @@ import uuid
 
 from sqlalchemy import func, select
 
+from brain.contracts.thread_references import THREAD_DISCUSSION_THREAD_PREFIX
 from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
@@ -280,7 +281,6 @@ _TERMINAL_RUN_IDEA_STATUS = {
 }
 _AI_TIMELINE_SURFACES = {"ai_timeline", "thread_timeline", "cortex_thread", "main_thread"}
 _THREAD_DISCUSSION_SURFACE = "thread_discussion"
-_THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 _SLACK_SURFACE = "slack"
 _SLACK_REPLY_TOOL = "post_slack_reply"
 _SLACK_VISIBLE_ACTION_TOOLS = {_SLACK_REPLY_TOOL, "react_to_slack_message"}
@@ -318,7 +318,7 @@ def _run_is_thread_discussion_conversation(run: AgentRunRow) -> bool:
         if container.get("surface") == _THREAD_DISCUSSION_SURFACE:
             return True
     thread_id = str(getattr(run, "thread_id", "") or "")
-    return thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+    return thread_id.startswith(THREAD_DISCUSSION_THREAD_PREFIX)
 
 
 def _run_surface_value(run: AgentRunRow, key: str) -> str:
@@ -540,8 +540,8 @@ def _run_discussion_thread_id(run: AgentRunRow) -> str:
             return value
     thread_id = str(getattr(run, "thread_id", "") or "")
     return (
-        thread_id[len(_THREAD_DISCUSSION_THREAD_PREFIX):]
-        if thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+        thread_id[len(THREAD_DISCUSSION_THREAD_PREFIX):]
+        if thread_id.startswith(THREAD_DISCUSSION_THREAD_PREFIX)
         else ""
     )
 

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from brain.contracts.thread_references import THREAD_DISCUSSION_THREAD_PREFIX
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime, cancel_event_is_set
 from brain.systems.runs.failures import failure_category_for_error, safe_terminal_run_message
 from brain.systems.runs.tools import wrap_tool_handlers
@@ -53,7 +54,6 @@ Runtime rules:
 _FAST_HIDDEN_TOOL_NAMES = {"cortex_reply", "cortex_visual_reply"}
 _THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
 _THREAD_DISCUSSION_SURFACE = "thread_discussion"
-_THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 
 
 def build_fast_system_prompt(
@@ -101,7 +101,7 @@ def _originated_from_thread_discussion(
             return True
         if isinstance(container.get("discussion_trigger"), dict):
             return True
-    return thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+    return thread_id.startswith(THREAD_DISCUSSION_THREAD_PREFIX)
 
 
 def fast_agent_tools_for_request(

--- a/brain/systems/runs/tool_catalog/handlers/browser.py
+++ b/brain/systems/runs/tool_catalog/handlers/browser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from brain.contracts.thread_references import resolve_idea_thread_reference
 from brain.systems.runs.tool_catalog.handlers.common import *
 
 
@@ -87,13 +88,14 @@ async def _record_browser_snapshot_artifact(result: dict, *, source_tool: str) -
 
 
 def _browser_session_context() -> tuple[str, str | None, int | None]:
-    idea_id = getattr(_agent_context, "idea_id", None)
-    if not idea_id:
-        raise ValueError("No idea_id in context — browser tools only work during cortex runs")
+    thread_reference = getattr(_agent_context, "idea_id", None)
+    idea_id = resolve_idea_thread_reference(thread_reference).require_idea_id(
+        operation="Browser tools"
+    )
     user_id = getattr(_agent_context, "user_id", None)
     run = getattr(_agent_context, "run", None)
     run_id = getattr(run, "run_id", None) if run else None
-    return str(idea_id), str(user_id) if user_id else None, run_id
+    return idea_id, str(user_id) if user_id else None, run_id
 
 
 _TOOL_RESULT_CONTENT_KEY = "_tool_result_content"

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from sqlalchemy import text
 
+from brain.contracts.thread_references import THREAD_DISCUSSION_THREAD_PREFIX
 from brain.platform.db.models.idea import Idea
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthBlockedPreflightResult,
@@ -41,7 +42,6 @@ from brain.systems.runs.store import AsyncAgentRunStore
 _VALID_MODEL_PROVIDERS = {"anthropic", "ollama", "openai"}
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
-THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 AGENT_RUN_CONTINUATION_TARGET = "agent_run_continuation"
 
 logger = logging.getLogger("work_intake")

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -14,6 +14,12 @@ from brain.app.api.main import app
 from brain.app.api.ws.auth import create_ws_token
 
 
+IDEA_HARNESS_ID = "00000000-0000-0000-0000-000000000101"
+IDEA_START_FAILURE_ID = "00000000-0000-0000-0000-000000000102"
+IDEA_DIRTY_ID = "00000000-0000-0000-0000-000000000103"
+IDEA_VISIBLE_ID = "00000000-0000-0000-0000-000000000104"
+
+
 class _FakeSession:
     async def run_sync(self, fn):
         return fn(self)
@@ -46,6 +52,87 @@ def _ws_token(user_id: str = "user-123", org_id: str = "org-123") -> str:
         session_id=f"session-{user_id}",
     )
     return token
+
+
+@pytest.mark.parametrize(
+    ("thread_reference", "expected_idea_id"),
+    [
+        (IDEA_HARNESS_ID, IDEA_HARNESS_ID),
+        (f"thread-discussion:{IDEA_HARNESS_ID}", IDEA_HARNESS_ID),
+    ],
+)
+def test_browser_context_resolves_idea_backed_thread_references(
+    thread_reference,
+    expected_idea_id,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import browser as browser_handlers
+
+    with bind_agent_context({"idea_id": thread_reference, "user_id": "user-123"}):
+        idea_id, user_id, run_id = browser_handlers._browser_session_context()
+
+    assert idea_id == expected_idea_id
+    assert user_id == "user-123"
+    assert run_id is None
+
+
+@pytest.mark.asyncio
+async def test_browser_open_rejects_headless_inbound_thread_before_session_query(monkeypatch):
+    from brain.contracts.thread_references import IdeaBackedThreadRequiredError
+    from brain.platform.browser import browser_sessions
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import browser as browser_handlers
+
+    create_session = AsyncMock()
+    monkeypatch.setattr(browser_sessions, "create_or_get_session", create_session)
+    inbound_thread_id = (
+        "inbound:c3c835df-b24d-407f-a5b3-92e8e9f4607d:"
+        "88e6143d-2e07-4c79-927c-fd319118dc27"
+    )
+
+    with bind_agent_context({"idea_id": inbound_thread_id, "user_id": "user-123"}):
+        with pytest.raises(
+            IdeaBackedThreadRequiredError,
+            match="idea-backed thread; this run is a headless inbound submission",
+        ):
+            await browser_handlers._handle_browser_session_open("https://docs.google.com")
+
+    create_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_call",
+    [
+        lambda service, idea_id: service.create_or_get_session(
+            idea_id=idea_id,
+            user_id="user-123",
+        ),
+        lambda service, idea_id: service.get_idea_org_id_async(idea_id),
+        lambda service, idea_id: service.get_active_session_record_async(idea_id),
+        lambda service, idea_id: service._load_active_session(idea_id),
+    ],
+)
+async def test_browser_service_rejects_inbound_thread_before_uuid_query(
+    monkeypatch,
+    service_call,
+):
+    from brain.contracts.thread_references import IdeaBackedThreadRequiredError
+    from brain.platform.browser.service import BrowserSessionService
+
+    class QueryingUOW:
+        async def __aenter__(self):
+            pytest.fail("browser service opened a database unit of work")
+
+    monkeypatch.setattr("brain.platform.browser.service.UnitOfWork", QueryingUOW)
+    service = BrowserSessionService()
+    inbound_thread_id = (
+        "inbound:c3c835df-b24d-407f-a5b3-92e8e9f4607d:"
+        "88e6143d-2e07-4c79-927c-fd319118dc27"
+    )
+
+    with pytest.raises(IdeaBackedThreadRequiredError, match="headless inbound submission"):
+        await service_call(service, inbound_thread_id)
 
 
 def _allow_ws_browser_session(monkeypatch, ws_router, *, allowed_org_id: str = "org-123", active: bool = True):
@@ -572,7 +659,7 @@ async def test_browser_service_records_browser_harness_resource_summary(monkeypa
     monkeypatch.setattr(BrowserSessionRuntime, "start", fake_start)
 
     record = BrowserSession(
-        idea_id="idea-harness",
+        idea_id=IDEA_HARNESS_ID,
         user_id="user-123",
         run_id=77,
         current_url="https://example.com",
@@ -608,7 +695,7 @@ async def test_browser_service_records_browser_harness_resource_summary(monkeypa
     monkeypatch.setattr("brain.platform.browser.service.UnitOfWork", lambda: _UOW())
 
     runtime = await service.create_or_get_session(
-        idea_id="idea-harness",
+        idea_id=IDEA_HARNESS_ID,
         user_id="user-123",
         run_id=77,
         url=None,
@@ -644,7 +731,7 @@ async def test_browser_service_marks_start_failure_before_reraising(monkeypatch)
     monkeypatch.setattr(BrowserSessionRuntime, "_handle_runtime_error", fake_handle_error)
 
     record = BrowserSession(
-        idea_id="idea-start-fail",
+        idea_id=IDEA_START_FAILURE_ID,
         user_id="user-123",
         run_id=77,
         current_url=None,
@@ -679,7 +766,7 @@ async def test_browser_service_marks_start_failure_before_reraising(monkeypatch)
 
     with pytest.raises(RuntimeError, match="chrome missing"):
         await service.create_or_get_session(
-            idea_id="idea-start-fail",
+            idea_id=IDEA_START_FAILURE_ID,
             user_id="user-123",
             run_id=77,
             storage_mode="ephemeral",
@@ -696,7 +783,7 @@ async def test_browser_service_recycles_dirty_active_session_before_creating_new
 
     service = BrowserSessionService()
     dirty_record = BrowserSession(
-        idea_id="idea-dirty",
+        idea_id=IDEA_DIRTY_ID,
         user_id="user-123",
         run_id=41,
         current_url="https://example.com",
@@ -749,7 +836,7 @@ async def test_browser_service_recycles_dirty_active_session_before_creating_new
     monkeypatch.setattr("brain.platform.browser.service.UnitOfWork", lambda: _UOW())
 
     runtime = await service.create_or_get_session(
-        idea_id="idea-dirty",
+        idea_id=IDEA_DIRTY_ID,
         user_id="user-123",
         run_id=42,
         url=None,
@@ -816,7 +903,7 @@ async def test_browser_service_captures_visible_frame_when_agent_opens_session(m
     monkeypatch.setattr("brain.platform.browser.service.UnitOfWork", lambda: _UOW())
 
     runtime = await service.create_or_get_session(
-        idea_id="idea-visible",
+        idea_id=IDEA_VISIBLE_ID,
         user_id="user-123",
         run_id=99,
         url="https://www.youtube.com",
@@ -827,7 +914,7 @@ async def test_browser_service_captures_visible_frame_when_agent_opens_session(m
     assert captures == [("sess-visible", "created", "https://www.youtube.com")]
     assert tool_traces == [{
         "run_id": 99,
-        "idea_id": "idea-visible",
+        "idea_id": IDEA_VISIBLE_ID,
         "session_id": "sess-visible",
         "url": "https://www.youtube.com",
         "action": "open",


### PR DESCRIPTION
> *This was generated by AI during a scheduled R3 run.*

Closes #812.

## What was broken

A headless `inbound_submission` run carries a **synthetic, non-UUID** `thread_id`:

```
inbound:c3c835df-b24d-407f-a5b3-92e8e9f4607d:88e6143d-2e07-4c79-927c-fd319118dc27
```

That value reached Postgres UUID columns and asyncpg raised a `DataError`, so `browser.open` failed and the canonical Google Sheet never opened.

The path, end to end:

1. `brain/systems/inbound/service.py:1346` mints `f"inbound:{connection_id}:{event.id}"`. This is the documented design (`docs/personal-agent-connections-mvp.md:766`), not a bug.
2. `brain/systems/runs/cortex/recording.py:217` copies `run.thread_id` into the agent context's `idea_id`.
3. `brain/platform/browser/service.py` compared that against `Idea.id` and `BrowserSession.idea_id` — both `UUID(as_uuid=False)`. Boom.

## Why it fails clearly instead of resolving

`browser_sessions.idea_id` is **NOT NULL with an FK to `ideas.id`**, and an inbound submission has **no `ideas` row at all**. There is no UUID hiding inside the composite id that points at a real Idea, so normalization cannot recover one. The ticket explicitly allows "or otherwise use a safe non-UUID path".

So the change fails **before** the query with a typed, actionable error instead of a raw asyncpg traceback.

## The change

One shared resolver, `brain/contracts/thread_references.py`, which turns a run thread reference into either a real idea UUID or an explicit reason it has none:

| input | result |
|---|---|
| a bare UUID | `IDEA` + canonical uuid |
| `thread-discussion:<uuid>` | `IDEA` + the underlying uuid |
| `inbound:<uuid>:<uuid>` | `INBOUND` → raises `IdeaBackedThreadRequiredError` |
| anything else | `NOT_IDEA_BACKED` → raises |

It lives in `brain.contracts` because the layering test allows `brain.platform → brain.contracts` but forbids `brain.platform → brain.systems`. The first attempt put it higher and `tests/test_architecture_boundaries.py` caught it.

It also folded a pre-existing duplication: `THREAD_DISCUSSION_THREAD_PREFIX` was defined in **three** files (`work_intake.py`, `cortex/runner.py`, `recipes/fast.py`) and now has one owner that all three import.

## Verification

The repo's own backend CI lane, run **serially on an unloaded machine** by the orchestrator (not by the worker), twice at this commit:

```
4944 passed, 11 skipped, 90 deselected — 0 failed, 0 errors
```

The diff touches `brain/**` and `tests/**` only, so the frontend lane does not apply.

The implementing worker reported `1 failed, 5 errors`. All six were `PermissionError: [Errno 1]` on `socket.bind` — the Codex sandbox blocking localhost binds. `4938 + 6 = 4944` accounts for them exactly, and they vanish outside the sandbox.

## How to check this without reading the diff

There is no UI here — it is a runtime crash on a headless path. The honest surfaces:

1. **The regression test names the bug.** `tests/test_browser_sessions.py::test_browser_open_rejects_headless_inbound_thread_before_session_query` uses the ticket's **exact** connection and event ids, and asserts `create_session.assert_not_awaited()` — proving no query is issued at all, which is the actual fix.
2. **On staging**, trigger an inbound submission that calls `browser.open`. Before: an asyncpg `DataError` in the run log. After: a one-line error saying the run is a headless inbound submission and browser tools need an idea-backed thread.
3. Normal cortex runs are unchanged — a real UUID `idea_id` takes the same path as before, with no extra query.

## Review findings NOT folded in — please see these

A cross-family Codex code-quality review returned **BLOCKING**. I verified each finding rather than acting on it, and deliberately did not fold two of them:

1. **"The prefix consolidation is incomplete."** *Verified misleading.* The 3→1 consolidation is real and complete. The reviewer found two survivors named `THREAD_DISCUSSION_CONVERSATION_PREFIX` (`chat.py:11`, `_discussion.py:32`) — a different constant for a different concern, pre-dating this ticket. Filed separately as #813 rather than merged blind.
2. **"The guard is scattered across 8 sites."** *Partly fair, not folded.* A fix pass attempted it and stopped on a real contradiction: the reviewer wanted `get_idea_org_id_async` restored to best-effort `None`, but `create_or_get_session` calls it — returning `None` there would let an invalid `idea_id` through to the insert and reproduce this very bug. **Raising is the correct behavior**, so the current shape stands. What remains genuinely redundant is cosmetic: `create_or_get_session` re-resolves an already-resolved value, and two sites validate `record.idea_id` read back out of a UUID column, where it cannot be invalid.
3. **`IdeaThreadReference` permits invalid combinations** — e.g. `(IDEA, None)` is constructible though the resolver never produces it. A `__post_init__` assert would close it. Not folded; low value, and the fix pass was spent on finding 2.

The reviewer's own summary of the change: *"puts thread-reference normalization in an architecture-safe shared layer and fails before an invalid database query."*