### PR TITLE
refactor(cycles): one shared clause for due illo-lane cycles

### DIFF
--- a/brain/app/ops/runtime_status.py
+++ b/brain/app/ops/runtime_status.py
@@ -14,7 +14,7 @@ from brain.app.scheduler.daemon import async_scheduler_health_snapshot
 from brain.app.scheduler.stale_run_reaper import agent_run_maintenance_snapshot
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.cycle import Cycle
-from brain.systems.cycles.common import due_illo_lane_cycle_clause
+from brain.systems.cycles.queries import due_illo_lane_cycle_clause
 from brain.systems.runs.cortex.queue_health import (
     QueueHealth,
     queued_backlog_health_snapshot_async,

--- a/brain/app/ops/runtime_status.py
+++ b/brain/app/ops/runtime_status.py
@@ -14,7 +14,7 @@ from brain.app.scheduler.daemon import async_scheduler_health_snapshot
 from brain.app.scheduler.stale_run_reaper import agent_run_maintenance_snapshot
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.cycle import Cycle
-from brain.systems.cycles.common import ILLO_LANE_EXECUTOR_BINDING
+from brain.systems.cycles.common import due_illo_lane_cycle_clause
 from brain.systems.runs.cortex.queue_health import (
     QueueHealth,
     queued_backlog_health_snapshot_async,
@@ -254,36 +254,20 @@ async def async_runtime_status_snapshot(
         await session.scalar(
             select(func.count())
             .select_from(Cycle)
-            .where(
-                Cycle.enabled.is_(True),
-                Cycle.deleted_at.is_(None),
-                Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-                Cycle.next_run_at.is_not(None),
-                Cycle.next_run_at < captured_at,
-            )
+            .where(due_illo_lane_cycle_clause(captured_at, inclusive=False))
         )
         or 0
     )
     oldest_overdue_cycle_at = await session.scalar(
         select(func.min(Cycle.next_run_at)).where(
-            Cycle.enabled.is_(True),
-            Cycle.deleted_at.is_(None),
-            Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-            Cycle.next_run_at.is_not(None),
-            Cycle.next_run_at < captured_at,
+            due_illo_lane_cycle_clause(captured_at, inclusive=False)
         )
     )
     overdue_cycles = list(
         (
             await session.scalars(
                 select(Cycle)
-                .where(
-                    Cycle.enabled.is_(True),
-                    Cycle.deleted_at.is_(None),
-                    Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-                    Cycle.next_run_at.is_not(None),
-                    Cycle.next_run_at < captured_at,
-                )
+                .where(due_illo_lane_cycle_clause(captured_at, inclusive=False))
                 .order_by(Cycle.next_run_at.asc())
                 .limit(20)
             )

--- a/brain/systems/cycles/common.py
+++ b/brain/systems/cycles/common.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from sqlalchemy import and_
+from sqlalchemy.sql.elements import ColumnElement
+
+from brain.platform.db.models.cycle import Cycle
 from brain.platform.providers.model_policy import (
     EFFORT_TIER_SET,
     PROVIDER_MODEL_OPTIONS,
@@ -69,6 +73,22 @@ def validate_executor_binding(value: str | None) -> str:
 def cycle_executor_binding(cycle) -> str:
     return validate_executor_binding(
         getattr(cycle, "executor_binding", None) or ILLO_LANE_EXECUTOR_BINDING
+    )
+
+
+def due_illo_lane_cycle_clause(
+    cutoff: datetime, *, inclusive: bool
+) -> ColumnElement[bool]:
+    """Select enabled, scheduled illo-lane cycles due by ``cutoff``."""
+    next_run_at_clause = (
+        Cycle.next_run_at <= cutoff if inclusive else Cycle.next_run_at < cutoff
+    )
+    return and_(
+        Cycle.deleted_at.is_(None),
+        Cycle.enabled.is_(True),
+        Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
+        Cycle.next_run_at.is_not(None),
+        next_run_at_clause,
     )
 
 

--- a/brain/systems/cycles/common.py
+++ b/brain/systems/cycles/common.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import and_
-from sqlalchemy.sql.elements import ColumnElement
-
-from brain.platform.db.models.cycle import Cycle
 from brain.platform.providers.model_policy import (
     EFFORT_TIER_SET,
     PROVIDER_MODEL_OPTIONS,
@@ -73,22 +69,6 @@ def validate_executor_binding(value: str | None) -> str:
 def cycle_executor_binding(cycle) -> str:
     return validate_executor_binding(
         getattr(cycle, "executor_binding", None) or ILLO_LANE_EXECUTOR_BINDING
-    )
-
-
-def due_illo_lane_cycle_clause(
-    cutoff: datetime, *, inclusive: bool
-) -> ColumnElement[bool]:
-    """Select enabled, scheduled illo-lane cycles due by ``cutoff``."""
-    next_run_at_clause = (
-        Cycle.next_run_at <= cutoff if inclusive else Cycle.next_run_at < cutoff
-    )
-    return and_(
-        Cycle.deleted_at.is_(None),
-        Cycle.enabled.is_(True),
-        Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-        Cycle.next_run_at.is_not(None),
-        next_run_at_clause,
     )
 
 

--- a/brain/systems/cycles/health.py
+++ b/brain/systems/cycles/health.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import Cycle, CycleRun
-from brain.systems.cycles.common import due_illo_lane_cycle_clause
+from brain.systems.cycles.queries import due_illo_lane_cycle_clause
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUS_VALUES
 
 

--- a/brain/systems/cycles/health.py
+++ b/brain/systems/cycles/health.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.common.time import assume_utc_optional
 from brain.platform.db.models.cycle import Cycle, CycleRun
-from brain.systems.cycles.common import ILLO_LANE_EXECUTOR_BINDING
+from brain.systems.cycles.common import due_illo_lane_cycle_clause
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUS_VALUES
 
 
@@ -68,21 +68,16 @@ async def async_legacy_cycle_backlog_snapshot(
 ) -> LegacyCycleBacklogSnapshot:
     now = now or _utc_now()
     stale_cutoff = now - timedelta(minutes=stale_after_minutes)
-    due_cycle_clause = and_(
-        Cycle.deleted_at.is_(None),
-        Cycle.enabled.is_(True),
-        Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-        Cycle.next_run_at.is_not(None),
-        Cycle.next_run_at <= stale_cutoff,
-    )
     due_cycle_count = await session.scalar(
-        select(func.count()).select_from(Cycle).where(due_cycle_clause)
+        select(func.count())
+        .select_from(Cycle)
+        .where(due_illo_lane_cycle_clause(stale_cutoff, inclusive=True))
     ) or 0
     stale_due_cycles = list(
         (
             await session.scalars(
                 select(Cycle)
-                .where(due_cycle_clause)
+                .where(due_illo_lane_cycle_clause(stale_cutoff, inclusive=True))
                 .order_by(Cycle.next_run_at.asc())
                 .limit(sample_limit)
             )

--- a/brain/systems/cycles/queries.py
+++ b/brain/systems/cycles/queries.py
@@ -1,0 +1,36 @@
+"""Shared SQL clauses for selecting Cycle rows.
+
+Kept out of ``common.py`` on purpose: that module holds constants and pure value
+helpers and is imported by contract and schema modules that must not inherit an
+ORM dependency.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import and_
+from sqlalchemy.sql.elements import ColumnElement
+
+from brain.platform.db.models.cycle import Cycle
+from brain.systems.cycles.common import ILLO_LANE_EXECUTOR_BINDING
+
+
+def due_illo_lane_cycle_clause(
+    cutoff: datetime, *, inclusive: bool
+) -> ColumnElement[bool]:
+    """Select enabled, scheduled illo-lane cycles due at ``cutoff``.
+
+    ``inclusive=True`` compares ``next_run_at <= cutoff``; ``inclusive=False``
+    compares ``next_run_at < cutoff``. Callers differ on this boundary and the
+    difference is deliberate, so it is always passed explicitly.
+    """
+    next_run_at_clause = (
+        Cycle.next_run_at <= cutoff if inclusive else Cycle.next_run_at < cutoff
+    )
+    return and_(
+        Cycle.deleted_at.is_(None),
+        Cycle.enabled.is_(True),
+        Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
+        Cycle.next_run_at.is_not(None),
+        next_run_at_clause,
+    )

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -44,6 +44,7 @@ from brain.systems.cycles.common import (
     canonical_execution_mode,
     cycle_executor_binding,
     cycle_run_launch_context,
+    due_illo_lane_cycle_clause,
     json_dict,
     short_identifier,
     validate_nonempty_trimmed,
@@ -660,13 +661,7 @@ async def _async_materialize_due_cycle_runs_once(
     async with UnitOfWork() as uow:
         stmt = (
             select(Cycle)
-            .where(
-                Cycle.deleted_at.is_(None),
-                Cycle.enabled.is_(True),
-                Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-                Cycle.next_run_at.is_not(None),
-                Cycle.next_run_at <= now,
-            )
+            .where(due_illo_lane_cycle_clause(now, inclusive=True))
             .order_by(Cycle.next_run_at.asc())
             .limit(limit)
             .with_for_update(skip_locked=True)
@@ -747,13 +742,7 @@ async def async_advance_cycle_schedule_past_gap(
     cycles = (
         await session.scalars(
             select(Cycle)
-            .where(
-                Cycle.deleted_at.is_(None),
-                Cycle.enabled.is_(True),
-                Cycle.executor_binding == ILLO_LANE_EXECUTOR_BINDING,
-                Cycle.next_run_at.is_not(None),
-                Cycle.next_run_at < catch_up_before,
-            )
+            .where(due_illo_lane_cycle_clause(catch_up_before, inclusive=False))
             .order_by(Cycle.next_run_at.asc(), Cycle.id.asc())
             .with_for_update()
         )

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -44,12 +44,12 @@ from brain.systems.cycles.common import (
     canonical_execution_mode,
     cycle_executor_binding,
     cycle_run_launch_context,
-    due_illo_lane_cycle_clause,
     json_dict,
     short_identifier,
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
+from brain.systems.cycles.queries import due_illo_lane_cycle_clause
 from brain.systems.cycles.contracts import normalize_cycle_run_kind
 from brain.systems.cycles.contract_gate import (
     async_prepare_cycle_run_visible_finalization,

--- a/tests/test_cycle_schedule_object.py
+++ b/tests/test_cycle_schedule_object.py
@@ -19,10 +19,8 @@ from brain.platform.db.models.cycle import (
 from brain.systems.cycles import commands, health as cycle_health
 from brain.systems.cycles import prompts, service, skill_refs
 from brain.systems.cycles.access import CycleActor
-from brain.systems.cycles.common import (
-    MANUAL_CYCLE_ORIGIN,
-    due_illo_lane_cycle_clause,
-)
+from brain.systems.cycles.common import MANUAL_CYCLE_ORIGIN
+from brain.systems.cycles.queries import due_illo_lane_cycle_clause
 from brain.systems.runs.execution_context import bind_agent_context
 from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
 

--- a/tests/test_cycle_schedule_object.py
+++ b/tests/test_cycle_schedule_object.py
@@ -19,7 +19,10 @@ from brain.platform.db.models.cycle import (
 from brain.systems.cycles import commands, health as cycle_health
 from brain.systems.cycles import prompts, service, skill_refs
 from brain.systems.cycles.access import CycleActor
-from brain.systems.cycles.common import MANUAL_CYCLE_ORIGIN
+from brain.systems.cycles.common import (
+    MANUAL_CYCLE_ORIGIN,
+    due_illo_lane_cycle_clause,
+)
 from brain.systems.runs.execution_context import bind_agent_context
 from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
 
@@ -126,6 +129,32 @@ def _schedule(*, binding: str, next_run_at: datetime) -> Cycle:
         skill_ids=[17] if binding == "personal-agent" else [],
         next_run_at=next_run_at,
     )
+
+
+@pytest.mark.asyncio
+async def test_due_illo_lane_cycle_clause_preserves_cutoff_boundary(schedule_session):
+    cutoff = datetime.now(timezone.utc).replace(microsecond=0)
+    cycle = _schedule(binding="illo-lane", next_run_at=cutoff)
+    schedule_session.add(cycle)
+    await schedule_session.flush()
+
+    strict_ids = (
+        await schedule_session.scalars(
+            select(Cycle.id).where(
+                due_illo_lane_cycle_clause(cutoff, inclusive=False)
+            )
+        )
+    ).all()
+    inclusive_ids = (
+        await schedule_session.scalars(
+            select(Cycle.id).where(
+                due_illo_lane_cycle_clause(cutoff, inclusive=True)
+            )
+        )
+    ).all()
+
+    assert strict_ids == []
+    assert inclusive_ids == [cycle.id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #840

## What this does

The "due illo-lane cycle" filter was five predicates written out **six times** across three modules. This replaces all six with one shared clause helper. No behaviour changes.

Each call site keeps the operator it has today. The helper takes an explicit `inclusive` flag, so the boundary is now visible at the call site instead of buried in a repeated block:

| site | operator | call |
|---|---|---|
| `runtime_status.py` (3 sites) | `<` | `inclusive=False` |
| `health.py` | `<=` | `inclusive=True` |
| `service.py` claim path | `<=` | `inclusive=True` |
| `service.py` catch-up sweep | `<` | `inclusive=False` |

The pre-existing boundary inconsistency the ticket describes (ops counts overdue with `<`, the scheduler claims with `<=`) is **preserved exactly**, not resolved. It is now one readable argument, so a later ticket can decide it deliberately.

## One deviation from the ticket, on purpose

The ticket asks for the helper in `brain/systems/cycles/common.py`. It went into a new `brain/systems/cycles/queries.py` instead.

A Codex quality review blocked the `common.py` placement: that module holds constants and pure value helpers, and **20 modules import it** — including `app/api/schemas/cycles.py` and `behavior_policy_contract.py`. Adding SQLAlchemy and `Cycle` imports there would make every pure schema and contract consumer inherit an ORM dependency. `common.py` now imports no SQLAlchemy at all.

The ticket's intent — one shared helper, no inline copies — is met. Only its named file changed.

## Acceptance, verified

- **No module writes the five predicates inline.** The only remaining `executor_binding == ILLO_LANE_EXECUTOR_BINDING` sites are the helper itself and `service.py:818`, the wake-by-name filter the ticket explicitly scopes out (it has no `next_run_at` predicate).
- **Every operator preserved** — table above.
- **Claim path locking unchanged**: `with_for_update(skip_locked=True)`, ordering and limit all intact at `service.py:667`.
- **Boundary test added and passing**: a cycle whose `next_run_at` equals the cutoff is excluded by the strict form and included by the inclusive form.
- **Backend suite green**: `5036 passed, 11 skipped, 90 deselected in 107.39s`, run serially at load 9.3 with no other suite running. The diff selects the backend lane only (`brain/**`, `tests/**`); the frontend lane is not triggered. The CI pre-step `check_cycle_context_admission` also passes.

## What to eyeball

This is a pure refactor with no UI surface. The thing worth a look is the operator table above — it is the one thing this change could have broken silently, and it is the reason the boundary test exists.

Two non-blocking notes from the review, left as-is:
- `is_not(None)` in the helper is redundant (either comparison already excludes NULL), kept because it documents scheduled eligibility.
- `service.py:818` correctly stays inline — it selects a *wakeable* cycle, not a *due* one.
