### PR TITLE
fix(inbound): give a failed preservation receipt a typed, machine-readable diagnostic (#861)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -63,7 +63,6 @@ from brain.systems.runs.cortex.read_models import (
     public_run_debug_event_payload,
     run_stream_payload,
 )
-from brain.systems.runs.failures import public_run_failure
 from brain.systems.runs.tool_event_read_model import tool_call_summary
 
 
@@ -1366,20 +1365,7 @@ async def _tool_get_result(
     )
     if result.mutated_inbound:
         await db.commit()
-    payload = result.payload
-    if isinstance(payload.get("failure"), dict):
-        return payload
-    for candidate in (
-        payload.get("event"),
-        payload.get("latest_receipt"),
-    ):
-        failure = dict(candidate.get("failure") or {}) if isinstance(candidate, dict) else {}
-        if not failure:
-            continue
-        public_failure = public_run_failure(failure.get("status"), failure.get("category"))
-        if public_failure is not None:
-            return {**payload, "failure": public_failure}
-    return payload
+    return result.payload
 
 
 async def _add_thread_trigger_result_if_needed(

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -1367,6 +1367,8 @@ async def _tool_get_result(
     if result.mutated_inbound:
         await db.commit()
     payload = result.payload
+    if isinstance(payload.get("failure"), dict):
+        return payload
     for candidate in (
         payload.get("event"),
         payload.get("latest_receipt"),

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -3,30 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
 from typing import Any
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.agent_run import AgentRunRow
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+from brain.systems.runs.failure_diagnostic import read_run_failure_diagnostic
 
 
 @dataclass(frozen=True)
 class InboundSubmissionResult:
     payload: dict[str, Any]
     mutated_inbound: bool = False
-
-
-_TOOL_EXECUTION_EVENT_TYPES = frozenset(
-    {"run.tool_started", "run.tool_completed", "run.tool_failed"}
-)
-_SAFE_DIAGNOSTIC_LABEL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,79}$")
-_CAPTURED_EXCEPTION_CLASS = re.compile(
-    r"^run_execution_failed: ([A-Za-z_][A-Za-z0-9_.]{0,79}):"
-)
 
 
 def _result_handling(action_result: dict[str, Any]) -> dict[str, Any]:
@@ -43,67 +33,6 @@ def _run_id(value: Any) -> int | None:
         return int(value) if value is not None else None
     except (TypeError, ValueError):
         return None
-
-
-def _safe_diagnostic_label(value: Any) -> str | None:
-    candidate = str(value or "").strip()
-    return candidate if _SAFE_DIAGNOSTIC_LABEL.fullmatch(candidate) else None
-
-
-async def _failure_diagnostic(
-    session: AsyncSession,
-    *,
-    run: AgentRunRow,
-) -> dict[str, Any] | None:
-    """Build bounded operator diagnostics for the programmatic receipt."""
-
-    if str(run.status or "") != "failed":
-        return None
-
-    events = list(
-        (
-            await session.scalars(
-                select(AgentRunEventRow)
-                .where(
-                    AgentRunEventRow.run_id == int(run.id),
-                    AgentRunEventRow.event_type.in_(
-                        (*_TOOL_EXECUTION_EVENT_TYPES, "run.failed")
-                    ),
-                )
-                .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
-            )
-        ).all()
-    )
-    tool_execution_started = any(
-        str(event.event_type or "") in _TOOL_EXECUTION_EVENT_TYPES for event in events
-    )
-    failure_event = next(
-        (event for event in events if str(event.event_type or "") == "run.failed"),
-        None,
-    )
-    event_payload = (
-        dict(failure_event.payload or {}) if failure_event is not None else {}
-    )
-    metadata_failure = dict((run.metadata_ or {}).get("failure") or {})
-    stage = _safe_diagnostic_label(
-        metadata_failure.get("stage") or event_payload.get("failure_stage")
-    ) or ("tool_execution" if tool_execution_started else "run_execution")
-    exception_class = _safe_diagnostic_label(
-        metadata_failure.get("exception_class") or event_payload.get("exception_class")
-    )
-    if exception_class is None:
-        captured = _CAPTURED_EXCEPTION_CLASS.match(str(event_payload.get("error") or ""))
-        exception_class = captured.group(1) if captured is not None else None
-
-    # Reconciliation follows a replacement run before this helper is called.
-    # A current run that is still failed has no scheduled successor.
-    return {
-        "stage": stage,
-        "exception_class": exception_class,
-        "tool_execution_started": tool_execution_started,
-        "terminal": True,
-        "retry_scheduled": False,
-    }
 
 
 async def read_inbound_submission_result(
@@ -127,7 +56,9 @@ async def read_inbound_submission_result(
     selected_run_id = _run_id(handling.get("run_id"))
     if selected_run_id is not None:
         current_run = await session.get(AgentRunRow, selected_run_id)
-        current_run_status = getattr(current_run, "status", None) if current_run is not None else None
+        current_run_status = (
+            getattr(current_run, "status", None) if current_run is not None else None
+        )
         receipt = await reconcile_inbound_triage_run(session, selected_run_id)
         reconciled = receipt is not None
         if reconciled:
@@ -141,7 +72,9 @@ async def read_inbound_submission_result(
     current_run_id = _run_id(handling.get("run_id"))
     if current_run_id is not None and current_run_id != selected_run_id:
         current_run = await session.get(AgentRunRow, current_run_id)
-        current_run_status = getattr(current_run, "status", None) if current_run is not None else None
+        current_run_status = (
+            getattr(current_run, "status", None) if current_run is not None else None
+        )
 
     receipts = await inbound_admin.list_receipts(
         session,
@@ -172,9 +105,9 @@ async def read_inbound_submission_result(
         None,
     )
     if failure is not None and current_run is not None:
-        diagnostic = await _failure_diagnostic(session, run=current_run)
+        diagnostic = await read_run_failure_diagnostic(session, run=current_run)
         if diagnostic is not None:
-            failure["diagnostic"] = diagnostic
+            failure["diagnostic"] = diagnostic.as_payload()
     return InboundSubmissionResult(
         payload={
             "event_id": str(event.id),

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 
@@ -16,6 +18,15 @@ from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 class InboundSubmissionResult:
     payload: dict[str, Any]
     mutated_inbound: bool = False
+
+
+_TOOL_EXECUTION_EVENT_TYPES = frozenset(
+    {"run.tool_started", "run.tool_completed", "run.tool_failed"}
+)
+_SAFE_DIAGNOSTIC_LABEL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,79}$")
+_CAPTURED_EXCEPTION_CLASS = re.compile(
+    r"^run_execution_failed: ([A-Za-z_][A-Za-z0-9_.]{0,79}):"
+)
 
 
 def _result_handling(action_result: dict[str, Any]) -> dict[str, Any]:
@@ -34,6 +45,67 @@ def _run_id(value: Any) -> int | None:
         return None
 
 
+def _safe_diagnostic_label(value: Any) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate if _SAFE_DIAGNOSTIC_LABEL.fullmatch(candidate) else None
+
+
+async def _failure_diagnostic(
+    session: AsyncSession,
+    *,
+    run: AgentRunRow,
+) -> dict[str, Any] | None:
+    """Build bounded operator diagnostics for the programmatic receipt."""
+
+    if str(run.status or "") != "failed":
+        return None
+
+    events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id == int(run.id),
+                    AgentRunEventRow.event_type.in_(
+                        (*_TOOL_EXECUTION_EVENT_TYPES, "run.failed")
+                    ),
+                )
+                .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+            )
+        ).all()
+    )
+    tool_execution_started = any(
+        str(event.event_type or "") in _TOOL_EXECUTION_EVENT_TYPES for event in events
+    )
+    failure_event = next(
+        (event for event in events if str(event.event_type or "") == "run.failed"),
+        None,
+    )
+    event_payload = (
+        dict(failure_event.payload or {}) if failure_event is not None else {}
+    )
+    metadata_failure = dict((run.metadata_ or {}).get("failure") or {})
+    stage = _safe_diagnostic_label(
+        metadata_failure.get("stage") or event_payload.get("failure_stage")
+    ) or ("tool_execution" if tool_execution_started else "run_execution")
+    exception_class = _safe_diagnostic_label(
+        metadata_failure.get("exception_class") or event_payload.get("exception_class")
+    )
+    if exception_class is None:
+        captured = _CAPTURED_EXCEPTION_CLASS.match(str(event_payload.get("error") or ""))
+        exception_class = captured.group(1) if captured is not None else None
+
+    # Reconciliation follows a replacement run before this helper is called.
+    # A current run that is still failed has no scheduled successor.
+    return {
+        "stage": stage,
+        "exception_class": exception_class,
+        "tool_execution_started": tool_execution_started,
+        "terminal": True,
+        "retry_scheduled": False,
+    }
+
+
 async def read_inbound_submission_result(
     session: AsyncSession,
     *,
@@ -50,11 +122,12 @@ async def read_inbound_submission_result(
     action_result = dict(event.action_result or {})
     handling = _result_handling(action_result)
     reconciled = False
+    current_run = None
     current_run_status = None
     selected_run_id = _run_id(handling.get("run_id"))
     if selected_run_id is not None:
-        run = await session.get(AgentRunRow, selected_run_id)
-        current_run_status = getattr(run, "status", None) if run is not None else None
+        current_run = await session.get(AgentRunRow, selected_run_id)
+        current_run_status = getattr(current_run, "status", None) if current_run is not None else None
         receipt = await reconcile_inbound_triage_run(session, selected_run_id)
         reconciled = receipt is not None
         if reconciled:
@@ -90,6 +163,18 @@ async def read_inbound_submission_result(
         or ("pending" if requires_evidence else "not_required")
     )
     latest_receipt = receipt_payloads[0] if receipt_payloads else None
+    failure = next(
+        (
+            dict(candidate["failure"])
+            for candidate in (event_payload, latest_receipt)
+            if isinstance(candidate, dict) and isinstance(candidate.get("failure"), dict)
+        ),
+        None,
+    )
+    if failure is not None and current_run is not None:
+        diagnostic = await _failure_diagnostic(session, run=current_run)
+        if diagnostic is not None:
+            failure["diagnostic"] = diagnostic
     return InboundSubmissionResult(
         payload={
             "event_id": str(event.id),
@@ -109,6 +194,7 @@ async def read_inbound_submission_result(
             "event": event_payload,
             "latest_receipt": latest_receipt,
             "receipts": receipt_payloads,
+            **({"failure": failure} if failure is not None else {}),
         },
         mutated_inbound=reconciled,
     )

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -1240,6 +1240,7 @@ async def _async_materialize_project_context(run_id: int) -> tuple[bool, dict[st
         return False, await _mark_run_failed_after_runner_error_async(
             int(run_id),
             message,
+            failure_stage="project_context_materialization",
             final_answer=(
                 "I could not start this run because the selected Project Context did not "
                 f"provide a usable workspace. {details}"
@@ -1262,6 +1263,8 @@ async def _mark_run_failed_after_runner_error_async(
     error: str,
     *,
     final_answer: str | None = None,
+    failure_stage: str = "runner_execution",
+    exception_class: str | None = None,
 ) -> dict[str, Any] | None:
     async with _unit_of_work_factory()() as uow:
         store = AsyncAgentRunStore(uow.session)
@@ -1276,7 +1279,13 @@ async def _mark_run_failed_after_runner_error_async(
             failure = public_run_failure(RunStatus.FAILED, category)
             await store.update_metadata(
                 int(run_id),
-                {"failure": {"category": category.value}},
+                {
+                    "failure": {
+                        "category": category.value,
+                        "stage": failure_stage,
+                        **({"exception_class": exception_class} if exception_class else {}),
+                    }
+                },
             )
             if final_answer:
                 # ``final_answer`` is an intent signal from runner setup code. It
@@ -1324,19 +1333,25 @@ def _mark_run_failed_after_runner_error(
     error: str,
     *,
     final_answer: str | None = None,
+    failure_stage: str = "runner_execution",
+    exception_class: str | None = None,
 ) -> dict[str, Any] | None:
     return asyncio.run(
         _mark_run_failed_after_runner_error_async(
             int(run_id),
             error,
             final_answer=final_answer,
+            failure_stage=failure_stage,
+            exception_class=exception_class,
         )
     )
 
 
 async def _process_claimed_run_async(run_id: int) -> bool:
+    failure_stage = "runner_execution"
     try:
         async with _run_heartbeat_async(int(run_id)):
+            failure_stage = "project_context_materialization"
             context_ready, status_payload = await _async_materialize_project_context(int(run_id))
             if not context_ready:
                 await _finalize_cycle_run_if_needed_async(
@@ -1348,6 +1363,7 @@ async def _process_claimed_run_async(run_id: int) -> bool:
                     publish_safe("status_change", status_payload)
                 return True
             status_payload = None
+            failure_stage = "recipe_execution"
             async with _unit_of_work_factory()() as uow:
                 completed_run = await _engine_for_session(uow.session).run_existing(int(run_id))
                 completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
@@ -1362,6 +1378,7 @@ async def _process_claimed_run_async(run_id: int) -> bool:
                         provider_errors_only=completed_status == "failed",
                     )
                 status_payload = await _settle_terminal_root_run_async(uow.session, int(run_id))
+                failure_stage = "runner_settlement"
             await _finalize_cycle_run_if_needed_async(int(run_id), status=completed_status)
         if status_payload:
             publish_safe("status_change", status_payload)
@@ -1379,6 +1396,8 @@ async def _process_claimed_run_async(run_id: int) -> bool:
             status_payload = await _mark_run_failed_after_runner_error_async(
                 int(run_id),
                 str(failure),
+                failure_stage=failure_stage,
+                exception_class=type(failure.original).__name__,
             )
             await _finalize_cycle_run_if_needed_async(
                 int(run_id),

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -31,6 +31,10 @@ from brain.systems.runs.evidence_health import (
 )
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
@@ -1240,7 +1244,7 @@ async def _async_materialize_project_context(run_id: int) -> tuple[bool, dict[st
         return False, await _mark_run_failed_after_runner_error_async(
             int(run_id),
             message,
-            failure_stage="project_context_materialization",
+            failure_stage=RunFailureStage.PROJECT_CONTEXT_MATERIALIZATION,
             final_answer=(
                 "I could not start this run because the selected Project Context did not "
                 f"provide a usable workspace. {details}"
@@ -1263,8 +1267,8 @@ async def _mark_run_failed_after_runner_error_async(
     error: str,
     *,
     final_answer: str | None = None,
-    failure_stage: str = "runner_execution",
-    exception_class: str | None = None,
+    failure_stage: RunFailureStage = RunFailureStage.RUNNER_EXECUTION,
+    exception_type: type[BaseException] | None = None,
 ) -> dict[str, Any] | None:
     async with _unit_of_work_factory()() as uow:
         store = AsyncAgentRunStore(uow.session)
@@ -1282,8 +1286,10 @@ async def _mark_run_failed_after_runner_error_async(
                 {
                     "failure": {
                         "category": category.value,
-                        "stage": failure_stage,
-                        **({"exception_class": exception_class} if exception_class else {}),
+                        **failure_diagnostic_metadata(
+                            stage=failure_stage,
+                            exception_type=exception_type,
+                        ),
                     }
                 },
             )
@@ -1333,8 +1339,8 @@ def _mark_run_failed_after_runner_error(
     error: str,
     *,
     final_answer: str | None = None,
-    failure_stage: str = "runner_execution",
-    exception_class: str | None = None,
+    failure_stage: RunFailureStage = RunFailureStage.RUNNER_EXECUTION,
+    exception_type: type[BaseException] | None = None,
 ) -> dict[str, Any] | None:
     return asyncio.run(
         _mark_run_failed_after_runner_error_async(
@@ -1342,16 +1348,16 @@ def _mark_run_failed_after_runner_error(
             error,
             final_answer=final_answer,
             failure_stage=failure_stage,
-            exception_class=exception_class,
+            exception_type=exception_type,
         )
     )
 
 
 async def _process_claimed_run_async(run_id: int) -> bool:
-    failure_stage = "runner_execution"
+    failure_stage = RunFailureStage.RUNNER_EXECUTION
     try:
         async with _run_heartbeat_async(int(run_id)):
-            failure_stage = "project_context_materialization"
+            failure_stage = RunFailureStage.PROJECT_CONTEXT_MATERIALIZATION
             context_ready, status_payload = await _async_materialize_project_context(int(run_id))
             if not context_ready:
                 await _finalize_cycle_run_if_needed_async(
@@ -1363,10 +1369,13 @@ async def _process_claimed_run_async(run_id: int) -> bool:
                     publish_safe("status_change", status_payload)
                 return True
             status_payload = None
-            failure_stage = "recipe_execution"
+            failure_stage = RunFailureStage.RECIPE_EXECUTION
             async with _unit_of_work_factory()() as uow:
                 completed_run = await _engine_for_session(uow.session).run_existing(int(run_id))
-                completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
+                failure_stage = RunFailureStage.RUNNER_SETTLEMENT
+                completed_status = str(
+                    getattr(completed_run.status, "value", completed_run.status) or ""
+                )
                 if completed_status in {"completed", "failed"}:
                     from brain.systems.cycles.contract_gate import (
                         async_prepare_cycle_run_visible_finalization,
@@ -1378,7 +1387,6 @@ async def _process_claimed_run_async(run_id: int) -> bool:
                         provider_errors_only=completed_status == "failed",
                     )
                 status_payload = await _settle_terminal_root_run_async(uow.session, int(run_id))
-                failure_stage = "runner_settlement"
             await _finalize_cycle_run_if_needed_async(int(run_id), status=completed_status)
         if status_payload:
             publish_safe("status_change", status_payload)
@@ -1397,7 +1405,7 @@ async def _process_claimed_run_async(run_id: int) -> bool:
                 int(run_id),
                 str(failure),
                 failure_stage=failure_stage,
-                exception_class=type(failure.original).__name__,
+                exception_type=type(failure.original),
             )
             await _finalize_cycle_run_if_needed_async(
                 int(run_id),

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1150,7 +1150,7 @@ def _make_result(
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
     effective_routing: dict[str, Any] | None = None,
-    error_type: str | None = None,
+    exception_type: type[BaseException] | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common fields."""
     return _runtime_make_result(
@@ -1161,7 +1161,7 @@ def _make_result(
         start_time,
         tool_calls,
         error=error,
-        error_type=error_type,
+        exception_type=exception_type,
         worker_results=worker_results,
         termination=termination,
         post_completion_tasks=post_completion_tasks,
@@ -2204,7 +2204,7 @@ async def run_agent_async(
                 start_time,
                 state.tool_calls_made,
                 error=f"API error: {e}",
-                error_type=type(e).__name__,
+                exception_type=type(e),
                 effective_routing=effective_routing,
             )
         logger.error("Agent %s: error: %s", session_id, e)
@@ -2216,7 +2216,7 @@ async def run_agent_async(
             start_time,
             state.tool_calls_made,
             error=str(e),
-            error_type=type(e).__name__,
+            exception_type=type(e),
             effective_routing=effective_routing,
         )
 

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1150,6 +1150,7 @@ def _make_result(
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
     effective_routing: dict[str, Any] | None = None,
+    error_type: str | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common fields."""
     return _runtime_make_result(
@@ -1160,6 +1161,7 @@ def _make_result(
         start_time,
         tool_calls,
         error=error,
+        error_type=error_type,
         worker_results=worker_results,
         termination=termination,
         post_completion_tasks=post_completion_tasks,
@@ -2202,6 +2204,7 @@ async def run_agent_async(
                 start_time,
                 state.tool_calls_made,
                 error=f"API error: {e}",
+                error_type=type(e).__name__,
                 effective_routing=effective_routing,
             )
         logger.error("Agent %s: error: %s", session_id, e)
@@ -2213,6 +2216,7 @@ async def run_agent_async(
             start_time,
             state.tool_calls_made,
             error=str(e),
+            error_type=type(e).__name__,
             effective_routing=effective_routing,
         )
 

--- a/brain/systems/runs/direct_loop/result.py
+++ b/brain/systems/runs/direct_loop/result.py
@@ -47,6 +47,7 @@ class AgentResult:
     termination: LoopTermination | None = None
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
     effective_routing: dict[str, Any] = field(default_factory=dict)
+    error_type: str | None = None
 
 
 def make_result(
@@ -61,6 +62,7 @@ def make_result(
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
     effective_routing: dict[str, Any] | None = None,
+    error_type: str | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common runtime fields."""
 
@@ -75,6 +77,7 @@ def make_result(
         duration_sec=int(time.time() - start_time),
         tool_calls=tool_calls,
         error=error,
+        error_type=error_type,
         termination=termination,
         worker_results=worker_results or [],
         post_completion_tasks=post_completion_tasks,

--- a/brain/systems/runs/direct_loop/result.py
+++ b/brain/systems/runs/direct_loop/result.py
@@ -47,7 +47,7 @@ class AgentResult:
     termination: LoopTermination | None = None
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
     effective_routing: dict[str, Any] = field(default_factory=dict)
-    error_type: str | None = None
+    exception_type: type[BaseException] | None = None
 
 
 def make_result(
@@ -62,7 +62,7 @@ def make_result(
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
     effective_routing: dict[str, Any] | None = None,
-    error_type: str | None = None,
+    exception_type: type[BaseException] | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common runtime fields."""
 
@@ -77,7 +77,7 @@ def make_result(
         duration_sec=int(time.time() - start_time),
         tool_calls=tool_calls,
         error=error,
-        error_type=error_type,
+        exception_type=exception_type,
         termination=termination,
         worker_results=worker_results or [],
         post_completion_tasks=post_completion_tasks,

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -16,6 +16,10 @@ from brain.systems.runs.context import RunContextLoader
 from brain.systems.runs.domain import AgentRun, AgentRunRequest
 from brain.systems.runs.events import activity_event, run_event, text_delta_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.failures import (
     RunFailureCategory,
     coerce_failure_category,
@@ -53,8 +57,8 @@ class RunRecipeResult:
     # Optional user-safe text. Failed runs must never put raw errors here.
     final_output: str | None = None
     failure_category: RunFailureCategory | str | None = None
-    failure_stage: str | None = None
-    exception_class: str | None = None
+    failure_stage: RunFailureStage | None = None
+    exception_type: type[BaseException] | None = None
     artifacts: tuple = ()
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
 
@@ -303,8 +307,8 @@ class AsyncAgentRunEngine:
                 error,
                 final_output=result.final_output,
                 failure_category=result.failure_category or failure_category_for_error(error),
-                failure_stage=result.failure_stage or "recipe_execution",
-                exception_class=result.exception_class,
+                failure_stage=result.failure_stage or RunFailureStage.RECIPE_EXECUTION,
+                exception_type=result.exception_type,
                 execution_claim=execution_claim,
             )
         if result_status == RunStatus.CANCELED:
@@ -372,8 +376,8 @@ class AsyncAgentRunEngine:
                 f"Chantier declare failed: {failure}",
                 final_output=safe_terminal_run_message(RunStatus.FAILED, RunFailureCategory.INTERNAL),
                 failure_category=RunFailureCategory.INTERNAL,
-                failure_stage="completion_verification",
-                exception_class=type(exc).__name__,
+                failure_stage=RunFailureStage.COMPLETION_VERIFICATION,
+                exception_type=type(exc),
                 execution_claim=execution_claim,
             )
         if guarantee is not None:
@@ -430,8 +434,8 @@ class AsyncAgentRunEngine:
         *,
         final_output: str | None = None,
         failure_category: RunFailureCategory | str | None = None,
-        failure_stage: str = "recipe_execution",
-        exception_class: str | None = None,
+        failure_stage: RunFailureStage = RunFailureStage.RECIPE_EXECUTION,
+        exception_type: type[BaseException] | None = None,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
         row = await self._prepare_terminal_write(run_id)
@@ -441,8 +445,10 @@ class AsyncAgentRunEngine:
             category = coerce_failure_category(failure_category or failure_category_for_error(error))
             failure_metadata = {
                 "category": category.value,
-                "stage": failure_stage,
-                **({"exception_class": exception_class} if exception_class else {}),
+                **failure_diagnostic_metadata(
+                    stage=failure_stage,
+                    exception_type=exception_type,
+                ),
             }
             await self.store.update_metadata(
                 run_id,

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -53,6 +53,8 @@ class RunRecipeResult:
     # Optional user-safe text. Failed runs must never put raw errors here.
     final_output: str | None = None
     failure_category: RunFailureCategory | str | None = None
+    failure_stage: str | None = None
+    exception_class: str | None = None
     artifacts: tuple = ()
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
 
@@ -301,6 +303,8 @@ class AsyncAgentRunEngine:
                 error,
                 final_output=result.final_output,
                 failure_category=result.failure_category or failure_category_for_error(error),
+                failure_stage=result.failure_stage or "recipe_execution",
+                exception_class=result.exception_class,
                 execution_claim=execution_claim,
             )
         if result_status == RunStatus.CANCELED:
@@ -368,6 +372,8 @@ class AsyncAgentRunEngine:
                 f"Chantier declare failed: {failure}",
                 final_output=safe_terminal_run_message(RunStatus.FAILED, RunFailureCategory.INTERNAL),
                 failure_category=RunFailureCategory.INTERNAL,
+                failure_stage="completion_verification",
+                exception_class=type(exc).__name__,
                 execution_claim=execution_claim,
             )
         if guarantee is not None:
@@ -424,6 +430,8 @@ class AsyncAgentRunEngine:
         *,
         final_output: str | None = None,
         failure_category: RunFailureCategory | str | None = None,
+        failure_stage: str = "recipe_execution",
+        exception_class: str | None = None,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
         row = await self._prepare_terminal_write(run_id)
@@ -431,9 +439,14 @@ class AsyncAgentRunEngine:
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             category = coerce_failure_category(failure_category or failure_category_for_error(error))
+            failure_metadata = {
+                "category": category.value,
+                "stage": failure_stage,
+                **({"exception_class": exception_class} if exception_class else {}),
+            }
             await self.store.update_metadata(
                 run_id,
-                {"failure": {"category": category.value}},
+                {"failure": failure_metadata},
             )
             safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
             failed = await self.store.set_status(

--- a/brain/systems/runs/failure_diagnostic.py
+++ b/brain/systems/runs/failure_diagnostic.py
@@ -1,0 +1,169 @@
+"""Typed persistence and read projection for terminal run diagnostics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+
+
+_DIAGNOSTIC_SCHEMA = "typed_v1"
+_TOOL_EXECUTION_EVENT_TYPES = frozenset(
+    {"run.tool_started", "run.tool_completed", "run.tool_failed"}
+)
+
+
+class RunFailureStage(str, Enum):
+    """Closed set of terminal failure stages written by run producers."""
+
+    RUNNER_EXECUTION = "runner_execution"
+    PROJECT_CONTEXT_MATERIALIZATION = "project_context_materialization"
+    RECIPE_EXECUTION = "recipe_execution"
+    AGENT_EXECUTION = "agent_execution"
+    COMPLETION_VERIFICATION = "completion_verification"
+    RUNNER_SETTLEMENT = "runner_settlement"
+    UNKNOWN = "unknown"
+
+
+class DiagnosticValueState(str, Enum):
+    """Whether a projected diagnostic value is usable by the caller."""
+
+    KNOWN = "known"
+    UNKNOWN = "unknown"
+    REDACTED = "redacted"
+
+
+@dataclass(frozen=True)
+class RunFailureDiagnostic:
+    """Safe typed projection of one failed run's diagnostic metadata."""
+
+    stage: RunFailureStage
+    stage_state: DiagnosticValueState
+    exception_class: str | None
+    exception_class_state: DiagnosticValueState
+    tool_execution_started: bool
+    terminal: bool = True
+    retry_scheduled: bool = False
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage.value,
+            "stage_state": self.stage_state.value,
+            "exception_class": self.exception_class,
+            "exception_class_state": self.exception_class_state.value,
+            "tool_execution_started": self.tool_execution_started,
+            "terminal": self.terminal,
+            "retry_scheduled": self.retry_scheduled,
+        }
+
+
+def failure_diagnostic_metadata(
+    *,
+    stage: RunFailureStage,
+    exception_type: type[BaseException] | None = None,
+) -> dict[str, Any]:
+    """Encode diagnostics that came from typed run producers."""
+
+    if not isinstance(stage, RunFailureStage):
+        raise TypeError("failure stage must be a RunFailureStage")
+    if stage is RunFailureStage.UNKNOWN:
+        raise ValueError("failure producers cannot write an unknown stage")
+    if exception_type is not None and (
+        not isinstance(exception_type, type)
+        or not issubclass(exception_type, BaseException)
+    ):
+        raise TypeError("exception type must be a BaseException class")
+    return {
+        "diagnostic_schema": _DIAGNOSTIC_SCHEMA,
+        "stage": stage.value,
+        **(
+            {"exception_class": exception_type.__name__}
+            if exception_type is not None
+            else {}
+        ),
+    }
+
+
+def _stage_projection(
+    failure_metadata: Mapping[str, Any],
+) -> tuple[RunFailureStage, DiagnosticValueState]:
+    if "stage" not in failure_metadata:
+        return RunFailureStage.UNKNOWN, DiagnosticValueState.UNKNOWN
+    try:
+        stage = RunFailureStage(failure_metadata["stage"])
+    except (TypeError, ValueError):
+        return RunFailureStage.UNKNOWN, DiagnosticValueState.REDACTED
+    if stage is RunFailureStage.UNKNOWN:
+        return stage, DiagnosticValueState.UNKNOWN
+    return stage, DiagnosticValueState.KNOWN
+
+
+def _exception_class_projection(
+    failure_metadata: Mapping[str, Any],
+) -> tuple[str | None, DiagnosticValueState]:
+    if "exception_class" not in failure_metadata:
+        return None, DiagnosticValueState.UNKNOWN
+    exception_class = failure_metadata.get("exception_class")
+    if (
+        failure_metadata.get("diagnostic_schema") != _DIAGNOSTIC_SCHEMA
+        or not isinstance(exception_class, str)
+        or not exception_class
+    ):
+        return None, DiagnosticValueState.REDACTED
+    return exception_class, DiagnosticValueState.KNOWN
+
+
+async def read_run_failure_diagnostic(
+    session: AsyncSession,
+    *,
+    run: AgentRunRow,
+) -> RunFailureDiagnostic | None:
+    """Read the canonical diagnostic projection for a failed run."""
+
+    run_status = getattr(run.status, "value", run.status)
+    if str(run_status or "") != "failed":
+        return None
+
+    event_types = (
+        await session.scalars(
+            select(AgentRunEventRow.event_type).where(
+                AgentRunEventRow.run_id == int(run.id),
+                AgentRunEventRow.event_type.in_(_TOOL_EXECUTION_EVENT_TYPES),
+            )
+        )
+    ).all()
+    metadata = run.metadata_ if isinstance(run.metadata_, Mapping) else {}
+    stored_failure = metadata.get("failure")
+    failure_metadata = stored_failure if isinstance(stored_failure, Mapping) else {}
+    stage, stage_state = _stage_projection(failure_metadata)
+    exception_class, exception_class_state = _exception_class_projection(
+        failure_metadata
+    )
+    return RunFailureDiagnostic(
+        stage=stage,
+        stage_state=stage_state,
+        exception_class=exception_class,
+        exception_class_state=exception_class_state,
+        tool_execution_started=any(
+            str(event_type or "") in _TOOL_EXECUTION_EVENT_TYPES
+            for event_type in event_types
+        ),
+        # Replacement retries have their own current run. A still-failed run
+        # is terminal and has no retry scheduled on this run identity.
+        retry_scheduled=False,
+    )
+
+
+__all__ = [
+    "DiagnosticValueState",
+    "RunFailureDiagnostic",
+    "RunFailureStage",
+    "failure_diagnostic_metadata",
+    "read_run_failure_diagnostic",
+]

--- a/brain/systems/runs/failure_diagnostic.py
+++ b/brain/systems/runs/failure_diagnostic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -14,6 +15,22 @@ from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
 
 
 _DIAGNOSTIC_SCHEMA = "typed_v1"
+_EXCEPTION_CLASS_WITHHELD = "exception_class_withheld"
+
+
+def _module_level_exception_type(
+    module_name: object,
+    class_name: str,
+) -> type[BaseException] | None:
+    if not isinstance(module_name, str):
+        return None
+    module = sys.modules.get(module_name)
+    candidate = getattr(module, class_name, None) if module is not None else None
+    if not isinstance(candidate, type) or not issubclass(candidate, BaseException):
+        return None
+    return candidate
+
+
 _TOOL_EXECUTION_EVENT_TYPES = frozenset(
     {"run.tool_started", "run.tool_completed", "run.tool_failed"}
 )
@@ -79,11 +96,23 @@ def failure_diagnostic_metadata(
         or not issubclass(exception_type, BaseException)
     ):
         raise TypeError("exception type must be a BaseException class")
+    exception_is_module_level = exception_type is not None and (
+        _module_level_exception_type(
+            exception_type.__module__,
+            exception_type.__name__,
+        )
+        is exception_type
+    )
     return {
         "diagnostic_schema": _DIAGNOSTIC_SCHEMA,
         "stage": stage.value,
         **(
-            {"exception_class": exception_type.__name__}
+            {
+                "exception_class": exception_type.__name__,
+                "exception_module": exception_type.__module__,
+            }
+            if exception_is_module_level
+            else {_EXCEPTION_CLASS_WITHHELD: True}
             if exception_type is not None
             else {}
         ),
@@ -108,12 +137,22 @@ def _exception_class_projection(
     failure_metadata: Mapping[str, Any],
 ) -> tuple[str | None, DiagnosticValueState]:
     if "exception_class" not in failure_metadata:
+        if (
+            failure_metadata.get("diagnostic_schema") == _DIAGNOSTIC_SCHEMA
+            and failure_metadata.get(_EXCEPTION_CLASS_WITHHELD) is True
+        ):
+            return None, DiagnosticValueState.REDACTED
         return None, DiagnosticValueState.UNKNOWN
     exception_class = failure_metadata.get("exception_class")
     if (
         failure_metadata.get("diagnostic_schema") != _DIAGNOSTIC_SCHEMA
         or not isinstance(exception_class, str)
         or not exception_class
+        or _module_level_exception_type(
+            failure_metadata.get("exception_module"),
+            exception_class,
+        )
+        is None
     ):
         return None, DiagnosticValueState.REDACTED
     return exception_class, DiagnosticValueState.KNOWN

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from brain.contracts.thread_references import THREAD_DISCUSSION_THREAD_PREFIX
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime, cancel_event_is_set
+from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.failures import failure_category_for_error, safe_terminal_run_message
 from brain.systems.runs.tools import wrap_tool_handlers
 from brain.systems.runs.status import RunStatus
@@ -258,8 +259,8 @@ class FastRecipe(BaseRunRecipe):
                 error=str(exc),
                 final_output=safe_terminal_run_message(RunStatus.FAILED, category),
                 failure_category=category,
-                failure_stage="agent_execution",
-                exception_class=type(exc).__name__,
+                failure_stage=RunFailureStage.AGENT_EXECUTION,
+                exception_type=type(exc),
                 status=RunStatus.FAILED,
             )
 
@@ -277,8 +278,8 @@ class FastRecipe(BaseRunRecipe):
                 error=error,
                 final_output=safe_terminal_run_message(status, category),
                 failure_category=category,
-                failure_stage="agent_execution",
-                exception_class=getattr(result, "error_type", None),
+                failure_stage=RunFailureStage.AGENT_EXECUTION,
+                exception_type=getattr(result, "exception_type", None),
                 status=status,
                 post_completion_tasks=tuple(getattr(result, "post_completion_tasks", ()) or ()),
             )

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -258,6 +258,8 @@ class FastRecipe(BaseRunRecipe):
                 error=str(exc),
                 final_output=safe_terminal_run_message(RunStatus.FAILED, category),
                 failure_category=category,
+                failure_stage="agent_execution",
+                exception_class=type(exc).__name__,
                 status=RunStatus.FAILED,
             )
 
@@ -275,6 +277,8 @@ class FastRecipe(BaseRunRecipe):
                 error=error,
                 final_output=safe_terminal_run_message(status, category),
                 failure_category=category,
+                failure_stage="agent_execution",
+                exception_class=getattr(result, "error_type", None),
                 status=status,
                 post_completion_tasks=tuple(getattr(result, "post_completion_tasks", ()) or ()),
             )

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -14,6 +14,7 @@ from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.context import compact_project_reference
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
+from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.failures import failure_category_for_error, public_run_failure
 from brain.systems.runs.recipes.base import BaseRunRecipe
 from brain.systems.runs.recipes.shared import (
@@ -224,6 +225,7 @@ class WorkerRecipe(BaseRunRecipe):
             status = RunStatus.FAILED
             failure_category = failure_category_for_error(exc)
             failure = public_run_failure(status, failure_category)
+            exception_type = type(exc)
             output = ""
             post_completion_tasks = ()
         else:
@@ -246,6 +248,7 @@ class WorkerRecipe(BaseRunRecipe):
             error = None
             failure_category = None
             failure = None
+            exception_type = None
             if status == RunStatus.FAILED:
                 error = (
                     safe_provider_error_sentinel(detected_provider_error)
@@ -258,6 +261,7 @@ class WorkerRecipe(BaseRunRecipe):
                 )
                 failure_category = failure_category_for_error(error)
                 failure = public_run_failure(status, failure_category)
+                exception_type = getattr(result, "exception_type", None)
                 output = ""
             post_completion_tasks = tuple(getattr(result, "post_completion_tasks", ()) or ())
         await _record_effective_routing(runtime, effective_routing)
@@ -287,6 +291,12 @@ class WorkerRecipe(BaseRunRecipe):
             error=error,
             final_output=public_output if status == RunStatus.FAILED else None,
             failure_category=failure_category,
+            failure_stage=(
+                RunFailureStage.AGENT_EXECUTION
+                if status == RunStatus.FAILED
+                else None
+            ),
+            exception_type=exception_type,
             artifacts=(worker_result,),
             post_completion_tasks=post_completion_tasks,
         )

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -492,11 +492,15 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
 
 async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(monkeypatch):
     from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.failure_diagnostic import RunFailureStage
     from brain.systems.runs.recipes.fast import FastRecipe
     from brain.systems.runs.status import RunStatus
 
     raw_delta = "partial provider diagnostic token=fast-stream-secret"
     raw_error = "peer closed connection without sending complete message body"
+
+    class RemoteProtocolError(RuntimeError):
+        pass
 
     async def fake_invoke(spec):
         await spec.on_stream_delta(raw_delta)
@@ -504,7 +508,7 @@ async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(mo
             output=raw_delta,
             success=False,
             error=raw_error,
-            error_type="RemoteProtocolError",
+            exception_type=RemoteProtocolError,
         )
 
     monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
@@ -518,8 +522,8 @@ async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(mo
     assert result.status == RunStatus.FAILED
     assert result.error == raw_error
     assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
-    assert result.failure_stage == "agent_execution"
-    assert result.exception_class == "RemoteProtocolError"
+    assert result.failure_stage == RunFailureStage.AGENT_EXECUTION
+    assert result.exception_type is RemoteProtocolError
     assert raw_delta not in streamed
     assert raw_error not in streamed
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -500,7 +500,12 @@ async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(mo
 
     async def fake_invoke(spec):
         await spec.on_stream_delta(raw_delta)
-        return SimpleNamespace(output=raw_delta, success=False, error=raw_error)
+        return SimpleNamespace(
+            output=raw_delta,
+            success=False,
+            error=raw_error,
+            error_type="RemoteProtocolError",
+        )
 
     monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
     monkeypatch.setattr("brain.systems.runs.recipes.fast.build_tool_handlers", lambda **_kwargs: {})
@@ -513,6 +518,8 @@ async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(mo
     assert result.status == RunStatus.FAILED
     assert result.error == raw_error
     assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
+    assert result.failure_stage == "agent_execution"
+    assert result.exception_class == "RemoteProtocolError"
     assert raw_delta not in streamed
     assert raw_error not in streamed
 

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1743,7 +1743,10 @@ async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
     assert result == {"run_id": run.id}
     assert row is not None
     assert row.status == RunStatus.FAILED.value
-    assert row.metadata_["failure"] == {"category": "upstream"}
+    assert row.metadata_["failure"] == {
+        "category": "upstream",
+        "stage": "runner_execution",
+    }
     assert [artifact.text for artifact in artifacts] == [UPSTREAM_FAILED_RUN_MESSAGE]
     assert [event.payload for event in text_events] == [{"text": UPSTREAM_FAILED_RUN_MESSAGE}]
     assert all(raw_diagnostic not in str(value) for value in (artifacts, text_events))
@@ -1902,6 +1905,11 @@ async def test_runner_commit_failure_rolls_back_then_settles_in_fresh_uow(
     assert opened_uows == 2
     assert row is not None
     assert row.status == RunStatus.FAILED.value
+    assert row.metadata_["failure"] == {
+        "category": "internal",
+        "stage": "runner_settlement",
+        "exception_class": "RuntimeError",
+    }
     assert failed_event.payload["error"] == (
         "run_execution_failed: RuntimeError: commit exploded"
     )
@@ -2037,7 +2045,10 @@ async def test_interactive_slack_transport_failure_never_persists_raw_error_as_f
     )
 
     assert result.status == RunStatus.FAILED
-    assert result.metadata["failure"] == {"category": "upstream"}
+    assert result.metadata["failure"] == {
+        "category": "upstream",
+        "stage": "agent_execution",
+    }
     assert [artifact.text for artifact in final_answers] == [UPSTREAM_FAILED_RUN_MESSAGE]
     assert all(raw_error not in str(artifact.text) for artifact in final_answers)
 

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1745,6 +1745,7 @@ async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
     assert row.status == RunStatus.FAILED.value
     assert row.metadata_["failure"] == {
         "category": "upstream",
+        "diagnostic_schema": "typed_v1",
         "stage": "runner_execution",
     }
     assert [artifact.text for artifact in artifacts] == [UPSTREAM_FAILED_RUN_MESSAGE]
@@ -1877,7 +1878,11 @@ async def test_runner_commit_failure_rolls_back_then_settles_in_fresh_uow(
         return None
 
     monkeypatch.setattr(runner, "_unit_of_work_factory", lambda: CommitAwareUoW)
-    monkeypatch.setattr(runner, "_engine_for_session", lambda session: CompletingEngine(session))
+    monkeypatch.setattr(
+        runner,
+        "_engine_for_session",
+        lambda session: CompletingEngine(session),
+    )
     monkeypatch.setattr(runner, "_run_heartbeat_async", heartbeat)
     monkeypatch.setattr(runner, "_async_materialize_project_context", materialize)
     monkeypatch.setattr(runner, "_settle_terminal_root_run_async", no_settlement)
@@ -1907,12 +1912,117 @@ async def test_runner_commit_failure_rolls_back_then_settles_in_fresh_uow(
     assert row.status == RunStatus.FAILED.value
     assert row.metadata_["failure"] == {
         "category": "internal",
+        "diagnostic_schema": "typed_v1",
         "stage": "runner_settlement",
         "exception_class": "RuntimeError",
     }
     assert failed_event.payload["error"] == (
         "run_execution_failed: RuntimeError: commit exploded"
     )
+
+
+@pytest.mark.parametrize("failure_boundary", ("contract_gate", "settlement"))
+async def test_runner_finalization_failures_use_runner_settlement_stage(
+    monkeypatch,
+    session_factory,
+    failure_boundary,
+):
+    from contextlib import asynccontextmanager
+
+    from brain.systems.runs.cortex import runner
+
+    setup_session = session_factory()
+    store = AsyncAgentRunStore(setup_session)
+    run = await store.create_run(
+        _run_request(
+            thread_id=f"thread-{failure_boundary}-failure",
+            message=f"{failure_boundary} failure",
+        )
+    )
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+    await setup_session.commit()
+    await setup_session.close()
+
+    class TestUoW:
+        def __init__(self):
+            self.session = session_factory()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, _exc, _tb):
+            try:
+                if exc_type is None:
+                    await self.session.commit()
+                else:
+                    await self.session.rollback()
+            finally:
+                await self.session.close()
+
+    class CompletingEngine:
+        def __init__(self, session):
+            self.session = session
+
+        async def run_existing(self, run_id):
+            row = await self.session.get(AgentRunRow, int(run_id))
+            assert row is not None
+            row.status = RunStatus.COMPLETED.value
+            return SimpleNamespace(status=RunStatus.COMPLETED)
+
+    @asynccontextmanager
+    async def heartbeat(_run_id):
+        yield
+
+    async def materialize(_run_id):
+        return True, None
+
+    settlement_calls = 0
+
+    async def settle(_session, _run_id):
+        nonlocal settlement_calls
+        settlement_calls += 1
+        if failure_boundary == "settlement" and settlement_calls == 1:
+            raise RuntimeError("settlement exploded")
+        return None
+
+    async def contract_gate(*_args, **_kwargs):
+        if failure_boundary == "contract_gate":
+            raise RuntimeError("contract gate exploded")
+
+    async def no_cycle_finalization(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(runner, "_unit_of_work_factory", lambda: TestUoW)
+    monkeypatch.setattr(
+        runner,
+        "_engine_for_session",
+        lambda session: CompletingEngine(session),
+    )
+    monkeypatch.setattr(runner, "_run_heartbeat_async", heartbeat)
+    monkeypatch.setattr(runner, "_async_materialize_project_context", materialize)
+    monkeypatch.setattr(runner, "_settle_terminal_root_run_async", settle)
+    monkeypatch.setattr(runner, "_finalize_cycle_run_if_needed_async", no_cycle_finalization)
+    monkeypatch.setattr(
+        "brain.systems.cycles.contract_gate.async_prepare_cycle_run_visible_finalization",
+        contract_gate,
+    )
+
+    processed = await runner._process_claimed_run_async(run.id)
+
+    inspection_session = session_factory()
+    row = await inspection_session.get(AgentRunRow, run.id)
+    await inspection_session.close()
+
+    assert processed is False
+    assert row is not None
+    assert row.status == RunStatus.FAILED.value
+    assert row.metadata_["failure"] == {
+        "category": "internal",
+        "diagnostic_schema": "typed_v1",
+        "stage": "runner_settlement",
+        "exception_class": "RuntimeError",
+    }
 
 
 async def test_oversized_system_admission_error_reaches_run_failed_event(
@@ -2047,6 +2157,7 @@ async def test_interactive_slack_transport_failure_never_persists_raw_error_as_f
     assert result.status == RunStatus.FAILED
     assert result.metadata["failure"] == {
         "category": "upstream",
+        "diagnostic_schema": "typed_v1",
         "stage": "agent_execution",
     }
     assert [artifact.text for artifact in final_answers] == [UPSTREAM_FAILED_RUN_MESSAGE]

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1915,6 +1915,7 @@ async def test_runner_commit_failure_rolls_back_then_settles_in_fresh_uow(
         "diagnostic_schema": "typed_v1",
         "stage": "runner_settlement",
         "exception_class": "RuntimeError",
+        "exception_module": "builtins",
     }
     assert failed_event.payload["error"] == (
         "run_execution_failed: RuntimeError: commit exploded"
@@ -2022,6 +2023,7 @@ async def test_runner_finalization_failures_use_runner_settlement_stage(
         "diagnostic_schema": "typed_v1",
         "stage": "runner_settlement",
         "exception_class": "RuntimeError",
+        "exception_module": "builtins",
     }
 
 

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -19,7 +19,10 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import service as inbound
 from brain.systems.inbound.preservation import PRESERVATION_MISSING_REASON
 from brain.systems.runs.events import run_event
-from brain.systems.runs.failure_diagnostic import RunFailureStage
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 
@@ -608,7 +611,7 @@ async def test_get_result_lazily_reconciles_completed_submission_run(session):
     assert payload["evidence_status"] == "not_required"
 
 
-async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(session):
+async def test_get_result_failed_preservation_reports_exception_class_states(session):
     from brain.app.api.routers.agent_mcp import _tool_get_result
     from brain.systems.runs.engine import AsyncAgentRunEngine
     from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
@@ -636,7 +639,7 @@ async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(s
         run_event(run_id, "run.tool_started", {"tool_name": "workspace_search"})
     )
     raw_diagnostic = "provider failed with token=receipt-secret"
-    exception_type = type("Erreur_accentuée" + ("e" * 90), (RuntimeError,), {})
+    exception_type = ValueError
     await AsyncAgentRunEngine(session, recipes={}).fail(
         run_id,
         raw_diagnostic,
@@ -671,11 +674,59 @@ async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(s
     assert payload["retry_lineage"] is None
     assert raw_diagnostic not in json.dumps(payload)
 
+    synthesized_exception = type(
+        "sk_live_abc123DEF456token",
+        (Exception,),
+        {},
+    )
+    synthesized_metadata = failure_diagnostic_metadata(
+        stage=RunFailureStage.AGENT_EXECUTION,
+        exception_type=synthesized_exception,
+    )
+    assert "exception_class" not in synthesized_metadata
+    await store.update_metadata(
+        run_id,
+        {"failure": {"category": "internal", **synthesized_metadata}},
+    )
+
+    redacted_payload = await _tool_get_result(
+        session,
+        principal,
+        {"event_id": result["event_id"]},
+    )
+
+    assert redacted_payload["failure"]["diagnostic"]["exception_class"] is None
+    assert (
+        redacted_payload["failure"]["diagnostic"]["exception_class_state"]
+        == "redacted"
+    )
+
+    absent_metadata = failure_diagnostic_metadata(
+        stage=RunFailureStage.AGENT_EXECUTION,
+    )
+    await store.update_metadata(
+        run_id,
+        {"failure": {"category": "internal", **absent_metadata}},
+    )
+
+    absent_payload = await _tool_get_result(
+        session,
+        principal,
+        {"event_id": result["event_id"]},
+    )
+
+    assert absent_payload["failure"]["diagnostic"]["exception_class"] is None
+    assert (
+        absent_payload["failure"]["diagnostic"]["exception_class_state"]
+        == "unknown"
+    )
+
     await store.update_metadata(
         run_id,
         {
             "failure": {
                 "category": "internal",
+                "diagnostic_schema": "typed_v1",
                 "stage": "sk_live_abc123DEF456token",
                 "exception_class": "private_exception_token",
             }

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -605,3 +605,61 @@ async def test_get_result_lazily_reconciles_completed_submission_run(session):
     assert payload["handling_status"] == "completed"
     assert payload["run_status"] == "completed"
     assert payload["evidence_status"] == "not_required"
+
+
+async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(session):
+    from brain.app.api.routers.agent_mcp import _tool_get_result
+    from brain.systems.runs.engine import AsyncAgentRunEngine
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.memory",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve this durable finding.",
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:failed-result-diagnostic",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run_id = int(handling["run_id"])
+    store = AsyncAgentRunStore(session)
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    raw_diagnostic = "provider failed with token=receipt-secret"
+    await AsyncAgentRunEngine(session, recipes={}).fail(
+        run_id,
+        raw_diagnostic,
+        failure_stage="agent_execution",
+        exception_class="RuntimeError",
+    )
+
+    payload = await _tool_get_result(session, principal, {"event_id": result["event_id"]})
+
+    public_failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    assert payload["failure"] == {
+        **public_failure,
+        "diagnostic": {
+            "stage": "agent_execution",
+            "exception_class": "RuntimeError",
+            "tool_execution_started": False,
+            "terminal": True,
+            "retry_scheduled": False,
+        },
+    }
+    assert payload["event"]["failure"] == public_failure
+    assert payload["run_status"] == "failed"
+    assert payload["evidence_status"] == "failed"
+    assert payload["retry_attempt"] is None
+    assert payload["replacement_run_id"] is None
+    assert payload["retry_lineage"] is None
+    assert raw_diagnostic not in json.dumps(payload)

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -19,6 +19,7 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import service as inbound
 from brain.systems.inbound.preservation import PRESERVATION_MISSING_REASON
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 
@@ -631,12 +632,16 @@ async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(s
     store = AsyncAgentRunStore(session)
     await store.set_status(run_id, RunStatus.STARTING)
     await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_event(
+        run_event(run_id, "run.tool_started", {"tool_name": "workspace_search"})
+    )
     raw_diagnostic = "provider failed with token=receipt-secret"
+    exception_type = type("Erreur_accentuée" + ("e" * 90), (RuntimeError,), {})
     await AsyncAgentRunEngine(session, recipes={}).fail(
         run_id,
         raw_diagnostic,
-        failure_stage="agent_execution",
-        exception_class="RuntimeError",
+        failure_stage=RunFailureStage.AGENT_EXECUTION,
+        exception_type=exception_type,
     )
 
     payload = await _tool_get_result(session, principal, {"event_id": result["event_id"]})
@@ -650,8 +655,10 @@ async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(s
         **public_failure,
         "diagnostic": {
             "stage": "agent_execution",
-            "exception_class": "RuntimeError",
-            "tool_execution_started": False,
+            "stage_state": "known",
+            "exception_class": exception_type.__name__,
+            "exception_class_state": "known",
+            "tool_execution_started": True,
             "terminal": True,
             "retry_scheduled": False,
         },
@@ -663,3 +670,32 @@ async def test_get_result_failed_preservation_has_safe_programmatic_diagnostic(s
     assert payload["replacement_run_id"] is None
     assert payload["retry_lineage"] is None
     assert raw_diagnostic not in json.dumps(payload)
+
+    await store.update_metadata(
+        run_id,
+        {
+            "failure": {
+                "category": "internal",
+                "stage": "sk_live_abc123DEF456token",
+                "exception_class": "private_exception_token",
+            }
+        },
+    )
+
+    withheld_payload = await _tool_get_result(
+        session,
+        principal,
+        {"event_id": result["event_id"]},
+    )
+
+    assert withheld_payload["failure"]["diagnostic"] == {
+        "stage": "unknown",
+        "stage_state": "redacted",
+        "exception_class": None,
+        "exception_class_state": "redacted",
+        "tool_execution_started": True,
+        "terminal": True,
+        "retry_scheduled": False,
+    }
+    assert "sk_live_abc123DEF456token" not in json.dumps(withheld_payload)
+    assert "private_exception_token" not in json.dumps(withheld_payload)

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1399,6 +1399,7 @@ def test_project_context_root_uses_workspace_root_in_deploy(monkeypatch, tmp_pat
 
 
 def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
+    from brain.systems.runs.failure_diagnostic import RunFailureStage
     from brain.systems.runs.cortex import runner
 
     run = SimpleNamespace(
@@ -1466,7 +1467,7 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
     assert captured["run_id"] == 49
     assert "Project Context unavailable" in captured["error"]
     assert "did not provide a usable workspace" in captured["final_answer"]
-    assert captured["failure_stage"] == "project_context_materialization"
+    assert captured["failure_stage"] == RunFailureStage.PROJECT_CONTEXT_MATERIALIZATION
     public_activity = record_activity.await_args_list[-1]
     assert public_activity.args[2] == "Project context unavailable"
     assert public_activity.kwargs["issue_count"] == 1

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1448,8 +1448,13 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
         )),
     )
 
-    async def fake_mark_failed(run_id, error, *, final_answer=None):
-        captured.update({"run_id": run_id, "error": error, "final_answer": final_answer})
+    async def fake_mark_failed(run_id, error, *, final_answer=None, failure_stage=None):
+        captured.update({
+            "run_id": run_id,
+            "error": error,
+            "final_answer": final_answer,
+            "failure_stage": failure_stage,
+        })
         return {"idea_id": "idea-3", "new_status": "failed"}
 
     monkeypatch.setattr(runner, "_mark_run_failed_after_runner_error_async", fake_mark_failed)
@@ -1461,6 +1466,7 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
     assert captured["run_id"] == 49
     assert "Project Context unavailable" in captured["error"]
     assert "did not provide a usable workspace" in captured["final_answer"]
+    assert captured["failure_stage"] == "project_context_materialization"
     public_activity = record_activity.await_args_list[-1]
     assert public_activity.args[2] == "Project context unavailable"
     assert public_activity.kwargs["issue_count"] == 1

--- a/tests/test_worker_failure_surface_guards.py
+++ b/tests/test_worker_failure_surface_guards.py
@@ -113,7 +113,7 @@ def test_cli_and_checker_public_error_values_use_safe_failure_projectors():
         (
             "brain/app/api/routers/agent_mcp.py",
             "_tool_get_result",
-            {"public_run_failure"},
+            {"read_inbound_submission_result"},
         ),
         (
             "brain/systems/runs/recipes/workers.py",


### PR DESCRIPTION
Closes #861

## What was broken

A `preserve_knowledge` run failed with `category: internal`, zero tool calls, and the message *"I failed on this and it is still open — I will come back."* An identical resubmit worked 9 minutes later.

The obvious reading — "make the error message say more" — is wrong. `brain/systems/runs/failures.py` is docstringed *"user-safe terminal run messages"*: that opacity is deliberate, and rewording it is a product call. The real defect is that a **machine** caller polling `illo_get_result` gets the same first-person prose with **no diagnostic channel at all**, so it cannot tell "retry me" from "your payload is wrong".

It also settles the promise in that message: **nothing retries.** `reconciliation.py:37` puts `illo_submit` in the triage lane and `:453` limits readmission to the Slack lane, so a terminally-failed inbound run has no successor. The message tells callers something untrue.

## What this adds

A typed `failure.diagnostic` block on the `illo_get_result` payload, so an agent can route on the failure instead of parsing prose:

```json
"diagnostic": {
  "stage": "runner_settlement",
  "stage_state": "known",
  "exception_class": "TimeoutError",
  "exception_class_state": "known",
  "tool_execution_started": false,
  "terminal": true,
  "retry_scheduled": false
}
```

`retry_scheduled: false` is the field that contradicts the "I will come back" prose truthfully.

## This is a three-commit branch, and each commit corrects the one before

The first pass (`7211449a`) shipped a regex shape check and its commit message claimed the safety boundary was *"enforced structurally … cannot reach the field"*. **That claim was false.** A Codex review returned BLOCKING; I measured the guard rather than picking a side:

| value | first pass |
|---|---|
| `ValueError` | allowed ✅ |
| `sk_live_abc123DEF456token` | **allowed** ❌ |
| `Erreur_accentuée` | **dropped** ❌ |

It admitted a token-shaped secret and dropped legitimate class names — silently, so a caller could not tell withheld data from absent data. That is this ticket's own defect, one level down.

`bd9a81da` removed the whitelist entirely rather than patching it: the stage became a **closed enum** producers write directly, the string-parsing regex went away (exception types now flow structurally from `direct_agent.py`), and the read model moved out of the payload assembler into `brain/systems/runs/failure_diagnostic.py` so every caller shares one projection.

**A second review then caught the same class of mistake in that commit's own message.** It claimed *"a class name taken from a type object cannot be a secret."* That is also false — class names can be synthesized at runtime, and real libraries do it (`botocore` builds exception classes from server-provided error codes). Measured on `bd9a81da`:

```
Sneaky = type('sk_live_abc123DEF456token', (Exception,), {})
-> exception_class='sk_live_abc123DEF456token', state=known
```

A token-shaped name reached the receipt marked `known` — the original defect, one level further out. Two commits in a row asserted a safety property their guard did not have.

`001e8851` fixes it with a **provenance test, not another shape check** — a shape check is what `bd9a81da` correctly deleted. A class written in source is reachable as a module attribute under its own name; a runtime-synthesized one is not:

```python
mod = sys.modules.get(cls.__module__)
ok = mod is not None and getattr(mod, cls.__name__, None) is cls
```

Applied in the producer, so an unverifiable name never enters persisted metadata, and again on the reader side, because `7211449a` may already have written one.

| input | result |
|---|---|
| `ValueError`, `TimeoutError`, `asyncio.CancelledError`, `RunExecutionFailure` | `known` ✅ |
| `type('sk_live_abc123DEF456token', (Exception,), {})` | withheld → `redacted` ✅ |
| a legacy persisted unverifiable name | `redacted` ✅ |
| a genuinely absent value | `unknown` — still distinct from `redacted` ✅ |

No commit is amended — force-push is forbidden here, so each record is corrected in the next commit's message rather than rewritten.

## And one real bug, found by the review

`runner.py` set `runner_settlement` only *after* settlement, so a failure raised by the contract gate or by settlement was recorded as `recipe_execution`. On a feature whose entire job is naming where execution stopped, a **wrong** stage is worse than a missing one. The stage is now set immediately after `run_existing` succeeds and before both.

## How to check it (no code reading)

The surface is an MCP call, not a screen.

1. Trigger any `illo_submit` that terminally fails (or replay a known-failed event id).
2. Poll `illo_get_result` with that `event_id`.
3. The response's `failure` object now carries a `diagnostic` block in the shape above.

Judge these four:

- **`stage` names where it stopped**, and is one of the closed enum values — never a free-form string.
- **A withheld value says so.** `exception_class_state` reads `unknown` or `redacted` rather than the field silently being `null`, so "we don't know" is distinguishable from "nothing went wrong".
- **`retry_scheduled` is `false`** on a terminally-failed run — it must not repeat the "I will come back" claim.
- **The user-facing prose in `failures.py` is unchanged.** This PR deliberately does not touch it; that wording is a product call, not an engineering one.

## Verification

Repo CI command verbatim, no path argument, run serially at load 13 with no worker alive:

```
5014 passed, 11 skipped, 90 deselected in 86.62s
```

`meetbot/tests` ran (`pytest.ini` sets `testpaths = tests meetbot/tests`; a path argument would have silently dropped 45 tests). Backend lane only — the diff touches no `frontend/**` path.

Count reconciles across all three commits: 5012 on `7211449a`, +2 on `bd9a81da` (one new test parametrized over both corrected failure boundaries), and 5014 unchanged on `001e8851` because that commit **renamed** a test rather than adding one. The renamed test was pinned individually through the real CI invocation, not assumed.

Both implementing workers self-reported `BLOCKED` with a red. Both were wrong the same way: the block was a sandbox `index.lock` denial (no lock file existed at either reap) and the reds were localhost socket-bind permission errors. Serial re-runs came back 0 failed.

One thing worth knowing: `pytest tests/test_inbound_preservation.py` on its own fails to collect with a circular-import error. That is **pre-existing on `origin/main`** — verified in a throwaway worktree at the base commit — and it is why the CI command takes no path argument.

## What I did not do

Fix pass 2 was **not** put through a third Codex review. Two reviews ran and both found real defects; the second one's finding I then reproduced and closed myself, and verified on the four axes in the table above. That measurement is the evidence for this commit, not a reviewer's sign-off.

## Not in scope

The undiagnosed root cause of run 20006 itself. This PR makes the failure **diagnosable**; it does not fix whatever caused that particular internal error.
