### PR TITLE
fix(inbound): attribute GitHub issue comments, and say why they do not preserve (#855)

### DIFF
--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -103,6 +103,20 @@ _GITHUB_ARTIFACT_KINDS = {
     "comment": "github_issue_comment",
 }
 
+# Canonical id encodings for the kinds above. Keep every GitHub ref id built
+# here so the encoding stays one decision: an issue or pull request is
+# "owner/repo#number", and a comment appends its own id because many comments
+# share one issue number. A reader splits on ":comment:" to recover the issue.
+_GITHUB_COMMENT_REF_INFIX = ":comment:"
+
+
+def _github_artifact_ref_id(repo: str, number: int) -> str:
+    return f"{repo}#{number}"
+
+
+def _github_comment_ref_id(repo: str, issue_number: int, comment_id: int) -> str:
+    return f"{_github_artifact_ref_id(repo, issue_number)}{_GITHUB_COMMENT_REF_INFIX}{comment_id}"
+
 # Ref kinds that represent routed/created WORK (something a teammate or
 # their agent picks up), as opposed to conversation, memory, or plumbing
 # state. This mirrors how preservation.py filters mutated refs by kind.
@@ -268,7 +282,13 @@ def _add_github_artifact_ref(
             str(artifact.get("type") or artifact_key).strip() or artifact_key
         )
         if number > 0 and kind is not None:
-            _add_ref(refs, seen, kind=kind, value=f"{repo}#{number}", source=source)
+            _add_ref(
+                refs,
+                seen,
+                kind=kind,
+                value=_github_artifact_ref_id(repo, number),
+                source=source,
+            )
 
     comment = value.get("comment")
     if not isinstance(comment, Mapping):
@@ -284,7 +304,7 @@ def _add_github_artifact_ref(
         refs,
         seen,
         kind=_GITHUB_ARTIFACT_KINDS["comment"],
-        value=f"{repo}#{issue_number}:comment:{comment_id}",
+        value=_github_comment_ref_id(repo, issue_number, comment_id),
         source=source,
     )
 

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -93,12 +93,14 @@ _OBJECT_REF_KINDS = {
 }
 
 # GitHub artifacts come back as {"repo": "owner/name", "issue": {"type",
-# "number", ...}} (the connector's payload contract), not as *_id keys, so
-# the maps above cannot see them. Without this extraction a run whose whole
-# outcome is a filed issue reports no durable refs at all.
+# "number", ...}} or {"repo": "owner/name", "issue_number": N, "comment":
+# {"id", ...}} (the connector payload contracts), not as *_id keys, so the
+# maps above cannot see them. Without this extraction a run whose whole
+# outcome is a filed issue or posted comment reports no durable refs at all.
 _GITHUB_ARTIFACT_KINDS = {
     "issue": "github_issue",
     "pull_request": "github_pull_request",
+    "comment": "github_issue_comment",
 }
 
 # Ref kinds that represent routed/created WORK (something a teammate or
@@ -251,19 +253,40 @@ def _add_github_artifact_ref(
     source: str,
 ) -> None:
     repo = str(value.get("repo") or "").strip()
-    issue = value.get("issue")
-    if repo.count("/") != 1 or not isinstance(issue, Mapping):
+    if repo.count("/") != 1:
+        return
+
+    for artifact_key in ("issue", "pull_request"):
+        artifact = value.get(artifact_key)
+        if not isinstance(artifact, Mapping):
+            continue
+        try:
+            number = int(str(artifact.get("number") or "").strip())
+        except (TypeError, ValueError):
+            continue
+        kind = _GITHUB_ARTIFACT_KINDS.get(
+            str(artifact.get("type") or artifact_key).strip() or artifact_key
+        )
+        if number > 0 and kind is not None:
+            _add_ref(refs, seen, kind=kind, value=f"{repo}#{number}", source=source)
+
+    comment = value.get("comment")
+    if not isinstance(comment, Mapping):
         return
     try:
-        number = int(str(issue.get("number") or "").strip())
+        issue_number = int(str(value.get("issue_number") or "").strip())
+        comment_id = int(str(comment.get("id") or "").strip())
     except (TypeError, ValueError):
         return
-    if number < 1:
+    if issue_number < 1 or comment_id < 1:
         return
-    kind = _GITHUB_ARTIFACT_KINDS.get(str(issue.get("type") or "issue").strip() or "issue")
-    if kind is None:
-        return
-    _add_ref(refs, seen, kind=kind, value=f"{repo}#{number}", source=source)
+    _add_ref(
+        refs,
+        seen,
+        kind=_GITHUB_ARTIFACT_KINDS["comment"],
+        value=f"{repo}#{issue_number}:comment:{comment_id}",
+        source=source,
+    )
 
 
 def _collect_refs(value: Any, refs: list[dict[str, str]], seen: set[tuple[str, str]], *, source: str) -> None:

--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -70,6 +70,11 @@ PRESERVATION_ACCEPTABLE_TARGET_KINDS = (
 PRESERVATION_MISSING_REASON = (
     "Preservation was requested, but the completed Illo run did not produce durable storage evidence."
 )
+PRESERVATION_NON_DURABLE_REASON = (
+    "Preservation was requested, but the completed Illo run mutated only a non-durable surface. "
+    "Use an Illo-owned memory, domain, project, handoff, thread, artifact, or workspace-app surface "
+    "to preserve the knowledge."
+)
 
 
 @dataclass(frozen=True)
@@ -249,10 +254,13 @@ def preservation_evidence_result(
 
     acceptable_kinds = {str(kind) for kind in result["acceptable_target_kinds"]}
     acceptable_tools = {str(tool) for tool in result["acceptable_tools"]}
-    mutated_refs = [
+    observed_mutated_refs = [
         dict(ref)
         for ref in attribution.get("mutated_target_refs", [])
-        if str(ref.get("kind") or "") in acceptable_kinds
+        if isinstance(ref, Mapping)
+    ]
+    mutated_refs = [
+        ref for ref in observed_mutated_refs if str(ref.get("kind") or "") in acceptable_kinds
     ]
     tool_names = [str(tool) for tool in attribution.get("tool_names", [])]
     matching_tools = [tool for tool in tool_names if tool in acceptable_tools]
@@ -263,7 +271,14 @@ def preservation_evidence_result(
         return result
 
     result["status"] = "missing"
-    result["reason"] = PRESERVATION_MISSING_REASON
+    non_durable_refs = [
+        ref for ref in observed_mutated_refs if str(ref.get("kind") or "") not in acceptable_kinds
+    ]
+    if non_durable_refs:
+        result["reason"] = PRESERVATION_NON_DURABLE_REASON
+        result["non_durable_target_refs"] = non_durable_refs
+    else:
+        result["reason"] = PRESERVATION_MISSING_REASON
     result["tool_names"] = matching_tools or tool_names
     result["mutated_target_refs"] = []
     return result
@@ -273,6 +288,7 @@ __all__ = [
     "PRESERVATION_ACCEPTABLE_TARGET_KINDS",
     "PRESERVATION_ACCEPTABLE_TOOLS",
     "PRESERVATION_MISSING_REASON",
+    "PRESERVATION_NON_DURABLE_REASON",
     "submission_preservation_contract",
     "submission_preservation_prompt_lines",
     "preservation_contract_from_run_metadata",

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -84,6 +84,27 @@ async def test_created_pull_request_ref_kind(session):
     assert "github_pull_request" in kinds
 
 
+async def test_created_pull_request_top_level_payload_ref_kind(session):
+    # async_create_repo_pull_request returns {"repo", "pull_request": {...}},
+    # not the nested {"issue": {...}} shape the other PR test covers.
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "create_github_pull_request", {
+        "repo": "uwear-ai/uwear-website",
+        "pull_request": {"type": "pull_request", "number": 220},
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+
+    assert {
+        "kind": "github_pull_request",
+        "id": "uwear-ai/uwear-website#220",
+        "source": "create_github_pull_request",
+    } in attribution["mutated_target_refs"]
+
+
 async def test_github_issue_comment_becomes_a_mutated_ref(session):
     run_id = await _seed_run(session)
     session.add(_tool_event(run_id, 1, "add_github_issue_comment", {

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -84,6 +84,35 @@ async def test_created_pull_request_ref_kind(session):
     assert "github_pull_request" in kinds
 
 
+async def test_github_issue_comment_becomes_a_mutated_ref(session):
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "add_github_issue_comment", {
+        "repo": "uwear-ai/uwear-backend",
+        "issue_number": 1884,
+        "comment": {
+            "id": 5440364747,
+            "node_id": "IC_kwDOLtZ_Ds8AAAABREVgyw",
+            "html_url": (
+                "https://github.com/uwear-ai/uwear-backend/issues/1884"
+                "#issuecomment-5440364747"
+            ),
+        },
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+
+    assert attribution["mutated_target_refs"] == [
+        {
+            "kind": "github_issue_comment",
+            "id": "uwear-ai/uwear-backend#1884:comment:5440364747",
+            "source": "add_github_issue_comment",
+        }
+    ]
+
+
 def test_work_item_vocabulary_is_the_expected_set():
     assert WORK_ITEM_REF_KINDS == {
         "github_issue", "github_pull_request", "idea", "domain_record",

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -17,6 +17,7 @@ from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundE
 from brain.platform.db.models.org import Org, User
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import service as inbound
+from brain.systems.inbound.preservation import PRESERVATION_MISSING_REASON
 from brain.systems.runs.events import run_event
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -304,11 +305,92 @@ async def test_preservation_submission_without_durable_evidence_stays_actionable
     assert event.status == "review_required"
     assert event.action_result["handling"]["status"] == "needs_action"
     assert event.action_result["handling"]["run_status"] == "completed"
-    assert event.action_result["handling"]["evidence_contract"]["status"] == "missing"
+    evidence = event.action_result["handling"]["evidence_contract"]
+    assert evidence["status"] == "missing"
+    assert evidence["reason"] == PRESERVATION_MISSING_REASON
+    assert "non_durable_target_refs" not in evidence
     assert "did not produce durable storage evidence" in event.error
     assert receipt.status == "review_required"
     assert receipt.tool_use["status"] == "needs_action"
     assert receipt.tool_use["evidence_contract"]["status"] == "missing"
+
+
+async def test_preservation_submission_with_github_comment_names_non_durable_evidence(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.session-preserve",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve this diagnosis for later use.",
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:github-comment-evidence",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    store = AsyncAgentRunStore(session)
+    run_id = int(handling["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "add_github_issue_comment",
+                "args": {
+                    "repo": "uwear-ai/uwear-backend",
+                    "issue_number": 1884,
+                    "body": "Durable diagnosis.",
+                },
+                "result": json.dumps(
+                    {
+                        "repo": "uwear-ai/uwear-backend",
+                        "issue_number": 1884,
+                        "comment": {
+                            "id": 5440364747,
+                            "node_id": "IC_kwDOLtZ_Ds8AAAABREVgyw",
+                            "html_url": (
+                                "https://github.com/uwear-ai/uwear-backend/issues/1884"
+                                "#issuecomment-5440364747"
+                            ),
+                        },
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
+    await store.append_final_answer_once(
+        run_id,
+        "Preserved the diagnosis on GitHub issue #1884.",
+        root_run_id=run_id,
+    )
+    await store.set_status(run_id, RunStatus.COMPLETED)
+
+    event = await session.get(InboundEventRow, result["event_id"])
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert event is not None
+    assert event.status == "review_required"
+    evidence = event.action_result["handling"]["evidence_contract"]
+    expected_ref = {
+        "kind": "github_issue_comment",
+        "id": "uwear-ai/uwear-backend#1884:comment:5440364747",
+        "source": "add_github_issue_comment",
+    }
+    assert evidence["status"] == "missing"
+    assert evidence["mutated_target_refs"] == []
+    assert evidence["non_durable_target_refs"] == [expected_ref]
+    assert evidence["reason"] != PRESERVATION_MISSING_REASON
+    assert "non-durable surface" in evidence["reason"]
+    assert "Illo-owned" in evidence["reason"]
+    assert receipt.status == "review_required"
+    assert receipt.tool_use["evidence_contract"]["non_durable_target_refs"] == [expected_ref]
+    assert receipt.tool_use["attribution"]["mutated_target_refs"] == [expected_ref]
 
 
 async def test_preservation_submission_with_explicit_memory_evidence_reconciles_processed(session):
@@ -363,6 +445,7 @@ async def test_preservation_submission_with_explicit_memory_evidence_reconciles_
     assert event.error is None
     evidence = event.action_result["handling"]["evidence_contract"]
     assert evidence["status"] == "satisfied"
+    assert "non_durable_target_refs" not in evidence
     assert {"kind": "memory_source", "id": "91", "source": "memory_ingest_source"} in evidence["mutated_target_refs"]
     assert receipt.status == "processed"
     assert "memory_source" in {ref["kind"] for ref in receipt.tool_use["attribution"]["mutated_target_refs"]}


### PR DESCRIPTION
Closes #855

## What was wrong

A `preserve_knowledge` run whose only write was `add_github_issue_comment` came back with `mutated_target_refs: []` and a bare `evidence_status: "missing"`. The receipt neither recorded that anything was written nor explained the verdict, while the run's own final answer claimed the diagnosis had been preserved.

I read the incident run directly from Illo (run `19794`, event `182c0cbb-268c-4d1d-b66a-abb218a9e0ec`) before writing any code. It made exactly one write call, which returned:

```json
{"repo": "uwear-ai/uwear-backend", "issue_number": 1884,
 "comment": {"id": 5440364747, "html_url": "..."}}
```

Two different layers were wrong in two different ways.

**Attribution could not see the artifact at all.** `_GITHUB_ARTIFACT_KINDS` mapped only `issue` and `pull_request`, so the payload above produced no ref. That is the same bug the existing comment in that file already describes for filed issues, one artifact kind later.

**The preservation verdict was right but silent.** A comment on a third-party GitHub repo is not an Illo-owned surface, so `missing` is the correct answer. It just never said so.

## What changed

- Attribution emits a `github_issue_comment` ref for the comment payload, and now also reads a top-level `pull_request` key — the shape `async_create_repo_pull_request` actually returns, which the previous code missed.
- All GitHub ref ids are built by one pair of formatters, with the encoding documented next to the kind map.
- A `missing` verdict caused by a non-durable mutation now carries `PRESERVATION_NON_DURABLE_REASON` and lists the offending refs under `non_durable_target_refs`. The nothing-happened case keeps the original reason, so the two stay distinguishable.

**`PRESERVATION_ACCEPTABLE_TOOLS` and `PRESERVATION_ACCEPTABLE_TARGET_KINDS` are deliberately unchanged**, and `mutated_target_refs` keeps meaning "acceptable refs only". Widening either would let a non-Illo surface satisfy preservation, which is the opposite of what this contract is for. The runtime guidance already tells agents to pick an Illo-owned surface.

## How to check it

Local gate, the workflow's command verbatim, run serially on an idle machine:

```
venv/bin/python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
→ 5032 passed, 11 skipped, 0 failed (82.5s)
```

`meetbot/tests` is included (no path argument). Diff selects the backend lane only — no `frontend/**` files, no migration.

Three behaviours are pinned by test:
1. the real incident payload yields exactly one `github_issue_comment` ref;
2. an end-to-end `preserve_knowledge` run whose only write is that comment still reports `missing`, names the non-durable ref, and gives the new reason;
3. a run with a real `memory_source` ref still reports `satisfied` and gains no `non_durable_target_refs` key.

## Known limitation, not fixed here

A Codex code-quality review flagged, correctly, that `_add_github_artifact_ref` now encodes three connector payload shapes inside the *generic* recursive ref walker. The cleaner design is for each GitHub tool to emit explicit refs at its own boundary and let the existing `_EXPLICIT_REF_KEYS` collector pick them up, which would delete the shape-sniffing entirely. That is a cross-cutting change to the tool handlers, well beyond this bug, so it is filed separately rather than smuggled in here.

This PR also does not touch the run's prose. The final answer is model-authored text; making it agree with the evidence contract is a separate concern.
