### PR TITLE
docs(meetbot): state the layered silence guarantee; add a media-capture probe (#847)

### DIFF
--- a/meetbot/engine.py
+++ b/meetbot/engine.py
@@ -74,10 +74,12 @@ class PlaywrightMeetEngine:
             # contract, not a caption-language preference; spoken French stays separate.
             context_options: dict[str, object] = {
                 "viewport": {"width": 1280, "height": 720},
-                # Deliberately NO microphone/camera permission grant: a page
-                # that never receives the permission structurally cannot send
-                # audio or video, which is the real silence guarantee. The
-                # mute-toggle pass below is best-effort cosmetics on top.
+                # Media silence is layered. Chromium's fake-UI flag bypasses
+                # prompts, so no single layer is the guarantee: Playwright applies
+                # an empty permission override, fake-device substitutes synthetic
+                # sources, and the container exposes no real capture hardware. The
+                # Meet mute pass below adds UI defense in depth. The join can
+                # continue without a grant through _dismiss_media_prompt.
                 "permissions": [],
                 "locale": self._config.ui_locale,
                 "extra_http_headers": {
@@ -384,12 +386,12 @@ async def _ensure_media_muted(
     off_selectors: tuple[str, ...],
     on_selectors: tuple[str, ...],
 ) -> None:
-    """Best-effort toggle-off; never a join precondition.
+    """Best-effort Meet-level toggle-off; never a join precondition.
 
-    The context grants no microphone/camera permission, so the page cannot
-    transmit either way. A bot with no device sees NO mute control at all —
-    absence is the normal permissionless state, not an error (first live
-    join failed here when this raised).
+    The context permission override, synthetic sources, and container isolation
+    operate below this UI control. When media access is unavailable, Meet can
+    omit the control altogether; absence is not an error (the first live join
+    failed here when this raised).
     """
 
     if await first_visible(page, on_selectors) is not None:

--- a/meetbot/scripts/__init__.py
+++ b/meetbot/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone meetbot diagnostic scripts."""

--- a/meetbot/scripts/probe_media_capture.py
+++ b/meetbot/scripts/probe_media_capture.py
@@ -1,0 +1,128 @@
+"""Probe Chromium media capture with the meetbot browser configuration.
+
+This standalone probe exists to settle #847. It launches Chromium with the
+exact flags and context options the engine uses, then calls getUserMedia and
+prints a JSON verdict.
+
+getUserMedia exists only in a secure context, and a data: page is NOT one —
+probing there rejects with a TypeError that proves nothing about permissions.
+The probe therefore serves its page from 127.0.0.1, which the spec treats as
+a potentially trustworthy origin, and reports a missing mediaDevices API as
+its own distinct outcome.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.server
+import json
+import threading
+from typing import Any
+
+from meetbot.config import MeetbotConfig
+
+
+_PROBE_HTML = """<!doctype html>
+<meta charset="utf-8">
+<script>
+window.mediaCaptureVerdict = (async () => {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    return {
+      outcome: "no-mediadevices",
+      error_name: null,
+      device_labels: [],
+      secure_context: window.isSecureContext,
+    };
+  }
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video: true,
+    });
+    const deviceLabels = stream.getTracks().map((track) => track.label);
+    stream.getTracks().forEach((track) => track.stop());
+    return {
+      outcome: "resolved",
+      error_name: null,
+      device_labels: deviceLabels,
+      secure_context: window.isSecureContext,
+    };
+  } catch (error) {
+    return {
+      outcome: "rejected",
+      error_name: error?.name ?? "Error",
+      device_labels: [],
+      secure_context: window.isSecureContext,
+    };
+  }
+})();
+</script>
+"""
+
+
+class _ProbeHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - http.server contract
+        body = _PROBE_HTML.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:
+        return
+
+
+async def _probe() -> dict[str, Any]:
+    from playwright.async_api import async_playwright
+
+    config = MeetbotConfig.from_env()
+    context_options: dict[str, object] = {
+        "viewport": {"width": 1280, "height": 720},
+        "permissions": [],
+        "locale": config.ui_locale,
+        "extra_http_headers": {
+            "Accept-Language": f"{config.ui_locale},en;q=0.9",
+        },
+    }
+    if config.storage_state_path.is_file():
+        context_options["storage_state"] = str(config.storage_state_path)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ProbeHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(
+                headless=False,
+                args=[
+                    "--use-fake-ui-for-media-stream",
+                    "--use-fake-device-for-media-stream",
+                    "--disable-dev-shm-usage",
+                    "--no-sandbox",
+                    f"--lang={config.ui_locale}",
+                ],
+            )
+            context = await browser.new_context(**context_options)
+            try:
+                page = await context.new_page()
+                await page.goto(
+                    f"http://127.0.0.1:{port}/probe", wait_until="load"
+                )
+                return await page.evaluate("window.mediaCaptureVerdict")
+            finally:
+                await context.close()
+                await browser.close()
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def main() -> None:
+    print(json.dumps(asyncio.run(_probe()), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Works #847 (leaves it open — the container probe run is the closing step).

## What this does

- `meetbot/engine.py`: the two comments that called `permissions=[]` alone "the real silence guarantee" now state the actual layering — empty permission override + fake-device synthetic sources + no real capture hardware in the container, with the Meet mute pass as UI defense in depth. No runtime change.
- `meetbot/scripts/probe_media_capture.py` (new): a standalone probe that launches Chromium with the engine's exact flags and context options, calls `getUserMedia({audio, video})`, and prints a JSON verdict (resolved + device labels / rejected + error name / no-mediadevices). It serves its page from `127.0.0.1` because a `data:` page is not a secure context and would reject with a TypeError that proves nothing about permissions (the review caught the first draft doing exactly that).

## Semantics established during investigation

Playwright's `permissions: []` is an empty CDP `Browser.grantPermissions` override (grant-listed, reject-others). Chromium's `--use-fake-ui-for-media-stream` bypasses the prompt; `--use-fake-device-for-media-stream` substitutes synthetic sources. Chromium does not document which wins when both are active — hence the probe.

## To close #847

Run inside the meetbot container:
```
docker exec illospace-meetbot-1 python -m meetbot.scripts.probe_media_capture
```
and paste the JSON verdict on the ticket. Recommendation from the analysis: if the verdict is clean, remove `--use-fake-ui-for-media-stream` first in a follow-up (unnecessary since #648 accepts the no-media dialog) and KEEP `--use-fake-device-for-media-stream` as containment.

## Verification

`meetbot/tests`: 45 passed. Probe compile-checked; it needs the container's Playwright to run (not installed in the repo venv).

Implemented by Codex (gpt-5.6-sol) under a Claude director review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)