### PR TITLE
fix(inbound): tell "event not found" apart from "not visible to your connection" (#854)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -1374,8 +1374,9 @@ async def _tool_get_result(
         return {
             "event_id": event_id,
             "state": result.state.value,
-            "owned_by_another_connection": result.owned_by_another_connection,
+            "owned_by_another_connection": True,
         }
+    assert result.payload is not None
     return result.payload
 
 

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -54,7 +54,10 @@ from brain.systems.cycles.serializers import (
 from brain.systems.cycles.service import async_run_cycle_now
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
-from brain.systems.inbound.results import read_inbound_submission_result
+from brain.systems.inbound.results import (
+    InboundSubmissionResultState,
+    read_inbound_submission_result,
+)
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
 from brain.systems.knowledge.search import search_knowledge
 from brain.systems.runs.cortex.read_models import (
@@ -1365,6 +1368,14 @@ async def _tool_get_result(
     )
     if result.mutated_inbound:
         await db.commit()
+    if result.state is InboundSubmissionResultState.NOT_FOUND:
+        raise ValueError("Inbound event not found")
+    if result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION:
+        return {
+            "event_id": event_id,
+            "state": result.state.value,
+            "owned_by_another_connection": result.owned_by_another_connection,
+        }
     return result.payload
 
 

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -25,9 +25,13 @@ class InboundSubmissionResultState(str, Enum):
 @dataclass(frozen=True)
 class InboundSubmissionResult:
     state: InboundSubmissionResultState
-    payload: dict[str, Any]
-    owned_by_another_connection: bool = False
+    payload: dict[str, Any] | None = None
     mutated_inbound: bool = False
+
+    def __post_init__(self) -> None:
+        has_payload = self.payload is not None
+        if has_payload != (self.state is InboundSubmissionResultState.FOUND):
+            raise ValueError("payload must be present if and only if state is FOUND")
 
 
 def _result_handling(action_result: dict[str, Any]) -> dict[str, Any]:
@@ -63,14 +67,11 @@ async def read_inbound_submission_result(
         )
     except inbound_admin.InboundAdminError:
         return InboundSubmissionResult(
-            payload={},
             state=InboundSubmissionResultState.NOT_FOUND,
         )
     if str(event.connection_id) != str(connection_id):
         return InboundSubmissionResult(
-            payload={},
             state=InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION,
-            owned_by_another_connection=True,
         )
 
     action_result = dict(event.action_result or {})

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,9 +14,19 @@ from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 from brain.systems.runs.failure_diagnostic import read_run_failure_diagnostic
 
 
+class InboundSubmissionResultState(str, Enum):
+    """Whether an inbound event result is visible to the caller."""
+
+    FOUND = "found"
+    NOT_FOUND = "not_found"
+    NOT_VISIBLE_TO_CONNECTION = "not_visible_to_connection"
+
+
 @dataclass(frozen=True)
 class InboundSubmissionResult:
+    state: InboundSubmissionResultState
     payload: dict[str, Any]
+    owned_by_another_connection: bool = False
     mutated_inbound: bool = False
 
 
@@ -44,9 +55,23 @@ async def read_inbound_submission_result(
     include_payload: bool = True,
     limit: int = 25,
 ) -> InboundSubmissionResult:
-    event = await inbound_admin.require_event_for_org(session, org_id=org_id, event_id=event_id)
+    try:
+        event = await inbound_admin.require_event_for_org(
+            session,
+            org_id=org_id,
+            event_id=event_id,
+        )
+    except inbound_admin.InboundAdminError:
+        return InboundSubmissionResult(
+            payload={},
+            state=InboundSubmissionResultState.NOT_FOUND,
+        )
     if str(event.connection_id) != str(connection_id):
-        raise ValueError("Inbound event not found")
+        return InboundSubmissionResult(
+            payload={},
+            state=InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION,
+            owned_by_another_connection=True,
+        )
 
     action_result = dict(event.action_result or {})
     handling = _result_handling(action_result)
@@ -109,6 +134,7 @@ async def read_inbound_submission_result(
         if diagnostic is not None:
             failure["diagnostic"] = diagnostic.as_payload()
     return InboundSubmissionResult(
+        state=InboundSubmissionResultState.FOUND,
         payload={
             "event_id": str(event.id),
             "submission_id": str(event.id),
@@ -133,4 +159,8 @@ async def read_inbound_submission_result(
     )
 
 
-__all__ = ["InboundSubmissionResult", "read_inbound_submission_result"]
+__all__ = [
+    "InboundSubmissionResult",
+    "InboundSubmissionResultState",
+    "read_inbound_submission_result",
+]

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -31,6 +31,15 @@ _REPLY_RESULT = json.dumps({"operation": "posted", "channel_id": "C0PROD",
                             "message_ts": "1752600001.0"})
 
 
+def _result_api():
+    from brain.systems.inbound.results import (
+        InboundSubmissionResultState,
+        read_inbound_submission_result,
+    )
+
+    return InboundSubmissionResultState, read_inbound_submission_result
+
+
 @pytest.fixture
 async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
     return await async_sqlite_session_factory([
@@ -141,7 +150,6 @@ async def _seed_slack_lane(
     return str(event.id), int(run.id)
 
 
-
 @pytest.mark.parametrize(
     "failure_reason",
     [INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE, "server_error"],
@@ -224,8 +232,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     session,
     failure_reason,
 ):
-    from brain.systems.inbound.results import read_inbound_submission_result
-
+    _, read_inbound_submission_result = _result_api()
     event_id, original_run_id = await _seed_slack_lane(
         session,
         tool_results=[],
@@ -263,6 +270,81 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         {"run_id": original_run_id, "retry_attempt": 0},
         {"run_id": replacement.id, "retry_attempt": 1},
     ]
+
+
+async def test_submission_result_absent_event_has_not_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=str(uuid.uuid4()),
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.owned_by_another_connection is False
+
+
+async def test_submission_result_cross_org_event_has_not_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=str(uuid.uuid4()),
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.owned_by_another_connection is False
+
+
+async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
+    from types import SimpleNamespace
+
+    from brain.app.api.routers.agent_mcp import _tool_get_result
+
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+    other_connection_id = str(uuid.uuid4())
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=other_connection_id,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
+    assert result.owned_by_another_connection is True
+
+    wire_payload = await _tool_get_result(
+        session,
+        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
+        {"event_id": event_id},
+    )
+    assert wire_payload == {
+        "event_id": event_id,
+        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
+        "owned_by_another_connection": True,
+    }
+
+
+async def test_submission_result_visible_event_has_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.FOUND
+    assert result.owned_by_another_connection is False
+    assert result.payload["event_id"] == event_id
 
 
 async def test_non_transient_failed_monitor_run_is_not_readmitted(session):

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -17,6 +17,7 @@ from brain.platform.db.models.agent_run import (
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+from brain.systems.inbound.results import read_inbound_submission_result
 from brain.systems.runs.events import run_event
 from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
 from brain.systems.runs.status import RunStatus
@@ -29,15 +30,6 @@ _NOW = datetime(2026, 7, 16, 9, 0, tzinfo=timezone.utc)
 
 _REPLY_RESULT = json.dumps({"operation": "posted", "channel_id": "C0PROD",
                             "message_ts": "1752600001.0"})
-
-
-def _result_api():
-    from brain.systems.inbound.results import (
-        InboundSubmissionResultState,
-        read_inbound_submission_result,
-    )
-
-    return InboundSubmissionResultState, read_inbound_submission_result
 
 
 @pytest.fixture
@@ -232,7 +224,6 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     session,
     failure_reason,
 ):
-    _, read_inbound_submission_result = _result_api()
     event_id, original_run_id = await _seed_slack_lane(
         session,
         tool_results=[],
@@ -261,6 +252,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         connection_id=_CONN,
         event_id=event_id,
     )
+    assert result.payload is not None
     assert result.payload["run_id"] == replacement.id
     assert result.payload["run_status"] == "failed"
     assert result.payload["retry_attempt"] == 1
@@ -270,82 +262,6 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         {"run_id": original_run_id, "retry_attempt": 0},
         {"run_id": replacement.id, "retry_attempt": 1},
     ]
-
-
-async def test_submission_result_absent_event_has_not_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=_CONN,
-        event_id=str(uuid.uuid4()),
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_FOUND
-    assert result.owned_by_another_connection is False
-
-
-async def test_submission_result_cross_org_event_has_not_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=str(uuid.uuid4()),
-        connection_id=_CONN,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_FOUND
-    assert result.owned_by_another_connection is False
-
-
-async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
-    from types import SimpleNamespace
-
-    from brain.app.api.routers.agent_mcp import _tool_get_result
-
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-    other_connection_id = str(uuid.uuid4())
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=other_connection_id,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
-    assert result.owned_by_another_connection is True
-
-    wire_payload = await _tool_get_result(
-        session,
-        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
-        {"event_id": event_id},
-    )
-    assert wire_payload == {
-        "event_id": event_id,
-        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
-        "owned_by_another_connection": True,
-    }
-
-
-async def test_submission_result_visible_event_has_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=_CONN,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.FOUND
-    assert result.owned_by_another_connection is False
-    assert result.payload["event_id"] == event_id
-
 
 async def test_non_transient_failed_monitor_run_is_not_readmitted(session):
     event_id, original_run_id = await _seed_slack_lane(

--- a/tests/test_inbound_results.py
+++ b/tests/test_inbound_results.py
@@ -1,0 +1,80 @@
+"""Inbound submission result visibility tests."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+from brain.app.api.routers.agent_mcp import _tool_get_result
+from brain.systems.inbound.results import (
+    InboundSubmissionResultState,
+    read_inbound_submission_result,
+)
+from tests.test_inbound_reconciliation import _CONN, _ORG, _seed_slack_lane, session
+
+
+async def test_submission_result_absent_event_has_not_found_state(session):
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=str(uuid.uuid4()),
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.payload is None
+
+
+async def test_submission_result_cross_org_event_has_not_found_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=str(uuid.uuid4()),
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.payload is None
+
+
+async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+    other_connection_id = str(uuid.uuid4())
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=other_connection_id,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
+    assert result.payload is None
+
+    wire_payload = await _tool_get_result(
+        session,
+        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
+        {"event_id": event_id},
+    )
+    assert wire_payload == {
+        "event_id": event_id,
+        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
+        "owned_by_another_connection": True,
+    }
+
+
+async def test_submission_result_visible_event_has_found_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.FOUND
+    assert result.payload is not None
+    assert result.payload["event_id"] == event_id


### PR DESCRIPTION
## What was broken

`illo_get_result` answered the string `Inbound event not found` for **three** different situations, so a caller polling a real, completed preservation got the identical answer a never-existent UUID gets.

| situation | where | old answer |
|---|---|---|
| the row is absent | `admin.py:557-566` | `Inbound event not found` |
| the row belongs to another org | `admin.py:557-566` | `Inbound event not found` |
| the row is in **your own org**, owned by a different connection | `results.py:47-49` | `Inbound event not found` |

The third is the reported one. Event `3027cd6e-475f-426c-983a-baa353be7cf7` (run `19739`, `status: completed`) resolves fine through `run.get` and read as "not found" through `illo_get_result` — so a completed four-PR milestone could not be verified as archived, and the caller could not tell "my event is gone" from "my event is fine, you are asking from the wrong connection".

## The change

`read_inbound_submission_result` now returns a typed `InboundSubmissionResultState` — `FOUND` / `NOT_FOUND` / `NOT_VISIBLE_TO_CONNECTION` — instead of signalling through an exception message. It follows the closed-`str, Enum` shape that `RunFailureStage` / `DiagnosticValueState` established in #861 last week, rather than inventing a parallel vocabulary.

**The visibility rule is a deliberate decision, not an oversight:**

- **Absent or cross-org stays indistinguishable** and keeps answering `Inbound event not found`. Telling a cross-org caller that an id exists would leak existence across a tenant boundary, so that case is untouched on purpose.
- **Same-org / different-connection becomes distinct and machine-routable.** Same tenant, same principal, so naming it leaks nothing.
- The owning `connection_id` is **deliberately not** in the response. A caller that cannot see the event does not need the owner's id.

## Scope choice you may want to revisit

The ticket offered two acceptable routes: resolve the event across connections, **or** keep the scoping and return a distinct error. This PR takes the second.

That means the receipt is now **diagnosable** cross-connection but still not **readable** cross-connection — you learn to poll from the owning connection instead of being told "not found". I chose the conservative route because dropping the connection scope is a real isolation change that shouldn't be made unattended. If you'd rather any connection in an org read that org's inbound events, that is a small follow-up on this same seam.

## Code-quality review — one BLOCKING finding, folded

A Codex thermo-nuclear review (cross-family: the diff was Codex-written, this was a second independent Codex pass) returned **BLOCKING** on the first commit, and it was right. `InboundSubmissionResult` only *resembled* the pattern it was copying, because it could still express a contradiction:

- `owned_by_another_connection` repeated what `state` already said — one fact in two fields, free to disagree;
- `payload={}` was a placeholder standing in for "no payload", and nothing stopped a `NOT_FOUND` result carrying a full one.

Commit 2 makes the state the single owner: the boolean is gone, `payload` is `dict | None`, and `__post_init__` enforces the biconditional — **a payload is present if and only if the state is `FOUND`** — so the contradictory combinations are no longer constructible.

The review's three non-blocking notes are folded in the same commit: `_result_api()` (a helper returning two imports as an untyped positional tuple) is deleted for ordinary imports, and the four visibility tests move out of the *reconciliation* suite into a new `tests/test_inbound_results.py`, importing the seeding helpers rather than copying them.

**The wire response is unchanged by that refactor** — `_tool_get_result` still returns `owned_by_another_connection: true`, now derived as a literal in its own branch. The key is useful to an MCP caller; only the internal field was redundant.

Two things I did **not** change, so they are decisions rather than misses: the router keeps a bare `assert result.payload is not None` as a type-narrowing hint (the invariant is already enforced in `__post_init__`, so it cannot fire), and the new test module imports the `session` fixture from `test_inbound_reconciliation` instead of moving it to `conftest.py` — which avoids duplicating the fixture, at the cost of a test module importing another.

## Verification

Local only, run **serially**, never beside a live worker:

| run | result |
|---|---|
| commit 1 (`39a7f497`) | **5018 passed**, 0 failed, 11 skipped |
| commit 2 (`c0c68cc5`) | **5018 passed**, 0 failed, 11 skipped |

Count reconciled rather than assumed: `origin/main` is 5014, plus 4 new tests = 5018. The refactor moves tests rather than adding them, so the number is unchanged across the two commits — as it should be.

Command is the repo's CI lane verbatim, with **no path argument** (`pytest.ini` sets `testpaths = tests meetbot/tests`, and naming a path silently drops `meetbot/tests`):

```
venv/bin/python -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

Frontend lane is not selected — the diff touches no `frontend/**`.

Both Codex workers self-reported `BLOCKED` / `COMMIT: none`. Both were wrong the documented way: the "block" was the sandbox `index.lock` denial (no lock file existed at either reap) and the reds were `test_gpu_integration` socket-bind errors plus one auth-callback test. Re-run serially by the orchestrator, both came back 0 failed. The orchestrator committed both.

## How to check it yourself

On staging, from an agent connection that is **not** the one that submitted an event:

1. `illo_get_result` with a **random UUID** → still `Inbound event not found`.
2. `illo_get_result` with event `3027cd6e-475f-426c-983a-baa353be7cf7` → now `state: not_visible_to_connection`, and no `connection_id` in the response.
3. `illo_get_result` from the **owning** connection → the normal receipt payload, unchanged.

The interesting one is 1 vs 2: those two used to be byte-identical.

Closes #854
