### PR TITLE
fix(deploy): give the host interpreter pin a deploy-wide owner and an error contract (#834)

### DIFF
--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -5,8 +5,8 @@ ROOT="${ROOT:-$(cd "$COMPOSE_RUNTIME_LIB_DIR/../.." && pwd)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/deploy/compose/docker-compose.yml}"
 ENV_FILE="${ENV_FILE:-${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}}"
 RUNTIME_SERVICE_CATALOG="${RUNTIME_SERVICE_CATALOG:-$ROOT/deploy/compose/runtime-services.json}"
-WORKER_SWAP_PYTHON_BIN="${WORKER_SWAP_PYTHON_BIN:-python3}"
 
+source "$COMPOSE_RUNTIME_LIB_DIR/deploy-python-lib.sh"
 source "$COMPOSE_RUNTIME_LIB_DIR/worker-swap-lib.sh"
 source "$COMPOSE_RUNTIME_LIB_DIR/worker-lifecycle-lib.sh"
 
@@ -19,7 +19,7 @@ compose() {
 
 compose_env_value() {
   local key="$1" python_bin
-  python_bin="$(worker_swap_python_bin)"
+  python_bin="$(deploy_python_bin)"
   if ! "$python_bin" - "$ENV_FILE" "$key" <<'PY'
 from pathlib import Path
 import re
@@ -42,10 +42,12 @@ for line in path.read_text(encoding="utf-8").splitlines():
 PY
   then
     echo "Failed to read $key from $ENV_FILE with Python interpreter: $python_bin" >&2
-    return 1
+    return 2
   fi
 }
 
+# Exit status contract for compose_profile_enabled and compose_service_enabled:
+# 0 means enabled, 1 means disabled, and 2 or greater means an operational error.
 compose_profile_enabled() {
   local profile="$1" profiles
   if [ "${COMPOSE_PROFILES+x}" = "x" ]; then
@@ -62,8 +64,13 @@ compose_profile_enabled() {
 }
 
 compose_service_enabled() {
-  local service="$1" profile="${2:-$1}"
-  compose_profile_enabled "$profile" && return 0
+  local service="$1" profile="${2:-$1}" profile_status
+  if compose_profile_enabled "$profile"; then
+    return 0
+  else
+    profile_status=$?
+  fi
+  [ "$profile_status" -eq 1 ] || return "$profile_status"
   [ -n "$(compose_service_container_id "$service")" ]
 }
 

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -18,8 +18,9 @@ compose() {
 }
 
 compose_env_value() {
-  local key="$1"
-  python3 - "$ENV_FILE" "$key" <<'PY'
+  local key="$1" python_bin
+  python_bin="$(worker_swap_python_bin)"
+  if ! "$python_bin" - "$ENV_FILE" "$key" <<'PY'
 from pathlib import Path
 import re
 import sys
@@ -39,6 +40,10 @@ for line in path.read_text(encoding="utf-8").splitlines():
     print(value)
     break
 PY
+  then
+    echo "Failed to read $key from $ENV_FILE with Python interpreter: $python_bin" >&2
+    return 1
+  fi
 }
 
 compose_profile_enabled() {
@@ -46,7 +51,7 @@ compose_profile_enabled() {
   if [ "${COMPOSE_PROFILES+x}" = "x" ]; then
     profiles="$COMPOSE_PROFILES"
   else
-    profiles="$(compose_env_value COMPOSE_PROFILES)"
+    profiles="$(compose_env_value COMPOSE_PROFILES)" || return
   fi
   profiles=",${profiles// /,},"
   case "$profiles" in

--- a/deploy/scripts/deploy-python-lib.sh
+++ b/deploy/scripts/deploy-python-lib.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Shared host-side Python interpreter for deploy scripts. The worker-swap name
+# remains an accepted input while callers migrate to the deploy-wide contract.
+DEPLOY_PYTHON_BIN="${DEPLOY_PYTHON_BIN:-${WORKER_SWAP_PYTHON_BIN:-python3}}"
+
+deploy_python_bin() {
+  printf '%s\n' "$DEPLOY_PYTHON_BIN"
+}

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -98,7 +98,7 @@ need_command() {
 }
 
 need_command docker
-need_command python3
+need_command "$(worker_swap_python_bin)"
 
 if [ ! -f "$ENV_FILE" ]; then
   fail "missing $ENV_FILE; run deploy/scripts/init-secrets.sh"
@@ -128,7 +128,7 @@ for key in ILLO_PUBLIC_URL SECRET_KEY VAULT_MASTER_KEY DB_NAME DB_USER DB_PASSWO
 done
 
 if [ -n "${ILLO_PUBLIC_URL:-}" ]; then
-  if python3 - "$ILLO_PUBLIC_URL" <<'PY'
+  if "$(worker_swap_python_bin)" - "$ILLO_PUBLIC_URL" <<'PY'
 import sys
 from urllib.parse import urlparse
 
@@ -148,7 +148,7 @@ if [ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${EMBEDDING
 fi
 
 if [ -n "${VAULT_MASTER_KEY:-}" ]; then
-  if python3 - "$VAULT_MASTER_KEY" <<'PY'
+  if "$(worker_swap_python_bin)" - "$VAULT_MASTER_KEY" <<'PY'
 import base64
 import sys
 

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -10,6 +10,7 @@ ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$COMPOSE_DIR/.env}"
 # Provides compose() plus the shared stack invariants.
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
 source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"
+DEPLOY_PYTHON="$(deploy_python_bin)"
 
 # Doctor runs after a deploy, so it holds the updater to the same standard as
 # the always-on services; a bare monitor does not (a missing updater does not
@@ -98,7 +99,7 @@ need_command() {
 }
 
 need_command docker
-need_command "$(worker_swap_python_bin)"
+need_command "$DEPLOY_PYTHON"
 
 if [ ! -f "$ENV_FILE" ]; then
   fail "missing $ENV_FILE; run deploy/scripts/init-secrets.sh"
@@ -128,7 +129,7 @@ for key in ILLO_PUBLIC_URL SECRET_KEY VAULT_MASTER_KEY DB_NAME DB_USER DB_PASSWO
 done
 
 if [ -n "${ILLO_PUBLIC_URL:-}" ]; then
-  if "$(worker_swap_python_bin)" - "$ILLO_PUBLIC_URL" <<'PY'
+  if "$DEPLOY_PYTHON" - "$ILLO_PUBLIC_URL" <<'PY'
 import sys
 from urllib.parse import urlparse
 
@@ -148,7 +149,7 @@ if [ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${EMBEDDING
 fi
 
 if [ -n "${VAULT_MASTER_KEY:-}" ]; then
-  if "$(worker_swap_python_bin)" - "$VAULT_MASTER_KEY" <<'PY'
+  if "$DEPLOY_PYTHON" - "$VAULT_MASTER_KEY" <<'PY'
 import base64
 import sys
 
@@ -248,9 +249,13 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
     fi
 
     meetbot_expected=0
-    if compose_service_enabled meetbot; then
-      meetbot_expected=1
-    fi
+    meetbot_status=0
+    compose_service_enabled meetbot || meetbot_status=$?
+    case "$meetbot_status" in
+      0) meetbot_expected=1 ;;
+      1) ;;
+      *) fail "could not determine whether meetbot is enabled" ;;
+    esac
 
     services_to_check="$DOCTOR_REQUIRED_SERVICES"
     if [ "$meetbot_expected" = "1" ]; then

--- a/deploy/scripts/init-secrets.sh
+++ b/deploy/scripts/init-secrets.sh
@@ -7,6 +7,8 @@ COMPOSE_DIR="$ROOT/deploy/compose"
 ENV_FILE="$COMPOSE_DIR/.env"
 EXAMPLE_FILE="$COMPOSE_DIR/.env.production.example"
 
+source "$SCRIPT_DIR/worker-swap-lib.sh"
+
 PUBLIC_URL=""
 DOMAIN=""
 PRINT_NEXT=1
@@ -74,7 +76,7 @@ if [ ! -f "$ENV_FILE" ]; then
   cp "$EXAMPLE_FILE" "$ENV_FILE"
 fi
 
-python3 - "$ENV_FILE" "$DOMAIN" "$PUBLIC_URL" <<'PY'
+"$(worker_swap_python_bin)" - "$ENV_FILE" "$DOMAIN" "$PUBLIC_URL" <<'PY'
 from __future__ import annotations
 
 import base64

--- a/deploy/scripts/init-secrets.sh
+++ b/deploy/scripts/init-secrets.sh
@@ -7,7 +7,8 @@ COMPOSE_DIR="$ROOT/deploy/compose"
 ENV_FILE="$COMPOSE_DIR/.env"
 EXAMPLE_FILE="$COMPOSE_DIR/.env.production.example"
 
-source "$SCRIPT_DIR/worker-swap-lib.sh"
+source "$SCRIPT_DIR/deploy-python-lib.sh"
+DEPLOY_PYTHON="$(deploy_python_bin)"
 
 PUBLIC_URL=""
 DOMAIN=""
@@ -76,7 +77,7 @@ if [ ! -f "$ENV_FILE" ]; then
   cp "$EXAMPLE_FILE" "$ENV_FILE"
 fi
 
-"$(worker_swap_python_bin)" - "$ENV_FILE" "$DOMAIN" "$PUBLIC_URL" <<'PY'
+"$DEPLOY_PYTHON" - "$ENV_FILE" "$DOMAIN" "$PUBLIC_URL" <<'PY'
 from __future__ import annotations
 
 import base64

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -5,7 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$ROOT/deploy/compose/docker-compose.yml"
 
-source "$SCRIPT_DIR/worker-swap-lib.sh"
+source "$SCRIPT_DIR/deploy-python-lib.sh"
+DEPLOY_PYTHON="$(deploy_python_bin)"
 
 BUILD=0
 KEEP_RUNNING=0
@@ -62,7 +63,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 pick_free_port() {
-  "$(worker_swap_python_bin)" - <<'PY'
+  "$DEPLOY_PYTHON" - <<'PY'
 import socket
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -90,7 +91,7 @@ else
   esac
 fi
 
-"$(worker_swap_python_bin)" - "$ENV_FILE" "$PROJECT_NAME" "$SMOKE_API_PORT" "$SMOKE_WEB_PORT" <<'PY'
+"$DEPLOY_PYTHON" - "$ENV_FILE" "$PROJECT_NAME" "$SMOKE_API_PORT" "$SMOKE_WEB_PORT" <<'PY'
 from __future__ import annotations
 
 import re

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$ROOT/deploy/compose/docker-compose.yml"
 
+source "$SCRIPT_DIR/worker-swap-lib.sh"
+
 BUILD=0
 KEEP_RUNNING=0
 ENV_FILE=""
@@ -60,7 +62,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 pick_free_port() {
-  python3 - <<'PY'
+  "$(worker_swap_python_bin)" - <<'PY'
 import socket
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -88,7 +90,7 @@ else
   esac
 fi
 
-python3 - "$ENV_FILE" "$PROJECT_NAME" "$SMOKE_API_PORT" "$SMOKE_WEB_PORT" <<'PY'
+"$(worker_swap_python_bin)" - "$ENV_FILE" "$PROJECT_NAME" "$SMOKE_API_PORT" "$SMOKE_WEB_PORT" <<'PY'
 from __future__ import annotations
 
 import re

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -62,9 +62,16 @@ COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS="${ILLO_COMPOSE_WORKER_DRAIN_TIMEOU
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
 
 MEETBOT_ENABLED=0
-if compose_service_enabled meetbot; then
-  MEETBOT_ENABLED=1
-fi
+meetbot_status=0
+compose_service_enabled meetbot || meetbot_status=$?
+case "$meetbot_status" in
+  0) MEETBOT_ENABLED=1 ;;
+  1) ;;
+  *)
+    echo "Could not determine whether meetbot is enabled." >&2
+    exit "$meetbot_status"
+    ;;
+esac
 
 non_worker_services() {
   printf '%s\n' api scheduler web

--- a/deploy/scripts/worker-swap-lib.sh
+++ b/deploy/scripts/worker-swap-lib.sh
@@ -2,20 +2,23 @@
 
 # Shared worker-swap snapshot parsing, presentation, and decision helpers.
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy-python-lib.sh"
+
+# Backward-compatible name for callers outside this repository.
 worker_swap_python_bin() {
-  printf '%s\n' "${WORKER_SWAP_PYTHON_BIN:-python3}"
+  deploy_python_bin
 }
 
 worker_swap_contract() {
   local python_bin
-  python_bin="$(worker_swap_python_bin)"
+  python_bin="$(deploy_python_bin)"
   PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
     "$python_bin" -m brain.contracts.worker_swap "$@"
 }
 
 worker_swap_snapshot_acquire() {
   local python_bin
-  python_bin="$(worker_swap_python_bin)"
+  python_bin="$(deploy_python_bin)"
   PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
     "$python_bin" -m brain.app.cli.worker_swap_snapshot
 }

--- a/illo
+++ b/illo
@@ -266,11 +266,10 @@ launcher_python_bin() {
   fi
 }
 
+if [ -z "${DEPLOY_PYTHON_BIN:-}" ] && [ -z "${WORKER_SWAP_PYTHON_BIN:-}" ]; then
+  DEPLOY_PYTHON_BIN="$(launcher_python_bin)"
+fi
 source "$ROOT/deploy/scripts/worker-swap-lib.sh"
-
-worker_swap_python_bin() {
-  launcher_python_bin
-}
 
 production_env_file_path() {
   if [ -n "${ILLO_PRODUCTION_ENV_FILE:-}" ]; then

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT=$(pwd)
 PYTHON_BIN="$ROOT/venv/bin/python3"
-WORKER_SWAP_PYTHON_BIN="$PYTHON_BIN"
+DEPLOY_PYTHON_BIN="$PYTHON_BIN"
 
 source "$ROOT/deploy/scripts/worker-swap-lib.sh"
 

--- a/tests/test_launcher_uninstall_env_reset.py
+++ b/tests/test_launcher_uninstall_env_reset.py
@@ -27,16 +27,15 @@ def _write_launcher_functions(tmp_path: Path) -> Path:
     functions_file = tmp_path / "illo-functions.sh"
     functions_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-    # The launcher sources the canonical worker-swap policy from
-    # $ROOT/deploy/scripts/worker-swap-lib.sh, and $ROOT resolves to tmp_path when
-    # these extracted functions are sourced. Mirror the real dependency here rather
-    # than making the launcher's `source` conditional: a missing canonical lib must
-    # stay a hard failure, because degrading it silently would strip the status
-    # policy from the deploy drain guard.
-    lib_relpath = Path("deploy") / "scripts" / "worker-swap-lib.sh"
-    staged_lib = tmp_path / lib_relpath
-    staged_lib.parent.mkdir(parents=True, exist_ok=True)
-    staged_lib.write_text((ROOT / lib_relpath).read_text(encoding="utf-8"), encoding="utf-8")
+    # The launcher sources the canonical worker-swap policy, which consumes the
+    # shared deploy interpreter contract. $ROOT resolves to tmp_path when these
+    # extracted functions are sourced, so mirror both real dependencies here.
+    scripts_dir = Path("deploy") / "scripts"
+    for name in ("worker-swap-lib.sh", "deploy-python-lib.sh"):
+        lib_relpath = scripts_dir / name
+        staged_lib = tmp_path / lib_relpath
+        staged_lib.parent.mkdir(parents=True, exist_ok=True)
+        staged_lib.write_text((ROOT / lib_relpath).read_text(encoding="utf-8"), encoding="utf-8")
 
     return functions_file
 

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -590,6 +590,68 @@ def test_meetbot_profile_detection_honors_shell_precedence_wildcard_and_stopped_
     assert launcher_oneoff_only.returncode == 0
 
 
+def test_compose_env_value_reports_pinned_interpreter_failure(tmp_path):
+    runtime_lib = (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "scripts"
+        / "compose-runtime-lib.sh"
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("COMPOSE_PROFILES=meetbot\n")
+    broken_python = tmp_path / "broken-python"
+    broken_python.write_text("#!/usr/bin/env bash\nexit 42\n")
+    broken_python.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{runtime_lib}"; compose_env_value COMPOSE_PROFILES',
+        ],
+        env={
+            **os.environ,
+            "ENV_FILE": str(env_file),
+            "WORKER_SWAP_PYTHON_BIN": str(broken_python),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert str(broken_python) in result.stderr
+    assert result.stdout == ""
+
+
+def test_compose_profile_is_disabled_when_env_key_is_absent(tmp_path):
+    runtime_lib = (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "scripts"
+        / "compose-runtime-lib.sh"
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("SECRET_KEY=present\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'unset COMPOSE_PROFILES; source "{runtime_lib}"; compose_profile_enabled meetbot',
+        ],
+        env={key: value for key, value in os.environ.items() if key != "COMPOSE_PROFILES"}
+        | {
+            "ENV_FILE": str(env_file),
+            "WORKER_SWAP_PYTHON_BIN": sys.executable,
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == ""
+
+
 def test_compose_worker_restart_asserts_exactly_one_running_worker():
     runtime_lib = Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "compose-runtime-lib.sh"
     script = f'''

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -124,6 +124,9 @@ def test_ops_deploy_drains_worker_instead_of_restarting_active_runs():
     ).read_text()
 
     assert 'source "$ROOT/deploy/scripts/worker-swap-lib.sh"' in content
+    assert 'DEPLOY_PYTHON_BIN="$PYTHON_BIN"' in content
+    assert "worker_swap_python_bin()" in worker_swap_lib
+    assert "deploy_python_bin" in worker_swap_lib
     assert "worker_swap_snapshot" in content
     assert "restart_or_drain_worker" in content
     assert "start_worker_handoff" in content
@@ -590,7 +593,7 @@ def test_meetbot_profile_detection_honors_shell_precedence_wildcard_and_stopped_
     assert launcher_oneoff_only.returncode == 0
 
 
-def test_compose_env_value_reports_pinned_interpreter_failure(tmp_path):
+def test_compose_service_enabled_propagates_legacy_interpreter_failure(tmp_path):
     runtime_lib = (
         Path(__file__).resolve().parents[1]
         / "deploy"
@@ -607,10 +610,18 @@ def test_compose_env_value_reports_pinned_interpreter_failure(tmp_path):
         [
             "bash",
             "-c",
-            f'source "{runtime_lib}"; compose_env_value COMPOSE_PROFILES',
+            (
+                f'unset COMPOSE_PROFILES; source "{runtime_lib}"; '
+                'compose() { printf "unexpected container fallback\\n"; }; '
+                "compose_service_enabled meetbot"
+            ),
         ],
         env={
-            **os.environ,
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"COMPOSE_PROFILES", "DEPLOY_PYTHON_BIN", "WORKER_SWAP_PYTHON_BIN"}
+        }
+        | {
             "ENV_FILE": str(env_file),
             "WORKER_SWAP_PYTHON_BIN": str(broken_python),
         },
@@ -618,7 +629,7 @@ def test_compose_env_value_reports_pinned_interpreter_failure(tmp_path):
         text=True,
     )
 
-    assert result.returncode != 0
+    assert result.returncode == 2
     assert str(broken_python) in result.stderr
     assert result.stdout == ""
 
@@ -639,10 +650,14 @@ def test_compose_profile_is_disabled_when_env_key_is_absent(tmp_path):
             "-c",
             f'unset COMPOSE_PROFILES; source "{runtime_lib}"; compose_profile_enabled meetbot',
         ],
-        env={key: value for key, value in os.environ.items() if key != "COMPOSE_PROFILES"}
+        env={
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"COMPOSE_PROFILES", "DEPLOY_PYTHON_BIN", "WORKER_SWAP_PYTHON_BIN"}
+        }
         | {
             "ENV_FILE": str(env_file),
-            "WORKER_SWAP_PYTHON_BIN": sys.executable,
+            "DEPLOY_PYTHON_BIN": sys.executable,
         },
         capture_output=True,
         text=True,


### PR DESCRIPTION
Closes #834

## What this changes

`ops/deploy.sh` pinned the host interpreter, but only the worker-swap layer honoured the pin — the other host-side deploy scripts called a bare `python3`. Worse, `compose_env_value()` swallowed an interpreter failure and returned an empty string, which `compose_profile_enabled` read as **every compose profile disabled**. A wrong answer, silently, on a deploy path.

Two commits:

**1. Route every host-side call through the pin** (`5426630f`) — `compose-runtime-lib.sh`, `doctor.sh`, `init-secrets.sh`, `smoke-test.sh`. `compose_env_value()` now exits non-zero with a stderr line naming the binary.

**2. Give the contract an owner and an explicit error code** (`bf4a4501`) — folds in the maintainability review below.

- New `deploy/scripts/deploy-python-lib.sh` owns `DEPLOY_PYTHON_BIN` and `deploy_python_bin()`. The worker-swap lib now *consumes* that contract instead of owning it — `init-secrets.sh` and `smoke-test.sh` do no worker swapping and should never have had to source it.
- **Nothing breaks.** `DEPLOY_PYTHON_BIN="${DEPLOY_PYTHON_BIN:-${WORKER_SWAP_PYTHON_BIN:-python3}}"`, and `worker_swap_python_bin()` stays as a delegating wrapper, so any caller still setting the old name keeps working.
- `compose_profile_enabled` / `compose_service_enabled` now carry a stated contract: **`0` enabled, `1` disabled, `>=2` operational error**. `upgrade.sh` checks it and aborts with a message instead of quietly deciding meetbot is off.
- The interpreter is resolved once per script rather than by a command substitution at each call site.

**Container-side calls are deliberately untouched** — `doctor.sh:287` and `upgrade.sh:152` run through `compose exec -T`, where `python3` is the image's interpreter. The Dockerfiles are in the image's scope too.

## Why it mattered

Found the hard way. On the R3 automation host a stale `python3` made a worker-swap simulation spin against the 86400-second drain deadline in `wait_for_worker_exit()` instead of failing. #827 bounds that wait — a guard on the symptom. This removes the cause.

## How to check it — no UI, two commands

```
git grep -nE '(^|[^_[:alnum:]])python3 ' -- deploy/scripts/
```
Expect exactly two lines, both container-side: `doctor.sh:287`, `upgrade.sh:152`.

```
DEPLOY_PYTHON_BIN=/nonexistent/python bash -c \
  'source deploy/scripts/compose-runtime-lib.sh; compose_env_value COMPOSE_PROFILES; echo "exit=$?"'
```
Expect `exit=2` and a stderr line naming `/nonexistent/python`. Before this PR the same command printed an empty line and exited 0.

Then confirm the old name still works — swap `DEPLOY_PYTHON_BIN` for `WORKER_SWAP_PYTHON_BIN` in that command and expect the identical result.

## Verification

- **Full fast suite on the final tree: 4958 passed, 11 skipped, 0 failed, 112s.** Run serially at load 3.7 with zero other Codex workers on the machine, so the number is not a contention artifact.
- `bash -n` clean on every changed shell file, including `illo` and `ops/deploy.sh`.
- Tests cover both directions: the interpreter-failure path fails loudly through the **public** `compose_service_enabled` decision, and a healthy interpreter with a genuinely absent key still returns the quiet "disabled" answer.

## Review

A cross-family maintainability review (Codex) returned **BLOCKING** on the first commit with five findings. Four are folded into `bf4a4501`: the ownership/naming of the contract, the error-vs-disabled conflation, the repeated command substitutions, and the missing public-path test coverage.

The fifth is **declared out of scope**: splitting the 1,334-line `tests/test_safe_deploy.py` into a focused module. That module's size predates this ticket, and moving tests would bury this change's diff. Worth its own ticket if it keeps growing.

### One residual note

`deploy-python-lib.sh` resolves `DEPLOY_PYTHON_BIN` at **source time**. Every caller in this repo sets it before sourcing, so nothing here is affected — but an external caller that sets `WORKER_SWAP_PYTHON_BIN` *after* sourcing would no longer be honoured, where the old call-time lookup would have caught it. Flagging rather than guessing at an external contract.
