### PR TITLE
feat(cycles): alert when a schedule misses its receipt window (#820)

### DIFF
--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -16,6 +16,7 @@ from brain.app.api.config import CORS_ORIGINS, SECRET_KEY, validate_auth_config
 from brain.app.api.deps import get_db
 from brain.app.scheduler.overdue_monitor import SchedulerOverdueMonitor
 from brain.app.scheduler.stale_run_reaper import StaleRunReaper
+from brain.systems.cycles.silence_monitor import CycleSilenceMonitor
 
 validate_auth_config()
 
@@ -47,6 +48,7 @@ _OPS_THROTTLE_SEC = 2.0
 _run_event_consumer_task: asyncio.Task | None = None
 _scheduler_overdue_monitor_task: asyncio.Task[None] | None = None
 _stale_run_reaper_task: asyncio.Task[None] | None = None
+_cycle_silence_monitor_task: asyncio.Task[None] | None = None
 _GLOBAL_WS_EVENT_ALLOWLIST: frozenset[str] = frozenset()
 
 # Reference to the main asyncio event loop, set during lifespan startup.
@@ -197,7 +199,7 @@ def _schedule_product_event_publish(event_type, data):
 async def lifespan(app):
     """Wire the brain event bus to WebSocket broadcasting on startup."""
     global _main_loop, _run_event_consumer_task, _scheduler_overdue_monitor_task
-    global _stale_run_reaper_task
+    global _stale_run_reaper_task, _cycle_silence_monitor_task
     _main_loop = asyncio.get_running_loop()
     inline_runner_started = False
 
@@ -222,6 +224,16 @@ async def lifespan(app):
         "stale_run_reaper_started",
         host="api",
         monitor=stale_run_reaper.name,
+    )
+    cycle_silence_monitor = CycleSilenceMonitor()
+    _cycle_silence_monitor_task = _main_loop.create_task(
+        cycle_silence_monitor.run(),
+        name=cycle_silence_monitor.name,
+    )
+    logger.info(
+        "cycle_silence_monitor_started",
+        host="api",
+        monitor=cycle_silence_monitor.name,
     )
     await _ensure_starting_skill_bundle()
     if _should_start_run_event_consumer():
@@ -257,6 +269,18 @@ async def lifespan(app):
     try:
         yield
     finally:
+        if _cycle_silence_monitor_task is not None:
+            _cycle_silence_monitor_task.cancel()
+            try:
+                await _cycle_silence_monitor_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning(
+                    "cycle_silence_monitor_stop_failed",
+                    error=str(exc),
+                )
+            _cycle_silence_monitor_task = None
         if _stale_run_reaper_task is not None:
             _stale_run_reaper_task.cancel()
             try:

--- a/brain/platform/db/alembic/versions/0064_cycle_receipt_monitoring.py
+++ b/brain/platform/db/alembic/versions/0064_cycle_receipt_monitoring.py
@@ -1,0 +1,48 @@
+"""Add the receipt-monitoring epoch to Cycle schedules.
+
+Revision ID: 0064_cycle_receipt_monitoring
+Revises: 0063_cycle_schedule_bindings
+Create Date: 2026-08-17
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0064_cycle_receipt_monitoring"
+down_revision = "0063_cycle_schedule_bindings"
+branch_labels = None
+depends_on = None
+
+_TABLE = "cycles"
+_COLUMN = "receipt_monitoring_started_at"
+
+
+def _column_names() -> set[str]:
+    return {
+        str(column["name"])
+        for column in sa.inspect(op.get_bind()).get_columns(
+            _TABLE,
+            schema="public" if op.get_bind().dialect.name == "postgresql" else None,
+        )
+    }
+
+
+def upgrade() -> None:
+    if _COLUMN not in _column_names():
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                _COLUMN,
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _COLUMN in _column_names():
+        op.drop_column(_TABLE, _COLUMN)

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    func,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -147,6 +148,11 @@ class Cycle(Base, TimestampMixin):
         nullable=False,
         server_default=text("'[]'::jsonb"),
         default=list,
+    )
+    receipt_monitoring_started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
     )
     target_idea_id: Mapped[Optional[str]] = mapped_column(
         UUID(as_uuid=False), ForeignKey("ideas.id", ondelete="SET NULL"), nullable=True, index=True

--- a/brain/platform/db/repositories/cycle_silence.py
+++ b/brain/platform/db/repositories/cycle_silence.py
@@ -1,0 +1,79 @@
+"""Read models for Cycle receipt-silence observation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import func, select
+
+from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.platform.db.repositories.base import BaseRepository
+
+
+@dataclass(frozen=True, slots=True)
+class CycleReceiptSnapshot:
+    """Persistence-neutral inputs needed by the silence policy."""
+
+    cycle_id: int
+    name: str
+    executor_binding: str | None
+    schedule_expr: str
+    timezone: str
+    receipt_monitoring_started_at: datetime | None
+    created_at: datetime | None
+    last_receipt_at: datetime | None
+
+
+class CycleSilenceRepository(BaseRepository[Cycle]):
+    """Read enabled schedules with their latest completed receipt."""
+
+    model = Cycle
+
+    async def list_receipt_snapshots(self) -> tuple[CycleReceiptSnapshot, ...]:
+        latest_receipt = (
+            select(func.max(CycleRun.completed_at))
+            .where(CycleRun.cycle_id == Cycle.id)
+            .correlate(Cycle)
+            .scalar_subquery()
+        )
+        rows = (
+            await self._session.execute(
+                select(
+                    Cycle.id,
+                    Cycle.name,
+                    Cycle.executor_binding,
+                    Cycle.schedule_expr,
+                    Cycle.timezone,
+                    Cycle.receipt_monitoring_started_at,
+                    Cycle.created_at,
+                    latest_receipt.label("last_receipt_at"),
+                )
+                .where(
+                    Cycle.enabled.is_(True),
+                    Cycle.deleted_at.is_(None),
+                )
+                .order_by(Cycle.id.asc())
+            )
+        ).all()
+        return tuple(
+            CycleReceiptSnapshot(
+                cycle_id=int(cycle_id),
+                name=str(name),
+                executor_binding=executor_binding,
+                schedule_expr=str(schedule_expr),
+                timezone=str(timezone_name),
+                receipt_monitoring_started_at=monitoring_started_at,
+                created_at=created_at,
+                last_receipt_at=last_receipt_at,
+            )
+            for (
+                cycle_id,
+                name,
+                executor_binding,
+                schedule_expr,
+                timezone_name,
+                monitoring_started_at,
+                created_at,
+                last_receipt_at,
+            ) in rows
+        )

--- a/brain/systems/cycles/behavior_policy_contract.py
+++ b/brain/systems/cycles/behavior_policy_contract.py
@@ -111,6 +111,7 @@ class CyclePolicySnapshot:
     def apply_to(self, cycle: Cycle) -> None:
         """Apply this policy explicitly to its live Cycle fields."""
 
+        applied_at = datetime.now(timezone.utc)
         for field_name in self.configuration_field_names():
             setattr(cycle, field_name, deepcopy(getattr(self, field_name)))
         cycle.execution_mode = canonical_execution_mode()
@@ -119,7 +120,8 @@ class CyclePolicySnapshot:
             cycle.schedule_expr,
             cycle.timezone,
         )
-        cycle.updated_at = datetime.now(timezone.utc)
+        cycle.receipt_monitoring_started_at = applied_at
+        cycle.updated_at = applied_at
 
     def validated(self) -> CyclePolicySnapshot:
         """Return a normalized snapshot or raise for an invalid policy."""

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -72,6 +72,7 @@ async def async_create_cycle(
     guidance: str | None = None,
     rationale: str | None = None,
 ) -> Cycle:
+    monitoring_started_at = datetime.now(timezone.utc)
     validated_skill_ids = validate_cycle_skill_ids(skill_ids)
     validated_execution_policy_key = validate_cycle_execution_policy_key(
         execution_policy_key
@@ -98,9 +99,14 @@ async def async_create_cycle(
         execution_mode=canonical_execution_mode(),
         executor_binding=validate_executor_binding(executor_binding),
         skill_ids=validated_skill_ids,
+        receipt_monitoring_started_at=monitoring_started_at,
         target_idea_id=target_idea_id,
         reopen_archived=True,
-        next_run_at=compute_next_run_at(expr, tz_name),
+        next_run_at=compute_next_run_at(
+            expr,
+            tz_name,
+            from_dt=monitoring_started_at,
+        ),
     )
     session.add(cycle)
     await session.flush()

--- a/brain/systems/cycles/schedules.py
+++ b/brain/systems/cycles/schedules.py
@@ -1,7 +1,7 @@
 """Cycle schedule parsing and presentation."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from croniter import croniter
@@ -90,6 +90,28 @@ def compute_next_run_at(
     if next_local.tzinfo is None:
         next_local = next_local.replace(tzinfo=tz)
     return next_local.astimezone(timezone.utc)
+
+
+def compute_latest_run_at(
+    schedule_expr: str,
+    timezone_name: str,
+    *,
+    at_or_before: datetime,
+) -> datetime | None:
+    """Return the latest schedule slot on or before one aware instant."""
+    if at_or_before.tzinfo is None:
+        raise ValueError("at_or_before must be timezone-aware")
+    if is_one_time_schedule_expr(schedule_expr):
+        run_at = _parse_one_time_run_at(schedule_expr, timezone_name)
+        return run_at if run_at <= at_or_before else None
+
+    tz = ZoneInfo(validate_timezone_name(timezone_name))
+    local_baseline = at_or_before.astimezone(tz) + timedelta(microseconds=1)
+    iterator = croniter(validate_schedule_expr(schedule_expr), local_baseline)
+    previous_local = iterator.get_prev(datetime)
+    if previous_local.tzinfo is None:
+        previous_local = previous_local.replace(tzinfo=tz)
+    return previous_local.astimezone(timezone.utc)
 
 
 def humanize_schedule(schedule_expr: str, timezone_name: str) -> str:

--- a/brain/systems/cycles/schedules.py
+++ b/brain/systems/cycles/schedules.py
@@ -72,6 +72,25 @@ def validate_timezone_name(name: str) -> str:
     return value
 
 
+def _cron_iterator(
+    schedule_expr: str,
+    timezone_name: str,
+    baseline: datetime,
+):
+    timezone_info = ZoneInfo(validate_timezone_name(timezone_name))
+    local_baseline = baseline.astimezone(timezone_info)
+    return (
+        croniter(validate_schedule_expr(schedule_expr), local_baseline),
+        timezone_info,
+    )
+
+
+def _normalize_cron_result(result: datetime, timezone_info: ZoneInfo) -> datetime:
+    if result.tzinfo is None:
+        result = result.replace(tzinfo=timezone_info)
+    return result.astimezone(timezone.utc)
+
+
 def compute_next_run_at(
     schedule_expr: str,
     timezone_name: str,
@@ -82,14 +101,16 @@ def compute_next_run_at(
         run_at = _parse_one_time_run_at(schedule_expr, timezone_name)
         return None if from_dt is not None and run_at <= from_dt else run_at
 
-    tz = ZoneInfo(validate_timezone_name(timezone_name))
     baseline = from_dt or datetime.now(timezone.utc)
-    local_baseline = baseline.astimezone(tz)
-    iterator = croniter(validate_schedule_expr(schedule_expr), local_baseline)
-    next_local = iterator.get_next(datetime)
-    if next_local.tzinfo is None:
-        next_local = next_local.replace(tzinfo=tz)
-    return next_local.astimezone(timezone.utc)
+    iterator, timezone_info = _cron_iterator(
+        schedule_expr,
+        timezone_name,
+        baseline,
+    )
+    return _normalize_cron_result(
+        iterator.get_next(datetime),
+        timezone_info,
+    )
 
 
 def compute_latest_run_at(
@@ -105,13 +126,15 @@ def compute_latest_run_at(
         run_at = _parse_one_time_run_at(schedule_expr, timezone_name)
         return run_at if run_at <= at_or_before else None
 
-    tz = ZoneInfo(validate_timezone_name(timezone_name))
-    local_baseline = at_or_before.astimezone(tz) + timedelta(microseconds=1)
-    iterator = croniter(validate_schedule_expr(schedule_expr), local_baseline)
-    previous_local = iterator.get_prev(datetime)
-    if previous_local.tzinfo is None:
-        previous_local = previous_local.replace(tzinfo=tz)
-    return previous_local.astimezone(timezone.utc)
+    iterator, timezone_info = _cron_iterator(
+        schedule_expr,
+        timezone_name,
+        at_or_before + timedelta(microseconds=1),
+    )
+    return _normalize_cron_result(
+        iterator.get_prev(datetime),
+        timezone_info,
+    )
 
 
 def humanize_schedule(schedule_expr: str, timezone_name: str) -> str:

--- a/brain/systems/cycles/silence_alerts.py
+++ b/brain/systems/cycles/silence_alerts.py
@@ -1,0 +1,81 @@
+"""Slack adapter for Cycle receipt-silence alerts."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import os
+
+from brain.systems.cortex.thread_links import public_app_base_url
+from brain.systems.cycles.silence_policy import CycleSilenceCandidate
+from brain.systems.failure_guard.slack_delivery import (
+    FailureAlertPresentation,
+    FailureAlertSubject,
+    SlackFailureAlertPolicy,
+    async_deliver_failure_alert,
+)
+from brain.systems.slack.client import slack_web_client_from_runtime
+
+
+FailureAlertDelivery = Callable[..., Awaitable[None]]
+
+
+def _minutes(candidate: CycleSilenceCandidate) -> int:
+    return int(candidate.grace_margin.total_seconds() // 60)
+
+
+def _candidate_summary(candidate: CycleSilenceCandidate) -> str:
+    last_seen = (
+        candidate.last_receipt_at.isoformat()
+        if candidate.last_receipt_at is not None
+        else "never"
+    )
+    return "\n".join(
+        (
+            f"Binding: {candidate.binding}",
+            f"Expected receipt: {candidate.expected_at.isoformat()}",
+            f"Last receipt: {last_seen}",
+            f"Grace margin: {_minutes(candidate)}m",
+        )
+    )
+
+
+async def async_deliver_cycle_silence_alert(
+    candidate: CycleSilenceCandidate,
+    *,
+    deliver_alert: FailureAlertDelivery = async_deliver_failure_alert,
+) -> None:
+    """Compose and deliver one missed-receipt Slack alert."""
+    last_seen = (
+        candidate.last_receipt_at.isoformat()
+        if candidate.last_receipt_at is not None
+        else "never"
+    )
+    await deliver_alert(
+        policy=SlackFailureAlertPolicy(
+            provide_client=slack_web_client_from_runtime,
+            requested_by="cycle_silence_monitor",
+            reason="Deliver a missed Cycle receipt alert to the team.",
+            channel=(
+                os.getenv("ILLO_CYCLE_FAILURE_ALERT_CHANNEL", "").strip()
+                or "#alerts"
+            ),
+            unknown_error_text="Cycle receipt is missing",
+        ),
+        subject=FailureAlertSubject(
+            identity_label="Schedule",
+            identity=f"{candidate.name} (#{candidate.cycle_id})",
+            url_label="Schedule",
+            url=f"{public_app_base_url()}/cycles?cycle_id={candidate.cycle_id}",
+            link_label="open schedule state",
+        ),
+        presentation=FailureAlertPresentation(
+            title="Cycle schedule missed receipt",
+            summary=_candidate_summary(candidate),
+        ),
+        error_text=(
+            f"Expected a receipt at {candidate.expected_at.isoformat()}; "
+            f"last seen {last_seen}."
+        ),
+    )
+
+
+__all__ = ["async_deliver_cycle_silence_alert"]

--- a/brain/systems/cycles/silence_monitor.py
+++ b/brain/systems/cycles/silence_monitor.py
@@ -1,0 +1,375 @@
+"""Alert when an enabled Cycle schedule misses its receipt window."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import logging
+import os
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel.common.time import assume_utc_optional
+from brain.platform.db.models.cycle import (
+    Cycle,
+    CycleFailureGuardLatch,
+    CycleRun,
+)
+from brain.systems.cycles.common import cycle_executor_binding
+from brain.systems.cycles.schedules import compute_latest_run_at
+from brain.systems.cycles.silence_policy import (
+    CycleSilencePolicy,
+    async_cycle_silence_policy,
+)
+from brain.systems.cortex.thread_links import public_app_base_url
+from brain.systems.failure_guard.core import FailureGuardTriggerKind
+from brain.systems.failure_guard.cycle_latches import (
+    async_release_cycle_alert_latch,
+    async_try_claim_cycle_alert_latch,
+)
+from brain.systems.failure_guard.slack_delivery import (
+    FailureAlertPresentation,
+    FailureAlertSubject,
+    SlackFailureAlertPolicy,
+    async_deliver_failure_alert,
+)
+from brain.systems.slack.client import slack_web_client_from_runtime
+
+
+logger = logging.getLogger(__name__)
+
+CYCLE_MISSED_RECEIPT_TRIGGER_KIND = FailureGuardTriggerKind("missed_receipt")
+
+
+@dataclass(frozen=True, slots=True)
+class CycleSilenceCandidate:
+    cycle_id: int
+    name: str
+    binding: str
+    expected_at: datetime
+    last_receipt_at: datetime | None
+    grace_margin: timedelta
+
+
+@dataclass(frozen=True, slots=True)
+class CycleSilenceObservation:
+    candidates: tuple[CycleSilenceCandidate, ...]
+    latched_cycle_ids: frozenset[int]
+
+
+@dataclass(frozen=True, slots=True)
+class CycleSilenceCheck:
+    overdue_cycle_ids: tuple[int, ...]
+    alerted_cycle_ids: tuple[int, ...]
+
+
+PolicyProvider = Callable[[AsyncSession], Awaitable[CycleSilencePolicy]]
+CandidateProvider = Callable[..., Awaitable[CycleSilenceObservation]]
+AlertClaim = Callable[..., Awaitable[bool]]
+AlertRelease = Callable[..., Awaitable[None]]
+AlertDelivery = Callable[..., Awaitable[None]]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _latest_receipt_subquery():
+    return (
+        select(func.max(CycleRun.completed_at))
+        .where(CycleRun.cycle_id == Cycle.id)
+        .correlate(Cycle)
+        .scalar_subquery()
+    )
+
+
+def _missed_receipt_candidate(
+    cycle: Cycle,
+    *,
+    last_receipt_at: datetime | None,
+    now: datetime,
+    grace_margin: timedelta,
+) -> CycleSilenceCandidate | None:
+    expected_at = compute_latest_run_at(
+        cycle.schedule_expr,
+        cycle.timezone,
+        at_or_before=now - grace_margin,
+    )
+    if expected_at is None:
+        return None
+    monitoring_started_at = assume_utc_optional(
+        getattr(cycle, "receipt_monitoring_started_at", None)
+        or getattr(cycle, "created_at", None)
+    )
+    if monitoring_started_at is None or expected_at < monitoring_started_at:
+        return None
+    normalized_receipt = assume_utc_optional(last_receipt_at)
+    if normalized_receipt is not None and normalized_receipt >= expected_at:
+        return None
+    return CycleSilenceCandidate(
+        cycle_id=int(cycle.id),
+        name=str(cycle.name),
+        binding=cycle_executor_binding(cycle),
+        expected_at=expected_at,
+        last_receipt_at=normalized_receipt,
+        grace_margin=grace_margin,
+    )
+
+
+async def async_cycle_silence_observation(
+    session: AsyncSession,
+    *,
+    now: datetime,
+    grace_margin: timedelta,
+) -> CycleSilenceObservation:
+    """Read every enabled binding and its latest completed CycleRun receipt."""
+    latest_receipt = _latest_receipt_subquery()
+    rows = (
+        await session.execute(
+            select(Cycle, latest_receipt.label("last_receipt_at"))
+            .where(
+                Cycle.enabled.is_(True),
+                Cycle.deleted_at.is_(None),
+            )
+            .order_by(Cycle.id.asc())
+        )
+    ).all()
+    candidates: list[CycleSilenceCandidate] = []
+    for cycle, last_receipt_at in rows:
+        try:
+            candidate = _missed_receipt_candidate(
+                cycle,
+                last_receipt_at=last_receipt_at,
+                now=now,
+                grace_margin=grace_margin,
+            )
+        except ValueError:
+            logger.exception(
+                "Cycle receipt window could not be evaluated: cycle_id=%s",
+                cycle.id,
+            )
+            continue
+        if candidate is not None:
+            candidates.append(candidate)
+
+    latched_cycle_ids = frozenset(
+        int(cycle_id)
+        for cycle_id in (
+            await session.scalars(
+                select(CycleFailureGuardLatch.cycle_id).where(
+                    CycleFailureGuardLatch.trigger_kind
+                    == str(CYCLE_MISSED_RECEIPT_TRIGGER_KIND)
+                )
+            )
+        ).all()
+    )
+    return CycleSilenceObservation(
+        candidates=tuple(candidates),
+        latched_cycle_ids=latched_cycle_ids,
+    )
+
+
+async def _claim_cycle_silence_alert(
+    *,
+    cycle_id: int,
+    alerted_at: datetime,
+) -> bool:
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    async with UnitOfWork() as uow:
+        return await async_try_claim_cycle_alert_latch(
+            uow.session,
+            cycle_id=cycle_id,
+            trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+            alerted_at=alerted_at,
+        )
+
+
+async def _release_cycle_silence_alert(
+    *,
+    cycle_id: int,
+    alerted_at: datetime | None = None,
+) -> None:
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    async with UnitOfWork() as uow:
+        await async_release_cycle_alert_latch(
+            uow.session,
+            cycle_id=cycle_id,
+            trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+            alerted_at=alerted_at,
+        )
+
+
+def _minutes(duration: timedelta) -> int:
+    return int(duration.total_seconds() // 60)
+
+
+def _candidate_summary(candidate: CycleSilenceCandidate) -> str:
+    last_seen = (
+        candidate.last_receipt_at.isoformat()
+        if candidate.last_receipt_at is not None
+        else "never"
+    )
+    return "\n".join(
+        (
+            f"Binding: {candidate.binding}",
+            f"Expected receipt: {candidate.expected_at.isoformat()}",
+            f"Last receipt: {last_seen}",
+            f"Grace margin: {_minutes(candidate.grace_margin)}m",
+        )
+    )
+
+
+class CycleSilenceMonitor:
+    """Check receipt progress on the API loop, independent of executors."""
+
+    name = "cycle_silence_monitor"
+    check_interval_seconds = 5 * 60.0
+
+    def __init__(
+        self,
+        *,
+        policy_provider: PolicyProvider = async_cycle_silence_policy,
+        candidate_provider: CandidateProvider = async_cycle_silence_observation,
+        claim_alert: AlertClaim = _claim_cycle_silence_alert,
+        release_alert: AlertRelease = _release_cycle_silence_alert,
+        deliver_alert: AlertDelivery = async_deliver_failure_alert,
+    ) -> None:
+        self._policy_provider = policy_provider
+        self._candidate_provider = candidate_provider
+        self._claim_alert = claim_alert
+        self._release_alert = release_alert
+        self._deliver_alert = deliver_alert
+
+    async def run(self) -> None:
+        while True:
+            await asyncio.sleep(self.check_interval_seconds)
+            try:
+                await self._run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - the next interval retries
+                logger.exception("Cycle receipt-silence check failed safely")
+
+    async def _run_once(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> CycleSilenceCheck:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+        reference_time = assume_utc_optional(now or _utc_now())
+        if reference_time is None:
+            raise ValueError("now is required")
+        async with UnitOfWork() as uow:
+            observation = await self._observe(uow.session, now=reference_time)
+        return await self._evaluate(observation, now=reference_time)
+
+    async def _check(
+        self,
+        session: AsyncSession,
+        *,
+        now: datetime | None = None,
+    ) -> CycleSilenceCheck:
+        reference_time = assume_utc_optional(now or _utc_now())
+        if reference_time is None:
+            raise ValueError("now is required")
+        observation = await self._observe(session, now=reference_time)
+        return await self._evaluate(observation, now=reference_time)
+
+    async def _observe(
+        self,
+        session: AsyncSession,
+        *,
+        now: datetime,
+    ) -> CycleSilenceObservation:
+        policy = await self._policy_provider(session)
+        return await self._candidate_provider(
+            session,
+            now=now,
+            grace_margin=policy.grace_margin,
+        )
+
+    async def _evaluate(
+        self,
+        observation: CycleSilenceObservation,
+        *,
+        now: datetime,
+    ) -> CycleSilenceCheck:
+        overdue_ids = tuple(candidate.cycle_id for candidate in observation.candidates)
+        overdue_id_set = set(overdue_ids)
+        for cycle_id in sorted(observation.latched_cycle_ids - overdue_id_set):
+            await self._release_alert(cycle_id=cycle_id)
+
+        alerted_ids: list[int] = []
+        for candidate in observation.candidates:
+            claimed = await self._claim_alert(
+                cycle_id=candidate.cycle_id,
+                alerted_at=now,
+            )
+            if not claimed:
+                continue
+            try:
+                await self._deliver(candidate)
+            except Exception:  # noqa: BLE001 - release permits a later retry
+                logger.exception(
+                    "Cycle receipt-silence Slack delivery failed: cycle_id=%s",
+                    candidate.cycle_id,
+                )
+                await self._release_alert(
+                    cycle_id=candidate.cycle_id,
+                    alerted_at=now,
+                )
+                continue
+            alerted_ids.append(candidate.cycle_id)
+        return CycleSilenceCheck(
+            overdue_cycle_ids=overdue_ids,
+            alerted_cycle_ids=tuple(alerted_ids),
+        )
+
+    async def _deliver(self, candidate: CycleSilenceCandidate) -> None:
+        last_seen = (
+            candidate.last_receipt_at.isoformat()
+            if candidate.last_receipt_at is not None
+            else "never"
+        )
+        await self._deliver_alert(
+            policy=SlackFailureAlertPolicy(
+                provide_client=slack_web_client_from_runtime,
+                requested_by=self.name,
+                reason="Deliver a missed Cycle receipt alert to the team.",
+                channel=(
+                    os.getenv("ILLO_CYCLE_FAILURE_ALERT_CHANNEL", "").strip()
+                    or "#alerts"
+                ),
+                unknown_error_text="Cycle receipt is missing",
+            ),
+            subject=FailureAlertSubject(
+                identity_label="Schedule",
+                identity=f"{candidate.name} (#{candidate.cycle_id})",
+                url_label="Schedule",
+                url=f"{public_app_base_url()}/cycles?cycle_id={candidate.cycle_id}",
+                link_label="open schedule state",
+            ),
+            presentation=FailureAlertPresentation(
+                title="Cycle schedule missed receipt",
+                summary=_candidate_summary(candidate),
+            ),
+            error_text=(
+                f"Expected a receipt at {candidate.expected_at.isoformat()}; "
+                f"last seen {last_seen}."
+            ),
+        )
+
+
+__all__ = [
+    "CYCLE_MISSED_RECEIPT_TRIGGER_KIND",
+    "CycleSilenceCandidate",
+    "CycleSilenceCheck",
+    "CycleSilenceMonitor",
+    "CycleSilenceObservation",
+    "async_cycle_silence_observation",
+]

--- a/brain/systems/cycles/silence_monitor.py
+++ b/brain/systems/cycles/silence_monitor.py
@@ -1,4 +1,4 @@
-"""Alert when an enabled Cycle schedule misses its receipt window."""
+"""Orchestrate alerts when enabled Cycle schedules miss receipt windows."""
 from __future__ import annotations
 
 import asyncio
@@ -6,51 +6,27 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
-import os
 
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.common.time import assume_utc_optional
-from brain.platform.db.models.cycle import (
-    Cycle,
-    CycleFailureGuardLatch,
-    CycleRun,
+from brain.platform.db.repositories.cycle_silence import CycleSilenceRepository
+from brain.systems.cycles.silence_alerts import (
+    async_deliver_cycle_silence_alert,
 )
-from brain.systems.cycles.common import cycle_executor_binding
-from brain.systems.cycles.schedules import compute_latest_run_at
 from brain.systems.cycles.silence_policy import (
+    CycleSilenceCandidate,
     CycleSilencePolicy,
     async_cycle_silence_policy,
+    evaluate_cycle_silence_candidate,
 )
-from brain.systems.cortex.thread_links import public_app_base_url
 from brain.systems.failure_guard.core import FailureGuardTriggerKind
-from brain.systems.failure_guard.cycle_latches import (
-    async_release_cycle_alert_latch,
-    async_try_claim_cycle_alert_latch,
-)
-from brain.systems.failure_guard.slack_delivery import (
-    FailureAlertPresentation,
-    FailureAlertSubject,
-    SlackFailureAlertPolicy,
-    async_deliver_failure_alert,
-)
-from brain.systems.slack.client import slack_web_client_from_runtime
+from brain.systems.failure_guard.cycle_latches import CycleAlertLatchStore
 
 
 logger = logging.getLogger(__name__)
 
 CYCLE_MISSED_RECEIPT_TRIGGER_KIND = FailureGuardTriggerKind("missed_receipt")
-
-
-@dataclass(frozen=True, slots=True)
-class CycleSilenceCandidate:
-    cycle_id: int
-    name: str
-    binding: str
-    expected_at: datetime
-    last_receipt_at: datetime | None
-    grace_margin: timedelta
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,53 +45,11 @@ PolicyProvider = Callable[[AsyncSession], Awaitable[CycleSilencePolicy]]
 CandidateProvider = Callable[..., Awaitable[CycleSilenceObservation]]
 AlertClaim = Callable[..., Awaitable[bool]]
 AlertRelease = Callable[..., Awaitable[None]]
-AlertDelivery = Callable[..., Awaitable[None]]
+AlertDelivery = Callable[[CycleSilenceCandidate], Awaitable[None]]
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _latest_receipt_subquery():
-    return (
-        select(func.max(CycleRun.completed_at))
-        .where(CycleRun.cycle_id == Cycle.id)
-        .correlate(Cycle)
-        .scalar_subquery()
-    )
-
-
-def _missed_receipt_candidate(
-    cycle: Cycle,
-    *,
-    last_receipt_at: datetime | None,
-    now: datetime,
-    grace_margin: timedelta,
-) -> CycleSilenceCandidate | None:
-    expected_at = compute_latest_run_at(
-        cycle.schedule_expr,
-        cycle.timezone,
-        at_or_before=now - grace_margin,
-    )
-    if expected_at is None:
-        return None
-    monitoring_started_at = assume_utc_optional(
-        getattr(cycle, "receipt_monitoring_started_at", None)
-        or getattr(cycle, "created_at", None)
-    )
-    if monitoring_started_at is None or expected_at < monitoring_started_at:
-        return None
-    normalized_receipt = assume_utc_optional(last_receipt_at)
-    if normalized_receipt is not None and normalized_receipt >= expected_at:
-        return None
-    return CycleSilenceCandidate(
-        cycle_id=int(cycle.id),
-        name=str(cycle.name),
-        binding=cycle_executor_binding(cycle),
-        expected_at=expected_at,
-        last_receipt_at=normalized_receipt,
-        grace_margin=grace_margin,
-    )
 
 
 async def async_cycle_silence_observation(
@@ -124,46 +58,28 @@ async def async_cycle_silence_observation(
     now: datetime,
     grace_margin: timedelta,
 ) -> CycleSilenceObservation:
-    """Read every enabled binding and its latest completed CycleRun receipt."""
-    latest_receipt = _latest_receipt_subquery()
-    rows = (
-        await session.execute(
-            select(Cycle, latest_receipt.label("last_receipt_at"))
-            .where(
-                Cycle.enabled.is_(True),
-                Cycle.deleted_at.is_(None),
-            )
-            .order_by(Cycle.id.asc())
-        )
-    ).all()
+    """Evaluate persisted receipt snapshots and read current alert edges."""
+    snapshots = await CycleSilenceRepository(session).list_receipt_snapshots()
     candidates: list[CycleSilenceCandidate] = []
-    for cycle, last_receipt_at in rows:
+    for snapshot in snapshots:
         try:
-            candidate = _missed_receipt_candidate(
-                cycle,
-                last_receipt_at=last_receipt_at,
+            candidate = evaluate_cycle_silence_candidate(
+                snapshot,
                 now=now,
                 grace_margin=grace_margin,
             )
         except ValueError:
             logger.exception(
                 "Cycle receipt window could not be evaluated: cycle_id=%s",
-                cycle.id,
+                snapshot.cycle_id,
             )
             continue
         if candidate is not None:
             candidates.append(candidate)
 
-    latched_cycle_ids = frozenset(
-        int(cycle_id)
-        for cycle_id in (
-            await session.scalars(
-                select(CycleFailureGuardLatch.cycle_id).where(
-                    CycleFailureGuardLatch.trigger_kind
-                    == str(CYCLE_MISSED_RECEIPT_TRIGGER_KIND)
-                )
-            )
-        ).all()
+    latched_cycle_ids = await CycleAlertLatchStore.load_cycle_ids_for_trigger(
+        session,
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
     )
     return CycleSilenceObservation(
         candidates=tuple(candidates),
@@ -179,11 +95,10 @@ async def _claim_cycle_silence_alert(
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
     async with UnitOfWork() as uow:
-        return await async_try_claim_cycle_alert_latch(
-            uow.session,
-            cycle_id=cycle_id,
-            trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
-            alerted_at=alerted_at,
+        store = CycleAlertLatchStore(session=uow.session, cycle_id=cycle_id)
+        return await store.try_claim_latch(
+            CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+            alerted_at,
         )
 
 
@@ -195,32 +110,11 @@ async def _release_cycle_silence_alert(
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
     async with UnitOfWork() as uow:
-        await async_release_cycle_alert_latch(
-            uow.session,
-            cycle_id=cycle_id,
-            trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        store = CycleAlertLatchStore(session=uow.session, cycle_id=cycle_id)
+        await store.release_latch(
+            CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
             alerted_at=alerted_at,
         )
-
-
-def _minutes(duration: timedelta) -> int:
-    return int(duration.total_seconds() // 60)
-
-
-def _candidate_summary(candidate: CycleSilenceCandidate) -> str:
-    last_seen = (
-        candidate.last_receipt_at.isoformat()
-        if candidate.last_receipt_at is not None
-        else "never"
-    )
-    return "\n".join(
-        (
-            f"Binding: {candidate.binding}",
-            f"Expected receipt: {candidate.expected_at.isoformat()}",
-            f"Last receipt: {last_seen}",
-            f"Grace margin: {_minutes(candidate.grace_margin)}m",
-        )
-    )
 
 
 class CycleSilenceMonitor:
@@ -236,7 +130,7 @@ class CycleSilenceMonitor:
         candidate_provider: CandidateProvider = async_cycle_silence_observation,
         claim_alert: AlertClaim = _claim_cycle_silence_alert,
         release_alert: AlertRelease = _release_cycle_silence_alert,
-        deliver_alert: AlertDelivery = async_deliver_failure_alert,
+        deliver_alert: AlertDelivery = async_deliver_cycle_silence_alert,
     ) -> None:
         self._policy_provider = policy_provider
         self._candidate_provider = candidate_provider
@@ -313,7 +207,7 @@ class CycleSilenceMonitor:
             if not claimed:
                 continue
             try:
-                await self._deliver(candidate)
+                await self._deliver_alert(candidate)
             except Exception:  # noqa: BLE001 - release permits a later retry
                 logger.exception(
                     "Cycle receipt-silence Slack delivery failed: cycle_id=%s",
@@ -330,44 +224,9 @@ class CycleSilenceMonitor:
             alerted_cycle_ids=tuple(alerted_ids),
         )
 
-    async def _deliver(self, candidate: CycleSilenceCandidate) -> None:
-        last_seen = (
-            candidate.last_receipt_at.isoformat()
-            if candidate.last_receipt_at is not None
-            else "never"
-        )
-        await self._deliver_alert(
-            policy=SlackFailureAlertPolicy(
-                provide_client=slack_web_client_from_runtime,
-                requested_by=self.name,
-                reason="Deliver a missed Cycle receipt alert to the team.",
-                channel=(
-                    os.getenv("ILLO_CYCLE_FAILURE_ALERT_CHANNEL", "").strip()
-                    or "#alerts"
-                ),
-                unknown_error_text="Cycle receipt is missing",
-            ),
-            subject=FailureAlertSubject(
-                identity_label="Schedule",
-                identity=f"{candidate.name} (#{candidate.cycle_id})",
-                url_label="Schedule",
-                url=f"{public_app_base_url()}/cycles?cycle_id={candidate.cycle_id}",
-                link_label="open schedule state",
-            ),
-            presentation=FailureAlertPresentation(
-                title="Cycle schedule missed receipt",
-                summary=_candidate_summary(candidate),
-            ),
-            error_text=(
-                f"Expected a receipt at {candidate.expected_at.isoformat()}; "
-                f"last seen {last_seen}."
-            ),
-        )
-
 
 __all__ = [
     "CYCLE_MISSED_RECEIPT_TRIGGER_KIND",
-    "CycleSilenceCandidate",
     "CycleSilenceCheck",
     "CycleSilenceMonitor",
     "CycleSilenceObservation",

--- a/brain/systems/cycles/silence_policy.py
+++ b/brain/systems/cycles/silence_policy.py
@@ -1,13 +1,17 @@
-"""Database-backed policy for Cycle receipt-silence detection."""
+"""Policy and pure evaluation for Cycle receipt-silence detection."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 import logging
+from typing import Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.time import assume_utc_optional
+from brain.systems.cycles.common import cycle_executor_binding
+from brain.systems.cycles.schedules import compute_latest_run_at
 from brain.systems.runtime_settings.memory import _async_read_runtime_config_value
 
 
@@ -21,6 +25,59 @@ MAX_CYCLE_SILENCE_GRACE_MINUTES = 10_080
 @dataclass(frozen=True, slots=True)
 class CycleSilencePolicy:
     grace_margin: timedelta
+
+
+@dataclass(frozen=True, slots=True)
+class CycleSilenceCandidate:
+    cycle_id: int
+    name: str
+    binding: str
+    expected_at: datetime
+    last_receipt_at: datetime | None
+    grace_margin: timedelta
+
+
+class CycleReceiptSnapshot(Protocol):
+    cycle_id: int
+    name: str
+    executor_binding: str | None
+    schedule_expr: str
+    timezone: str
+    receipt_monitoring_started_at: datetime | None
+    created_at: datetime | None
+    last_receipt_at: datetime | None
+
+
+def evaluate_cycle_silence_candidate(
+    snapshot: CycleReceiptSnapshot,
+    *,
+    now: datetime,
+    grace_margin: timedelta,
+) -> CycleSilenceCandidate | None:
+    """Return an overdue candidate using only the supplied snapshot and time."""
+    expected_at = compute_latest_run_at(
+        snapshot.schedule_expr,
+        snapshot.timezone,
+        at_or_before=now - grace_margin,
+    )
+    if expected_at is None:
+        return None
+    monitoring_started_at = assume_utc_optional(
+        snapshot.receipt_monitoring_started_at or snapshot.created_at
+    )
+    if monitoring_started_at is None or expected_at < monitoring_started_at:
+        return None
+    normalized_receipt = assume_utc_optional(snapshot.last_receipt_at)
+    if normalized_receipt is not None and normalized_receipt >= expected_at:
+        return None
+    return CycleSilenceCandidate(
+        cycle_id=snapshot.cycle_id,
+        name=snapshot.name,
+        binding=cycle_executor_binding(snapshot),
+        expected_at=expected_at,
+        last_receipt_at=normalized_receipt,
+        grace_margin=grace_margin,
+    )
 
 
 def _grace_minutes(value: object) -> int:
@@ -58,6 +115,8 @@ async def async_cycle_silence_policy(
 
 __all__ = [
     "CYCLE_SILENCE_RUNTIME_SETTINGS_KEY",
+    "CycleSilenceCandidate",
     "CycleSilencePolicy",
     "async_cycle_silence_policy",
+    "evaluate_cycle_silence_candidate",
 ]

--- a/brain/systems/cycles/silence_policy.py
+++ b/brain/systems/cycles/silence_policy.py
@@ -1,0 +1,63 @@
+"""Database-backed policy for Cycle receipt-silence detection."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import json
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.systems.runtime_settings.memory import _async_read_runtime_config_value
+
+
+logger = logging.getLogger(__name__)
+
+CYCLE_SILENCE_RUNTIME_SETTINGS_KEY = "runtime_cycle_silence"
+DEFAULT_CYCLE_SILENCE_GRACE_MINUTES = 30
+MAX_CYCLE_SILENCE_GRACE_MINUTES = 10_080
+
+
+@dataclass(frozen=True, slots=True)
+class CycleSilencePolicy:
+    grace_margin: timedelta
+
+
+def _grace_minutes(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= MAX_CYCLE_SILENCE_GRACE_MINUTES
+    ):
+        raise ValueError(
+            "grace_minutes must be an integer between 1 and "
+            f"{MAX_CYCLE_SILENCE_GRACE_MINUTES}"
+        )
+    return value
+
+
+async def async_cycle_silence_policy(
+    session: AsyncSession,
+) -> CycleSilencePolicy:
+    """Load the live installation policy, falling back safely when invalid."""
+    grace_minutes = DEFAULT_CYCLE_SILENCE_GRACE_MINUTES
+    raw = await _async_read_runtime_config_value(
+        session,
+        CYCLE_SILENCE_RUNTIME_SETTINGS_KEY,
+    )
+    if raw:
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                raise ValueError("runtime cycle silence settings must be an object")
+            grace_minutes = _grace_minutes(payload.get("grace_minutes"))
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Ignoring invalid runtime Cycle silence settings")
+    return CycleSilencePolicy(grace_margin=timedelta(minutes=grace_minutes))
+
+
+__all__ = [
+    "CYCLE_SILENCE_RUNTIME_SETTINGS_KEY",
+    "CycleSilencePolicy",
+    "async_cycle_silence_policy",
+]

--- a/brain/systems/failure_guard/cycle_latches.py
+++ b/brain/systems/failure_guard/cycle_latches.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.cycle import CycleFailureGuardLatch
@@ -12,6 +14,58 @@ from brain.systems.failure_guard.core import (
     FailureGuardLatch,
     FailureGuardTriggerKind,
 )
+
+
+def _latch_insert(session: AsyncSession):
+    if session.get_bind().dialect.name == "sqlite":
+        return sqlite_insert(CycleFailureGuardLatch)
+    return postgresql_insert(CycleFailureGuardLatch)
+
+
+async def async_try_claim_cycle_alert_latch(
+    session: AsyncSession,
+    *,
+    cycle_id: int,
+    trigger_kind: FailureGuardTriggerKind,
+    alerted_at: datetime,
+) -> bool:
+    """Atomically claim one cycle alert edge across concurrent replicas."""
+    claim = (
+        _latch_insert(session)
+        .values(
+            cycle_id=cycle_id,
+            trigger_kind=str(trigger_kind),
+            alerted_at=alerted_at,
+        )
+        .on_conflict_do_nothing(
+            index_elements=[
+                CycleFailureGuardLatch.cycle_id,
+                CycleFailureGuardLatch.trigger_kind,
+            ]
+        )
+        .returning(CycleFailureGuardLatch.cycle_id)
+    )
+    result = await session.execute(claim)
+    return result.scalar_one_or_none() == cycle_id
+
+
+async def async_release_cycle_alert_latch(
+    session: AsyncSession,
+    *,
+    cycle_id: int,
+    trigger_kind: FailureGuardTriggerKind,
+    alerted_at: datetime | None = None,
+) -> None:
+    """Release one cycle alert edge, optionally fencing an old delivery."""
+    statement = delete(CycleFailureGuardLatch).where(
+        CycleFailureGuardLatch.cycle_id == cycle_id,
+        CycleFailureGuardLatch.trigger_kind == str(trigger_kind),
+    )
+    if alerted_at is not None:
+        statement = statement.where(
+            CycleFailureGuardLatch.alerted_at == alerted_at,
+        )
+    await session.execute(statement)
 
 
 @dataclass(frozen=True)

--- a/brain/systems/failure_guard/cycle_latches.py
+++ b/brain/systems/failure_guard/cycle_latches.py
@@ -22,52 +22,6 @@ def _latch_insert(session: AsyncSession):
     return postgresql_insert(CycleFailureGuardLatch)
 
 
-async def async_try_claim_cycle_alert_latch(
-    session: AsyncSession,
-    *,
-    cycle_id: int,
-    trigger_kind: FailureGuardTriggerKind,
-    alerted_at: datetime,
-) -> bool:
-    """Atomically claim one cycle alert edge across concurrent replicas."""
-    claim = (
-        _latch_insert(session)
-        .values(
-            cycle_id=cycle_id,
-            trigger_kind=str(trigger_kind),
-            alerted_at=alerted_at,
-        )
-        .on_conflict_do_nothing(
-            index_elements=[
-                CycleFailureGuardLatch.cycle_id,
-                CycleFailureGuardLatch.trigger_kind,
-            ]
-        )
-        .returning(CycleFailureGuardLatch.cycle_id)
-    )
-    result = await session.execute(claim)
-    return result.scalar_one_or_none() == cycle_id
-
-
-async def async_release_cycle_alert_latch(
-    session: AsyncSession,
-    *,
-    cycle_id: int,
-    trigger_kind: FailureGuardTriggerKind,
-    alerted_at: datetime | None = None,
-) -> None:
-    """Release one cycle alert edge, optionally fencing an old delivery."""
-    statement = delete(CycleFailureGuardLatch).where(
-        CycleFailureGuardLatch.cycle_id == cycle_id,
-        CycleFailureGuardLatch.trigger_kind == str(trigger_kind),
-    )
-    if alerted_at is not None:
-        statement = statement.where(
-            CycleFailureGuardLatch.alerted_at == alerted_at,
-        )
-    await session.execute(statement)
-
-
 @dataclass(frozen=True)
 class CycleAlertLatchStore:
     """Persist alert latches shared by cycle-scoped policy owners."""
@@ -100,6 +54,60 @@ class CycleAlertLatchStore:
         )
         self.session.add(latch)
         return latch
+
+    async def try_claim_latch(
+        self,
+        trigger_kind: FailureGuardTriggerKind,
+        alerted_at: datetime,
+    ) -> bool:
+        """Atomically claim one alert edge across concurrent replicas."""
+        claim = (
+            _latch_insert(self.session)
+            .values(
+                cycle_id=self.cycle_id,
+                trigger_kind=str(trigger_kind),
+                alerted_at=alerted_at,
+            )
+            .on_conflict_do_nothing(
+                index_elements=[
+                    CycleFailureGuardLatch.cycle_id,
+                    CycleFailureGuardLatch.trigger_kind,
+                ]
+            )
+            .returning(CycleFailureGuardLatch.cycle_id)
+        )
+        result = await self.session.execute(claim)
+        return result.scalar_one_or_none() == self.cycle_id
+
+    async def release_latch(
+        self,
+        trigger_kind: FailureGuardTriggerKind,
+        *,
+        alerted_at: datetime | None = None,
+    ) -> None:
+        """Release one alert edge, optionally fencing an old delivery."""
+        statement = delete(CycleFailureGuardLatch).where(
+            CycleFailureGuardLatch.cycle_id == self.cycle_id,
+            CycleFailureGuardLatch.trigger_kind == str(trigger_kind),
+        )
+        if alerted_at is not None:
+            statement = statement.where(
+                CycleFailureGuardLatch.alerted_at == alerted_at,
+            )
+        await self.session.execute(statement)
+
+    @staticmethod
+    async def load_cycle_ids_for_trigger(
+        session: AsyncSession,
+        trigger_kind: FailureGuardTriggerKind,
+    ) -> frozenset[int]:
+        """Return every cycle with a latch for one trigger kind."""
+        cycle_ids = await session.scalars(
+            select(CycleFailureGuardLatch.cycle_id).where(
+                CycleFailureGuardLatch.trigger_kind == str(trigger_kind)
+            )
+        )
+        return frozenset(int(cycle_id) for cycle_id in cycle_ids.all())
 
     async def delete_latch(
         self,

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -252,6 +252,41 @@ async def test_lifespan_hosts_stale_run_reaper_outside_daemon():
     assert api_main._stale_run_reaper_task is None
 
 
+@pytest.mark.asyncio
+async def test_lifespan_hosts_cycle_silence_monitor_outside_executors():
+    monitor_started = asyncio.Event()
+
+    async def monitor_loop():
+        monitor_started.set()
+        await asyncio.Future()
+
+    monitor = MagicMock()
+    monitor.name = "cycle_silence_monitor"
+    monitor.run = monitor_loop
+
+    with patch("brain.app.api.main._should_start_inline_runner", return_value=False):
+        with patch("brain.app.api.main._should_start_run_event_consumer", return_value=False):
+            with patch("brain.platform.events.set_publisher"):
+                with patch(
+                    "brain.app.api.main._ensure_starting_skill_bundle",
+                    new=AsyncMock(),
+                ):
+                    with patch(
+                        "brain.app.api.main.CycleSilenceMonitor",
+                        return_value=monitor,
+                    ) as monitor_type:
+                        async with api_main.lifespan(app):
+                            await asyncio.wait_for(monitor_started.wait(), timeout=1)
+                            assert api_main._cycle_silence_monitor_task is not None
+                            assert (
+                                api_main._cycle_silence_monitor_task.get_name()
+                                == "cycle_silence_monitor"
+                            )
+
+    monitor_type.assert_called_once_with()
+    assert api_main._cycle_silence_monitor_task is None
+
+
 def test_inline_runner_honors_launcher_dispatcher_env(monkeypatch):
     monkeypatch.delenv("CORTEX_INLINE_RUNNER", raising=False)
     monkeypatch.setenv("CORTEX_INLINE_DISPATCHER", "1")

--- a/tests/test_cycle_silence_monitor.py
+++ b/tests/test_cycle_silence_monitor.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib
+import json
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from brain.platform.db.models.cycle import (
+    Cycle,
+    CycleFailureGuardLatch,
+    CycleRun,
+)
+from brain.platform.db.models.vault import VaultConfig
+from brain.systems.cycles.common import (
+    ILLO_LANE_EXECUTOR_BINDING,
+    PERSONAL_AGENT_EXECUTOR_BINDING,
+)
+from brain.systems.cycles.schedules import compute_latest_run_at
+from brain.systems.cycles.silence_monitor import (
+    CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+    CycleSilenceCandidate,
+    CycleSilenceMonitor,
+    CycleSilenceObservation,
+    _missed_receipt_candidate,
+)
+from brain.systems.cycles.silence_policy import (
+    CYCLE_SILENCE_RUNTIME_SETTINGS_KEY,
+    CycleSilencePolicy,
+    async_cycle_silence_policy,
+)
+from brain.systems.failure_guard.cycle_latches import (
+    async_release_cycle_alert_latch,
+    async_try_claim_cycle_alert_latch,
+)
+
+
+NOW = datetime(2026, 8, 17, 13, 0, tzinfo=timezone.utc)
+GRACE = timedelta(minutes=30)
+MIGRATION_MODULE = (
+    "brain.platform.db.alembic.versions.0064_cycle_receipt_monitoring"
+)
+
+
+@pytest.fixture
+async def silence_session(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    return await async_sqlite_session_factory(
+        [
+            Cycle.__table__,
+            CycleRun.__table__,
+            CycleFailureGuardLatch.__table__,
+            VaultConfig.__table__,
+        ]
+    )
+
+
+def _cycle(
+    *,
+    binding: str,
+    schedule_expr: str = "0 9 * * *",
+    timezone_name: str = "UTC",
+    monitoring_started_at: datetime = NOW - timedelta(days=7),
+    name: str = "Laptop release radar",
+) -> Cycle:
+    return Cycle(
+        id=41,
+        user_id=str(uuid4()),
+        org_id=None,
+        name=name,
+        prompt="Run the schedule.",
+        schedule_expr=schedule_expr,
+        timezone=timezone_name,
+        enabled=True,
+        executor_binding=binding,
+        skill_ids=[],
+        receipt_monitoring_started_at=monitoring_started_at,
+        next_run_at=NOW + timedelta(days=1),
+        created_at=monitoring_started_at,
+        updated_at=monitoring_started_at,
+    )
+
+
+class _FakeLatch:
+    def __init__(self) -> None:
+        self.cycle_ids: set[int] = set()
+
+    async def claim(self, *, cycle_id: int, alerted_at: datetime) -> bool:
+        del alerted_at
+        if cycle_id in self.cycle_ids:
+            return False
+        self.cycle_ids.add(cycle_id)
+        return True
+
+    async def release(
+        self,
+        *,
+        cycle_id: int,
+        alerted_at: datetime | None = None,
+    ) -> None:
+        del alerted_at
+        self.cycle_ids.discard(cycle_id)
+
+
+@pytest.mark.parametrize(
+    "binding",
+    (ILLO_LANE_EXECUTOR_BINDING, PERSONAL_AGENT_EXECUTOR_BINDING),
+)
+async def test_day_old_receipt_alert_names_schedule_binding_and_times(
+    silence_session,
+    binding,
+):
+    cycle = _cycle(binding=binding)
+    silence_session.add(cycle)
+    await silence_session.flush()
+    last_receipt_at = NOW - timedelta(days=1, hours=3, minutes=55)
+    silence_session.add(
+        CycleRun(
+            cycle_id=cycle.id,
+            scheduled_for=NOW - timedelta(days=1, hours=4),
+            completed_at=last_receipt_at,
+            status="completed",
+            prompt_snapshot="Run the schedule.",
+        )
+    )
+    await silence_session.flush()
+
+    latch = _FakeLatch()
+    deliveries = []
+
+    async def deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    monitor = CycleSilenceMonitor(
+        claim_alert=latch.claim,
+        release_alert=latch.release,
+        deliver_alert=deliver,
+    )
+    result = await monitor._check(silence_session, now=NOW)
+    repeated = await monitor._check(silence_session, now=NOW + timedelta(minutes=1))
+
+    assert result.alerted_cycle_ids == (cycle.id,)
+    assert repeated.alerted_cycle_ids == ()
+    assert cycle.executor_binding == binding
+    assert len(deliveries) == 1
+    alert = deliveries[0]
+    assert alert["policy"].channel == "#alerts"
+    assert alert["subject"].identity == f"Laptop release radar (#{cycle.id})"
+    assert f"Binding: {binding}" in alert["presentation"].summary
+    assert f"Expected receipt: {NOW.replace(hour=9).isoformat()}" in (
+        alert["presentation"].summary
+    )
+    assert f"Last receipt: {last_receipt_at.isoformat()}" in (
+        alert["presentation"].summary
+    )
+
+
+def test_weekday_every_two_hour_schedule_stays_quiet_all_week_when_healthy():
+    cycle = _cycle(
+        binding=PERSONAL_AGENT_EXECUTOR_BINDING,
+        schedule_expr="0 */2 * * 1-5",
+        timezone_name="America/Toronto",
+        monitoring_started_at=datetime(2026, 8, 10, tzinfo=timezone.utc),
+    )
+    start = datetime(2026, 8, 10, 4, 0, tzinfo=timezone.utc)
+    last_receipt_at: datetime | None = None
+    alerts = []
+
+    for step in range(7 * 24 * 12 + 1):
+        now = start + timedelta(minutes=5 * step)
+        latest_due = compute_latest_run_at(
+            cycle.schedule_expr,
+            cycle.timezone,
+            at_or_before=now - timedelta(minutes=5),
+        )
+        if latest_due is not None and latest_due >= cycle.receipt_monitoring_started_at:
+            last_receipt_at = latest_due + timedelta(minutes=5)
+        candidate = _missed_receipt_candidate(
+            cycle,
+            last_receipt_at=last_receipt_at,
+            now=now,
+            grace_margin=GRACE,
+        )
+        if candidate is not None:
+            alerts.append(candidate)
+
+    assert alerts == []
+
+
+def test_weekend_pause_does_not_treat_elapsed_wall_time_as_the_cadence():
+    cycle = _cycle(
+        binding=PERSONAL_AGENT_EXECUTOR_BINDING,
+        schedule_expr="0 */2 * * 1-5",
+        timezone_name="America/Toronto",
+        monitoring_started_at=datetime(2026, 8, 10, tzinfo=timezone.utc),
+    )
+    friday_receipt = datetime(2026, 8, 15, 2, 5, tzinfo=timezone.utc)
+
+    for hour in range(48):
+        weekend_now = datetime(2026, 8, 15, 3, 0, tzinfo=timezone.utc) + timedelta(
+            hours=hour
+        )
+        assert (
+            _missed_receipt_candidate(
+                cycle,
+                last_receipt_at=friday_receipt,
+                now=weekend_now,
+                grace_margin=GRACE,
+            )
+            is None
+        )
+
+    monday_late = datetime(2026, 8, 17, 4, 31, tzinfo=timezone.utc)
+    candidate = _missed_receipt_candidate(
+        cycle,
+        last_receipt_at=friday_receipt,
+        now=monday_late,
+        grace_margin=GRACE,
+    )
+    assert candidate is not None
+    assert candidate.expected_at == datetime(2026, 8, 17, 4, 0, tzinfo=timezone.utc)
+
+
+def test_long_cadence_does_not_alert_before_the_next_real_slot():
+    cycle = _cycle(
+        binding=ILLO_LANE_EXECUTOR_BINDING,
+        schedule_expr="0 9 1 * *",
+        monitoring_started_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    august_receipt = datetime(2026, 8, 1, 9, 5, tzinfo=timezone.utc)
+
+    assert (
+        _missed_receipt_candidate(
+            cycle,
+            last_receipt_at=august_receipt,
+            now=datetime(2026, 8, 31, 23, 59, tzinfo=timezone.utc),
+            grace_margin=GRACE,
+        )
+        is None
+    )
+    assert (
+        _missed_receipt_candidate(
+            cycle,
+            last_receipt_at=august_receipt,
+            now=datetime(2026, 9, 1, 9, 31, tzinfo=timezone.utc),
+            grace_margin=GRACE,
+        )
+        is not None
+    )
+
+
+def test_new_schedule_waits_for_its_first_post_creation_slot():
+    cycle = _cycle(
+        binding=PERSONAL_AGENT_EXECUTOR_BINDING,
+        monitoring_started_at=NOW - timedelta(minutes=1),
+    )
+
+    assert (
+        _missed_receipt_candidate(
+            cycle,
+            last_receipt_at=None,
+            now=NOW,
+            grace_margin=GRACE,
+        )
+        is None
+    )
+    assert (
+        _missed_receipt_candidate(
+            cycle,
+            last_receipt_at=None,
+            now=NOW + timedelta(days=1, minutes=31),
+            grace_margin=GRACE,
+        )
+        is not None
+    )
+
+
+async def test_recovery_releases_latch_and_later_silence_realerts():
+    latch = _FakeLatch()
+    deliveries = []
+    silent = True
+    candidate = CycleSilenceCandidate(
+        cycle_id=41,
+        name="Weekday AWS check",
+        binding=PERSONAL_AGENT_EXECUTOR_BINDING,
+        expected_at=NOW - timedelta(hours=1),
+        last_receipt_at=NOW - timedelta(hours=3),
+        grace_margin=GRACE,
+    )
+
+    async def policy(_session):
+        return CycleSilencePolicy(grace_margin=GRACE)
+
+    async def candidates(_session, *, now, grace_margin):
+        del now, grace_margin
+        return CycleSilenceObservation(
+            candidates=(candidate,) if silent else (),
+            latched_cycle_ids=frozenset(latch.cycle_ids),
+        )
+
+    async def deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    monitor = CycleSilenceMonitor(
+        policy_provider=policy,
+        candidate_provider=candidates,
+        claim_alert=latch.claim,
+        release_alert=latch.release,
+        deliver_alert=deliver,
+    )
+
+    first = await monitor._check(Mock(), now=NOW)
+    repeated = await monitor._check(Mock(), now=NOW + timedelta(minutes=5))
+    silent = False
+    recovered = await monitor._check(Mock(), now=NOW + timedelta(minutes=10))
+    silent = True
+    later = await monitor._check(Mock(), now=NOW + timedelta(hours=3))
+
+    assert first.alerted_cycle_ids == (41,)
+    assert repeated.alerted_cycle_ids == ()
+    assert recovered.overdue_cycle_ids == ()
+    assert later.alerted_cycle_ids == (41,)
+    assert len(deliveries) == 2
+
+
+async def test_failed_delivery_releases_latch_for_the_next_tick():
+    latch = _FakeLatch()
+    attempts = 0
+    candidate = CycleSilenceCandidate(
+        cycle_id=41,
+        name="Weekday AWS check",
+        binding=PERSONAL_AGENT_EXECUTOR_BINDING,
+        expected_at=NOW - timedelta(hours=1),
+        last_receipt_at=NOW - timedelta(hours=3),
+        grace_margin=GRACE,
+    )
+
+    async def policy(_session):
+        return CycleSilencePolicy(grace_margin=GRACE)
+
+    async def candidates(_session, *, now, grace_margin):
+        del now, grace_margin
+        return CycleSilenceObservation(
+            candidates=(candidate,),
+            latched_cycle_ids=frozenset(latch.cycle_ids),
+        )
+
+    async def deliver(**_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("Slack unavailable")
+
+    monitor = CycleSilenceMonitor(
+        policy_provider=policy,
+        candidate_provider=candidates,
+        claim_alert=latch.claim,
+        release_alert=latch.release,
+        deliver_alert=deliver,
+    )
+
+    first = await monitor._check(Mock(), now=NOW)
+    retry = await monitor._check(Mock(), now=NOW + timedelta(minutes=5))
+
+    assert first.alerted_cycle_ids == ()
+    assert retry.alerted_cycle_ids == (41,)
+    assert attempts == 2
+
+
+async def test_database_latch_claim_is_atomic_and_rearms(silence_session):
+    cycle = _cycle(binding=ILLO_LANE_EXECUTOR_BINDING)
+    silence_session.add(cycle)
+    await silence_session.flush()
+
+    first = await async_try_claim_cycle_alert_latch(
+        silence_session,
+        cycle_id=cycle.id,
+        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        alerted_at=NOW,
+    )
+    repeated = await async_try_claim_cycle_alert_latch(
+        silence_session,
+        cycle_id=cycle.id,
+        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        alerted_at=NOW + timedelta(minutes=5),
+    )
+    await async_release_cycle_alert_latch(
+        silence_session,
+        cycle_id=cycle.id,
+        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+    )
+    rearmed = await async_try_claim_cycle_alert_latch(
+        silence_session,
+        cycle_id=cycle.id,
+        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        alerted_at=NOW + timedelta(hours=3),
+    )
+
+    assert first is True
+    assert repeated is False
+    assert rearmed is True
+
+
+async def test_grace_margin_loads_from_runtime_state_without_a_deploy(
+    silence_session,
+):
+    silence_session.add(
+        VaultConfig(
+            key=CYCLE_SILENCE_RUNTIME_SETTINGS_KEY,
+            value=json.dumps({"grace_minutes": 90}),
+        )
+    )
+    await silence_session.flush()
+
+    policy = await async_cycle_silence_policy(silence_session)
+
+    assert policy.grace_margin == timedelta(minutes=90)
+
+
+def test_receipt_monitoring_migration_stacks_on_schedule_bindings(monkeypatch):
+    migration = importlib.import_module(MIGRATION_MODULE)
+    operations = Mock()
+    monkeypatch.setattr(migration, "op", operations)
+    monkeypatch.setattr(migration, "_column_names", lambda: set())
+
+    migration.upgrade()
+
+    assert migration.revision == "0064_cycle_receipt_monitoring"
+    assert migration.down_revision == "0063_cycle_schedule_bindings"
+    column = operations.add_column.call_args.args[1]
+    assert column.name == "receipt_monitoring_started_at"
+    assert column.nullable is False
+
+
+def test_exact_cron_boundary_is_included_in_latest_slot():
+    boundary = datetime(2026, 8, 17, 9, 0, tzinfo=timezone.utc)
+
+    assert compute_latest_run_at(
+        "0 9 * * *",
+        "UTC",
+        at_or_before=boundary,
+    ) == boundary

--- a/tests/test_cycle_silence_monitor.py
+++ b/tests/test_cycle_silence_monitor.py
@@ -14,27 +14,29 @@ from brain.platform.db.models.cycle import (
     CycleRun,
 )
 from brain.platform.db.models.vault import VaultConfig
+from brain.platform.db.repositories.cycle_silence import CycleReceiptSnapshot
 from brain.systems.cycles.common import (
     ILLO_LANE_EXECUTOR_BINDING,
     PERSONAL_AGENT_EXECUTOR_BINDING,
 )
-from brain.systems.cycles.schedules import compute_latest_run_at
+from brain.systems.cycles.schedules import (
+    compute_latest_run_at,
+    compute_next_run_at,
+)
+from brain.systems.cycles.silence_alerts import async_deliver_cycle_silence_alert
 from brain.systems.cycles.silence_monitor import (
     CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
-    CycleSilenceCandidate,
     CycleSilenceMonitor,
     CycleSilenceObservation,
-    _missed_receipt_candidate,
 )
 from brain.systems.cycles.silence_policy import (
     CYCLE_SILENCE_RUNTIME_SETTINGS_KEY,
+    CycleSilenceCandidate,
     CycleSilencePolicy,
     async_cycle_silence_policy,
+    evaluate_cycle_silence_candidate,
 )
-from brain.systems.failure_guard.cycle_latches import (
-    async_release_cycle_alert_latch,
-    async_try_claim_cycle_alert_latch,
-)
+from brain.systems.failure_guard.cycle_latches import CycleAlertLatchStore
 
 
 NOW = datetime(2026, 8, 17, 13, 0, tzinfo=timezone.utc)
@@ -85,6 +87,29 @@ def _cycle(
     )
 
 
+def _silence_candidate(
+    cycle: Cycle,
+    *,
+    last_receipt_at: datetime | None,
+    now: datetime,
+    grace_margin: timedelta,
+) -> CycleSilenceCandidate | None:
+    return evaluate_cycle_silence_candidate(
+        CycleReceiptSnapshot(
+            cycle_id=cycle.id,
+            name=cycle.name,
+            executor_binding=cycle.executor_binding,
+            schedule_expr=cycle.schedule_expr,
+            timezone=cycle.timezone,
+            receipt_monitoring_started_at=cycle.receipt_monitoring_started_at,
+            created_at=cycle.created_at,
+            last_receipt_at=last_receipt_at,
+        ),
+        now=now,
+        grace_margin=grace_margin,
+    )
+
+
 class _FakeLatch:
     def __init__(self) -> None:
         self.cycle_ids: set[int] = set()
@@ -132,8 +157,14 @@ async def test_day_old_receipt_alert_names_schedule_binding_and_times(
     latch = _FakeLatch()
     deliveries = []
 
-    async def deliver(**kwargs):
+    async def capture_delivery(**kwargs):
         deliveries.append(kwargs)
+
+    async def deliver(candidate):
+        await async_deliver_cycle_silence_alert(
+            candidate,
+            deliver_alert=capture_delivery,
+        )
 
     monitor = CycleSilenceMonitor(
         claim_alert=latch.claim,
@@ -179,7 +210,7 @@ def test_weekday_every_two_hour_schedule_stays_quiet_all_week_when_healthy():
         )
         if latest_due is not None and latest_due >= cycle.receipt_monitoring_started_at:
             last_receipt_at = latest_due + timedelta(minutes=5)
-        candidate = _missed_receipt_candidate(
+        candidate = _silence_candidate(
             cycle,
             last_receipt_at=last_receipt_at,
             now=now,
@@ -205,7 +236,7 @@ def test_weekend_pause_does_not_treat_elapsed_wall_time_as_the_cadence():
             hours=hour
         )
         assert (
-            _missed_receipt_candidate(
+            _silence_candidate(
                 cycle,
                 last_receipt_at=friday_receipt,
                 now=weekend_now,
@@ -215,7 +246,7 @@ def test_weekend_pause_does_not_treat_elapsed_wall_time_as_the_cadence():
         )
 
     monday_late = datetime(2026, 8, 17, 4, 31, tzinfo=timezone.utc)
-    candidate = _missed_receipt_candidate(
+    candidate = _silence_candidate(
         cycle,
         last_receipt_at=friday_receipt,
         now=monday_late,
@@ -234,7 +265,7 @@ def test_long_cadence_does_not_alert_before_the_next_real_slot():
     august_receipt = datetime(2026, 8, 1, 9, 5, tzinfo=timezone.utc)
 
     assert (
-        _missed_receipt_candidate(
+        _silence_candidate(
             cycle,
             last_receipt_at=august_receipt,
             now=datetime(2026, 8, 31, 23, 59, tzinfo=timezone.utc),
@@ -243,7 +274,7 @@ def test_long_cadence_does_not_alert_before_the_next_real_slot():
         is None
     )
     assert (
-        _missed_receipt_candidate(
+        _silence_candidate(
             cycle,
             last_receipt_at=august_receipt,
             now=datetime(2026, 9, 1, 9, 31, tzinfo=timezone.utc),
@@ -260,7 +291,7 @@ def test_new_schedule_waits_for_its_first_post_creation_slot():
     )
 
     assert (
-        _missed_receipt_candidate(
+        _silence_candidate(
             cycle,
             last_receipt_at=None,
             now=NOW,
@@ -269,7 +300,7 @@ def test_new_schedule_waits_for_its_first_post_creation_slot():
         is None
     )
     assert (
-        _missed_receipt_candidate(
+        _silence_candidate(
             cycle,
             last_receipt_at=None,
             now=NOW + timedelta(days=1, minutes=31),
@@ -302,8 +333,8 @@ async def test_recovery_releases_latch_and_later_silence_realerts():
             latched_cycle_ids=frozenset(latch.cycle_ids),
         )
 
-    async def deliver(**kwargs):
-        deliveries.append(kwargs)
+    async def deliver(candidate):
+        deliveries.append(candidate)
 
     monitor = CycleSilenceMonitor(
         policy_provider=policy,
@@ -349,7 +380,7 @@ async def test_failed_delivery_releases_latch_for_the_next_tick():
             latched_cycle_ids=frozenset(latch.cycle_ids),
         )
 
-    async def deliver(**_kwargs):
+    async def deliver(_candidate):
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -376,32 +407,40 @@ async def test_database_latch_claim_is_atomic_and_rearms(silence_session):
     silence_session.add(cycle)
     await silence_session.flush()
 
-    first = await async_try_claim_cycle_alert_latch(
-        silence_session,
-        cycle_id=cycle.id,
-        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
-        alerted_at=NOW,
+    store = CycleAlertLatchStore(session=silence_session, cycle_id=cycle.id)
+    first = await store.try_claim_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        NOW,
     )
-    repeated = await async_try_claim_cycle_alert_latch(
-        silence_session,
-        cycle_id=cycle.id,
-        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+    repeated = await store.try_claim_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        NOW + timedelta(minutes=5),
+    )
+    await store.release_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
         alerted_at=NOW + timedelta(minutes=5),
     )
-    await async_release_cycle_alert_latch(
-        silence_session,
-        cycle_id=cycle.id,
-        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+    fenced = await store.try_claim_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        NOW + timedelta(minutes=10),
     )
-    rearmed = await async_try_claim_cycle_alert_latch(
+    latched_cycle_ids = await CycleAlertLatchStore.load_cycle_ids_for_trigger(
         silence_session,
-        cycle_id=cycle.id,
-        trigger_kind=CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
-        alerted_at=NOW + timedelta(hours=3),
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+    )
+    await store.release_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        alerted_at=NOW,
+    )
+    rearmed = await store.try_claim_latch(
+        CYCLE_MISSED_RECEIPT_TRIGGER_KIND,
+        NOW + timedelta(hours=3),
     )
 
     assert first is True
     assert repeated is False
+    assert fenced is False
+    assert latched_cycle_ids == frozenset({cycle.id})
     assert rearmed is True
 
 
@@ -444,3 +483,22 @@ def test_exact_cron_boundary_is_included_in_latest_slot():
         "UTC",
         at_or_before=boundary,
     ) == boundary
+
+
+def test_forward_and_backward_slots_agree_across_dst_transition():
+    before_spring_forward = datetime(2026, 3, 7, 14, 0, tzinfo=timezone.utc)
+    after_spring_forward = datetime(2026, 3, 8, 13, 0, tzinfo=timezone.utc)
+
+    next_slot = compute_next_run_at(
+        "0 9 * * *",
+        "America/Toronto",
+        from_dt=before_spring_forward,
+    )
+    latest_slot = compute_latest_run_at(
+        "0 9 * * *",
+        "America/Toronto",
+        at_or_before=after_spring_forward,
+    )
+
+    assert next_slot == after_spring_forward
+    assert latest_slot == next_slot


### PR DESCRIPTION
> *This was generated by AI during triage.*

Closes #820

Detects when a Cycle schedule misses its expected receipt window and alerts Slack `#alerts`. **Detection only — no failover**, per the ticket.

## Was stacked on [#836](https://github.com/Illospace/illospace/pull/836), now retargeted to `main`

#820 declares *"Blocked by the schedule-object ticket (expected cadence must live on the schedule row)"* — it builds directly on #818's `executor_binding` and cadence columns. #836 carried those and **merged at 16:11Z as a merge commit**, deliberately not a squash, so this branch's ancestry stayed intact rather than conflicting across every file its parent touched.

Verified after that merge: `git merge-base --is-ancestor` confirms the parent's tip is on `main`, and this PR's net diff against `main` is only its own 1,259 lines.

## The design decision that matters

A schedule is silent when it has **no receipt for the latest cron slot at or before now**, plus a grace margin — *not* when elapsed wall-clock time exceeds the cadence.

That distinction is the whole ticket. An elapsed-time rule would page every Monday morning for every weekday-only schedule, which is the false-positive failure the ticket calls out.

## Verification

**Fast suite: `5035 passed, 11 skipped, 0 failed`** — the repo's own CI command, run serially with no other workers. `alembic heads` prints exactly one: `0064_cycle_receipt_monitoring`, stacked on `0063`. No `frontend/**` path, so that lane is not selected.

The three acceptance checks are pinned by tests, not by inspection:

| ticket acceptance | test |
|---|---|
| disabled stub for a day → alert names schedule and last receipt | `test_day_old_receipt_alert_names_schedule_binding_and_times` |
| normal cadence → **zero** false positives, weekday-only crons respected | `test_weekday_every_two_hour_schedule_stays_quiet_all_week_when_healthy` — simulates a full week at 5-minute resolution, asserts zero alerts |
| weekend pause is not treated as silence | `test_weekend_pause_does_not_treat_elapsed_wall_time_as_the_cadence` — walks 48 weekend hours asserting silence, then asserts the Monday 04:00Z slot *does* alert |
| alert carries name, binding, expected vs last-seen | same test as row 1 |

Also pinned: latch dedup and re-arm, failed-delivery release, grace margin loading from runtime state, and forward/backward slot agreement across a Toronto spring-forward.

## What a reviewer should drive

No UI. On the local stack or staging:

1. **Disable a personal-agent stub for longer than its cadence + grace.** One alert in `#alerts` naming the schedule, its binding, and expected vs last-seen times.
2. **Leave a healthy weekday schedule alone over a weekend.** Silence — this is the one that used to be easy to get wrong.
3. **Let it stay silent.** It must not re-alert every tick; the latch holds until recovery.
4. **Tune the grace margin** via runtime settings (`runtime_cycle_silence`, `grace_minutes`) and confirm it takes effect **without a deploy**.

## Review folded in

A cross-family maintainability review returned **BLOCKING** on three findings; all three are fixed in the second commit.

1. `silence_monitor.py` had several owners at 375 lines → split into a pure policy, a repository, a Slack adapter and orchestration (now 234).
2. **It reused the latch table while forking its persistence API** — free claim/release functions and direct model reads beside the canonical store. `CycleAlertLatchStore` now owns atomic claim, fenced release and trigger-wide lookup; the parallel path is deleted.
3. `compute_next_run_at` / `compute_latest_run_at` were two schedule engines that could drift on DST → both now share `_cron_iterator` and `_normalize_cron_result`, differing only in `get_next` vs `get_prev`.

## Two known notes, deliberately not fixed here

- **`brain/app/api/main.py:228` now holds a third copy of global task startup/shutdown logic.** It wants a small managed background-task owner before a fourth monitor extends the pattern. Wider than this ticket.
- **`tests/test_cycle_silence_monitor.py` mixes policy, migration, latch, schedule and orchestration tests.** Worth splitting by owner later.
