### PR TITLE
fix(runs,inbound,project-context): typed failure stages, result visibility, clones off the event loop, actionable pre-tool preservation errors (#865, #854, #860, #868)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -1374,8 +1374,9 @@ async def _tool_get_result(
         return {
             "event_id": event_id,
             "state": result.state.value,
-            "owned_by_another_connection": result.owned_by_another_connection,
+            "owned_by_another_connection": True,
         }
+    assert result.payload is not None
     return result.payload
 
 

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -54,7 +54,10 @@ from brain.systems.cycles.serializers import (
 from brain.systems.cycles.service import async_run_cycle_now
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
-from brain.systems.inbound.results import read_inbound_submission_result
+from brain.systems.inbound.results import (
+    InboundSubmissionResultState,
+    read_inbound_submission_result,
+)
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
 from brain.systems.knowledge.search import search_knowledge
 from brain.systems.runs.cortex.read_models import (
@@ -1365,6 +1368,14 @@ async def _tool_get_result(
     )
     if result.mutated_inbound:
         await db.commit()
+    if result.state is InboundSubmissionResultState.NOT_FOUND:
+        raise ValueError("Inbound event not found")
+    if result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION:
+        return {
+            "event_id": event_id,
+            "state": result.state.value,
+            "owned_by_another_connection": result.owned_by_another_connection,
+        }
     return result.payload
 
 

--- a/brain/app/cli/run.py
+++ b/brain/app/cli/run.py
@@ -27,8 +27,9 @@ from sqlalchemy import text as sa_text
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.runs.failure_diagnostic import (
     RunFailureStage,
-    failure_diagnostic_metadata,
+    run_failure_metadata,
 )
+from brain.systems.runs.failures import RunFailureCategory
 from brain.systems.task_domain import TaskDomain, classify_task_domain
 # ============================================================
 # Inline Allowlist
@@ -335,12 +336,10 @@ async def complete_run(session, run_id: int, outcome: str, notes: str = None) ->
     }.get(outcome, "completed")
     metadata_patch = {"outcome": outcome, "outcome_notes": notes}
     if status == "failed":
-        metadata_patch["failure"] = {
-            "category": "internal",
-            **failure_diagnostic_metadata(
-                stage=RunFailureStage.RUNNER_SETTLEMENT,
-            ),
-        }
+        metadata_patch["failure"] = run_failure_metadata(
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.RUNNER_SETTLEMENT,
+        )
     await session.execute(sa_text("""
         UPDATE agent_runs
         SET status = :status,

--- a/brain/app/cli/run.py
+++ b/brain/app/cli/run.py
@@ -25,6 +25,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".
 from sqlalchemy import text as sa_text
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.task_domain import TaskDomain, classify_task_domain
 # ============================================================
 # Inline Allowlist
@@ -329,6 +333,14 @@ async def complete_run(session, run_id: int, outcome: str, notes: str = None) ->
         "failure": "failed",
         "cancelled": "canceled",
     }.get(outcome, "completed")
+    metadata_patch = {"outcome": outcome, "outcome_notes": notes}
+    if status == "failed":
+        metadata_patch["failure"] = {
+            "category": "internal",
+            **failure_diagnostic_metadata(
+                stage=RunFailureStage.RUNNER_SETTLEMENT,
+            ),
+        }
     await session.execute(sa_text("""
         UPDATE agent_runs
         SET status = :status,
@@ -339,7 +351,7 @@ async def complete_run(session, run_id: int, outcome: str, notes: str = None) ->
         WHERE id = :id
     """), {
         "status": status,
-        "metadata_patch": json.dumps({"outcome": outcome, "outcome_notes": notes}),
+        "metadata_patch": json.dumps(metadata_patch),
         "id": run_id,
     })
 

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -393,7 +393,11 @@ def _git_output(cwd: Path, *args: str) -> str | None:
 
 
 def _existing_git_checkout(destination: Path, slug: str, branch: str | None) -> dict[str, str] | None:
-    """Return metadata for an existing checkout without mutating local state."""
+    """Return metadata for an existing checkout without mutating local state.
+
+    BLOCKING: reaches ``check_output_sync`` via ``_git_output``. Async callers
+    MUST go through ``run_blocking`` (see #860).
+    """
 
     if not destination.exists():
         return None
@@ -444,6 +448,12 @@ def _clone_github_repo(
     token: str | None,
     branch: str | None,
 ) -> dict[str, str]:
+    """Clone a GitHub repo. BLOCKING: rmtree, mkdir, git subprocess, git reads.
+
+    Async callers MUST go through ``run_blocking``. Calling this directly from a
+    coroutine freezes the whole worker for the clone's duration, which trips the
+    queue-stall watchdog and restart-loops the process (see #860).
+    """
     if destination.exists():
         shutil.rmtree(destination, ignore_errors=True)
     destination.parent.mkdir(parents=True, exist_ok=True)

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -12,7 +12,7 @@ import tempfile
 from typing import Any
 
 from brain.contracts.github import parse_github_repo_slug
-from brain.platform.async_io import check_output_sync, run_subprocess_sync
+from brain.platform.async_io import check_output_sync, run_blocking, run_subprocess_sync
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.drafts import load_draft_metadata, sync_draft_from_root
@@ -799,7 +799,7 @@ async def _materialize_resource(
 
     destination = _safe_repo_destination(workspace_root, slug)
     branch = _clean_text(resource.get("branch") or resource.get("default_branch") or resource.get("branch_hint"))
-    existing_checkout = _existing_git_checkout(destination, slug, branch)
+    existing_checkout = await run_blocking(_existing_git_checkout, destination, slug, branch)
     if existing_checkout:
         clone = existing_checkout
         repo_path = Path(clone["path"])
@@ -847,7 +847,7 @@ async def _materialize_resource(
             errors.append(prefix + token_error)
             continue
         try:
-            clone = _clone_github_repo(slug, destination, token=token, branch=branch)
+            clone = await run_blocking(_clone_github_repo, slug, destination, token=token, branch=branch)
         except Exception as exc:
             prefix = f"Vault key {key_name}: " if key_name else "public clone: "
             errors.append(prefix + _sanitize_git_error(str(exc)))

--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -228,6 +228,15 @@ def preservation_contract_from_run_metadata(metadata: Mapping[str, Any]) -> dict
     return _json_dict(submission.get("preservation"))
 
 
+def run_requires_durable_preservation(
+    metadata: Mapping[str, Any] | None,
+) -> bool:
+    """Return whether a run carries the durable-preservation contract."""
+
+    contract = preservation_contract_from_run_metadata(_json_dict(metadata))
+    return contract.get("requires_durable_evidence") is True
+
+
 def preservation_evidence_result(
     contract: Mapping[str, Any] | None,
     *,
@@ -292,5 +301,6 @@ __all__ = [
     "submission_preservation_contract",
     "submission_preservation_prompt_lines",
     "preservation_contract_from_run_metadata",
+    "run_requires_durable_preservation",
     "preservation_evidence_result",
 ]

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -25,9 +25,13 @@ class InboundSubmissionResultState(str, Enum):
 @dataclass(frozen=True)
 class InboundSubmissionResult:
     state: InboundSubmissionResultState
-    payload: dict[str, Any]
-    owned_by_another_connection: bool = False
+    payload: dict[str, Any] | None = None
     mutated_inbound: bool = False
+
+    def __post_init__(self) -> None:
+        has_payload = self.payload is not None
+        if has_payload != (self.state is InboundSubmissionResultState.FOUND):
+            raise ValueError("payload must be present if and only if state is FOUND")
 
 
 def _result_handling(action_result: dict[str, Any]) -> dict[str, Any]:
@@ -63,14 +67,11 @@ async def read_inbound_submission_result(
         )
     except inbound_admin.InboundAdminError:
         return InboundSubmissionResult(
-            payload={},
             state=InboundSubmissionResultState.NOT_FOUND,
         )
     if str(event.connection_id) != str(connection_id):
         return InboundSubmissionResult(
-            payload={},
             state=InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION,
-            owned_by_another_connection=True,
         )
 
     action_result = dict(event.action_result or {})

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,9 +14,19 @@ from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 from brain.systems.runs.failure_diagnostic import read_run_failure_diagnostic
 
 
+class InboundSubmissionResultState(str, Enum):
+    """Whether an inbound event result is visible to the caller."""
+
+    FOUND = "found"
+    NOT_FOUND = "not_found"
+    NOT_VISIBLE_TO_CONNECTION = "not_visible_to_connection"
+
+
 @dataclass(frozen=True)
 class InboundSubmissionResult:
+    state: InboundSubmissionResultState
     payload: dict[str, Any]
+    owned_by_another_connection: bool = False
     mutated_inbound: bool = False
 
 
@@ -44,9 +55,23 @@ async def read_inbound_submission_result(
     include_payload: bool = True,
     limit: int = 25,
 ) -> InboundSubmissionResult:
-    event = await inbound_admin.require_event_for_org(session, org_id=org_id, event_id=event_id)
+    try:
+        event = await inbound_admin.require_event_for_org(
+            session,
+            org_id=org_id,
+            event_id=event_id,
+        )
+    except inbound_admin.InboundAdminError:
+        return InboundSubmissionResult(
+            payload={},
+            state=InboundSubmissionResultState.NOT_FOUND,
+        )
     if str(event.connection_id) != str(connection_id):
-        raise ValueError("Inbound event not found")
+        return InboundSubmissionResult(
+            payload={},
+            state=InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION,
+            owned_by_another_connection=True,
+        )
 
     action_result = dict(event.action_result or {})
     handling = _result_handling(action_result)
@@ -109,6 +134,7 @@ async def read_inbound_submission_result(
         if diagnostic is not None:
             failure["diagnostic"] = diagnostic.as_payload()
     return InboundSubmissionResult(
+        state=InboundSubmissionResultState.FOUND,
         payload={
             "event_id": str(event.id),
             "submission_id": str(event.id),
@@ -133,4 +159,8 @@ async def read_inbound_submission_result(
     )
 
 
-__all__ = ["InboundSubmissionResult", "read_inbound_submission_result"]
+__all__ = [
+    "InboundSubmissionResult",
+    "InboundSubmissionResultState",
+    "read_inbound_submission_result",
+]

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -31,10 +31,7 @@ from brain.systems.runs.evidence_health import (
 )
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
-from brain.systems.runs.failure_diagnostic import (
-    RunFailureStage,
-    failure_diagnostic_metadata,
-)
+from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
@@ -1281,18 +1278,6 @@ async def _mark_run_failed_after_runner_error_async(
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
             category = failure_category_for_error(error)
             failure = public_run_failure(RunStatus.FAILED, category)
-            await store.update_metadata(
-                int(run_id),
-                {
-                    "failure": {
-                        "category": category.value,
-                        **failure_diagnostic_metadata(
-                            stage=failure_stage,
-                            exception_type=exception_type,
-                        ),
-                    }
-                },
-            )
             if final_answer:
                 # ``final_answer`` is an intent signal from runner setup code. It
                 # can contain materializer diagnostics, so only persist the
@@ -1322,7 +1307,13 @@ async def _mark_run_failed_after_runner_error_async(
                     root_run_id=row.root_run_id,
                 )
             )
-            await store.set_status(int(run_id), RunStatus.FAILED, reason=error[:500])
+            await store.fail_run(
+                int(run_id),
+                category=category,
+                stage=failure_stage,
+                reason=error[:500],
+                exception_type=exception_type,
+            )
             from brain.systems.runs.chantier_continuation import (
                 queue_worker_continuation_for_terminal_run,
             )

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -31,13 +31,15 @@ from brain.systems.runs.evidence_health import (
 )
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
-from brain.systems.runs.failure_diagnostic import RunFailureStage
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_category_for_run_context,
+    run_tool_execution_started,
+)
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
-    failure_category_for_run_context,
     public_run_failure,
-    run_requires_durable_preservation,
     safe_terminal_run_message,
     terminal_run_notice_condition,
 )
@@ -1278,20 +1280,22 @@ async def _mark_run_failed_after_runner_error_async(
                 anchor_run_id=row.parent_run_id or row.id,
             )
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
+            from brain.systems.inbound.preservation import (
+                run_requires_durable_preservation,
+            )
+
             category = failure_category_for_error(error)
-            tool_execution_started = False
-            if run_requires_durable_preservation(row.metadata_):
-                for event_type in (
-                    "run.tool_started",
-                    "run.tool_completed",
-                    "run.tool_failed",
-                ):
-                    if await store.has_event_type(int(run_id), event_type):
-                        tool_execution_started = True
-                        break
+            requires_durable_preservation = run_requires_durable_preservation(
+                row.metadata_
+            )
+            tool_execution_started = (
+                await run_tool_execution_started(uow.session, run_id=int(run_id))
+                if requires_durable_preservation
+                else False
+            )
             category = failure_category_for_run_context(
                 category,
-                metadata=row.metadata_,
+                requires_durable_preservation=requires_durable_preservation,
                 tool_execution_started=tool_execution_started,
                 failure_stage=failure_stage,
             )

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -35,7 +35,9 @@ from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
+    failure_category_for_run_context,
     public_run_failure,
+    run_requires_durable_preservation,
     safe_terminal_run_message,
     terminal_run_notice_condition,
 )
@@ -1277,6 +1279,22 @@ async def _mark_run_failed_after_runner_error_async(
             )
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
             category = failure_category_for_error(error)
+            tool_execution_started = False
+            if run_requires_durable_preservation(row.metadata_):
+                for event_type in (
+                    "run.tool_started",
+                    "run.tool_completed",
+                    "run.tool_failed",
+                ):
+                    if await store.has_event_type(int(run_id), event_type):
+                        tool_execution_started = True
+                        break
+            category = failure_category_for_run_context(
+                category,
+                metadata=row.metadata_,
+                tool_execution_started=tool_execution_started,
+                failure_stage=failure_stage,
+            )
             failure = public_run_failure(RunStatus.FAILED, category)
             if final_answer:
                 # ``final_answer`` is an intent signal from runner setup code. It

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -237,10 +237,11 @@ class AsyncAgentRunEngine:
         if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
             return to_domain(row)
         if not str(row.org_id or "").strip():
-            return await self.store.set_status(
+            return await self.fail(
                 row.id,
-                RunStatus.FAILED,
-                reason="AgentRun missing workspace org_id",
+                "AgentRun missing workspace org_id",
+                failure_category=RunFailureCategory.INTERNAL,
+                failure_stage=RunFailureStage.RUNNER_EXECUTION,
                 execution_claim=execution_claim,
             )
         request = AgentRunRequest(
@@ -338,6 +339,13 @@ class AsyncAgentRunEngine:
         status: RunStatus = RunStatus.COMPLETED,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
+        if status == RunStatus.FAILED:
+            return await self.fail(
+                run_id,
+                output or "run_failed_during_completion",
+                failure_stage=RunFailureStage.RUNNER_SETTLEMENT,
+                execution_claim=execution_claim,
+            )
         row = await self.store.require_run(run_id)
         if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
             return to_domain(row)

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -16,10 +16,7 @@ from brain.systems.runs.context import RunContextLoader
 from brain.systems.runs.domain import AgentRun, AgentRunRequest
 from brain.systems.runs.events import activity_event, run_event, text_delta_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
-from brain.systems.runs.failure_diagnostic import (
-    RunFailureStage,
-    failure_diagnostic_metadata,
-)
+from brain.systems.runs.failure_diagnostic import RunFailureStage
 from brain.systems.runs.failures import (
     RunFailureCategory,
     coerce_failure_category,
@@ -451,22 +448,13 @@ class AsyncAgentRunEngine:
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             category = coerce_failure_category(failure_category or failure_category_for_error(error))
-            failure_metadata = {
-                "category": category.value,
-                **failure_diagnostic_metadata(
-                    stage=failure_stage,
-                    exception_type=exception_type,
-                ),
-            }
-            await self.store.update_metadata(
-                run_id,
-                {"failure": failure_metadata},
-            )
             safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
-            failed = await self.store.set_status(
+            failed = await self.store.fail_run(
                 run_id,
-                RunStatus.FAILED,
+                category=category,
+                stage=failure_stage,
                 reason=safe_error,
+                exception_type=exception_type,
                 execution_claim=execution_claim,
             )
             if failed.status != RunStatus.FAILED:

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -21,6 +21,8 @@ from brain.systems.runs.failures import (
     RunFailureCategory,
     coerce_failure_category,
     failure_category_for_error,
+    failure_category_for_run_context,
+    run_requires_durable_preservation,
     safe_terminal_run_message,
 )
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
@@ -448,6 +450,24 @@ class AsyncAgentRunEngine:
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             category = coerce_failure_category(failure_category or failure_category_for_error(error))
+            tool_execution_started = False
+            if run_requires_durable_preservation(row.metadata_):
+                for event_type in (
+                    "run.tool_started",
+                    "run.tool_completed",
+                    "run.tool_failed",
+                ):
+                    if await self.store.has_event_type(run_id, event_type):
+                        tool_execution_started = True
+                        break
+            category = failure_category_for_run_context(
+                category,
+                metadata=row.metadata_,
+                tool_execution_started=tool_execution_started,
+                failure_stage=failure_stage,
+            )
+            if category == RunFailureCategory.PRESERVATION_SETUP and final_output:
+                final_output = safe_terminal_run_message(RunStatus.FAILED, category)
             safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
             failed = await self.store.fail_run(
                 run_id,

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -16,13 +16,16 @@ from brain.systems.runs.context import RunContextLoader
 from brain.systems.runs.domain import AgentRun, AgentRunRequest
 from brain.systems.runs.events import activity_event, run_event, text_delta_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
-from brain.systems.runs.failure_diagnostic import RunFailureStage
+from brain.systems.runs.failure_diagnostic import (
+    ClassifiedRunFailure,
+    RunFailureStage,
+    failure_category_for_run_context,
+    run_tool_execution_started,
+)
 from brain.systems.runs.failures import (
     RunFailureCategory,
     coerce_failure_category,
     failure_category_for_error,
-    failure_category_for_run_context,
-    run_requires_durable_preservation,
     safe_terminal_run_message,
 )
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
@@ -55,8 +58,8 @@ class RunRecipeResult:
     error: str | None = None
     # Optional user-safe text. Failed runs must never put raw errors here.
     final_output: str | None = None
-    failure_category: RunFailureCategory | str | None = None
-    failure_stage: RunFailureStage | None = None
+    # Recipes must resolve this before building any public failure output or artifact.
+    classified_failure: ClassifiedRunFailure | None = None
     exception_type: type[BaseException] | None = None
     artifacts: tuple = ()
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
@@ -160,6 +163,39 @@ class RunRuntime:
         if self.tools is None:
             self.tools = AsyncRunToolExecutor(self.store, stream=self.stream)
         return self.tools
+
+    async def classify_failure(
+        self,
+        category: RunFailureCategory | str | None,
+        *,
+        stage: RunFailureStage,
+    ) -> ClassifiedRunFailure:
+        """Resolve failure context before a recipe builds public failure records."""
+
+        from brain.systems.inbound.preservation import (
+            run_requires_durable_preservation,
+        )
+
+        requires_durable_preservation = run_requires_durable_preservation(
+            self.request.metadata
+        )
+        tool_execution_started = (
+            await run_tool_execution_started(
+                self.store.session,
+                run_id=self.run.id,
+            )
+            if requires_durable_preservation
+            else False
+        )
+        return ClassifiedRunFailure(
+            category=failure_category_for_run_context(
+                category,
+                requires_durable_preservation=requires_durable_preservation,
+                tool_execution_started=tool_execution_started,
+                failure_stage=stage,
+            ),
+            stage=stage,
+        )
 
 
 class AsyncAgentRunEngine:
@@ -306,8 +342,17 @@ class AsyncAgentRunEngine:
                 run.id,
                 error,
                 final_output=result.final_output,
-                failure_category=result.failure_category or failure_category_for_error(error),
-                failure_stage=result.failure_stage or RunFailureStage.RECIPE_EXECUTION,
+                failure_category=(
+                    None
+                    if result.classified_failure is not None
+                    else failure_category_for_error(error)
+                ),
+                failure_stage=(
+                    result.classified_failure.stage
+                    if result.classified_failure is not None
+                    else RunFailureStage.RECIPE_EXECUTION
+                ),
+                classified_failure=result.classified_failure,
                 exception_type=result.exception_type,
                 execution_claim=execution_claim,
             )
@@ -442,6 +487,7 @@ class AsyncAgentRunEngine:
         final_output: str | None = None,
         failure_category: RunFailureCategory | str | None = None,
         failure_stage: RunFailureStage = RunFailureStage.RECIPE_EXECUTION,
+        classified_failure: ClassifiedRunFailure | None = None,
         exception_type: type[BaseException] | None = None,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
@@ -449,23 +495,31 @@ class AsyncAgentRunEngine:
         async with self._atomic_terminal_write():
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
-            category = coerce_failure_category(failure_category or failure_category_for_error(error))
-            tool_execution_started = False
-            if run_requires_durable_preservation(row.metadata_):
-                for event_type in (
-                    "run.tool_started",
-                    "run.tool_completed",
-                    "run.tool_failed",
-                ):
-                    if await self.store.has_event_type(run_id, event_type):
-                        tool_execution_started = True
-                        break
-            category = failure_category_for_run_context(
-                category,
-                metadata=row.metadata_,
-                tool_execution_started=tool_execution_started,
-                failure_stage=failure_stage,
-            )
+            if classified_failure is None:
+                from brain.systems.inbound.preservation import (
+                    run_requires_durable_preservation,
+                )
+
+                category = coerce_failure_category(
+                    failure_category or failure_category_for_error(error)
+                )
+                requires_durable_preservation = run_requires_durable_preservation(
+                    row.metadata_
+                )
+                tool_execution_started = (
+                    await run_tool_execution_started(self.store.session, run_id=run_id)
+                    if requires_durable_preservation
+                    else False
+                )
+                category = failure_category_for_run_context(
+                    category,
+                    requires_durable_preservation=requires_durable_preservation,
+                    tool_execution_started=tool_execution_started,
+                    failure_stage=failure_stage,
+                )
+            else:
+                category = classified_failure.category
+                failure_stage = classified_failure.stage
             if category == RunFailureCategory.PRESERVATION_SETUP and final_output:
                 final_output = safe_terminal_run_message(RunStatus.FAILED, category)
             safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))

--- a/brain/systems/runs/failure_diagnostic.py
+++ b/brain/systems/runs/failure_diagnostic.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
-from brain.systems.runs.failures import RunFailureCategory
+from brain.systems.runs.failures import RunFailureCategory, coerce_failure_category
 
 
 _DIAGNOSTIC_SCHEMA = "typed_v1"
@@ -47,6 +47,24 @@ class RunFailureStage(str, Enum):
     COMPLETION_VERIFICATION = "completion_verification"
     RUNNER_SETTLEMENT = "runner_settlement"
     UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ClassifiedRunFailure:
+    """A failure category resolved against its run context before presentation."""
+
+    category: RunFailureCategory
+    stage: RunFailureStage
+
+
+_PRE_TOOL_PRESERVATION_FAILURE_STAGES = frozenset(
+    {
+        RunFailureStage.RUNNER_EXECUTION,
+        RunFailureStage.PROJECT_CONTEXT_MATERIALIZATION,
+        RunFailureStage.RECIPE_EXECUTION,
+        RunFailureStage.AGENT_EXECUTION,
+    }
+)
 
 
 class DiagnosticValueState(str, Enum):
@@ -120,6 +138,47 @@ def failure_diagnostic_metadata(
     }
 
 
+def failure_category_for_run_context(
+    category: RunFailureCategory | str | None,
+    *,
+    requires_durable_preservation: bool,
+    tool_execution_started: bool,
+    failure_stage: RunFailureStage,
+) -> RunFailureCategory:
+    """Classify an internal pre-tool preservation failure as actionable setup work."""
+
+    resolved = coerce_failure_category(category)
+    if (
+        resolved is RunFailureCategory.INTERNAL
+        and requires_durable_preservation
+        and not tool_execution_started
+        and failure_stage in _PRE_TOOL_PRESERVATION_FAILURE_STAGES
+    ):
+        return RunFailureCategory.PRESERVATION_SETUP
+    return resolved
+
+
+async def run_tool_execution_started(
+    session: AsyncSession,
+    *,
+    run_id: int,
+) -> bool:
+    """Query the canonical event vocabulary for evidence of tool execution."""
+
+    event_types = (
+        await session.scalars(
+            select(AgentRunEventRow.event_type).where(
+                AgentRunEventRow.run_id == int(run_id),
+                AgentRunEventRow.event_type.in_(_TOOL_EXECUTION_EVENT_TYPES),
+            )
+        )
+    ).all()
+    return any(
+        str(event_type or "") in _TOOL_EXECUTION_EVENT_TYPES
+        for event_type in event_types
+    )
+
+
 def run_failure_metadata(
     *,
     category: RunFailureCategory,
@@ -189,14 +248,10 @@ async def read_run_failure_diagnostic(
     if str(run_status or "") != "failed":
         return None
 
-    event_types = (
-        await session.scalars(
-            select(AgentRunEventRow.event_type).where(
-                AgentRunEventRow.run_id == int(run.id),
-                AgentRunEventRow.event_type.in_(_TOOL_EXECUTION_EVENT_TYPES),
-            )
-        )
-    ).all()
+    tool_execution_started = await run_tool_execution_started(
+        session,
+        run_id=int(run.id),
+    )
     metadata = run.metadata_ if isinstance(run.metadata_, Mapping) else {}
     stored_failure = metadata.get("failure")
     failure_metadata = stored_failure if isinstance(stored_failure, Mapping) else {}
@@ -209,10 +264,7 @@ async def read_run_failure_diagnostic(
         stage_state=stage_state,
         exception_class=exception_class,
         exception_class_state=exception_class_state,
-        tool_execution_started=any(
-            str(event_type or "") in _TOOL_EXECUTION_EVENT_TYPES
-            for event_type in event_types
-        ),
+        tool_execution_started=tool_execution_started,
         # Replacement retries have their own current run. A still-failed run
         # is terminal and has no retry scheduled on this run identity.
         retry_scheduled=False,
@@ -220,10 +272,13 @@ async def read_run_failure_diagnostic(
 
 
 __all__ = [
+    "ClassifiedRunFailure",
     "DiagnosticValueState",
     "RunFailureDiagnostic",
     "RunFailureStage",
+    "failure_category_for_run_context",
     "failure_diagnostic_metadata",
     "read_run_failure_diagnostic",
+    "run_tool_execution_started",
     "run_failure_metadata",
 ]

--- a/brain/systems/runs/failure_diagnostic.py
+++ b/brain/systems/runs/failure_diagnostic.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.systems.runs.failures import RunFailureCategory
 
 
 _DIAGNOSTIC_SCHEMA = "typed_v1"
@@ -119,6 +120,25 @@ def failure_diagnostic_metadata(
     }
 
 
+def run_failure_metadata(
+    *,
+    category: RunFailureCategory,
+    stage: RunFailureStage,
+    exception_type: type[BaseException] | None = None,
+) -> dict[str, Any]:
+    """Encode the complete persisted envelope for one failed run."""
+
+    if not isinstance(category, RunFailureCategory):
+        raise TypeError("failure category must be a RunFailureCategory")
+    return {
+        "category": category.value,
+        **failure_diagnostic_metadata(
+            stage=stage,
+            exception_type=exception_type,
+        ),
+    }
+
+
 def _stage_projection(
     failure_metadata: Mapping[str, Any],
 ) -> tuple[RunFailureStage, DiagnosticValueState]:
@@ -205,4 +225,5 @@ __all__ = [
     "RunFailureStage",
     "failure_diagnostic_metadata",
     "read_run_failure_diagnostic",
+    "run_failure_metadata",
 ]

--- a/brain/systems/runs/failures.py
+++ b/brain/systems/runs/failures.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import Enum
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from brain.platform.integrations.provider_error_sentinel import provider_error_kind
 from brain.platform.integrations.providers import is_transient_transport_disconnect
@@ -15,6 +16,7 @@ class RunFailureCategory(str, Enum):
     INTERNAL = "internal"
     UPSTREAM = "upstream"
     VERIFICATION = "verification"
+    PRESERVATION_SETUP = "preservation_setup"
 
 
 class PublicRunFailure(TypedDict):
@@ -29,6 +31,11 @@ UPSTREAM_FAILED_RUN_MESSAGE = (
 )
 VERIFICATION_FAILED_RUN_MESSAGE = (
     "I couldn't safely verify this and it is still open — I will come back."
+)
+PRESERVATION_SETUP_FAILED_RUN_MESSAGE = (
+    "Illo could not start the preservation workflow before a durable-storage tool ran. "
+    "Retry this submission with the same idempotency key. If it fails again, check the "
+    "run provider and preservation-tool configuration."
 )
 CANCELED_RUN_MESSAGE = (
     "That run was canceled before it finished, but the ask is still open — I will come back."
@@ -54,6 +61,42 @@ def failure_category_for_error(error: BaseException | str | None) -> RunFailureC
     return RunFailureCategory.INTERNAL
 
 
+def run_requires_durable_preservation(metadata: Mapping[str, Any] | None) -> bool:
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    submission = metadata.get("submission")
+    submission = submission if isinstance(submission, Mapping) else {}
+    preservation = submission.get("preservation")
+    preservation = preservation if isinstance(preservation, Mapping) else {}
+    return preservation.get("requires_durable_evidence") is True
+
+
+def failure_category_for_run_context(
+    category: RunFailureCategory | str | None,
+    *,
+    metadata: Mapping[str, Any] | None,
+    tool_execution_started: bool,
+    failure_stage: Any,
+) -> RunFailureCategory:
+    """Classify an internal pre-tool preservation failure as actionable setup work."""
+
+    resolved = coerce_failure_category(category)
+    stage = str(getattr(failure_stage, "value", failure_stage) or "")
+    if (
+        resolved == RunFailureCategory.INTERNAL
+        and run_requires_durable_preservation(metadata)
+        and not tool_execution_started
+        and stage
+        in {
+            "runner_execution",
+            "project_context_materialization",
+            "recipe_execution",
+            "agent_execution",
+        }
+    ):
+        return RunFailureCategory.PRESERVATION_SETUP
+    return resolved
+
+
 def safe_terminal_run_message(
     status: RunStatus | str | None,
     category: RunFailureCategory | str | None = None,
@@ -76,6 +119,8 @@ def safe_terminal_run_message(
         return UPSTREAM_FAILED_RUN_MESSAGE
     if failure_category == RunFailureCategory.VERIFICATION:
         return VERIFICATION_FAILED_RUN_MESSAGE
+    if failure_category == RunFailureCategory.PRESERVATION_SETUP:
+        return PRESERVATION_SETUP_FAILED_RUN_MESSAGE
     return DEFAULT_FAILED_RUN_MESSAGE
 
 
@@ -123,12 +168,15 @@ __all__ = [
     "DEFAULT_FAILED_RUN_MESSAGE",
     "EXPIRED_RUN_MESSAGE",
     "PublicRunFailure",
+    "PRESERVATION_SETUP_FAILED_RUN_MESSAGE",
     "RunFailureCategory",
     "UPSTREAM_FAILED_RUN_MESSAGE",
     "VERIFICATION_FAILED_RUN_MESSAGE",
     "coerce_failure_category",
     "failure_category_for_error",
+    "failure_category_for_run_context",
     "public_run_failure",
+    "run_requires_durable_preservation",
     "safe_terminal_run_message",
     "terminal_run_notice_condition",
 ]

--- a/brain/systems/runs/failures.py
+++ b/brain/systems/runs/failures.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from enum import Enum
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from brain.platform.integrations.provider_error_sentinel import provider_error_kind
 from brain.platform.integrations.providers import is_transient_transport_disconnect
@@ -59,42 +58,6 @@ def failure_category_for_error(error: BaseException | str | None) -> RunFailureC
     if is_transient_transport_disconnect(error) or provider_error_kind(error):
         return RunFailureCategory.UPSTREAM
     return RunFailureCategory.INTERNAL
-
-
-def run_requires_durable_preservation(metadata: Mapping[str, Any] | None) -> bool:
-    metadata = metadata if isinstance(metadata, Mapping) else {}
-    submission = metadata.get("submission")
-    submission = submission if isinstance(submission, Mapping) else {}
-    preservation = submission.get("preservation")
-    preservation = preservation if isinstance(preservation, Mapping) else {}
-    return preservation.get("requires_durable_evidence") is True
-
-
-def failure_category_for_run_context(
-    category: RunFailureCategory | str | None,
-    *,
-    metadata: Mapping[str, Any] | None,
-    tool_execution_started: bool,
-    failure_stage: Any,
-) -> RunFailureCategory:
-    """Classify an internal pre-tool preservation failure as actionable setup work."""
-
-    resolved = coerce_failure_category(category)
-    stage = str(getattr(failure_stage, "value", failure_stage) or "")
-    if (
-        resolved == RunFailureCategory.INTERNAL
-        and run_requires_durable_preservation(metadata)
-        and not tool_execution_started
-        and stage
-        in {
-            "runner_execution",
-            "project_context_materialization",
-            "recipe_execution",
-            "agent_execution",
-        }
-    ):
-        return RunFailureCategory.PRESERVATION_SETUP
-    return resolved
 
 
 def safe_terminal_run_message(
@@ -174,9 +137,7 @@ __all__ = [
     "VERIFICATION_FAILED_RUN_MESSAGE",
     "coerce_failure_category",
     "failure_category_for_error",
-    "failure_category_for_run_context",
     "public_run_failure",
-    "run_requires_durable_preservation",
     "safe_terminal_run_message",
     "terminal_run_notice_condition",
 ]

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -255,11 +255,17 @@ class FastRecipe(BaseRunRecipe):
         except Exception as exc:
             logger.exception("fast_recipe_failed", extra={"run_id": runtime.run.id})
             category = failure_category_for_error(exc)
+            classified_failure = await runtime.classify_failure(
+                category,
+                stage=RunFailureStage.AGENT_EXECUTION,
+            )
             return RunRecipeResult(
                 error=str(exc),
-                final_output=safe_terminal_run_message(RunStatus.FAILED, category),
-                failure_category=category,
-                failure_stage=RunFailureStage.AGENT_EXECUTION,
+                final_output=safe_terminal_run_message(
+                    RunStatus.FAILED,
+                    classified_failure.category,
+                ),
+                classified_failure=classified_failure,
                 exception_type=type(exc),
                 status=RunStatus.FAILED,
             )
@@ -274,11 +280,17 @@ class FastRecipe(BaseRunRecipe):
         if status == RunStatus.FAILED:
             error = str(result_error or output or "fast_recipe_failed")
             category = failure_category_for_error(error)
+            classified_failure = await runtime.classify_failure(
+                category,
+                stage=RunFailureStage.AGENT_EXECUTION,
+            )
             return RunRecipeResult(
                 error=error,
-                final_output=safe_terminal_run_message(status, category),
-                failure_category=category,
-                failure_stage=RunFailureStage.AGENT_EXECUTION,
+                final_output=safe_terminal_run_message(
+                    status,
+                    classified_failure.category,
+                ),
+                classified_failure=classified_failure,
                 exception_type=getattr(result, "exception_type", None),
                 status=status,
                 post_completion_tasks=tuple(getattr(result, "post_completion_tasks", ()) or ()),

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -224,7 +224,7 @@ class WorkerRecipe(BaseRunRecipe):
             error = str(exc)
             status = RunStatus.FAILED
             failure_category = failure_category_for_error(exc)
-            failure = public_run_failure(status, failure_category)
+            failure = None
             exception_type = type(exc)
             output = ""
             post_completion_tasks = ()
@@ -260,11 +260,17 @@ class WorkerRecipe(BaseRunRecipe):
                     )
                 )
                 failure_category = failure_category_for_error(error)
-                failure = public_run_failure(status, failure_category)
                 exception_type = getattr(result, "exception_type", None)
                 output = ""
             post_completion_tasks = tuple(getattr(result, "post_completion_tasks", ()) or ())
         await _record_effective_routing(runtime, effective_routing)
+        classified_failure = None
+        if status == RunStatus.FAILED:
+            classified_failure = await runtime.classify_failure(
+                failure_category,
+                stage=RunFailureStage.AGENT_EXECUTION,
+            )
+            failure = public_run_failure(status, classified_failure.category)
         streamed_output = False
         if status == RunStatus.COMPLETED:
             for delta in pending_deltas:
@@ -290,12 +296,7 @@ class WorkerRecipe(BaseRunRecipe):
             status=status,
             error=error,
             final_output=public_output if status == RunStatus.FAILED else None,
-            failure_category=failure_category,
-            failure_stage=(
-                RunFailureStage.AGENT_EXECUTION
-                if status == RunStatus.FAILED
-                else None
-            ),
+            classified_failure=classified_failure,
             exception_type=exception_type,
             artifacts=(worker_result,),
             post_completion_tasks=post_completion_tasks,

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -35,9 +35,9 @@ from brain.systems.runs.domain import (
 from brain.systems.runs.events import run_event, status_changed_event
 from brain.systems.runs.failure_diagnostic import (
     RunFailureStage,
-    failure_diagnostic_metadata,
+    run_failure_metadata,
 )
-from brain.systems.runs.failures import safe_terminal_run_message
+from brain.systems.runs.failures import RunFailureCategory, safe_terminal_run_message
 from brain.systems.runs.ids import trace_id_for_run_id
 from brain.systems.runs.status import (
     RunStatus,
@@ -73,23 +73,6 @@ _CHILD_CREATION_TOKEN_METADATA_KEY = "parent_step_creation_token"
 _DEADLOCK_RETRY_ATTEMPTS = 3
 _DEADLOCK_RETRY_BASE_SECONDS = 0.05
 _UNSET = object()
-
-
-def _require_typed_failure_metadata(metadata: object) -> None:
-    run_metadata = metadata if isinstance(metadata, Mapping) else {}
-    failure = run_metadata.get("failure")
-    failure_metadata = failure if isinstance(failure, Mapping) else {}
-    try:
-        stage = RunFailureStage(failure_metadata.get("stage"))
-        expected = failure_diagnostic_metadata(stage=stage)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            "failed AgentRun transitions require typed failure diagnostic metadata"
-        ) from exc
-    if any(failure_metadata.get(key) != value for key, value in expected.items()):
-        raise ValueError(
-            "failed AgentRun transitions require typed failure diagnostic metadata"
-        )
 
 
 def _agent_run_deadline_seconds() -> int:
@@ -1071,6 +1054,84 @@ class AsyncAgentRunStore:
         )
         return run
 
+    async def fail_run(
+        self,
+        run_id: int,
+        *,
+        category: RunFailureCategory,
+        stage: RunFailureStage,
+        reason: str | None = None,
+        exception_type: type[BaseException] | None = None,
+        execution_claim: ExecutionClaim | None = None,
+    ) -> AgentRun:
+        """Atomically persist a typed failure envelope and failed status."""
+
+        run, _changed = await self.fail_run_with_result(
+            run_id,
+            category=category,
+            stage=stage,
+            reason=reason,
+            exception_type=exception_type,
+            execution_claim=execution_claim,
+        )
+        return run
+
+    async def fail_run_with_result(
+        self,
+        run_id: int,
+        *,
+        category: RunFailureCategory,
+        stage: RunFailureStage,
+        reason: str | None = None,
+        exception_type: type[BaseException] | None = None,
+        execution_claim: ExecutionClaim | None = None,
+        expected_updated_at: datetime | None | object = _UNSET,
+        expected_execution_token: str | None | object = _UNSET,
+        expected_execution_attempt: int | object = _UNSET,
+        rollback_on_conflict: bool = True,
+        transitioned_at: datetime | None = None,
+        before_status_events: tuple[AgentRunEvent, ...] = (),
+        after_status_events: tuple[AgentRunEvent, ...] = (),
+    ) -> tuple[AgentRun, bool]:
+        """Typed failed transition with compare-and-set result reporting."""
+
+        if execution_claim is not None and execution_claim.lost.is_set():
+            raise ExecutionClaimLost(
+                f"AgentRun {run_id} execution claim {execution_claim.attempt} is no longer current"
+            )
+        row = await self._locked_run(run_id)
+        metadata = dict(row.metadata_ or {})
+        try:
+            metadata["failure"] = run_failure_metadata(
+                category=category,
+                stage=stage,
+                exception_type=exception_type,
+            )
+        except (TypeError, ValueError):
+            logger.critical(
+                "AgentRun %s received malformed typed failure fields; "
+                "using internal settlement fallback",
+                run_id,
+            )
+            metadata["failure"] = run_failure_metadata(
+                category=RunFailureCategory.INTERNAL,
+                stage=RunFailureStage.RUNNER_SETTLEMENT,
+            )
+        return await self._set_status_on_locked_run(
+            row,
+            RunStatus.FAILED,
+            reason=reason,
+            execution_claim=execution_claim,
+            expected_updated_at=expected_updated_at,
+            expected_execution_token=expected_execution_token,
+            expected_execution_attempt=expected_execution_attempt,
+            rollback_on_conflict=rollback_on_conflict,
+            transitioned_at=transitioned_at,
+            metadata_update=metadata,
+            before_status_events=before_status_events,
+            after_status_events=after_status_events,
+        )
+
     async def interrupt_and_requeue(
         self,
         run_id: int,
@@ -1242,6 +1303,26 @@ class AsyncAgentRunStore:
         before_status_events: tuple[AgentRunEvent, ...] = (),
         after_status_events: tuple[AgentRunEvent, ...] = (),
     ) -> tuple[AgentRun, bool]:
+        if status == RunStatus.FAILED or status == RunStatus.FAILED.value:
+            logger.critical(
+                "AgentRun %s used generic set_status for FAILED; "
+                "using typed internal settlement fallback",
+                run_id,
+            )
+            return await self.fail_run_with_result(
+                run_id,
+                category=RunFailureCategory.INTERNAL,
+                stage=RunFailureStage.RUNNER_SETTLEMENT,
+                reason=reason,
+                execution_claim=execution_claim,
+                expected_updated_at=expected_updated_at,
+                expected_execution_token=expected_execution_token,
+                expected_execution_attempt=expected_execution_attempt,
+                rollback_on_conflict=rollback_on_conflict,
+                transitioned_at=transitioned_at,
+                before_status_events=before_status_events,
+                after_status_events=after_status_events,
+            )
         if execution_claim is not None and execution_claim.lost.is_set():
             raise ExecutionClaimLost(
                 f"AgentRun {run_id} execution claim {execution_claim.attempt} is no longer current"
@@ -1306,10 +1387,6 @@ class AsyncAgentRunStore:
             if execution_claim is not None:
                 await self.assert_execution_claim(execution_claim)
             return to_domain(row), False
-        if target == RunStatus.FAILED:
-            _require_typed_failure_metadata(
-                metadata_update if metadata_update is not None else row.metadata_
-            )
         now = transitioned_at or datetime.now(timezone.utc)
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -33,6 +33,10 @@ from brain.systems.runs.domain import (
     RunRecipe,
 )
 from brain.systems.runs.events import run_event, status_changed_event
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.failures import safe_terminal_run_message
 from brain.systems.runs.ids import trace_id_for_run_id
 from brain.systems.runs.status import (
@@ -69,6 +73,23 @@ _CHILD_CREATION_TOKEN_METADATA_KEY = "parent_step_creation_token"
 _DEADLOCK_RETRY_ATTEMPTS = 3
 _DEADLOCK_RETRY_BASE_SECONDS = 0.05
 _UNSET = object()
+
+
+def _require_typed_failure_metadata(metadata: object) -> None:
+    run_metadata = metadata if isinstance(metadata, Mapping) else {}
+    failure = run_metadata.get("failure")
+    failure_metadata = failure if isinstance(failure, Mapping) else {}
+    try:
+        stage = RunFailureStage(failure_metadata.get("stage"))
+        expected = failure_diagnostic_metadata(stage=stage)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "failed AgentRun transitions require typed failure diagnostic metadata"
+        ) from exc
+    if any(failure_metadata.get(key) != value for key, value in expected.items()):
+        raise ValueError(
+            "failed AgentRun transitions require typed failure diagnostic metadata"
+        )
 
 
 def _agent_run_deadline_seconds() -> int:
@@ -1285,6 +1306,10 @@ class AsyncAgentRunStore:
             if execution_claim is not None:
                 await self.assert_execution_claim(execution_claim)
             return to_domain(row), False
+        if target == RunStatus.FAILED:
+            _require_typed_failure_metadata(
+                metadata_update if metadata_update is not None else row.metadata_
+            )
         now = transitioned_at or datetime.now(timezone.utc)
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -522,7 +522,8 @@ async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(mo
     assert result.status == RunStatus.FAILED
     assert result.error == raw_error
     assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
-    assert result.failure_stage == RunFailureStage.AGENT_EXECUTION
+    assert result.classified_failure is not None
+    assert result.classified_failure.stage == RunFailureStage.AGENT_EXECUTION
     assert result.exception_type is RemoteProtocolError
     assert raw_delta not in streamed
     assert raw_error not in streamed
@@ -574,7 +575,8 @@ async def test_fast_interactive_slack_transport_failure_returns_plain_language_f
     assert calls == [replay_index]
     assert result.status.value == "failed"
     assert result.error == raw_error
-    assert result.failure_category == RunFailureCategory.UPSTREAM
+    assert result.classified_failure is not None
+    assert result.classified_failure.category == RunFailureCategory.UPSTREAM
     assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
     assert result.output == ""
     assert raw_error not in result.final_output
@@ -607,7 +609,8 @@ async def test_fast_interactive_slack_logic_failure_is_not_rewritten_or_retried(
     assert calls == ["invoke"]
     assert result.status.value == "failed"
     assert result.error == logic_error
-    assert result.failure_category == RunFailureCategory.INTERNAL
+    assert result.classified_failure is not None
+    assert result.classified_failure.category == RunFailureCategory.INTERNAL
     assert result.final_output == DEFAULT_FAILED_RUN_MESSAGE
     assert result.output == ""
     assert logic_error not in result.final_output

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -21,9 +21,9 @@ from brain.systems.runs.engine import AsyncAgentRunEngine, RunRecipeResult, RunR
 from brain.systems.runs.failure_diagnostic import (
     DiagnosticValueState,
     RunFailureStage,
-    failure_diagnostic_metadata,
     read_run_failure_diagnostic,
 )
+from brain.systems.runs.failures import RunFailureCategory
 from brain.contracts.statuses import (
     OPEN_RUN_STATUS_VALUES,
     RUN_STATUS_VALUES,
@@ -919,42 +919,29 @@ async def test_stale_status_cas_preserves_live_owner_and_prior_batch_changes(tmp
             (row.updated_at, row.execution_token, int(row.execution_attempt or 0))
             for row in stale_rows
         ]
-        failed_metadata = [
-            {
-                **dict(row.metadata_ or {}),
-                "failure": {
-                    "category": "internal",
-                    **failure_diagnostic_metadata(
-                        stage=RunFailureStage.RUNNER_EXECUTION
-                    ),
-                },
-            }
-            for row in stale_rows
-        ]
-
         async with factory() as live_session:
             live_store = AsyncAgentRunStore(live_session)
             assert await live_store.heartbeat_run(runs[1], now=now, reason="owner_is_alive")
             await live_session.commit()
 
-        _first, first_changed = await stale_store.set_status_with_result(
+        _first, first_changed = await stale_store.fail_run_with_result(
             runs[0],
-            RunStatus.FAILED,
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.RUNNER_EXECUTION,
             reason="runner_heartbeat_stale",
             expected_updated_at=expected[0][0],
             expected_execution_token=expected[0][1],
             expected_execution_attempt=expected[0][2],
-            metadata_update=failed_metadata[0],
             rollback_on_conflict=False,
         )
-        second, second_changed = await stale_store.set_status_with_result(
+        second, second_changed = await stale_store.fail_run_with_result(
             runs[1],
-            RunStatus.FAILED,
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.RUNNER_EXECUTION,
             reason="runner_heartbeat_stale",
             expected_updated_at=expected[1][0],
             expected_execution_token=expected[1][1],
             expected_execution_attempt=expected[1][2],
-            metadata_update=failed_metadata[1],
             rollback_on_conflict=False,
         )
         assert first_changed is True
@@ -1666,7 +1653,8 @@ async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory
     assert status_events[-1].payload["reason"] == "AgentRun missing workspace org_id"
 
 
-async def test_store_rejects_failed_transition_without_typed_diagnostic(
+async def test_generic_failed_transition_lands_typed_instead_of_stranding(
+    caplog,
     session_factory,
 ):
     session = session_factory()
@@ -1677,15 +1665,47 @@ async def test_store_rejects_failed_transition_without_typed_diagnostic(
     await store.set_status(run.id, RunStatus.STARTING)
     await store.set_status(run.id, RunStatus.RUNNING)
 
-    with pytest.raises(
-        ValueError,
-        match="failed AgentRun transitions require typed failure diagnostic metadata",
-    ):
+    with caplog.at_level("CRITICAL"):
         await store.set_status(run.id, RunStatus.FAILED, reason="untyped failure")
 
     row = await session.get(AgentRunRow, run.id)
     assert row is not None
-    assert row.status == RunStatus.RUNNING.value
+    assert row.status == RunStatus.FAILED.value
+    diagnostic = await read_run_failure_diagnostic(session, run=row)
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_SETTLEMENT
+    assert diagnostic.stage_state == DiagnosticValueState.KNOWN
+    assert "used generic set_status for FAILED" in caplog.text
+
+
+async def test_malformed_typed_failure_lands_typed_instead_of_stranding(
+    caplog,
+    session_factory,
+):
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(
+        _run_request(thread_id="thread-malformed-failure", message="fail safely")
+    )
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+
+    with caplog.at_level("CRITICAL"):
+        result = await store.fail_run(
+            run.id,
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.UNKNOWN,
+            reason="malformed failure",
+        )
+
+    row = await session.get(AgentRunRow, run.id)
+    assert result.status == RunStatus.FAILED
+    assert row is not None
+    diagnostic = await read_run_failure_diagnostic(session, run=row)
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_SETTLEMENT
+    assert diagnostic.stage_state == DiagnosticValueState.KNOWN
+    assert "received malformed typed failure fields" in caplog.text
 
 
 async def test_engine_complete_failed_status_uses_typed_settlement_diagnostic(

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -18,6 +18,12 @@ from sqlalchemy.schema import CreateTable
 
 from brain.systems.runs.domain import AgentRunRequest as _AgentRunRequest, RunRecipe
 from brain.systems.runs.engine import AsyncAgentRunEngine, RunRecipeResult, RunRuntime, StaticAnswerRecipe
+from brain.systems.runs.failure_diagnostic import (
+    DiagnosticValueState,
+    RunFailureStage,
+    failure_diagnostic_metadata,
+    read_run_failure_diagnostic,
+)
 from brain.contracts.statuses import (
     OPEN_RUN_STATUS_VALUES,
     RUN_STATUS_VALUES,
@@ -913,6 +919,18 @@ async def test_stale_status_cas_preserves_live_owner_and_prior_batch_changes(tmp
             (row.updated_at, row.execution_token, int(row.execution_attempt or 0))
             for row in stale_rows
         ]
+        failed_metadata = [
+            {
+                **dict(row.metadata_ or {}),
+                "failure": {
+                    "category": "internal",
+                    **failure_diagnostic_metadata(
+                        stage=RunFailureStage.RUNNER_EXECUTION
+                    ),
+                },
+            }
+            for row in stale_rows
+        ]
 
         async with factory() as live_session:
             live_store = AsyncAgentRunStore(live_session)
@@ -926,6 +944,7 @@ async def test_stale_status_cas_preserves_live_owner_and_prior_batch_changes(tmp
             expected_updated_at=expected[0][0],
             expected_execution_token=expected[0][1],
             expected_execution_attempt=expected[0][2],
+            metadata_update=failed_metadata[0],
             rollback_on_conflict=False,
         )
         second, second_changed = await stale_store.set_status_with_result(
@@ -935,6 +954,7 @@ async def test_stale_status_cas_preserves_live_owner_and_prior_batch_changes(tmp
             expected_updated_at=expected[1][0],
             expected_execution_token=expected[1][1],
             expected_execution_attempt=expected[1][2],
+            metadata_update=failed_metadata[1],
             rollback_on_conflict=False,
         )
         assert first_changed is True
@@ -1629,6 +1649,10 @@ async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory
     row = await session.get(AgentRunRow, result.id)
     assert row is not None
     assert row.status == RunStatus.FAILED.value
+    diagnostic = await read_run_failure_diagnostic(session, run=row)
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_EXECUTION
+    assert diagnostic.stage_state == DiagnosticValueState.KNOWN
     status_events = (
         await session.scalars(
             select(AgentRunEventRow)
@@ -1640,6 +1664,54 @@ async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory
         )
     ).all()
     assert status_events[-1].payload["reason"] == "AgentRun missing workspace org_id"
+
+
+async def test_store_rejects_failed_transition_without_typed_diagnostic(
+    session_factory,
+):
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(
+        _run_request(thread_id="thread-failure-invariant", message="fail safely")
+    )
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+
+    with pytest.raises(
+        ValueError,
+        match="failed AgentRun transitions require typed failure diagnostic metadata",
+    ):
+        await store.set_status(run.id, RunStatus.FAILED, reason="untyped failure")
+
+    row = await session.get(AgentRunRow, run.id)
+    assert row is not None
+    assert row.status == RunStatus.RUNNING.value
+
+
+async def test_engine_complete_failed_status_uses_typed_settlement_diagnostic(
+    session_factory,
+):
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(
+        _run_request(thread_id="thread-failed-completion", message="settle safely")
+    )
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+
+    result = await AsyncAgentRunEngine(session, recipes={}).complete(
+        run.id,
+        output="settlement failed",
+        status=RunStatus.FAILED,
+    )
+
+    assert result.status == RunStatus.FAILED
+    row = await session.get(AgentRunRow, run.id)
+    assert row is not None
+    diagnostic = await read_run_failure_diagnostic(session, run=row)
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_SETTLEMENT
+    assert diagnostic.stage_state == DiagnosticValueState.KNOWN
 
 
 async def test_claim_and_completion_are_idempotent(session_factory):
@@ -1748,6 +1820,10 @@ async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
         "diagnostic_schema": "typed_v1",
         "stage": "runner_execution",
     }
+    diagnostic = await read_run_failure_diagnostic(session, run=row)
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_EXECUTION
+    assert diagnostic.stage_state == DiagnosticValueState.KNOWN
     assert [artifact.text for artifact in artifacts] == [UPSTREAM_FAILED_RUN_MESSAGE]
     assert [event.payload for event in text_events] == [{"text": UPSTREAM_FAILED_RUN_MESSAGE}]
     assert all(raw_diagnostic not in str(value) for value in (artifacts, text_events))

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -2277,6 +2277,72 @@ async def test_interactive_slack_transport_failure_never_persists_raw_error_as_f
     assert all(raw_error not in str(event.payload) for event in text_completed_events)
 
 
+async def test_worker_failure_receipt_matches_terminal_preservation_category(
+    monkeypatch,
+    session_factory,
+):
+    from brain.systems.runs.failures import PRESERVATION_SETUP_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.workers import WorkerRecipe
+
+    async def fake_invoke(_spec):
+        return SimpleNamespace(output="", success=False, error="worker failed")
+
+    async def no_usage(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.build_agent_tools",
+        lambda _role: [],
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.build_tool_handlers",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.invoke_direct_agent_async",
+        fake_invoke,
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.async_summarize_run_usage_in_savepoint",
+        no_usage,
+    )
+
+    session = session_factory()
+    result = await AsyncAgentRunEngine(
+        session,
+        recipes={RunRecipe.WORKER.value: WorkerRecipe()},
+    ).run(
+        _run_request(
+            thread_id="thread-preservation-receipt",
+            message="Preserve this result.",
+            recipe=RunRecipe.WORKER,
+            model_policy={"model": "openai/gpt-5.6-sol", "thinking": "high"},
+            metadata={
+                "submission": {
+                    "preservation": {"requires_durable_evidence": True},
+                },
+            },
+        )
+    )
+
+    worker_receipt = (
+        await session.scalars(
+            select(AgentRunArtifactRow).where(
+                AgentRunArtifactRow.run_id == result.id,
+                AgentRunArtifactRow.artifact_type == "worker_result",
+            )
+        )
+    ).one()
+
+    terminal_category = result.metadata["failure"]["category"]
+    assert terminal_category == "preservation_setup"
+    assert worker_receipt.payload["failure"]["category"] == terminal_category
+    assert worker_receipt.payload["failure"]["message"] == (
+        PRESERVATION_SETUP_FAILED_RUN_MESSAGE
+    )
+    assert worker_receipt.text == PRESERVATION_SETUP_FAILED_RUN_MESSAGE
+
+
 async def test_failed_cycle_engine_events_do_not_surface_raw_provider_error(session_factory):
     raw_provider_error = (
         "An error occurred while processing your request. Contact help.openai.com with request ID "

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -23,6 +23,10 @@ from brain.systems.runs.failure_diagnostic import (
     RunFailureStage,
     failure_diagnostic_metadata,
 )
+from brain.systems.runs.failures import (
+    DEFAULT_FAILED_RUN_MESSAGE,
+    PRESERVATION_SETUP_FAILED_RUN_MESSAGE,
+)
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 
@@ -614,7 +618,6 @@ async def test_get_result_lazily_reconciles_completed_submission_run(session):
 async def test_get_result_failed_preservation_reports_exception_class_states(session):
     from brain.app.api.routers.agent_mcp import _tool_get_result
     from brain.systems.runs.engine import AsyncAgentRunEngine
-    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
 
     principal = await _seed_connection(session)
     result = await inbound.submit_inbound_envelope(
@@ -750,3 +753,66 @@ async def test_get_result_failed_preservation_reports_exception_class_states(ses
     }
     assert "sk_live_abc123DEF456token" not in json.dumps(withheld_payload)
     assert "private_exception_token" not in json.dumps(withheld_payload)
+
+
+async def test_codex_session_preservation_pre_tool_failure_is_actionable(session):
+    from brain.app.api.routers.agent_mcp import _tool_get_result
+    from brain.systems.runs.engine import AsyncAgentRunEngine
+
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.session-preserve",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve the reusable result of Illospace issue #868.",
+            "source": {
+                "source_tool": "codex",
+                "repo": "Illospace/illospace",
+                "branch": "illo-qa/868-preserve-knowledge-preflight",
+                "session_id": "session-868",
+                "run_id": "run-868",
+                "task_title": "Fix preserve_knowledge pre-tool failures",
+                "files_touched": ["brain/systems/inbound/preservation.py"],
+                "repository": "https://github.com/Illospace/illospace",
+                "issue": "https://github.com/Illospace/illospace/issues/868",
+                "pull_request": "https://github.com/Illospace/illospace/pull/866",
+            },
+            "idempotency_key": "codex:session-preserve:issue-868",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run_id = int(handling["run_id"])
+    run = await session.get(AgentRunRow, run_id)
+    assert run is not None
+    assert run.metadata_["submission"]["source"]["source_tool"] == "codex"
+    assert "memory_ingest_source" in run.metadata_["submission"]["preservation"]["acceptable_tools"]
+    store = AsyncAgentRunStore(session)
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await AsyncAgentRunEngine(session, recipes={}).fail(
+        run_id,
+        "direct agent failed before its first tool call",
+        final_output=DEFAULT_FAILED_RUN_MESSAGE,
+        failure_stage=RunFailureStage.AGENT_EXECUTION,
+        exception_type=RuntimeError,
+    )
+
+    payload = await _tool_get_result(session, principal, {"event_id": result["event_id"]})
+
+    assert payload["failure"]["category"] == "preservation_setup"
+    assert payload["failure"]["message"] == PRESERVATION_SETUP_FAILED_RUN_MESSAGE
+    assert payload["failure"]["message"] != DEFAULT_FAILED_RUN_MESSAGE
+    assert payload["failure"]["diagnostic"] == {
+        "stage": "agent_execution",
+        "stage_state": "known",
+        "exception_class": "RuntimeError",
+        "exception_class_state": "known",
+        "tool_execution_started": False,
+        "terminal": True,
+        "retry_scheduled": False,
+    }
+    assert payload["evidence_status"] == "failed"

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -18,6 +18,10 @@ from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundE
 from brain.platform.db.models.org import User
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -72,6 +76,26 @@ def _slack_envelope() -> dict:
         },
         "hints": {},
     }
+
+
+async def _set_failed_run(
+    store: AsyncAgentRunStore,
+    run_id: int,
+    *,
+    reason: str,
+) -> None:
+    await store.update_metadata(
+        run_id,
+        {
+            "failure": {
+                "category": "internal",
+                **failure_diagnostic_metadata(
+                    stage=RunFailureStage.AGENT_EXECUTION
+                ),
+            }
+        },
+    )
+    await store.set_status(run_id, RunStatus.FAILED, reason=reason)
 
 
 async def _seed_slack_lane(
@@ -158,9 +182,9 @@ async def test_transient_failed_monitor_run_readmits_once_and_replacement_replie
     )
 
     store = AsyncAgentRunStore(session)
-    await store.set_status(
+    await _set_failed_run(
+        store,
         original_run_id,
-        RunStatus.FAILED,
         reason=failure_reason,
     )
 
@@ -232,17 +256,17 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         run_status="running",
     )
     store = AsyncAgentRunStore(session)
-    await store.set_status(
+    await _set_failed_run(
+        store,
         original_run_id,
-        RunStatus.FAILED,
         reason=failure_reason,
     )
     replacement = (await session.scalars(
         select(AgentRunRow).where(AgentRunRow.id != original_run_id)
     )).one()
-    await store.set_status(
+    await _set_failed_run(
+        store,
         replacement.id,
-        RunStatus.FAILED,
         reason=failure_reason,
     )
     await reconcile_inbound_triage_run(session, replacement.id)
@@ -272,9 +296,9 @@ async def test_non_transient_failed_monitor_run_is_not_readmitted(session):
         run_status="running",
     )
 
-    await AsyncAgentRunStore(session).set_status(
+    await _set_failed_run(
+        AsyncAgentRunStore(session),
         original_run_id,
-        RunStatus.FAILED,
         reason="Refused because the requested operation violates policy",
     )
 

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -31,6 +31,15 @@ _REPLY_RESULT = json.dumps({"operation": "posted", "channel_id": "C0PROD",
                             "message_ts": "1752600001.0"})
 
 
+def _result_api():
+    from brain.systems.inbound.results import (
+        InboundSubmissionResultState,
+        read_inbound_submission_result,
+    )
+
+    return InboundSubmissionResultState, read_inbound_submission_result
+
+
 @pytest.fixture
 async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
     return await async_sqlite_session_factory([
@@ -141,7 +150,6 @@ async def _seed_slack_lane(
     return str(event.id), int(run.id)
 
 
-
 @pytest.mark.parametrize(
     "failure_reason",
     [INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE, "server_error"],
@@ -224,8 +232,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     session,
     failure_reason,
 ):
-    from brain.systems.inbound.results import read_inbound_submission_result
-
+    _, read_inbound_submission_result = _result_api()
     event_id, original_run_id = await _seed_slack_lane(
         session,
         tool_results=[],
@@ -263,6 +270,81 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         {"run_id": original_run_id, "retry_attempt": 0},
         {"run_id": replacement.id, "retry_attempt": 1},
     ]
+
+
+async def test_submission_result_absent_event_has_not_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=str(uuid.uuid4()),
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.owned_by_another_connection is False
+
+
+async def test_submission_result_cross_org_event_has_not_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=str(uuid.uuid4()),
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.owned_by_another_connection is False
+
+
+async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
+    from types import SimpleNamespace
+
+    from brain.app.api.routers.agent_mcp import _tool_get_result
+
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+    other_connection_id = str(uuid.uuid4())
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=other_connection_id,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
+    assert result.owned_by_another_connection is True
+
+    wire_payload = await _tool_get_result(
+        session,
+        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
+        {"event_id": event_id},
+    )
+    assert wire_payload == {
+        "event_id": event_id,
+        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
+        "owned_by_another_connection": True,
+    }
+
+
+async def test_submission_result_visible_event_has_found_state(session):
+    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.FOUND
+    assert result.owned_by_another_connection is False
+    assert result.payload["event_id"] == event_id
 
 
 async def test_non_transient_failed_monitor_run_is_not_readmitted(session):

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -17,6 +17,7 @@ from brain.platform.db.models.agent_run import (
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+from brain.systems.inbound.results import read_inbound_submission_result
 from brain.systems.runs.events import run_event
 from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
 from brain.systems.runs.status import RunStatus
@@ -29,15 +30,6 @@ _NOW = datetime(2026, 7, 16, 9, 0, tzinfo=timezone.utc)
 
 _REPLY_RESULT = json.dumps({"operation": "posted", "channel_id": "C0PROD",
                             "message_ts": "1752600001.0"})
-
-
-def _result_api():
-    from brain.systems.inbound.results import (
-        InboundSubmissionResultState,
-        read_inbound_submission_result,
-    )
-
-    return InboundSubmissionResultState, read_inbound_submission_result
 
 
 @pytest.fixture
@@ -232,7 +224,6 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     session,
     failure_reason,
 ):
-    _, read_inbound_submission_result = _result_api()
     event_id, original_run_id = await _seed_slack_lane(
         session,
         tool_results=[],
@@ -261,6 +252,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         connection_id=_CONN,
         event_id=event_id,
     )
+    assert result.payload is not None
     assert result.payload["run_id"] == replacement.id
     assert result.payload["run_status"] == "failed"
     assert result.payload["retry_attempt"] == 1
@@ -270,82 +262,6 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         {"run_id": original_run_id, "retry_attempt": 0},
         {"run_id": replacement.id, "retry_attempt": 1},
     ]
-
-
-async def test_submission_result_absent_event_has_not_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=_CONN,
-        event_id=str(uuid.uuid4()),
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_FOUND
-    assert result.owned_by_another_connection is False
-
-
-async def test_submission_result_cross_org_event_has_not_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=str(uuid.uuid4()),
-        connection_id=_CONN,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_FOUND
-    assert result.owned_by_another_connection is False
-
-
-async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
-    from types import SimpleNamespace
-
-    from brain.app.api.routers.agent_mcp import _tool_get_result
-
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-    other_connection_id = str(uuid.uuid4())
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=other_connection_id,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
-    assert result.owned_by_another_connection is True
-
-    wire_payload = await _tool_get_result(
-        session,
-        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
-        {"event_id": event_id},
-    )
-    assert wire_payload == {
-        "event_id": event_id,
-        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
-        "owned_by_another_connection": True,
-    }
-
-
-async def test_submission_result_visible_event_has_found_state(session):
-    InboundSubmissionResultState, read_inbound_submission_result = _result_api()
-    event_id, _ = await _seed_slack_lane(session, tool_results=[])
-
-    result = await read_inbound_submission_result(
-        session,
-        org_id=_ORG,
-        connection_id=_CONN,
-        event_id=event_id,
-    )
-
-    assert result.state is InboundSubmissionResultState.FOUND
-    assert result.owned_by_another_connection is False
-    assert result.payload["event_id"] == event_id
-
 
 async def test_non_transient_failed_monitor_run_is_not_readmitted(session):
     event_id, original_run_id = await _seed_slack_lane(

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -18,10 +18,8 @@ from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundE
 from brain.platform.db.models.org import User
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 from brain.systems.runs.events import run_event
-from brain.systems.runs.failure_diagnostic import (
-    RunFailureStage,
-    failure_diagnostic_metadata,
-)
+from brain.systems.runs.failure_diagnostic import RunFailureStage
+from brain.systems.runs.failures import RunFailureCategory
 from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -76,26 +74,6 @@ def _slack_envelope() -> dict:
         },
         "hints": {},
     }
-
-
-async def _set_failed_run(
-    store: AsyncAgentRunStore,
-    run_id: int,
-    *,
-    reason: str,
-) -> None:
-    await store.update_metadata(
-        run_id,
-        {
-            "failure": {
-                "category": "internal",
-                **failure_diagnostic_metadata(
-                    stage=RunFailureStage.AGENT_EXECUTION
-                ),
-            }
-        },
-    )
-    await store.set_status(run_id, RunStatus.FAILED, reason=reason)
 
 
 async def _seed_slack_lane(
@@ -182,9 +160,10 @@ async def test_transient_failed_monitor_run_readmits_once_and_replacement_replie
     )
 
     store = AsyncAgentRunStore(session)
-    await _set_failed_run(
-        store,
+    await store.fail_run(
         original_run_id,
+        category=RunFailureCategory.INTERNAL,
+        stage=RunFailureStage.AGENT_EXECUTION,
         reason=failure_reason,
     )
 
@@ -256,17 +235,19 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
         run_status="running",
     )
     store = AsyncAgentRunStore(session)
-    await _set_failed_run(
-        store,
+    await store.fail_run(
         original_run_id,
+        category=RunFailureCategory.INTERNAL,
+        stage=RunFailureStage.AGENT_EXECUTION,
         reason=failure_reason,
     )
     replacement = (await session.scalars(
         select(AgentRunRow).where(AgentRunRow.id != original_run_id)
     )).one()
-    await _set_failed_run(
-        store,
+    await store.fail_run(
         replacement.id,
+        category=RunFailureCategory.INTERNAL,
+        stage=RunFailureStage.AGENT_EXECUTION,
         reason=failure_reason,
     )
     await reconcile_inbound_triage_run(session, replacement.id)
@@ -296,9 +277,10 @@ async def test_non_transient_failed_monitor_run_is_not_readmitted(session):
         run_status="running",
     )
 
-    await _set_failed_run(
-        AsyncAgentRunStore(session),
+    await AsyncAgentRunStore(session).fail_run(
         original_run_id,
+        category=RunFailureCategory.INTERNAL,
+        stage=RunFailureStage.AGENT_EXECUTION,
         reason="Refused because the requested operation violates policy",
     )
 

--- a/tests/test_inbound_results.py
+++ b/tests/test_inbound_results.py
@@ -1,0 +1,80 @@
+"""Inbound submission result visibility tests."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+from brain.app.api.routers.agent_mcp import _tool_get_result
+from brain.systems.inbound.results import (
+    InboundSubmissionResultState,
+    read_inbound_submission_result,
+)
+from tests.test_inbound_reconciliation import _CONN, _ORG, _seed_slack_lane, session
+
+
+async def test_submission_result_absent_event_has_not_found_state(session):
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=str(uuid.uuid4()),
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.payload is None
+
+
+async def test_submission_result_cross_org_event_has_not_found_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=str(uuid.uuid4()),
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_FOUND
+    assert result.payload is None
+
+
+async def test_submission_result_owned_by_another_connection_has_distinct_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+    other_connection_id = str(uuid.uuid4())
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=other_connection_id,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION
+    assert result.payload is None
+
+    wire_payload = await _tool_get_result(
+        session,
+        SimpleNamespace(org_id=_ORG, connection_id=other_connection_id),
+        {"event_id": event_id},
+    )
+    assert wire_payload == {
+        "event_id": event_id,
+        "state": InboundSubmissionResultState.NOT_VISIBLE_TO_CONNECTION.value,
+        "owned_by_another_connection": True,
+    }
+
+
+async def test_submission_result_visible_event_has_found_state(session):
+    event_id, _ = await _seed_slack_lane(session, tool_results=[])
+
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+
+    assert result.state is InboundSubmissionResultState.FOUND
+    assert result.payload is not None
+    assert result.payload["event_id"] == event_id

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -40,6 +40,10 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound import service as inbound
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failure_diagnostic import (
+    RunFailureStage,
+    failure_diagnostic_metadata,
+)
 from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -841,7 +845,13 @@ async def test_inbound_triage_receipt_reconciles_when_illo_run_fails(session):
         idempotency_key="jira:PROJ-2:updated",
     )
     run = await session.get(AgentRunRow, int(triage["run_id"]))
-    run.metadata_ = {**dict(run.metadata_ or {}), "failure": {"category": "upstream"}}
+    run.metadata_ = {
+        **dict(run.metadata_ or {}),
+        "failure": {
+            "category": "upstream",
+            **failure_diagnostic_metadata(stage=RunFailureStage.AGENT_EXECUTION),
+        },
+    }
     await _finish_triage_run(
         session,
         triage,

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -40,11 +40,8 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound import service as inbound
 from brain.systems.runs.events import run_event
-from brain.systems.runs.failure_diagnostic import (
-    RunFailureStage,
-    failure_diagnostic_metadata,
-)
-from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+from brain.systems.runs.failure_diagnostic import RunFailureStage
+from brain.systems.runs.failures import RunFailureCategory, UPSTREAM_FAILED_RUN_MESSAGE
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.user_domains.service import AsyncDomainService
@@ -459,13 +456,22 @@ async def _finish_triage_run(
     status: RunStatus,
     final_answer: str,
     reason: str | None = None,
+    failure_category: RunFailureCategory = RunFailureCategory.INTERNAL,
 ) -> None:
     store = AsyncAgentRunStore(session)
     run_id = int(triage["run_id"])
     await store.set_status(run_id, RunStatus.STARTING)
     await store.set_status(run_id, RunStatus.RUNNING)
     await store.append_final_answer_once(run_id, final_answer, root_run_id=run_id)
-    await store.set_status(run_id, status, reason=reason)
+    if status == RunStatus.FAILED:
+        await store.fail_run(
+            run_id,
+            category=failure_category,
+            stage=RunFailureStage.AGENT_EXECUTION,
+            reason=reason,
+        )
+    else:
+        await store.set_status(run_id, status, reason=reason)
 
 
 async def test_webhook_requires_authenticated_source_identity(session):
@@ -844,20 +850,13 @@ async def test_inbound_triage_receipt_reconciles_when_illo_run_fails(session):
         issue_key="PROJ-2",
         idempotency_key="jira:PROJ-2:updated",
     )
-    run = await session.get(AgentRunRow, int(triage["run_id"]))
-    run.metadata_ = {
-        **dict(run.metadata_ or {}),
-        "failure": {
-            "category": "upstream",
-            **failure_diagnostic_metadata(stage=RunFailureStage.AGENT_EXECUTION),
-        },
-    }
     await _finish_triage_run(
         session,
         triage,
         status=RunStatus.FAILED,
         final_answer=raw_diagnostic,
         reason="triage worker crashed",
+        failure_category=RunFailureCategory.UPSTREAM,
     )
 
     event = (await session.scalars(select(InboundEventRow))).one()

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1,4 +1,6 @@
+import asyncio
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -131,6 +133,66 @@ def test_github_clone_uses_lightweight_command_and_configurable_timeout(tmp_path
     assert calls[0]["env"]["GIT_TERMINAL_PROMPT"] == "0"
     assert calls[0]["env"]["ILLO_GITHUB_PROJECT_CONTEXT_TOKEN"] == "secret-token"
     assert "secret-token" not in " ".join(calls[0]["command"])
+
+
+async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+
+    clone_started = threading.Event()
+    release_clone = threading.Event()
+    released_by_event_loop = []
+
+    def fake_run_subprocess(command, **_kwargs):
+        clone_started.set()
+        released_by_event_loop.append(release_clone.wait(timeout=1))
+        Path(command[-1]).mkdir(parents=True)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_git_output(_cwd, *args):
+        if args == ("branch", "--show-current"):
+            return "main"
+        if args == ("rev-parse", "HEAD"):
+            return "abc123"
+        return None
+
+    async def record_loop_progress():
+        while not clone_started.is_set():
+            await asyncio.sleep(0)
+        ticks = 0
+        for _ in range(3):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        release_clone.set()
+        return ticks
+
+    monkeypatch.setattr(materializer, "run_subprocess_sync", fake_run_subprocess)
+    monkeypatch.setattr(materializer, "_git_output", fake_git_output)
+
+    resource = {
+        "kind": "repo",
+        "name": "example-org/example-repo",
+        "repo": "example-org/example-repo",
+        "uri": "https://github.com/example-org/example-repo",
+        "branch": "main",
+    }
+    materialization, ticks = await asyncio.gather(
+        materializer._materialize_resource(
+            resource,
+            workspace_root=tmp_path,
+            user_id=None,
+            org_id=None,
+        ),
+        record_loop_progress(),
+    )
+
+    workspace, error = materialization
+    assert error is None
+    assert workspace == {
+        "name": "example-org/example-repo",
+        "path": str(tmp_path / ".illo-project-context" / "github" / "example-org" / "example-repo"),
+    }
+    assert ticks == 3
+    assert released_by_event_loop == [True]
 
 
 def test_github_clone_timeout_env_is_bounded(monkeypatch):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -144,7 +144,11 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
 
     def fake_run_subprocess(command, **_kwargs):
         clone_started.set()
-        released_by_event_loop.append(release_clone.wait(timeout=1))
+        # The timeout is deadlock protection, not a timing assertion: only the
+        # event loop can set release_clone, so if the clone were still running
+        # ON the loop this returns False instead of hanging the suite. Keep it
+        # generous — a tight bound here would flake on a loaded CI box.
+        released_by_event_loop.append(release_clone.wait(timeout=30))
         Path(command[-1]).mkdir(parents=True)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -155,15 +159,13 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
             return "abc123"
         return None
 
-    async def record_loop_progress():
+    async def release_once_loop_is_responsive():
+        # This coroutine can only make progress while the clone is in flight if
+        # the clone is NOT holding the event loop. That is the whole assertion:
+        # no sleeps, no tick counting, just "did the loop keep scheduling".
         while not clone_started.is_set():
             await asyncio.sleep(0)
-        ticks = 0
-        for _ in range(3):
-            await asyncio.sleep(0.01)
-            ticks += 1
         release_clone.set()
-        return ticks
 
     monkeypatch.setattr(materializer, "run_subprocess_sync", fake_run_subprocess)
     monkeypatch.setattr(materializer, "_git_output", fake_git_output)
@@ -175,14 +177,14 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
         "uri": "https://github.com/example-org/example-repo",
         "branch": "main",
     }
-    materialization, ticks = await asyncio.gather(
+    materialization, _ = await asyncio.gather(
         materializer._materialize_resource(
             resource,
             workspace_root=tmp_path,
             user_id=None,
             org_id=None,
         ),
-        record_loop_progress(),
+        release_once_loop_is_responsive(),
     )
 
     workspace, error = materialization
@@ -191,7 +193,7 @@ async def test_github_clone_keeps_event_loop_responsive(tmp_path, monkeypatch):
         "name": "example-org/example-repo",
         "path": str(tmp_path / ".illo-project-context" / "github" / "example-org" / "example-repo"),
     }
-    assert ticks == 3
+    # False here means the clone blocked the loop until the timeout expired.
     assert released_by_event_loop == [True]
 
 

--- a/tests/test_run_failure_invariants.py
+++ b/tests/test_run_failure_invariants.py
@@ -1,0 +1,139 @@
+"""Architecture and schema invariants for terminal run failures."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from brain.systems.runs.failure_diagnostic import (
+    DiagnosticValueState,
+    RunFailureStage,
+    read_run_failure_diagnostic,
+    run_failure_metadata,
+)
+from brain.systems.runs.failures import RunFailureCategory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _is_failed_status(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "RunStatus"
+        and node.attr == "FAILED"
+    ) or (isinstance(node, ast.Constant) and node.value == "failed")
+
+
+def test_production_failed_transitions_use_typed_api() -> None:
+    violations: list[str] = []
+    for path in (ROOT / "brain").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_name(node) not in {"set_status", "set_status_with_result"}:
+                continue
+            status_arg = node.args[1] if len(node.args) > 1 else next(
+                (
+                    keyword.value
+                    for keyword in node.keywords
+                    if keyword.arg == "status"
+                ),
+                None,
+            )
+            if status_arg is not None and _is_failed_status(status_arg):
+                violations.append(str(path.relative_to(ROOT)))
+
+    assert violations == []
+
+
+def test_production_has_no_hand_built_failure_envelope() -> None:
+    violations: list[str] = []
+    for path in (ROOT / "brain").rglob("*.py"):
+        if path.name == "failure_diagnostic.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            has_category = any(
+                isinstance(key, ast.Constant) and key.value == "category"
+                for key in node.keys
+                if key is not None
+            )
+            spreads_diagnostic = any(
+                isinstance(value, ast.Call)
+                and _call_name(value) == "failure_diagnostic_metadata"
+                for key, value in zip(node.keys, node.values, strict=True)
+                if key is None
+            )
+            if has_category and spreads_diagnostic:
+                violations.append(str(path.relative_to(ROOT)))
+
+    assert violations == []
+
+
+def test_failure_envelope_builder_rejects_unknown_stage() -> None:
+    with pytest.raises(ValueError, match="cannot write an unknown stage"):
+        run_failure_metadata(
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.UNKNOWN,
+        )
+
+
+def test_failure_envelope_builder_rejects_inconsistent_types() -> None:
+    with pytest.raises(TypeError, match="failure category"):
+        run_failure_metadata(  # type: ignore[arg-type]
+            category="internal",
+            stage=RunFailureStage.RUNNER_EXECUTION,
+        )
+    with pytest.raises(TypeError, match="exception type"):
+        run_failure_metadata(
+            category=RunFailureCategory.INTERNAL,
+            stage=RunFailureStage.RUNNER_EXECUTION,
+            exception_type=RuntimeError("not a class"),  # type: ignore[arg-type]
+        )
+
+
+async def test_reader_redacts_inconsistent_exception_identity() -> None:
+    class EmptyEventResult:
+        def all(self) -> list[str]:
+            return []
+
+    class EmptyEventSession:
+        async def scalars(self, _query):
+            return EmptyEventResult()
+
+    run = SimpleNamespace(
+        id=1,
+        status="failed",
+        metadata_={
+            "failure": {
+                "category": "internal",
+                "diagnostic_schema": "typed_v1",
+                "stage": "runner_execution",
+                "exception_class": "RuntimeError",
+                "exception_module": "not.a.loaded.module",
+            }
+        },
+    )
+
+    diagnostic = await read_run_failure_diagnostic(EmptyEventSession(), run=run)
+
+    assert diagnostic is not None
+    assert diagnostic.stage == RunFailureStage.RUNNER_EXECUTION
+    assert diagnostic.exception_class is None
+    assert diagnostic.exception_class_state == DiagnosticValueState.REDACTED

--- a/tests/test_run_failure_invariants.py
+++ b/tests/test_run_failure_invariants.py
@@ -11,13 +11,13 @@ import pytest
 from brain.systems.runs.failure_diagnostic import (
     DiagnosticValueState,
     RunFailureStage,
+    failure_category_for_run_context,
     read_run_failure_diagnostic,
     run_failure_metadata,
 )
 from brain.systems.runs.failures import (
     DEFAULT_FAILED_RUN_MESSAGE,
     RunFailureCategory,
-    failure_category_for_run_context,
     safe_terminal_run_message,
 )
 from brain.systems.runs.status import RunStatus
@@ -117,11 +117,7 @@ def test_failure_envelope_builder_rejects_inconsistent_types() -> None:
 def test_pre_tool_preservation_failure_cannot_be_unknown_and_generic() -> None:
     category = failure_category_for_run_context(
         RunFailureCategory.INTERNAL,
-        metadata={
-            "submission": {
-                "preservation": {"requires_durable_evidence": True},
-            }
-        },
+        requires_durable_preservation=True,
         tool_execution_started=False,
         failure_stage=RunFailureStage.AGENT_EXECUTION,
     )

--- a/tests/test_run_failure_invariants.py
+++ b/tests/test_run_failure_invariants.py
@@ -14,7 +14,13 @@ from brain.systems.runs.failure_diagnostic import (
     read_run_failure_diagnostic,
     run_failure_metadata,
 )
-from brain.systems.runs.failures import RunFailureCategory
+from brain.systems.runs.failures import (
+    DEFAULT_FAILED_RUN_MESSAGE,
+    RunFailureCategory,
+    failure_category_for_run_context,
+    safe_terminal_run_message,
+)
+from brain.systems.runs.status import RunStatus
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -106,6 +112,32 @@ def test_failure_envelope_builder_rejects_inconsistent_types() -> None:
             stage=RunFailureStage.RUNNER_EXECUTION,
             exception_type=RuntimeError("not a class"),  # type: ignore[arg-type]
         )
+
+
+def test_pre_tool_preservation_failure_cannot_be_unknown_and_generic() -> None:
+    category = failure_category_for_run_context(
+        RunFailureCategory.INTERNAL,
+        metadata={
+            "submission": {
+                "preservation": {"requires_durable_evidence": True},
+            }
+        },
+        tool_execution_started=False,
+        failure_stage=RunFailureStage.AGENT_EXECUTION,
+    )
+    envelope = run_failure_metadata(
+        category=category,
+        stage=RunFailureStage.AGENT_EXECUTION,
+    )
+    message = safe_terminal_run_message(RunStatus.FAILED, category)
+
+    assert category == RunFailureCategory.PRESERVATION_SETUP
+    assert envelope["stage"] == RunFailureStage.AGENT_EXECUTION.value
+    assert message != DEFAULT_FAILED_RUN_MESSAGE
+    assert not (
+        envelope["stage"] == RunFailureStage.UNKNOWN.value
+        and message == DEFAULT_FAILED_RUN_MESSAGE
+    )
 
 
 async def test_reader_redacts_inconsistent_exception_identity() -> None:

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -282,6 +282,47 @@ class TestCompleteHook:
         assert mock_session.execute.call_count >= 2
         assert result == {"run_id": 42, "outcome": "success"}
 
+    async def test_complete_failure_writes_known_settlement_diagnostic(self):
+        from types import SimpleNamespace
+
+        from brain.app.cli.run import complete_run
+        from brain.systems.runs.failure_diagnostic import (
+            DiagnosticValueState,
+            RunFailureStage,
+            read_run_failure_diagnostic,
+        )
+
+        mock_session = MagicMock()
+        mock_result = MagicMock()
+        mock_result.mappings.return_value.first.return_value = {
+            "id": 42,
+            "metadata": {"legacy_source": "cli.run"},
+        }
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await complete_run(
+            mock_session,
+            run_id=42,
+            outcome="failure",
+            notes="worker reported failure",
+        )
+
+        update_params = mock_session.execute.await_args_list[1].args[1]
+        metadata = json.loads(update_params["metadata_patch"])
+        projection_session = MagicMock()
+        projected_events = MagicMock()
+        projected_events.all.return_value = []
+        projection_session.scalars = AsyncMock(return_value=projected_events)
+        diagnostic = await read_run_failure_diagnostic(
+            projection_session,
+            run=SimpleNamespace(id=42, status="failed", metadata_=metadata),
+        )
+
+        assert result == {"run_id": 42, "outcome": "failure"}
+        assert diagnostic is not None
+        assert diagnostic.stage == RunFailureStage.RUNNER_SETTLEMENT
+        assert diagnostic.stage_state == DiagnosticValueState.KNOWN
+
     async def test_complete_with_invalid_id(self):
         mock_session = MagicMock()
         mock_result = MagicMock()


### PR DESCRIPTION
One PR for the four fixes that were waiting, so this is a single merge click.
It replaces draft PRs #862 and #864, which are folded in here and can be closed.

Closes #860
Closes #854
Closes #865
Closes #868

---

## What is in it

**1. Git clones move off the worker event loop** (was #862, issue #860)
A project-context clone ran on the event loop and froze the worker, which then
tripped the queue-stall watchdog.

**2. `illo_get_result` stops giving one answer to three questions** (was #864, issue #854)
"Event not found", "not visible to your connection", and a genuine transport
failure all returned the same thing, so a caller could not tell "retry me" from
"you cannot see this".

**3. A terminal-failed run always names its failure stage** (new, issue #865)
This is the one worth a second look.

**4. A preservation run that dies before any tool runs now says something useful** (issue #868)
Added Aug 31, after the rest of this PR was already open. See the section below —
it is the recurrence this PR predicted.

## On #865 — what it fixes, and what it deliberately does not

Four `preserve_knowledge` runs failed today (20072, 20073, 20074, 20075) with an
opaque receipt and zero tool calls. PR #863 had already shipped the typed
diagnostic that was supposed to explain such a failure, and the receipts still
read `stage: unknown`.

The reason: `unknown` is what the reader returns when the `failure` block has no
`stage` key at all. Three producers wrote that block without going through the
typed helper — the missing-org preflight, the completion settlement path, and
the legacy CLI `complete_run`. All three now use one shared builder,
`run_failure_metadata()`, which lives in the module that owns the schema.

**The scope limit, stated plainly: this restores the diagnostic, not the
preservation path.** Why those four runs failed still needs the production run
rows, which is exactly what the missing stage was blocking. Expect the next
occurrence to name a real stage; that is the point of the change. #865 should
stay open in spirit even though it auto-closes here — reopen or file the
follow-up once a stage-carrying receipt appears.

**A design note you may want to challenge.** The first version enforced the
invariant by raising from inside `set_status`. A code review caught that this
raise happens while a failure is *already* being handled: it rolled back the
terminal write and could leave the run nonterminal. That trades an opaque
receipt for a stuck run, which is worse. So the enforcement moved to a typed
atomic `store.fail_run()` that writes envelope and status in one transition, and
a generic `set_status(FAILED)` now logs CRITICAL and settles through the typed
path instead of raising. An unwired producer is loud, and the run still
terminates.

## How to check it (staging, as a user)

1. Submit any `preserve_knowledge` via `illo_submit`, let it complete, and
   confirm the success path is unchanged — `evidence_status: satisfied` with a
   non-empty `mutated_target_refs`.
2. Call `illo_get_result` for an event id that does not exist, then for one that
   belongs to another connection. The two answers must now differ.
3. If any run fails, read its receipt: `stage` must name a real stage, never
   `unknown`. That is the whole fix.
4. Watch the logs for `used generic set_status for FAILED` — a CRITICAL line
   there means a producer we did not find. None fires in the test suite.

## Verification

Local only — this repo has no CI minutes by decision.

| | |
|---|---|
| suite | `pytest -m "not requires_db and not requires_browser and not live_provider"`, no path argument |
| result | **5028 passed, 0 failed, 11 skipped** (92s) |
| baseline | `origin/main` @ `d2978080` = **5014 passed** — so +14 tests, none lost |
| load during | 2.9 (a result is invalid above 20) |
| lanes | backend only — no migration and no `frontend/**` file in the diff |
| merge | all three branches merged clean off current `origin/main`, zero conflicts |

The #865 worker first reported a red; re-run serially at low load it was
5023 passed, 0 failed. The red was machine contention, not the change.

## Assumptions

- The four failing preservation runs share one cause with #861. Not proven — it
  is the reported shape, and this PR does not depend on it being true.
- `RUNNER_SETTLEMENT` is the right stage for the fallback. It is honest rather
  than precise: a producer that reaches it did not declare its own stage.

---

# Added Aug 31 — #868, the recurrence this PR predicted

This PR said, on Aug 28:

> "Expect the next occurrence to name a real stage; that is the point of the change."

The next occurrence arrived on **Aug 30** as
[#868](https://github.com/Illospace/illospace/issues/868): a `preserve_knowledge`
submission accepted, queued, then settled FAILED with **no workspace mutation** and
the generic `DEFAULT_FAILED_RUN_MESSAGE`. Because this PR had not merged, the
instrument that would have explained it was not deployed.

So #868 is folded in here rather than opened as a second PR.

## What #868 turned out to be

The decisive field in the receipt is `tool_execution_started: false` — the run went
terminal **before any tool ran**. `brain/systems/runs/recipes/fast.py:260` classified
that pre-tool direct-agent failure as `internal`, and `internal` settles with the
generic "I failed on this and it is still open" message. Nothing told the caller
whether to retry.

There is now a `PRESERVATION_SETUP` failure category whose message names the retry
path, and an `internal` failure is reclassified into it when the run requires durable
preservation, no tool execution has started, and the stage is one of the pre-tool
stages.

**A lead that was wrong, recorded so nobody re-runs it:** `PRESERVATION_ACCEPTABLE_TOOLS`
was *not* the cause. It lists executed evidence tools, not submission sources;
`source_tool: codex` was already accepted.

## The review changed the shape of it

A maintainability review came back **BLOCKING** with four findings, and the fourth was
the one worth the pass: worker output and receipts were built *before* the contextual
classification, so a persisted failure artifact could read `internal` while the run's
terminal metadata read `preservation_setup`. That is a self-contradicting receipt —
the exact defect the rest of this PR exists to remove. Shipping it would have
reintroduced the disease while curing it.

All four are folded:

| finding | resolution |
|---|---|
| classifier took `Any` and re-declared stage strings | moved into `failure_diagnostic.py`, typed to `RunFailureStage`, compares enum members |
| engine and runner each hardcoded the tool-event names | one canonical query in `failure_diagnostic.py`, called from both |
| preservation metadata decoded in `failures.py` | predicate moved beside the schema in `brain/systems/inbound/preservation.py` |
| artifacts persisted before classification | classify once before any output or receipt is built; pinned by `test_worker_failure_receipt_matches_terminal_preservation_category` |

## Gate — re-measured Aug 31, not carried over

| | |
|---|---|
| this branch | **5031 passed, 0 failed**, 11 skipped, 90 deselected (90s) |
| baseline `df8d0b25` | **5028 passed, 0 failed** — measured the same way, same run |
| net | +3 tests, none lost; skipped and deselected identical |
| load during | 4.8 (a result is invalid above 20) |
| lanes | backend only — no migration, no `frontend/**` in the diff |

Both numbers were measured serially this run with no Codex worker live. The build
worker reported 6 failures; every one was a localhost-bind `PermissionError` inside
the Codex sandbox, and all six pass outside it.

## How to check #868 on staging

1. Submit a `preserve_knowledge` via `illo_submit` that cannot reach a durable tool
   (a bad provider or preservation-tool configuration).
2. `illo_get_result` for it. The message must now name the retry path and the
   configuration to check — not "I failed on this and it is still open".
3. A healthy submission must be unchanged: `evidence_status: satisfied` with a
   non-empty `mutated_target_refs`.

## What this still does not do

It does not explain the original four failures (20072–20075) or #868's run 20241.
Those need the production run rows. This makes the *next* one legible and tells the
caller whether retrying is worth anything.
