### PR TITLE
test(deploy): bound the worker-swap simulator so the fast suite cannot hang (#827)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
 asyncio_mode = auto
+timeout = 120
 markers =
     integration: marks tests requiring a live database (deselect with '-m "not integration"')
     requires_db: marks tests needing Docker test DB (deselect with '-m "not requires_db"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,6 @@ accelerate>=1.0
 # production image too; the "Local" voice provider degrades to unavailable if
 # this is somehow missing.
 faster-whisper>=1.0
+
+# Test safety
+pytest-timeout>=2.4

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 RUNTIME_LIB = ROOT / "deploy" / "scripts" / "compose-runtime-lib.sh"
+SIMULATOR_TIMEOUT_SECONDS = 5
 
 
 def _simulator(
@@ -187,8 +190,48 @@ echo "RUNNING=$(compose ps --status running -q worker 2>/dev/null | sort | paste
 '''
 
 
-def _run(script: str) -> subprocess.CompletedProcess:
-    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+def _run(script: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=SIMULATOR_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = (
+            exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout
+        )
+        stderr = (
+            exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr
+        )
+        pytest.fail(
+            f"worker-swap simulator did not exit within {SIMULATOR_TIMEOUT_SECONDS}s\n"
+            f"--- captured stdout ---\n{stdout or ''}\n"
+            f"--- captured stderr ---\n{stderr or ''}",
+            pytrace=False,
+        )
+
+
+def test_run_fails_with_captured_output_when_simulator_times_out(monkeypatch):
+    def time_out(*args, **kwargs):
+        assert kwargs["timeout"] == SIMULATOR_TIMEOUT_SECONDS
+        raise subprocess.TimeoutExpired(
+            cmd=args[0],
+            timeout=kwargs["timeout"],
+            output=b"simulator stdout\n",
+            stderr=b"simulator stderr\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    with pytest.raises(pytest.fail.Exception) as failure:
+        _run("exit 0")
+
+    message = str(failure.value)
+    assert "did not exit within 5s" in message
+    assert "simulator stdout" in message
+    assert "simulator stderr" in message
 
 
 def _calls(state: Path) -> str:


### PR DESCRIPTION
Closes #827

> *This was generated by AI during triage.*

The fast suite could hang for **24 hours** instead of failing. This bounds it.

## What changed

1. `tests/test_worker_swap_deploy.py` — `_run()` now passes `timeout=5` and, on `subprocess.TimeoutExpired`, fails the test with the **captured stdout and stderr** instead of hanging or raising a bare error.
2. `requirements.txt` — adds `pytest-timeout>=2.4`.
3. `pytest.ini` — `timeout = 120`, a global per-test ceiling so no single test can ever wedge the suite again.
4. A new test proves the fast-fail path reports the captured output.

## Why it mattered more than the ticket said

The ticket named one test. **Six** call sites in that file set `drain_timeout_seconds=86400` — lines 368, 394, 482, 526, 615, 633 — so one suite run could lose up to six days. The deadline in `deploy/scripts/compose-runtime-lib.sh:512-530` uses bash `$SECONDS`, which is wall clock, so the test's no-op `sleep` shim cannot bound it. An explicit `timeout=` is the only thing that works.

This was reproduced live twice while gating an unrelated PR on 2026-08-17, on an idle host: two consecutive tests wedged at 8m50s and 10m22s, both at ~2.5% CPU. A wedged run **looks idle, not busy** — that is why it went unnoticed for 13 hours on 2026-08-14.

## Verification

| gate | before | after |
| --- | --- | --- |
| `tests/test_worker_swap_deploy.py` alone | hangs — up to 6×24h | **25 passed in 2.94s** |
| whole fast suite | never completed | **4957 passed, 11 skipped, 0 failed, 90.31s** |

Forced-hang demonstration: the simulator loop was edited to never clear `handoff-1.running`; the test failed in **5.37s** with the captured output, instead of hanging. That edit is not in the diff.

The whole-suite run above is the first time this suite has completed on this host. Load average was ~6 and no other work was running.

## The trigger is a broken `python3`, and this PR is the guard rather than the cure

Found after the fix landed, and it changes how to read this ticket.

On a **clean `origin/main`** with `/opt/homebrew/bin` ahead of `/usr/bin` on `PATH`, the supposedly-hanging file passes in **2.18 seconds**:

```
git worktree add --detach /tmp/base origin/main
PATH="/opt/homebrew/bin:$PATH" venv/bin/python -m pytest tests/test_worker_swap_deploy.py -q
->  24 passed in 2.18s
```

With the default `PATH` on this host, `/usr/bin` wins and `python3` is **Xcode's 3.9.6**. The simulator shells out to `python3`, which then dies importing `brain/contracts/worker_lifecycle.py`:

```
ImportError: cannot import name 'StrEnum' from 'enum'   # StrEnum is 3.11+
```

The drain loop therefore never observes the worker exiting and spins against the 86400-second wall-clock deadline. That is the 24-hour hang.

So the honest framing: **the hang is an environment fault, and this PR is defense in depth.** It is still worth merging — an unbounded wait is a latent trap whatever causes it, and a bounded red in 5 seconds is strictly better than a 24-hour wedge. But merging it will not, by itself, stop a machine with a bad `PATH` from producing 12 red tests in this file instead of 12 hung ones. The interpreter is the thing to fix, and it belongs in its own ticket.

## Two notes for the reviewer

- **`pytest-timeout` must be installed for the `pytest.ini` ceiling to do anything.** Without the plugin, pytest ignores the unknown `timeout` key with only a warning — a silent no-op. It is in `requirements.txt` now; anyone with an existing virtualenv needs to reinstall.
- The ticket flagged an unexplained observation: the wedged run carried `HANDOFF_DIES_AFTER_TICKS=1`, so the `definitively_not_claiming` fast-exit should have fired and did not. That was investigated and **not** reproduced. It stays unexplained. It does not affect this fix, which converts any such hang into a red test in seconds — but it means the underlying fast-exit path may still have a bug worth its own ticket.
