### PR TITLE
fix(skills): expose workspace-local skills to the MCP read surface

### DIFF
--- a/brain/platform/db/repositories/skills.py
+++ b/brain/platform/db/repositories/skills.py
@@ -123,10 +123,13 @@ def _visible_installation(*, org_id: str, user_id: str):
     )
 
 
-def _workspace_local_skill():
-    # The installation gate controls distributed skills. A private skill that
-    # never came through a bundle was authored in this workspace, so reading it
-    # here is not a distribution event.
+def _unbundled_private_skill():
+    # The installation gate controls DISTRIBUTED skills, so a skill that never
+    # came through a bundle is not a distribution event to read.
+    #
+    # This proves "unbundled and private", not ownership: `skills` carries no
+    # org_id/user_id, so a caller's workspace is not expressible here. Scoping
+    # these per org needs an owner column on the table, not a wider predicate.
     return and_(
         Skill.bundle_version_id.is_(None),
         Skill.trust_level == "private_local",
@@ -136,7 +139,7 @@ def _workspace_local_skill():
 def _visible_skill(*, org_id: str, user_id: str):
     return or_(
         _visible_installation(org_id=org_id, user_id=user_id),
-        _workspace_local_skill(),
+        _unbundled_private_skill(),
     )
 
 

--- a/brain/platform/db/repositories/skills.py
+++ b/brain/platform/db/repositories/skills.py
@@ -123,6 +123,23 @@ def _visible_installation(*, org_id: str, user_id: str):
     )
 
 
+def _workspace_local_skill():
+    # The installation gate controls distributed skills. A private skill that
+    # never came through a bundle was authored in this workspace, so reading it
+    # here is not a distribution event.
+    return and_(
+        Skill.bundle_version_id.is_(None),
+        Skill.trust_level == "private_local",
+    )
+
+
+def _visible_skill(*, org_id: str, user_id: str):
+    return or_(
+        _visible_installation(org_id=org_id, user_id=user_id),
+        _workspace_local_skill(),
+    )
+
+
 class SkillRepository(BaseRepository[Skill]):
     """CRUD + domain queries for Skill."""
 
@@ -150,12 +167,12 @@ class SkillRepository(BaseRepository[Skill]):
         return (await self._session.scalars(_active_skill_stmt(with_executions=True))).all()
 
     async def a_list_visible(self, *, org_id: str, user_id: str) -> Sequence[Skill]:
-        """Return active skills installed for the user or system."""
+        """Return active installed or workspace-local skills visible to the user."""
         stmt = (
             select(Skill)
             .where(
                 _not_archived(),
-                _visible_installation(org_id=org_id, user_id=user_id),
+                _visible_skill(org_id=org_id, user_id=user_id),
             )
             .order_by(Skill.name, Skill.id)
             .options(load_only(*_SKILL_LIST_COLUMNS))
@@ -217,12 +234,12 @@ class SkillRepository(BaseRepository[Skill]):
         skill_id: int | None = None,
         name: str | None = None,
     ) -> Skill | None:
-        """Return one active skill installed for the user or system."""
+        """Return one active installed or workspace-local skill visible to the user."""
         if (skill_id is None) == (name is None):
             raise ValueError("Exactly one of skill_id or name is required")
         stmt = select(Skill).where(
             _not_archived(),
-            _visible_installation(org_id=org_id, user_id=user_id),
+            _visible_skill(org_id=org_id, user_id=user_id),
         )
         if skill_id is not None:
             stmt = stmt.where(Skill.id == skill_id)

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -71,6 +71,7 @@ async def _install_skill(
     archived=False,
     review_status="approved",
 ):
+    skill.bundle_version_id = skill.id
     installation = SkillInstallation(
         bundle_id=skill.id,
         bundle_version_id=skill.id,
@@ -134,7 +135,12 @@ async def test_visible_skills_are_scoped_to_system_org_and_user(repo, session):
     personal = await _make_skill(repo, session, name="personal")
     other_user = await _make_skill(repo, session, name="other-user")
     other_org = await _make_skill(repo, session, name="other-org")
-    unscoped = await _make_skill(repo, session, name="unscoped")
+    unscoped = await _make_skill(
+        repo,
+        session,
+        name="unscoped",
+        bundle_version_id=999,
+    )
     await _install_skill(session, system, enabled_scope="system")
     await _install_skill(session, org, org_id="org-1", user_id=None, enabled_scope="org")
     await _install_skill(session, personal, org_id="org-1", user_id="user-1")
@@ -155,6 +161,57 @@ async def test_visible_skills_are_scoped_to_system_org_and_user(repo, session):
         user_id="user-1",
         name="personal",
     ) is personal
+
+
+async def test_workspace_local_skill_is_visible_without_installation(repo, session):
+    local = await _make_skill(
+        repo,
+        session,
+        name="runtime-authored",
+        bundle_version_id=None,
+        trust_level="private_local",
+    )
+    distributed = await _make_skill(
+        repo,
+        session,
+        name="distributed-without-installation",
+        bundle_version_id=999,
+        trust_level="private_local",
+    )
+
+    visible = await repo.a_list_visible(org_id="org-1", user_id="user-1")
+
+    assert visible == [local]
+    assert await repo.a_get_visible(
+        org_id="org-1",
+        user_id="user-1",
+        skill_id=local.id,
+    ) is local
+    assert await repo.a_get_visible(
+        org_id="org-1",
+        user_id="user-1",
+        name=local.name,
+    ) is local
+    assert await repo.a_get_visible(
+        org_id="org-1",
+        user_id="user-1",
+        skill_id=distributed.id,
+    ) is None
+
+    local.archived = True
+    await session.flush()
+
+    assert await repo.a_list_visible(org_id="org-1", user_id="user-1") == []
+    assert await repo.a_get_visible(
+        org_id="org-1",
+        user_id="user-1",
+        skill_id=local.id,
+    ) is None
+    assert await repo.a_get_visible(
+        org_id="org-1",
+        user_id="user-1",
+        name=local.name,
+    ) is None
 
 
 def test_agent_skill_contracts_match_repository_projections():

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -163,7 +163,7 @@ async def test_visible_skills_are_scoped_to_system_org_and_user(repo, session):
     ) is personal
 
 
-async def test_workspace_local_skill_is_visible_without_installation(repo, session):
+async def test_unbundled_private_skill_is_visible_without_installation(repo, session):
     local = await _make_skill(
         repo,
         session,


### PR DESCRIPTION
> *This was generated by AI during triage.*

Closes #825

## What was broken

`illo_read skills.get {skill_id: 56}` answered **"Skill not found"** for a skill Illo had authored and verified minutes earlier. Every skill Illo writes at runtime was invisible to the MCP read surface that #823/#824 just shipped — which is exactly the class of skills the routines architecture (#822) depends on.

Cause: `a_list_visible` and `a_get_visible` gated every read behind an `exists()` over `skill_installations`. Runtime-authored skills never get an installation row, so the gate excluded them. The row cannot be faked either — `bundle_id`, `bundle_version_id` and `installed_digest` are all NOT NULL.

## What changed

A skill is now visible when **either** of these holds:

- it has an approved, enabled installation row — **unchanged**; or
- it is **workspace-local**: `bundle_version_id IS NULL` **and** `trust_level = 'private_local'`.

The installation gate exists to control *distributed* skills. A skill that never came through a bundle was authored inside this workspace, and a workspace reading its own local skills is not a distribution event.

Both read methods share one `_visible_skill()` predicate, so they cannot drift apart, and archived skills stay excluded on the new path.

## One thing to know before you merge

The ticket proposed exposing runtime skills "belonging to the caller's workspace". **That is not expressible today**: the `skills` table has no `org_id` and no `user_id` column — org scoping lives entirely in `skill_installations`. So workspace-local skills become readable by **any** authenticated bridge principal, regardless of org.

In practice this matches the rest of the codebase: every other reader of this table (`a_list_active`, `a_get_by_name`, the CLI, the jobs) is already org-blind. But it is a genuine widening, and if Illo ever serves a second org, per-org scoping needs a real owner column on `skills` — not a tweak to this predicate. Flagging it rather than burying it.

Bundle-distributed skills are provably unaffected: `_materialize_skill_projection` types `bundle_version_id: int` (non-optional), so every bundle-installed skill row carries one and can never match the new clause.

## How to check it (no code reading needed)

On **illo-dev**, with the bridge connection you already use:

1. `illo_read skills.get {skill_id: 56}` → returns the `uwear-r-ads` record instead of "Skill not found".
2. `illo_read skills.get {name: "uwear-r-ads"}` → same record, by name.
3. `illo_read skills.list` → now includes 46, 50, 52, 56, 57 alongside the installed ones.
4. Archive any runtime skill → it disappears from both again.

If step 1 still says "Skill not found" after deploy, the change did not take effect — that is the single check that matters.

## Verification

| run | result |
|---|---|
| `origin/main` baseline, zero changes | 4955 passed, 11 skipped, 0 errors |
| this branch | **4956 passed, 11 skipped, 0 errors** |

Delta is exactly +1 — the new test. Both runs serial, load average under 7, using the repo's own CI command (`pytest tests/ -m "not requires_db and not requires_browser and not live_provider"`).

The Codex build worker reported 5 errors in `test_gpu_integration.py`; those are its sandbox denying localhost socket binds (the same sandbox that denied it a git lock), and they do **not** reproduce outside it. Proven by the baseline row above rather than assumed.

Python-only diff, so the frontend lane does not apply.

A Codex code-quality review (cross-family, `xhigh`) returned **APPROVE_WITH_NOTES with zero blocking findings**. Its one actionable note was folded in: the predicate had been named `_workspace_local_skill()`, which implies proven workspace ownership the schema cannot establish. It is now `_unbundled_private_skill()` — named for what it actually proves — and the comment says what it does and does not establish. The full suite was re-run after that change on the exact tree being shipped.

## Assumptions

- Option 1 from the ticket was implemented, as the ticket recommended. Option 2 (author-with-installation) was not attempted.
- `trust_level` matching is restricted to `private_local`; `agent_draft` skills stay invisible deliberately.
- Acceptance clauses 1–2 are verified against live illo-dev by you; a worktree cannot reach that database. Clauses 3–4 are covered by the new test.
