### PR TITLE
docs: fix two stale module docstrings from the illo-lifecycle build

### DIFF
--- a/brain/app/api/routers/github_webhooks.py
+++ b/brain/app/api/routers/github_webhooks.py
@@ -15,10 +15,11 @@ Config (env):
                                    ingestion authority; Slice 3 assignment then
                                    re-routes ownership (business/product → Reda).
 
-Activation is a deliberate step: register with
-``app.include_router(github_webhooks.router)`` once the GitHub App (PR #265) is
-live and the two env vars are set. It is intentionally NOT auto-registered so it
-cannot affect app startup before then.
+This router is always mounted: ``brain/app/api/main.py`` registers it at app
+startup (#279). Configuration is enforced per request, not at import or mount
+time — until BOTH env vars above are set (and the configured connection row
+exists), ``POST /webhooks/github`` answers HTTP 503, so mounting before the
+GitHub App is configured is inert and cannot affect app startup.
 """
 
 from __future__ import annotations

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -6,9 +6,18 @@ here we only read ``domain_events`` since the last run, count the unclaimed pool
 and post the resulting messages. ``post`` is injectable so the orchestration is
 testable without Slack.
 
-Wiring (runtime): register a cycle whose program calls
+Wiring (runtime): nothing calls ``run_notify_cycle`` in production today — no
+cycle is registered for it; its only callers are its tests
+(``tests/test_change_notifications.py``). The sweeps it wraps run through other
+paths instead: the alert-resolution harvest is a tracker-maintenance step
+(``brain/systems/tracker_maintenance.py``), and obligation-notice delivery is
+driven from ``brain/systems/runs/obligation_notices.py`` itself. The team-digest
+responsibility lives with the coordinator cycle — see the "Team Digest Contract"
+in ``brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md``.
+
+If this module is ever activated, register a cycle whose program calls
 ``run_notify_cycle(session, org_id=…, channel_id=<the team channel>,
-since=<cycle.last_run_at>)`` on its cadence (default ~30 min). Urgent items post
+since=<cycle.last_run_at>)`` on its cadence (~30 min). Urgent items post
 immediately; a quiet interval posts nothing. The channel is the team channel Illo
 already works in — not a new channel, not DMs.
 """


### PR DESCRIPTION
## Summary

- `brain/app/api/routers/github_webhooks.py`: the module docstring still claimed the router is "intentionally NOT auto-registered" and that mounting is a future deliberate step. It has been mounted at startup since #279 (`brain/app/api/main.py:422`) and self-gates per request with HTTP 503 until `ILLO_GITHUB_WEBHOOK_SECRET` and `ILLO_GITHUB_CONNECTION_ID` are configured. The docstring now describes that contract. Docstring only — no runtime change.
- `brain/systems/change_notifications_cycle.py`: the docstring described runtime wiring that never happened — `run_notify_cycle` has zero production callers (grep finds it only in its own module, its tests, and spec prose). The docstring now says so plainly and points at where the wrapped responsibilities actually run: the alert-resolution harvest via `brain/systems/tracker_maintenance.py`, obligation-notice delivery via `brain/systems/runs/obligation_notices.py`, and the team digest via the coordinator cycle's Team Digest Contract (`uwear-engineering-triage/SKILL.md`). The module is kept rather than deleted — removing it (with `change_notifications.py` and its tests) is an owner decision, since it may still be intended future wiring.

## Testing

- [ ] Backend tests: not run — docstring-only diff, no code paths changed; both files pass `python -m py_compile`.
- [ ] Frontend checks/build: n/a.
- [x] Manual verification: confirmed the mount at `main.py:397`/`main.py:422` and the request-time 503 gates (`_webhook_secret`, `_connection_id`, `_load_github_connection`); confirmed via repo-wide grep that `run_notify_cycle` is only referenced by its own module and `tests/test_change_notifications.py`.

## Public Release Hygiene

- [x] No secrets, logs, database dumps, uploads, private operator notes, or personal paths.
- [x] New environment variables are documented in `.env.example`. (None added — the docstrings reference existing vars.)
- [x] New public-facing behavior is documented in `README.md` or `docs/`. (No behavior change.)
- [x] License/notice impact has been considered. (None.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp7MtBj6zqqvB6DLzNpcDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cp7MtBj6zqqvB6DLzNpcDU)_