### PR TITLE
fix(preservation): attribute curation sources so memory_supersede satisfies the evidence contract (#828)

### DIFF
--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -54,6 +54,8 @@ _DIRECT_REF_KINDS = {
     "project_profile_id": "project_context",
     "handoff_id": "launch_handoff",
     "source_id": "memory_source",
+    "curation_source_id": "memory_source",
+    "replacement_source_id": "memory_source",
     "span_id": "memory_span",
     "span_ids": "memory_span",
     "content_node_id": "memory_node",

--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -45,6 +45,7 @@ PRESERVATION_OUTCOME_VALUES = frozenset(
 )
 PRESERVATION_ACCEPTABLE_TOOLS = (
     "memory_ingest_source",
+    "memory_supersede",
     "brain_encode",
     "manage_domain",
     "manage_project",
@@ -58,6 +59,7 @@ PRESERVATION_ACCEPTABLE_TARGET_KINDS = (
     "memory_source",
     "memory_node",
     "memory_assertion",
+    "memory_edge",
     "domain_record",
     "domain",
     "project_context",

--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -59,7 +59,6 @@ PRESERVATION_ACCEPTABLE_TARGET_KINDS = (
     "memory_source",
     "memory_node",
     "memory_assertion",
-    "memory_edge",
     "domain_record",
     "domain",
     "project_context",

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -368,6 +368,65 @@ async def test_preservation_submission_with_explicit_memory_evidence_reconciles_
     assert "memory_source" in {ref["kind"] for ref in receipt.tool_use["attribution"]["mutated_target_refs"]}
 
 
+async def test_preservation_submission_with_memory_supersede_edge_reconciles_processed(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.memory",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve this correction to an existing memory.",
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:memory-supersede-evidence",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    store = AsyncAgentRunStore(session)
+    run_id = int(handling["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "memory_supersede",
+                "args": {"old_node": 2153, "new_node": 2160},
+                "result": json.dumps(
+                    {
+                        "action": "supersede",
+                        "old_node": 2153,
+                        "new_node": 2160,
+                        "edge_id": 11658,
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
+    await store.append_final_answer_once(run_id, "Superseded the stale memory.", root_run_id=run_id)
+    await store.set_status(run_id, RunStatus.COMPLETED)
+
+    event = await session.get(InboundEventRow, result["event_id"])
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert event is not None
+    assert event.status == "processed"
+    assert event.error is None
+    evidence = event.action_result["handling"]["evidence_contract"]
+    assert evidence["status"] == "satisfied"
+    assert "memory_supersede" in evidence["acceptable_tools"]
+    assert "memory_edge" in evidence["acceptable_target_kinds"]
+    assert evidence["tool_names"] == ["memory_supersede"]
+    assert evidence["mutated_target_refs"] == [
+        {"kind": "memory_edge", "id": "11658", "source": "memory_supersede"}
+    ]
+    assert receipt.status == "processed"
+
+
 async def test_get_result_lazily_reconciles_completed_submission_run(session):
     principal = await _seed_connection(session)
     result = await inbound.submit_inbound_envelope(

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -368,7 +368,7 @@ async def test_preservation_submission_with_explicit_memory_evidence_reconciles_
     assert "memory_source" in {ref["kind"] for ref in receipt.tool_use["attribution"]["mutated_target_refs"]}
 
 
-async def test_preservation_submission_with_memory_supersede_edge_reconciles_processed(session):
+async def test_preservation_submission_with_memory_supersede_source_reconciles_processed(session):
     principal = await _seed_connection(session)
     result = await inbound.submit_inbound_envelope(
         session,
@@ -380,6 +380,71 @@ async def test_preservation_submission_with_memory_supersede_edge_reconciles_pro
             "message": "Preserve this correction to an existing memory.",
             "source": {"source_tool": "codex"},
             "idempotency_key": "codex:submission:memory-supersede-evidence",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    store = AsyncAgentRunStore(session)
+    run_id = int(handling["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "memory_supersede",
+                "args": {
+                    "old_node": 2153,
+                    "new_content": "Corrected durable content for the superseded memory.",
+                },
+                "result": json.dumps(
+                    {
+                        "action": "supersede",
+                        "old_node": 2153,
+                        "new_node": 2160,
+                        "edge_id": 11658,
+                        "curation_source_id": 11659,
+                        "replacement_source_id": 11660,
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
+    await store.append_final_answer_once(run_id, "Superseded the stale memory.", root_run_id=run_id)
+    await store.set_status(run_id, RunStatus.COMPLETED)
+
+    event = await session.get(InboundEventRow, result["event_id"])
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert event is not None
+    assert event.status == "processed"
+    assert event.error is None
+    evidence = event.action_result["handling"]["evidence_contract"]
+    assert evidence["status"] == "satisfied"
+    assert "memory_supersede" in evidence["acceptable_tools"]
+    assert "memory_edge" not in evidence["acceptable_target_kinds"]
+    assert evidence["tool_names"] == ["memory_supersede"]
+    assert evidence["mutated_target_refs"] == [
+        {"kind": "memory_source", "id": "11659", "source": "memory_supersede"},
+        {"kind": "memory_source", "id": "11660", "source": "memory_supersede"},
+    ]
+    assert receipt.status == "processed"
+
+
+async def test_preservation_submission_with_memory_supersede_edge_only_stays_actionable(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.memory",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve this correction to an existing memory.",
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:memory-supersede-edge-only",
         },
         ingress_context={"surface": "test"},
     )
@@ -414,17 +479,17 @@ async def test_preservation_submission_with_memory_supersede_edge_reconciles_pro
     receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
 
     assert event is not None
-    assert event.status == "processed"
-    assert event.error is None
+    assert event.status == "review_required"
     evidence = event.action_result["handling"]["evidence_contract"]
-    assert evidence["status"] == "satisfied"
+    assert evidence["status"] == "missing"
     assert "memory_supersede" in evidence["acceptable_tools"]
-    assert "memory_edge" in evidence["acceptable_target_kinds"]
+    assert "memory_edge" not in evidence["acceptable_target_kinds"]
     assert evidence["tool_names"] == ["memory_supersede"]
-    assert evidence["mutated_target_refs"] == [
+    assert evidence["mutated_target_refs"] == []
+    assert receipt.status == "review_required"
+    assert receipt.tool_use["attribution"]["mutated_target_refs"] == [
         {"kind": "memory_edge", "id": "11658", "source": "memory_supersede"}
     ]
-    assert receipt.status == "processed"
 
 
 async def test_get_result_lazily_reconciles_completed_submission_run(session):


### PR DESCRIPTION
Closes #828

> *This was generated by AI during triage.*

A durable `memory_supersede` write was scored as **no preservation evidence at all**, so the receipt reported `evidence_status: missing` for knowledge that really had been preserved.

## The cause

`supersede_memory` (`brain/systems/reconstructive_memory/curation.py:109-213`) **always** writes a durable curation source and returns it as `curation_source_id` — and, when it ingests new content, a second one as `replacement_source_id`.

`_DIRECT_REF_KINDS` in `brain/systems/inbound/attribution.py` mapped neither key. It maps `source_id → memory_source` and `edge_id → memory_edge`, so the only reference that survived attribution was the **edge**. `memory_edge` is not an accepted target kind, so the contract saw nothing.

The receipt was not wrong to reject the edge. It was never shown the real evidence.

## The fix — three lines of production code

```python
"curation_source_id": "memory_source",
"replacement_source_id": "memory_source",   # attribution.py
"memory_supersede",                          # PRESERVATION_ACCEPTABLE_TOOLS
```

The durable source rows now surface as `memory_source`, which was **already** an accepted kind. Nothing about the contract had to be widened.

## What this PR deliberately does NOT do

An earlier attempt added `memory_edge` to `PRESERVATION_ACCEPTABLE_TARGET_KINDS`. **That was reverted.** An edge is a link between two nodes, not content. Accepting an edge as sole evidence would let a run that merely re-pointed two pre-existing memories report as having preserved knowledge — the receipt lying in the opposite direction, which is worse than the false negative this ticket reports.

A regression test pins that down: a `memory_supersede` result carrying **only** an edge and no source must **not** satisfy the contract. That test is what stops the contract being re-widened silently later.

## Scope found during the fix

`link`, `archive` and `policy-archive` curation paths had the same invisible-source gap. They all flow through the one map, so the same two lines fix them too. There is no separate merge path.

## Verification

**Fast suite: 4958 passed, 11 skipped, 0 failed, 105.0s.** Whole suite, nothing excluded, on an idle host.

## Acceptance check for a reviewer

Run an `illo_submit` with `desired_outcome="preserve_knowledge"` whose agent calls `memory_supersede`, then poll `illo_get_result`. It should come back `evidence_status: satisfied` with a `memory_source` entry in `mutated_target_refs` — not `missing`. The original failing case was event `afe420c2-dbb6-4a98-be9d-e6265f9fd1b5`.

Note this cannot be exercised against production Illo until #829 is resolved (`api.illo.space` has no DNS record); the tailnet MCP endpoint does work.
