### PR TITLE
fix(knowledge): hide retired deploy fields from tracker knowledge text (#845)

### DIFF
--- a/brain/systems/deploy_record_contract.py
+++ b/brain/systems/deploy_record_contract.py
@@ -11,18 +11,9 @@ from collections.abc import Mapping
 from typing import Any
 
 
-DEPLOY_EVIDENCE_FIELDS = frozenset(
-    {
-        "fix_pr",
-        "fix_merge_sha",
-        "verified",
-        "verified_at",
-    }
-)
-
 # These fields belonged to the retired persisted deploy-state model. They are
-# hidden unconditionally at read boundaries until the re-runnable backfill
-# removes them.
+# hidden unconditionally at serialization and record-to-text read boundaries
+# until the re-runnable backfill removes them.
 RETIRED_DEPLOY_FIELDS = frozenset(
     {
         "deploy_state",
@@ -30,10 +21,6 @@ RETIRED_DEPLOY_FIELDS = frozenset(
         "fix_merged_at",
         "promotion_recommended_at",
     }
-)
-
-DEPLOY_FIELDS_HIDDEN_FROM_RECORD_PROSE = (
-    DEPLOY_EVIDENCE_FIELDS | RETIRED_DEPLOY_FIELDS
 )
 
 

--- a/brain/systems/knowledge/connectors/domain_records.py
+++ b/brain/systems/knowledge/connectors/domain_records.py
@@ -10,6 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
 from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
+from brain.systems.deploy_record_contract import (
+    deploy_ticket_object_keys,
+    record_data_for_serialization,
+)
 from brain.systems.knowledge.connectors.base import (
     KnowledgeDraft,
     KnowledgeEnumeration,
@@ -55,10 +59,20 @@ class DomainRecordsConnector:
                 ensure_ascii=False,
                 sort_keys=True,
             )
+            record_data = (
+                record.data if isinstance(record.data, dict) else {}
+            )
+            serialized_data = record_data_for_serialization(
+                object_type.key,
+                record_data,
+            )
             raw_text = str(record.search_text or "").strip()
-            if not raw_text:
+            if object_type.key in deploy_ticket_object_keys() or not raw_text:
+                # search_text is cached and can retain retired searchable fields
+                # after the record data is cleaned. Rebuild tracker text from the
+                # same safe data used by external serializers.
                 raw_text = json.dumps(
-                    record.data if isinstance(record.data, dict) else {},
+                    serialized_data,
                     default=str,
                     ensure_ascii=False,
                     sort_keys=True,

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -450,6 +450,66 @@ async def test_domain_records_connector_advances_and_resumes_watermark_with_id_t
     ) == ["domain_record:1", "domain_record:2", "domain_record:3"]
 
 
+async def test_domain_records_connector_hides_retired_deploy_fields_from_text(
+    session,
+):
+    updated_at = datetime(2026, 8, 19, 12, 30, tzinfo=timezone.utc)
+    retired_values = {
+        "deploy_state": "legacy-staging",
+        "deployed_at": "2026-08-18T10:00:00+00:00",
+        "fix_merged_at": "2026-08-18T09:00:00+00:00",
+        "promotion_recommended_at": "2026-08-18T09:30:00+00:00",
+    }
+    session.add_all(
+        [
+            Domain(
+                id=845,
+                org_id=_ORG_ID,
+                slug="deploy-tracker",
+                name="Deploy Tracker",
+                created_at=updated_at,
+                updated_at=updated_at,
+            ),
+            DomainObjectType(
+                id=845,
+                domain_id=845,
+                key="ticket",
+                name="Ticket",
+                created_at=updated_at,
+                updated_at=updated_at,
+            ),
+            DomainRecord(
+                id=845,
+                org_id=_ORG_ID,
+                domain_id=845,
+                object_type_id=845,
+                title="Legacy deploy record",
+                data={"summary": "Safe tracker context", **retired_values},
+                search_text=" ".join(
+                    [
+                        "Legacy deploy record",
+                        *(f"{key} {value}" for key, value in retired_values.items()),
+                    ]
+                ),
+                version=1,
+                created_at=updated_at,
+                updated_at=updated_at,
+            ),
+        ]
+    )
+    await session.flush()
+
+    result = await DomainRecordsConnector().enumerate_changed(session, {})
+
+    assert len(result.drafts) == 1
+    draft = result.drafts[0]
+    rendered = f"{draft.summary}\n{draft.raw_text}"
+    assert "Safe tracker context" in rendered
+    for key, value in retired_values.items():
+        assert key not in rendered
+        assert value not in rendered
+
+
 async def test_memory_connector_mirrors_only_shared_source_backed_memories(
     session,
     embedding_runtime,


### PR DESCRIPTION
Closes #845

## What this does

The investigation confirmed the suspected leak, in a newer path than expected: `af8344a9` wired `DEPLOY_FIELDS_HIDDEN_FROM_RECORD_PROSE` into `briefing/gather.py`, #706 deleted that whole package, and the knowledge connector added later built tracker text from **cached `search_text` or raw `record.data`** — so the four retired deploy fields (`deploy_state`, `deployed_at`, `fix_merged_at`, `promotion_recommended_at`) could leak into knowledge items even though every JSON read boundary hides them.

- `brain/systems/knowledge/connectors/domain_records.py`: deploy-ticket records now rebuild their indexed text through `record_data_for_serialization` (same owner the serializers use), never trusting stale `search_text`.
- `brain/systems/deploy_record_contract.py`: deletes the two dead constants (`DEPLOY_FIELDS_HIDDEN_FROM_RECORD_PROSE` and `DEPLOY_EVIDENCE_FIELDS` — both had zero references).
- New pin: `test_domain_records_connector_hides_retired_deploy_fields_from_text` asserts all four fields and their values stay out of the rendered summary+text, including via stale search_text.

## Verification

Targeted 3 passed; fast suite 4,985 passed locally (sandbox-only socket failures excluded — CI is the gate).

Implemented by Codex (gpt-5.6-sol) under a Claude director review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)