### PR TITLE
fix(project-context): run git clones off the worker event loop (#860)

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -393,7 +393,11 @@ def _git_output(cwd: Path, *args: str) -> str | None:
 
 
 def _existing_git_checkout(destination: Path, slug: str, branch: str | None) -> dict[str, str] | None:
-    """Return metadata for an existing checkout without mutating local state."""
+    """Return metadata for an existing checkout without mutating local state.
+
+    BLOCKING: reaches ``check_output_sync`` via ``_git_output``. Async callers
+    MUST go through ``run_blocking`` (see #860).
+    """
 
     if not destination.exists():
         return None
@@ -444,6 +448,12 @@ def _clone_github_repo(
     token: str | None,
     branch: str | None,
 ) -> dict[str, str]:
+    """Clone a GitHub repo. BLOCKING: rmtree, mkdir, git subprocess, git reads.
+
+    Async callers MUST go through ``run_blocking``. Calling this directly from a
+    coroutine freezes the whole worker for the clone's duration, which trips the
+    queue-stall watchdog and restart-loops the process (see #860).
+    """
     if destination.exists():
         shutil.rmtree(destination, ignore_errors=True)
     destination.parent.mkdir(parents=True, exist_ok=True)

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -12,7 +12,7 @@ import tempfile
 from typing import Any
 
 from brain.contracts.github import parse_github_repo_slug
-from brain.platform.async_io import check_output_sync, run_subprocess_sync
+from brain.platform.async_io import check_output_sync, run_blocking, run_subprocess_sync
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.drafts import load_draft_metadata, sync_draft_from_root
@@ -799,7 +799,7 @@ async def _materialize_resource(
 
     destination = _safe_repo_destination(workspace_root, slug)
     branch = _clean_text(resource.get("branch") or resource.get("default_branch") or resource.get("branch_hint"))
-    existing_checkout = _existing_git_checkout(destination, slug, branch)
+    existing_checkout = await run_blocking(_existing_git_checkout, destination, slug, branch)
     if existing_checkout:
         clone = existing_checkout
         repo_path = Path(clone["path"])
@@ -847,7 +847,7 @@ async def _materialize_resource(
             errors.append(prefix + token_error)
             continue
         try:
-            clone = _clone_github_repo(slug, destination, token=token, branch=branch)
+            clone = await run_blocking(_clone_github_repo, slug, destination, token=token, branch=branch)
         except Exception as exc:
             prefix = f"Vault key {key_name}: " if key_name else "public clone: "
             errors.append(prefix + _sanitize_git_error(str(exc)))

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1,4 +1,6 @@
+import asyncio
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -131,6 +133,66 @@ def test_github_clone_uses_lightweight_command_and_configurable_timeout(tmp_path
     assert calls[0]["env"]["GIT_TERMINAL_PROMPT"] == "0"
     assert calls[0]["env"]["ILLO_GITHUB_PROJECT_CONTEXT_TOKEN"] == "secret-token"
     assert "secret-token" not in " ".join(calls[0]["command"])
+
+
+async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+
+    clone_started = threading.Event()
+    release_clone = threading.Event()
+    released_by_event_loop = []
+
+    def fake_run_subprocess(command, **_kwargs):
+        clone_started.set()
+        released_by_event_loop.append(release_clone.wait(timeout=1))
+        Path(command[-1]).mkdir(parents=True)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_git_output(_cwd, *args):
+        if args == ("branch", "--show-current"):
+            return "main"
+        if args == ("rev-parse", "HEAD"):
+            return "abc123"
+        return None
+
+    async def record_loop_progress():
+        while not clone_started.is_set():
+            await asyncio.sleep(0)
+        ticks = 0
+        for _ in range(3):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        release_clone.set()
+        return ticks
+
+    monkeypatch.setattr(materializer, "run_subprocess_sync", fake_run_subprocess)
+    monkeypatch.setattr(materializer, "_git_output", fake_git_output)
+
+    resource = {
+        "kind": "repo",
+        "name": "example-org/example-repo",
+        "repo": "example-org/example-repo",
+        "uri": "https://github.com/example-org/example-repo",
+        "branch": "main",
+    }
+    materialization, ticks = await asyncio.gather(
+        materializer._materialize_resource(
+            resource,
+            workspace_root=tmp_path,
+            user_id=None,
+            org_id=None,
+        ),
+        record_loop_progress(),
+    )
+
+    workspace, error = materialization
+    assert error is None
+    assert workspace == {
+        "name": "example-org/example-repo",
+        "path": str(tmp_path / ".illo-project-context" / "github" / "example-org" / "example-repo"),
+    }
+    assert ticks == 3
+    assert released_by_event_loop == [True]
 
 
 def test_github_clone_timeout_env_is_bounded(monkeypatch):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -144,7 +144,11 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
 
     def fake_run_subprocess(command, **_kwargs):
         clone_started.set()
-        released_by_event_loop.append(release_clone.wait(timeout=1))
+        # The timeout is deadlock protection, not a timing assertion: only the
+        # event loop can set release_clone, so if the clone were still running
+        # ON the loop this returns False instead of hanging the suite. Keep it
+        # generous — a tight bound here would flake on a loaded CI box.
+        released_by_event_loop.append(release_clone.wait(timeout=30))
         Path(command[-1]).mkdir(parents=True)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -155,15 +159,13 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
             return "abc123"
         return None
 
-    async def record_loop_progress():
+    async def release_once_loop_is_responsive():
+        # This coroutine can only make progress while the clone is in flight if
+        # the clone is NOT holding the event loop. That is the whole assertion:
+        # no sleeps, no tick counting, just "did the loop keep scheduling".
         while not clone_started.is_set():
             await asyncio.sleep(0)
-        ticks = 0
-        for _ in range(3):
-            await asyncio.sleep(0.01)
-            ticks += 1
         release_clone.set()
-        return ticks
 
     monkeypatch.setattr(materializer, "run_subprocess_sync", fake_run_subprocess)
     monkeypatch.setattr(materializer, "_git_output", fake_git_output)
@@ -175,14 +177,14 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
         "uri": "https://github.com/example-org/example-repo",
         "branch": "main",
     }
-    materialization, ticks = await asyncio.gather(
+    materialization, _ = await asyncio.gather(
         materializer._materialize_resource(
             resource,
             workspace_root=tmp_path,
             user_id=None,
             org_id=None,
         ),
-        record_loop_progress(),
+        release_once_loop_is_responsive(),
     )
 
     workspace, error = materialization
@@ -191,7 +193,7 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
         "name": "example-org/example-repo",
         "path": str(tmp_path / ".illo-project-context" / "github" / "example-org" / "example-repo"),
     }
-    assert ticks == 3
+    # False here means the clone blocked the loop until the timeout expired.
     assert released_by_event_loop == [True]
 
 


### PR DESCRIPTION
## What broke

Project-context git clones ran as a blocking `subprocess.run` **on the worker's asyncio event loop**. Each clone froze the entire worker — every in-flight agent run, the claim loop, all event emission — for as long as the clone took. When one run materialized several repos back to back, the freeze outlasted the queue-stall watchdog's 45s grace. The watchdog read the frozen loop as a stalled queue and exited the worker for restart; the restarted worker reclaimed the same runs, re-cloned the same repos, and froze again.

Observed on illo-dev on 2026-08-28: two kills in 8 minutes (14:06:49Z, 14:13:28Z), the log stream silent for 2–3 minutes in each window, and run 19987's `turn 3` only appearing at 14:16 after two restarts.

## The change

`_materialize_resource` now dispatches both blocking git helpers through `run_blocking` (which is `asyncio.to_thread`):

| line | before | after |
|---|---|---|
| 802 | `_existing_git_checkout(...)` | `await run_blocking(_existing_git_checkout, ...)` |
| 850 | `_clone_github_repo(...)` | `await run_blocking(_clone_github_repo, ...)` |

Offloading the **whole helper** rather than just its `subprocess.run` matters: `_clone_github_repo`'s body is `shutil.rmtree` + `mkdir` + `subprocess.run` + two `_git_output` reads, and `_existing_git_checkout` reaches `check_output_sync` the same way. Moving only the subprocess call would have left the rmtree and the git reads on the loop.

It also lets `_clone_github_repo` stay a plain `def`, so **nothing inside it changed** — the clone timeout, the `finally` block that unlinks the askpass script and pops the token from `env`, the token-candidate fallthrough, and `_sanitize_git_error` all behave exactly as before.

**The watchdog is deliberately untouched.** The ticket lists a loop-liveness heartbeat as a "consider", not as acceptance. It belongs in its own change.

## Code-quality review

A Codex thermo-nuclear review (cross-family — the diff was Codex-written, so this was a second, independent Codex pass at `xhigh`) returned **APPROVE_WITH_NOTES**, `BLOCKING_FINDINGS: none`, `BUGS: none`, 6 files read.

It confirmed the seam: *"the call-site seam is correct because `_materialize_resource` is the only production caller… I would ship this seam"*, and that `await run_blocking(...)` is already the established project spelling (`self_update.py` does the same).

Both of its non-blocking notes are folded in as the second commit:

1. **Blocking boundary made legible.** Both offloaded helpers now say in their docstring that they block and that async callers must use `run_blocking`. The seam was right; nothing at the definition told the next caller which side of it they were on.
2. **Test de-flaked.** The first version asserted `ticks == 3` off three 10 ms sleeps and gave the clone a 1 s release window — which would flake on a loaded box, and this machine sits at load ~19 routinely. It is now a plain two-event handshake with a 30 s bound that exists only so a regression fails instead of hanging the suite. No timing assertion remains.

## How I know the test isn't decorative

The new test blocks the faked clone on a `threading.Event` and asserts that a concurrent coroutine still ticks three times *and* is the thing that releases it.

I verified it has teeth rather than assuming it: I reverted `materializer.py` to `origin/main`, kept the test, and ran it.

```
assert released_by_event_loop == [True]
E   assert [False] == [True]
```

`[False]` is the `wait` timing out — on the pre-fix code the frozen loop never reaches the release. Restored the fix and it passes.

I re-ran that same check **after** the de-flaking rewrite rather than assuming the teeth survived it: still `assert [False] == [True]` with the two call sites reverted, and 0.56 s to pass against the fix.

## Verification

- **Backend fast suite, the CI command verbatim, no path argument** (so `meetbot/tests` actually ran): **5012 passed, 11 skipped, 90 deselected, 0 failed** in 87s. That reconciles — `main` gates at 5011 and this adds exactly one test.
- `python -m brain.jobs.check_cycle_context_admission` → `ok: true`, 3 cycles.
- Lanes: the diff touches `brain/**` and `tests/**` only, so `paths-filter` selects the **backend** lane. No `frontend/**` path, so that lane does not apply.
- **Stated, not hidden:** Spotlight held this machine's load at ~19 during the run. Contention manufactures failures, never passes, so a clean 0-failed still holds.

## What to check on staging

This has no UI. Exercise it on **illo-dev**, where the restart loop was observed:

1. `docker logs -f illospace-worker-1` while a run materializes several repos (a cycle fan-out sweep does it naturally).
2. During a clone, confirm the log keeps producing lines from *other* concurrent runs — the old symptom was a total 2–3 minute silence across every run.
3. Confirm `agent-run worker queue stalled; exiting for restart` does not appear, and `RestartCount` stays put.
4. Confirm clones still succeed and a private repo still resolves through its token candidate — the credential path is the part most worth a second look, even though it is untouched.

## Assumptions

- `run_blocking` is the right seam because `_clone_github_repo` is blocking end to end, not just at its subprocess call.
- The two dirty-worktree helpers elsewhere in the file (`check_output_sync`, `run_subprocess_sync` imports remain) are reached from sync paths; the worker checked and left them alone deliberately.

Closes #860
