### PR TITLE
refactor(cleanup): remove the three packet-lane orphans (#842)

### DIFF
--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -461,30 +461,8 @@ async def summarize_inbound_run_attribution(
     }
 
 
-def durable_work_refs(attribution: Mapping[str, Any] | None) -> list[dict[str, str]]:
-    """Mutated refs proving the run created or routed durable WORK.
-
-    Only refs of work-item kinds count, and refs produced by conversational
-    tools (``side_effect_class == "chat_message"``) never do. A Slack reply
-    is an answer, not routed work.
-    """
-    out: list[dict[str, str]] = []
-    for ref in (attribution or {}).get("mutated_target_refs") or []:
-        if not isinstance(ref, Mapping):
-            continue
-        if str(ref.get("kind") or "") not in WORK_ITEM_REF_KINDS:
-            continue
-        source = str(ref.get("source") or "")
-        registration = get_tool_registration(source) if source else None
-        if _enum_value(getattr(registration, "side_effect_class", "")) == "chat_message":
-            continue
-        out.append({str(key): str(value) for key, value in ref.items()})
-    return out
-
-
 __all__ = [
     "WORK_ITEM_REF_KINDS",
     "collect_result_refs",
-    "durable_work_refs",
     "summarize_inbound_run_attribution",
 ]

--- a/brain/systems/launch_handoffs.py
+++ b/brain/systems/launch_handoffs.py
@@ -204,46 +204,6 @@ def _is_actionable(row: LaunchHandoff, now: datetime) -> bool:
     return row.status == "open" and (expires_at is None or expires_at > now)
 
 
-def parse_member_agent_targets(raw: str | None) -> dict[str, str]:
-    """Parse ``ILLO_MEMBER_AGENT_TARGETS`` into canonical UUID-keyed targets."""
-    targets: dict[str, str] = {}
-    for chunk in str(raw or "").split(","):
-        entry = chunk.strip()
-        if not entry:
-            continue
-        if "=" not in entry:
-            raise LaunchHandoffError(
-                "ILLO_MEMBER_AGENT_TARGETS entries must use <user-uuid>=<target>"
-            )
-        user_id, target = (part.strip() for part in entry.split("=", 1))
-        try:
-            canonical_user_id = str(uuid.UUID(user_id))
-        except ValueError as exc:
-            raise LaunchHandoffError(
-                f"ILLO_MEMBER_AGENT_TARGETS user id must be a UUID: {user_id or '<empty>'}"
-            ) from exc
-        if not target:
-            raise LaunchHandoffError(
-                f"ILLO_MEMBER_AGENT_TARGETS target is empty for user {canonical_user_id}"
-            )
-        targets[canonical_user_id] = target.lower()
-    return targets
-
-
-def agent_target_for_member(
-    user_id: Any,
-    targets: dict[str, str],
-    *,
-    default: str = TARGET_CODEX,
-) -> str:
-    """Look up a member's configured target, falling back for unknown owners."""
-    canonical_user_id = _uuid_or_none(user_id)
-    fallback = (_clean_optional_string(default) or TARGET_CODEX).lower()
-    if not canonical_user_id:
-        return fallback
-    return (_clean_optional_string(targets.get(canonical_user_id)) or fallback).lower()
-
-
 def _strip_candidate(value: Any) -> str:
     cleaned = str(value or "").strip()
     while cleaned and cleaned[-1] in _TRAILING_PUNCTUATION:

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -1535,90 +1535,6 @@ async def _handle_check_fix_deploy_state(
     return _indeterminate_deploy_result(repo_slug, error=last_error)
 
 
-async def github_read_ref_for_backend(
-    *,
-    repo_slug: str,
-    number: int,
-    org_id: str,
-    user_id: str | None = None,
-) -> dict[str, Any] | None:
-    """Read one issue/PR for BACKEND callers (e.g. dossier gathering).
-
-    Reuses the handler-owned token candidates with EXPLICIT org context (no
-    run ``_agent_context`` exists on backend paths) and the ordered-read
-    preference. Returns a FLAT contract — ``{kind, title, body, state,
-    body_total_chars, checks?}`` — or ``None`` when every candidate saw a
-    genuine 404 on both the PR and exact-issue endpoints. Auth/permission
-    errors fall through to the next candidate; other errors propagate.
-
-    NOTE: candidate resolution may write vault access-audit rows. That write
-    belongs to the auth owner, not to this backend read path.
-    """
-    from brain.systems.cortex.project_context.github import (
-        async_get_issue,
-        async_get_pull_request,
-    )
-
-    candidates = await _github_token_candidates(
-        repo_slug=repo_slug,
-        token_secret_key=None,
-        org_id=org_id,
-        user_id=user_id,
-    )
-    read_candidates = _ordered_read_candidates(
-        candidates, repo_slug=repo_slug, state=_github_read_state()
-    )
-    if not read_candidates:
-        raise GitHubConnectorError(status_code=401, message="No GitHub token candidates were available")
-
-    clean_number = int(number)
-    last_error: GitHubConnectorError | None = None
-    saw_not_found = False
-    for candidate in read_candidates:
-        token = candidate.get("token")
-        try:
-            wrapper = await async_get_pull_request(repo_slug, clean_number, token=token)
-            detail = dict(wrapper.get("pull_request") or {})
-            return {
-                "kind": "github_pr",
-                "title": detail.get("title"),
-                "body": detail.get("body"),
-                "state": detail.get("state"),
-                "body_total_chars": int(wrapper.get("body_total_chars") or 0),
-                "checks": wrapper.get("checks"),
-            }
-        except GitHubConnectorError as exc:
-            if exc.status_code != 404:
-                last_error = exc
-                if exc.status_code in {401, 403}:
-                    continue
-                raise
-        # PR endpoint 404 → the ref may be a plain issue; exact read, same token.
-        try:
-            wrapper = await async_get_issue(repo_slug, clean_number, token=token)
-            issue = dict(wrapper.get("issue") or {})
-            return {
-                "kind": "github_issue",
-                "title": issue.get("title"),
-                "body": issue.get("body"),
-                "state": issue.get("state"),
-                "body_total_chars": int(issue.get("body_total_chars") or 0),
-            }
-        except GitHubConnectorError as exc:
-            if exc.status_code == 404:
-                saw_not_found = True
-                continue
-            last_error = exc
-            if exc.status_code in {401, 403}:
-                continue
-            raise
-    if saw_not_found:
-        return None
-    if last_error is not None:
-        raise last_error
-    return None
-
-
 async def github_issue_closure_for_backend(
     *,
     repo_slug: str,
@@ -1776,5 +1692,4 @@ __all__ = [
     "_handle_update_github_issue",
     "github_deploy_states_for_backend",
     "github_issue_closure_for_backend",
-    "github_read_ref_for_backend",
 ]

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -58,9 +58,6 @@ x-illo-env: &illo-env
   ILLO_PRODUCT_OWNER_USER_ID: ${ILLO_PRODUCT_OWNER_USER_ID:-}
   ILLO_REPO_OWNERS: ${ILLO_REPO_OWNERS:-}
   ILLO_UNCLAIMED_POOL_USER_ID: ${ILLO_UNCLAIMED_POOL_USER_ID:-}
-  # Handoff packets (specs/illo-handoff-packets): per-member launch targets.
-  # Empty default = codex for everyone (mint.py's config-with-default).
-  ILLO_MEMBER_AGENT_TARGETS: ${ILLO_MEMBER_AGENT_TARGETS:-}
   ILLO_GITHUB_WEBHOOK_SECRET: ${ILLO_GITHUB_WEBHOOK_SECRET:-}
   ILLO_GITHUB_CONNECTION_ID: ${ILLO_GITHUB_CONNECTION_ID:-}
 x-backend-service: &backend-service

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -15,7 +15,6 @@ import pytest
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
 from brain.systems.inbound.attribution import (
     WORK_ITEM_REF_KINDS,
-    durable_work_refs,
     summarize_inbound_run_attribution,
 )
 from brain.systems.runs.status import RunStatus
@@ -68,10 +67,6 @@ async def test_created_github_issue_becomes_a_mutated_ref(session):
     refs = attribution["mutated_target_refs"]
     assert {"kind": "github_issue", "id": "uwear-ai/uwear-backend#616",
             "source": "create_github_issue"} in refs
-    assert durable_work_refs(attribution) == [
-        {"kind": "github_issue", "id": "uwear-ai/uwear-backend#616",
-         "source": "create_github_issue"}
-    ]
 
 
 async def test_created_pull_request_ref_kind(session):
@@ -87,55 +82,6 @@ async def test_created_pull_request_ref_kind(session):
     )
     kinds = {ref["kind"] for ref in attribution["mutated_target_refs"]}
     assert "github_pull_request" in kinds
-
-
-async def test_error_payload_with_repo_yields_no_artifact_ref(session):
-    """The handler's failure shape carries ``repo`` but no ``issue`` — it must
-    never read as created work."""
-    run_id = await _seed_run(session)
-    session.add(_tool_event(run_id, 1, "create_github_issue", {
-        "error": "No GitHub App identity is connected",
-        "no_write_token": True,
-        "repo": "uwear-ai/uwear-backend",
-    }))
-    await session.flush()
-
-    attribution = await summarize_inbound_run_attribution(
-        session, run_id=run_id, status=RunStatus.COMPLETED
-    )
-    assert durable_work_refs(attribution) == []
-
-
-async def test_slack_reply_never_counts_as_durable_work(session):
-    run_id = await _seed_run(session)
-    session.add(_tool_event(run_id, 1, "post_slack_reply", {
-        "operation": "posted",
-        "channel_id": "C123",
-        "message_ts": "1752600000.0",
-    }))
-    await session.flush()
-
-    attribution = await summarize_inbound_run_attribution(
-        session, run_id=run_id, status=RunStatus.COMPLETED
-    )
-    assert durable_work_refs(attribution) == []
-
-
-def test_predicate_filters_kinds_and_chat_sources():
-    attribution = {
-        "mutated_target_refs": [
-            {"kind": "github_issue", "id": "a/b#1", "source": "create_github_issue"},
-            {"kind": "idea", "id": "i-1", "source": "manage_idea"},
-            {"kind": "message", "id": "m-1", "source": "post_chat_message"},
-            # work-item kind, but produced by a conversational tool:
-            {"kind": "thread", "id": "t-1", "source": "post_slack_reply"},
-            {"kind": "memory_source", "id": "s-1", "source": "brain_encode"},
-        ]
-    }
-    refs = durable_work_refs(attribution)
-    assert [ref["kind"] for ref in refs] == ["github_issue", "idea"]
-    assert durable_work_refs(None) == []
-    assert durable_work_refs({}) == []
 
 
 def test_work_item_vocabulary_is_the_expected_set():
@@ -175,8 +121,6 @@ async def test_truncated_result_preview_recovers_refs_from_result_refs(session):
     assert {"kind": "domain_record", "id": "1823", "source": "manage_domain"} in (
         attribution["mutated_target_refs"]
     )
-    durable = durable_work_refs(attribution)
-    assert any(ref["kind"] == "domain_record" and ref["id"] == "1823" for ref in durable)
 
 
 def test_event_payload_carries_full_result_refs_beside_preview():

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -47,8 +47,7 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
 @pytest.fixture(autouse=True)
 def _hermetic_assignment_env(monkeypatch):
     for key in ("ILLO_BUSINESS_OWNER_USER_ID", "ILLO_PRODUCT_OWNER_USER_ID",
-                "ILLO_REPO_OWNERS", "ILLO_UNCLAIMED_POOL_USER_ID",
-                "ILLO_MEMBER_AGENT_TARGETS"):
+                "ILLO_REPO_OWNERS", "ILLO_UNCLAIMED_POOL_USER_ID"):
         monkeypatch.delenv(key, raising=False)
 
 

--- a/tests/test_thread_url_references.py
+++ b/tests/test_thread_url_references.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from brain.systems.cortex.thread_links import (
     canonicalize_thread_reference,
     extract_thread_reference_values,
@@ -17,10 +15,6 @@ from brain.systems.cortex.thread_read_model import (
 )
 from brain.systems.cortex.object_references import store_object_references_for_source
 from brain.systems.launch_handoffs import (
-    TARGET_CLAUDE,
-    TARGET_CODEX,
-    LaunchHandoffError,
-    agent_target_for_member,
     claude_prompt_for_handoff,
     codex_deep_link_for_handoff,
     extract_launch_handoff_reference_values,
@@ -28,7 +22,6 @@ from brain.systems.launch_handoffs import (
     launch_handoff_reference_payload,
     launch_handoff_route_for_id,
     launch_handoff_url_for_id,
-    parse_member_agent_targets,
 )
 
 
@@ -144,32 +137,6 @@ def test_launch_handoff_preview_and_codex_prompt_are_compact(monkeypatch):
     assert "`illo_read`" in claude_prompt
     assert "`handoff.get`" in claude_prompt
     assert f'{{"handoff_id":"{HANDOFF_ID}"}}' in claude_prompt
-
-
-def test_parse_member_agent_targets_uses_canonical_uuid_keys():
-    claude_user = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"
-    codex_user = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
-
-    targets = parse_member_agent_targets(
-        f" {claude_user}=Claude, {codex_user}=codex "
-    )
-
-    assert targets == {
-        claude_user.lower(): TARGET_CLAUDE,
-        codex_user: TARGET_CODEX,
-    }
-    assert agent_target_for_member(claude_user, targets) == TARGET_CLAUDE
-    assert agent_target_for_member(None, targets) == TARGET_CODEX
-
-
-def test_parse_member_agent_targets_rejects_non_uuid_keys():
-    with pytest.raises(LaunchHandoffError, match="user id must be a UUID"):
-        parse_member_agent_targets("reda=claude")
-
-
-def test_parse_member_agent_targets_accepts_empty_configuration():
-    assert parse_member_agent_targets("") == {}
-    assert parse_member_agent_targets(None) == {}
 
 
 def test_preview_summary_from_handoff_compacts_runtime_checkpoint():


### PR DESCRIPTION
Closes #842

## What this does

Deletes the three orphans the packet-lane retirement (#706) left behind, verified to have zero production callers:

- `github_read_ref_for_backend` (`handlers/github.py`) — no caller at all, not even a test.
- `parse_member_agent_targets` / `agent_target_for_member` (`launch_handoffs.py`) + the `ILLO_MEMBER_AGENT_TARGETS` compose env — the launch router resolves targets from `?target=`/`row.target_tool`, never the member map.
- `durable_work_refs` (`inbound/attribution.py`) — mint's old predicate; preservation filters `mutated_target_refs` inline and never calls it.

`collect_result_refs` stays (live caller at `brain/systems/runs/tools.py:736`). Tests covering only the orphans are removed; the hermetic-env fixture drops the deleted var.

Pure deletion: −241 lines, +1.

## Verification

Targeted tests 54 passed; fast suite 4,978 passed locally (a handful of sandbox-only socket failures, unrelated — CI is the gate).

## Merge-order note

Both this and #846 touch the comment above `ILLO_MEMBER_AGENT_TARGETS` in `docker-compose.yml`; whichever merges second resolves one trivial hunk (this deletion wins).

Implemented by Codex (gpt-5.6-sol) under a Claude director review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)