### PR TITLE
fix(inbound): a merged pull request must not read as closed

### DIFF
--- a/brain/systems/inbound/github_webhook.py
+++ b/brain/systems/inbound/github_webhook.py
@@ -95,20 +95,31 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
         source_updated_at = comment.get("updated_at") or source_updated_at
 
     merge_hints = {}
+    summary_action = action
     if event == "pull_request":
+        merged = subject.get("merged") is True
+        if merged:
+            pr_outcome = "merged"
+        elif state == "closed":
+            pr_outcome = "closed_unmerged"
+        else:
+            pr_outcome = "open"
         merge_hints = {
-            "merged": subject.get("merged") is True,
+            "merged": merged,
+            "pr_outcome": pr_outcome,
             "base_ref": (subject.get("base") or {}).get("ref"),
             "head_ref": (subject.get("head") or {}).get("ref"),
             "merge_commit_sha": subject.get("merge_commit_sha"),
             "merged_at": subject.get("merged_at"),
         }
+        if pr_outcome == "merged":
+            summary_action = "merged"
 
     where = f" #{number}" if number else ""
     summary = (
-        f"GitHub {noun}{where} {action}: {title}".strip()
+        f"GitHub {noun}{where} {summary_action}: {title}".strip()
         if title
-        else f"GitHub {noun}{where} {action}".strip()
+        else f"GitHub {noun}{where} {summary_action}".strip()
     )
 
     return {

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -361,14 +361,19 @@ a human action. This never-merge rule is absolute for staging→main.
 - `In Review`: non-draft PR is open and awaiting review, CI, or merge.
 - `Blocked`: failing CI, requested changes, unclear owner, missing info, or
   external dependency.
-- `Done`: linked PR merged or issue closed. For an alert-linked ticket (one
+- `Done`: a pull request with GitHub `merged == true`, or an issue with GitHub
+  `state == "closed"`. Never treat a merged pull request's raw closed state as
+  cancellation. For an alert-linked ticket (one
   with a `rollbar_item`), `Done` additionally requires the fix deployed to
   prod by current ancestry AND `verified=true` per **Deploy State on Read** —
   merged-to-staging is not done. A `Done` item must
   not appear in anyone's priority workset — see **Before Posting** and
   **Public Output**.
-- `Canceled` / `wontfix`: obsolete, duplicate, invalid, intentionally closed,
-  or not worth doing.
+- `Canceled` / `wontfix`: for a pull request, GitHub `state == "closed"` and
+  `merged` is not true; otherwise obsolete, duplicate, invalid, intentionally
+  closed, or not worth doing. Test `merged` for truth, never for `== false` —
+  a stored record can carry `merged: null` when the field was never read, and
+  an equality test silently drops that row on the floor.
 
 ## Identities
 

--- a/docs/329-live-delta.md
+++ b/docs/329-live-delta.md
@@ -41,9 +41,9 @@ Expected memory mirror fingerprint:
 Core record `1155`, slug `uwear-engineering-triage`, must become the exact
 mirror of `SKILL.md`:
 
-- characters: `31800` (must remain `< 34000`);
-- bytes: `31896`; and
-- SHA-256: `52fbb96829c54b6861ddbc37f49a21ae71088ff5a48b9076d22f11711729fa6f`.
+- characters: `32198` (must remain `< 34000`);
+- bytes: `32296`; and
+- SHA-256: `f9c4e66e28ba63416d55f2b1f30b01e674a3c1aabbc96c774807f9c330097efb`.
 
 ## Safety and idempotency
 

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -75,7 +75,7 @@ class TestEventToEnvelope:
         assert "Login is broken" in env["summary"]
         assert env["payload"] is payload  # full payload carried for the projection
 
-    def test_pull_request_closed(self):
+    def test_pull_request_merged(self):
         payload = {
             "action": "closed",
             "repository": {"full_name": "o/r"},
@@ -92,11 +92,73 @@ class TestEventToEnvelope:
         assert env["hints"]["state"] == "closed"
         assert env["hints"]["number"] == 7
         assert env["hints"]["merged"] is True
+        assert env["hints"]["pr_outcome"] == "merged"
         assert env["hints"]["base_ref"] == "main"
         assert env["hints"]["head_ref"] == "staging"
         assert env["hints"]["merge_commit_sha"] == "abc123"
         assert env["hints"]["merged_at"] == "2026-07-08T11:01:00Z"
+        assert env["hints"]["action"] == "closed"
+        assert env["summary"] == "GitHub pull request #7 merged: Add feature"
+        assert "closed" not in env["summary"]
         assert env["idempotency_key"] is None  # no delivery id
+
+    def test_pull_request_closed_unmerged(self):
+        payload = {
+            "action": "closed",
+            "repository": {"full_name": "o/r"},
+            "pull_request": {
+                "number": 8,
+                "title": "Drop feature",
+                "state": "closed",
+                "merged": False,
+                "merged_at": None,
+            },
+        }
+        env = github_event_to_envelope("pull_request", payload)
+        assert env["hints"]["action"] == "closed"
+        assert env["hints"]["state"] == "closed"
+        assert env["hints"]["merged"] is False
+        assert env["hints"]["merged_at"] is None
+        assert env["hints"]["pr_outcome"] == "closed_unmerged"
+        assert env["summary"] == "GitHub pull request #8 closed: Drop feature"
+
+    def test_pull_request_closed_without_merged_field(self):
+        # A stored/replayed payload can omit `merged` entirely. Absent must read
+        # as "not merged" rather than as merged, so the outcome stays truthful.
+        payload = {
+            "action": "closed",
+            "repository": {"full_name": "o/r"},
+            "pull_request": {
+                "number": 10,
+                "title": "Stale payload",
+                "state": "closed",
+            },
+        }
+        env = github_event_to_envelope("pull_request", payload)
+        assert env["hints"]["merged"] is False
+        assert env["hints"]["merged_at"] is None
+        assert env["hints"]["pr_outcome"] == "closed_unmerged"
+        assert env["summary"] == "GitHub pull request #10 closed: Stale payload"
+
+    def test_pull_request_opened(self):
+        payload = {
+            "action": "opened",
+            "repository": {"full_name": "o/r"},
+            "pull_request": {
+                "number": 9,
+                "title": "Try feature",
+                "state": "open",
+                "merged": False,
+                "merged_at": None,
+            },
+        }
+        env = github_event_to_envelope("pull_request", payload)
+        assert env["hints"]["action"] == "opened"
+        assert env["hints"]["state"] == "open"
+        assert env["hints"]["merged"] is False
+        assert env["hints"]["merged_at"] is None
+        assert env["hints"]["pr_outcome"] == "open"
+        assert env["summary"] == "GitHub pull request #9 opened: Try feature"
 
     def test_issue_comment_anchors_on_issue_keeps_comment_details(self):
         payload = {


### PR DESCRIPTION
Closes #838

## What was wrong

GitHub closes a pull request in two opposite cases that share one `state` value:

| outcome | `action` | `state` | `merged` |
|---|---|---|---|
| merged | `closed` | `closed` | `true` |
| abandoned | `closed` | `closed` | `false` |

`github_event_to_envelope` in `brain/systems/inbound/github_webhook.py` carried
`merged` in `hints`, but it built the human-readable `summary` from `action`
alone. So a merged pull request produced:

> GitHub pull request #1267 **closed**: <title>

`brain/systems/inbound/service.py` hands that summary to the handler. "Closed"
was the only outcome word in the line a reader actually reads, and merged work
was recorded as `Canceled` — the inverse of what happened. Four `uwearaiapp`
PRs were written that way on 2026-08-17.

The ambiguity was untested: `test_pull_request_closed` fed `merged: True` and
asserted only on `hints`, never on the summary.

## What this changes

- **The summary tells the truth.** A merged PR now reads
  "GitHub pull request #7 merged: Add feature". A PR closed without merging is
  unchanged.
- **One explicit field instead of a two-field rule.** New hint `pr_outcome`
  with values `merged` / `closed_unmerged` / `open`, so a reader routes on the
  answer rather than re-deriving it.
- **`hints.action` keeps GitHub's raw wire value** (`closed`), along with
  `state`, `merged`, `merged_at`, `merge_commit_sha`. Other systems read those;
  nothing existing changed spelling or value.
- **The triage skill states the mapping** with field names, and says to test
  `merged` for truth rather than `== false`.
- `docs/329-live-delta.md` re-mirrors the SKILL.md fingerprint, which
  `tests/test_builtin_skill_suite.py` asserts byte-for-byte.

## Why `merged` is tested for truth, not for `== false`

Live tracker record 4912 (`uwear-ai/uwear-backend` PR #1765) holds
`merged: null`, `state: "open"`, `status: "Canceled"`. GitHub's truth for that
PR is `state=CLOSED`, `mergedAt=null`, closed 2026-08-14T16:47:06Z — so the
`Canceled` verdict is right and the two fields under it are stale.

That is the same class of bug seen from the other side: **`merged` can be
absent, not merely wrong.** A mapping written as `merged == false` silently
drops those rows. Hence the truthiness test, and a case covering a payload with
`merged` missing entirely.

Note this also corrects the issue body, which cites 4912 as holding
`merged: false`. It does not.

## The four rows named in the issue are already fixed

Read live at 2026-08-17T20:5xZ: records 4979 / 5012 / 5013 / 5053 all carry
`status: Done`, `state: "merged"`, `merged: true`, updated 18:56:52Z. The
correcting submission in the issue's Provenance section landed. **This PR is
the prevention half only** — it changes no data.

## How to check it

No UI. The change is one function plus its contract, so the surface is a
console.

**Locally, in ~10 seconds** — this is the whole behaviour:

```
venv/bin/python -c "
from brain.systems.inbound.github_webhook import github_event_to_envelope as f
merged = {'action':'closed','repository':{'full_name':'o/r'},'pull_request':{'number':1,'title':'T','state':'closed','merged':True}}
killed = {'action':'closed','repository':{'full_name':'o/r'},'pull_request':{'number':2,'title':'T','state':'closed','merged':False}}
for p in (merged, killed):
    e=f('pull_request',p); print(e['summary'],'|',e['hints']['pr_outcome'],'| action=',e['hints']['action'])
"
```

Expected:

```
GitHub pull request #1 merged: T | merged | action= closed
GitHub pull request #2 closed: T | closed_unmerged | action= closed
```

**End to end**, once merged: merge any PR in a synced repo, wait for the sync,
and read the `pull_request` record — `status` should be `Done`, not `Canceled`.

### Acceptance checks

1. A merged PR's summary contains "merged" and does not contain "closed".
2. A PR closed without merging still reads "closed", with
   `pr_outcome == "closed_unmerged"`.
3. `hints.action` is still GitHub's raw `closed` in both cases — no downstream
   reader of the wire value breaks.
4. A payload with `merged` absent is treated as not merged, never as merged.

## Verification

Ran the repo's own backend CI lane serially at load 3.76, not a subset picked
from the diff:

- `python -m brain.jobs.check_cycle_context_admission` → `ok: true`, 3 cycles passed
- `python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q`
  → **5038 passed, 11 skipped, 90 deselected, 0 failed** in 77s

The frontend lane is not selected: the diff touches no `frontend/**`.

The first gate run failed one test —
`test_uwear_triage_memory_delta_fingerprints_exact_bundle_mirrors` — caused by
this diff's own SKILL.md edit rather than by load. Fixed by re-mirroring the
fingerprint doc; the re-run above is the post-fix result.

## Assumptions

- `pr_outcome` is a new hint, so no existing consumer reads it yet. It is
  additive; the fix does not depend on anything adopting it.
- The prose edit in the triage bundle is in scope because the issue's failure
  was an agent reading a surface, not a hard-coded string. No repo code mapped
  a PR to the literal `Canceled` — `git grep -nE '"Canceled"' origin/main -- 'brain/**'`
  returns exactly one hit, a `run.canceled` run-event label in
  `_idea_ops.py:335`, unrelated to GitHub.

## Code-quality review (Codex, cross-family)

`VERDICT: APPROVE_WITH_NOTES`, no blocking findings. Its calls on the design
questions I put to it:

- **Keep `pr_outcome`** — the envelope is the right normalization boundary, and
  one semantic field stops each reader rebuilding the `merged`/`state` rule.
  Reach for a typed helper only if a second producer appears.
- **`summary_action`** cleanly separates the display value from GitHub's raw
  `action`; no restructuring of this 146-line module warranted now.
- **The prose belongs in the skill** — operational policy for the agent, while
  the code owns event normalization; the fingerprint update is the existing
  exact-mirror contract doing its job.

Its one open note: `pr_outcome` has no named Python consumer yet — inbound
hints are rendered for the agent — so do not add a second derivation of the
same rule elsewhere. Its other note, that it could not start the focused tests,
is about the reviewer's own environment (no SQLAlchemy on its default
interpreter); the full lane above ran green on the repo venv.
