### PR TITLE
fix(tracker): route merged PRs to Done, not Canceled (#838)

### DIFF
--- a/brain/systems/inbound/github_webhook.py
+++ b/brain/systems/inbound/github_webhook.py
@@ -95,20 +95,31 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
         source_updated_at = comment.get("updated_at") or source_updated_at
 
     merge_hints = {}
+    summary_action = action
     if event == "pull_request":
+        merged = subject.get("merged") is True
+        if merged:
+            pr_outcome = "merged"
+        elif state == "closed":
+            pr_outcome = "closed_unmerged"
+        else:
+            pr_outcome = "open"
         merge_hints = {
-            "merged": subject.get("merged") is True,
+            "merged": merged,
+            "pr_outcome": pr_outcome,
             "base_ref": (subject.get("base") or {}).get("ref"),
             "head_ref": (subject.get("head") or {}).get("ref"),
             "merge_commit_sha": subject.get("merge_commit_sha"),
             "merged_at": subject.get("merged_at"),
         }
+        if pr_outcome == "merged":
+            summary_action = "merged"
 
     where = f" #{number}" if number else ""
     summary = (
-        f"GitHub {noun}{where} {action}: {title}".strip()
+        f"GitHub {noun}{where} {summary_action}: {title}".strip()
         if title
-        else f"GitHub {noun}{where} {action}".strip()
+        else f"GitHub {noun}{where} {summary_action}".strip()
     )
 
     return {

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -361,14 +361,20 @@ a human action. This never-merge rule is absolute for staging→main.
 - `In Review`: non-draft PR is open and awaiting review, CI, or merge.
 - `Blocked`: failing CI, requested changes, unclear owner, missing info, or
   external dependency.
-- `Done`: linked PR merged or issue closed. For an alert-linked ticket (one
+- `Done`: a pull request with GitHub `pr_outcome == "merged"` (derived from
+  `merged == true`), or an issue with GitHub `state == "closed"`. Record a
+  merged PR with the progress note "PR merged on GitHub." Never treat its raw
+  closed state as cancellation. For an alert-linked ticket (one
   with a `rollbar_item`), `Done` additionally requires the fix deployed to
   prod by current ancestry AND `verified=true` per **Deploy State on Read** —
   merged-to-staging is not done. A `Done` item must
   not appear in anyone's priority workset — see **Before Posting** and
   **Public Output**.
-- `Canceled` / `wontfix`: obsolete, duplicate, invalid, intentionally closed,
-  or not worth doing.
+- `Canceled` / `wontfix`: a pull request with GitHub
+  `pr_outcome == "closed_unmerged"` (`state == "closed"` and `merged` is not
+  true), or work that is obsolete, duplicate, invalid, intentionally closed,
+  or not worth doing. Record a closed-unmerged PR with the progress note "PR
+  closed on GitHub without merge; no further review action."
 
 ## Identities
 

--- a/docs/329-live-delta.md
+++ b/docs/329-live-delta.md
@@ -41,9 +41,9 @@ Expected memory mirror fingerprint:
 Core record `1155`, slug `uwear-engineering-triage`, must become the exact
 mirror of `SKILL.md`:
 
-- characters: `31800` (must remain `< 34000`);
-- bytes: `31896`; and
-- SHA-256: `52fbb96829c54b6861ddbc37f49a21ae71088ff5a48b9076d22f11711729fa6f`.
+- characters: `32262` (must remain `< 34000`);
+- bytes: `32358`; and
+- SHA-256: `1344faa584147530bb16d5d5dcb94074beae67cac1ce8f80c44f08ce2bd2b903`.
 
 ## Safety and idempotency
 

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -143,6 +143,22 @@ def test_uwear_triage_chantier_primary_digest_keeps_person_coverage():
     assert "outcome summary in the goal's language" in procedure
 
 
+def test_uwear_triage_routes_pull_request_outcomes_to_terminal_tracker_statuses():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    states = bundle.skill_markdown.split("## States", 1)[1].split("## Identities", 1)[0]
+    contract = " ".join(states.split())
+
+    assert '`pr_outcome == "merged"`' in contract
+    assert "`Done`" in contract
+    assert '"PR merged on GitHub."' in contract
+    assert '`pr_outcome == "closed_unmerged"`' in contract
+    assert "`Canceled`" in contract
+    assert '"PR closed on GitHub without merge; no further review action."' in contract
+
+
 def test_uwear_triage_scheduled_memory_contract():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -75,7 +75,7 @@ class TestEventToEnvelope:
         assert "Login is broken" in env["summary"]
         assert env["payload"] is payload  # full payload carried for the projection
 
-    def test_pull_request_closed(self):
+    def test_pull_request_merged(self):
         payload = {
             "action": "closed",
             "repository": {"full_name": "o/r"},
@@ -92,11 +92,34 @@ class TestEventToEnvelope:
         assert env["hints"]["state"] == "closed"
         assert env["hints"]["number"] == 7
         assert env["hints"]["merged"] is True
+        assert env["hints"]["pr_outcome"] == "merged"
         assert env["hints"]["base_ref"] == "main"
         assert env["hints"]["head_ref"] == "staging"
         assert env["hints"]["merge_commit_sha"] == "abc123"
         assert env["hints"]["merged_at"] == "2026-07-08T11:01:00Z"
+        assert env["hints"]["action"] == "closed"
+        assert env["summary"] == "GitHub pull request #7 merged: Add feature"
         assert env["idempotency_key"] is None  # no delivery id
+
+    def test_pull_request_closed_unmerged(self):
+        payload = {
+            "action": "closed",
+            "repository": {"full_name": "o/r"},
+            "pull_request": {
+                "number": 8,
+                "title": "Drop feature",
+                "state": "closed",
+                "merged": False,
+                "merged_at": None,
+            },
+        }
+        env = github_event_to_envelope("pull_request", payload)
+        assert env["hints"]["action"] == "closed"
+        assert env["hints"]["state"] == "closed"
+        assert env["hints"]["merged"] is False
+        assert env["hints"]["merged_at"] is None
+        assert env["hints"]["pr_outcome"] == "closed_unmerged"
+        assert env["summary"] == "GitHub pull request #8 closed: Drop feature"
 
     def test_issue_comment_anchors_on_issue_keeps_comment_details(self):
         payload = {


### PR DESCRIPTION
Closes #838

## What this does

Two halves, matching where the bug actually lives:

1. **Envelope (code):** `github_event_to_envelope` now derives `pr_outcome` — `merged` / `closed_unmerged` / `open` — into `merge_hints`, and the human summary says **"GitHub pull request #N merged"** instead of "closed" for merged PRs. The one-word summary was what made every merge read as an abandonment.
2. **Playbook (prose):** the `uwear-engineering-triage` SKILL.md States section routes `Done` on `pr_outcome == merged` and `Canceled` only on `closed_unmerged`, with distinct progress notes. `docs/329-live-delta.md`'s mirror fingerprint (chars/bytes/SHA-256) is updated to the new SKILL.md.

Regression tests pin both halves (merged→Done wording, closed-unmerged→Canceled).

## After merge (important)

The LIVE playbook is `domain_records` id 1155, applied from SKILL.md by the activation CLI (`activate_uwear_engineering_triage`, per `docs/329-live-delta.md`). Until that activation step runs, live triage keeps the old routing. The four already-miswritten records (4979, 5012, 5013, 5053) are corrected through Illo separately (submission `c0b965e7`).

## Verification

Targeted 46 passed; fast suite 4,986 passed locally (sandbox-only socket failures excluded — CI is the gate). No live data touched.

Implemented by Codex (gpt-5.6-sol) under a Claude director review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)