### PR TITLE
fix(tools): omitted optional tool args stop reaching handlers as values (#870)

### DIFF
--- a/brain/systems/runs/predict_rlm_backend.py
+++ b/brain/systems/runs/predict_rlm_backend.py
@@ -828,12 +828,16 @@ def _make_async_tool_wrapper(
     annotations: dict[str, Any] = {"return": str}
     namespace: dict[str, Any] = {
         "_run": None,
-        "__omitted": _OMITTED_TOOL_ARGUMENT,
         "json": json,
         "Any": Any,
     }
 
     async def _run(**kwargs):
+        kwargs = {
+            name: value
+            for name, value in kwargs.items()
+            if value is not _OMITTED_TOOL_ARGUMENT
+        }
         try:
             result = await async_invoke_tool_handler(
                 handler,
@@ -896,8 +900,7 @@ def _make_async_tool_wrapper(
     kwargs_expr = ", ".join(f"'{name}': {name}" for name, _ in properties)
     function_src = (
         f"async def {tool_name}({signature_args}):\n"
-        f"    kwargs = {{key: value for key, value in {{{kwargs_expr}}}.items() if value is not __omitted}}\n"
-        f"    return await _run(**kwargs)\n"
+        f"    return await _run(**{{{kwargs_expr}}})\n"
     )
     exec_namespace = dict(namespace)
     exec(function_src, exec_namespace)  # noqa: S102 - controlled local generation from trusted schema

--- a/brain/systems/runs/predict_rlm_backend.py
+++ b/brain/systems/runs/predict_rlm_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import importlib.metadata
+import inspect
 import json
 import logging
 import os
@@ -792,6 +793,9 @@ def _tool_parameter_annotation(schema: dict[str, Any]) -> type:
     return _SCHEMA_TYPE_MAP.get(raw_type, str)
 
 
+_OMITTED_TOOL_ARGUMENT = object()
+
+
 def _tool_docstring(tool_name: str, definition: dict[str, Any]) -> str:
     lines = [definition.get("description") or f"Invoke the {tool_name} Illo tool."]
     properties = (definition.get("input_schema") or {}).get("properties") or {}
@@ -824,6 +828,7 @@ def _make_async_tool_wrapper(
     annotations: dict[str, Any] = {"return": str}
     namespace: dict[str, Any] = {
         "_run": None,
+        "__omitted": _OMITTED_TOOL_ARGUMENT,
         "json": json,
         "Any": Any,
     }
@@ -877,23 +882,34 @@ def _make_async_tool_wrapper(
     for param_name, schema in ordered_properties:
         default = schema.get("default", ...)
         annotation = _tool_parameter_annotation(schema)
-        annotations[param_name] = annotation
         if param_name in required and default is ...:
+            annotations[param_name] = annotation
             params.append(param_name)
         else:
-            namespace[f"__default_{param_name}"] = None if default is ... else default
+            annotations[param_name] = annotation | None
+            namespace[f"__default_{param_name}"] = (
+                _OMITTED_TOOL_ARGUMENT if default is ... else default
+            )
             params.append(f"{param_name}=__default_{param_name}")
 
     signature_args = ", ".join(params)
     kwargs_expr = ", ".join(f"'{name}': {name}" for name, _ in properties)
     function_src = (
         f"async def {tool_name}({signature_args}):\n"
-        f"    return await _run(**{{{kwargs_expr}}})\n"
+        f"    kwargs = {{key: value for key, value in {{{kwargs_expr}}}.items() if value is not __omitted}}\n"
+        f"    return await _run(**kwargs)\n"
     )
     exec_namespace = dict(namespace)
     exec(function_src, exec_namespace)  # noqa: S102 - controlled local generation from trusted schema
     fn = exec_namespace[tool_name]
     fn.__annotations__ = annotations
+    signature = inspect.signature(fn)
+    fn.__signature__ = signature.replace(parameters=[
+        parameter.replace(default=None)
+        if parameter.default is _OMITTED_TOOL_ARGUMENT
+        else parameter
+        for parameter in signature.parameters.values()
+    ])
     fn.__doc__ = _tool_docstring(tool_name, definition)
     return fn
 

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -239,7 +239,10 @@ GITHUB_TOOLS = [
         "name": "update_github_issue",
         "description": (
             "Update an EXISTING real GitHub issue via the GitHub API. This can transfer ownership, "
-            "change labels, open or close the issue, and edit its title or body. Each requested "
+            "change labels, open or close the issue, and edit its title or body. Only repo and "
+            "issue_number are required. Every other field is optional; omit a field to leave it "
+            "unchanged. Placeholder values such as 'preserve' or 'unchanged' are rejected, not "
+            "applied. Each requested "
             "field is applied independently, followed by an exact issue read-back. The result "
             "reports applied and failed fields separately, so a partial update is never presented "
             "as total success. This uses the same project-bound GitHub App write identity as issue "

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -991,6 +991,20 @@ def _update_has_only_auth_failures(payload: dict[str, Any]) -> bool:
     return bool(status_codes) and status_codes <= {401, 403, 404}
 
 
+_ISSUE_UPDATE_PLACEHOLDERS = frozenset({
+    "preserve",
+    "unchanged",
+    "keep",
+    "same",
+    "no change",
+    "nochange",
+    "<unchanged>",
+    "null",
+    "none",
+    "n/a",
+})
+
+
 async def _handle_update_github_issue(
     repo: str | None = None,
     issue_number: int | None = None,
@@ -1026,6 +1040,15 @@ async def _handle_update_github_issue(
             "error": "update_github_issue state must be open or closed",
             "status_code": 422,
         })
+    for field_name, value in (("title", title), ("body", body)):
+        if value is not None and str(value).strip().lower() in _ISSUE_UPDATE_PLACEHOLDERS:
+            return json.dumps({
+                "error": (
+                    f"update_github_issue {field_name} cannot be a placeholder; "
+                    f"omit {field_name} to leave it unchanged"
+                ),
+                "status_code": 422,
+            })
     clean_title = str(title).strip() if title is not None else None
     if title is not None and not clean_title:
         return json.dumps({

--- a/tests/test_predict_rlm_backend.py
+++ b/tests/test_predict_rlm_backend.py
@@ -153,7 +153,7 @@ def test_get_agent_worker_backend_settings_falls_back_when_deno_missing(monkeypa
     assert settings.fallback_reason == "deno is not installed on the server"
 
 
-async def test_make_async_tool_wrapper_puts_required_params_before_defaulted_ones():
+async def test_make_async_tool_wrapper_omits_missing_args_and_honors_schema_defaults():
     from brain.systems.runs.predict_rlm_backend import _make_async_tool_wrapper
 
     captured = {}
@@ -172,6 +172,7 @@ async def test_make_async_tool_wrapper_puts_required_params_before_defaulted_one
                 "type": "object",
                 "properties": {
                     "optional_first": {"type": "integer", "default": 7},
+                    "omitted_optional": {"type": "string"},
                     "required_second": {"type": "string"},
                 },
                 "required": ["required_second"],
@@ -185,7 +186,15 @@ async def test_make_async_tool_wrapper_puts_required_params_before_defaulted_one
     )
 
     signature = inspect.signature(wrapper)
-    assert list(signature.parameters) == ["required_second", "optional_first"]
+    assert list(signature.parameters) == [
+        "required_second",
+        "optional_first",
+        "omitted_optional",
+    ]
+    assert signature.parameters["required_second"].annotation is str
+    assert signature.parameters["optional_first"].annotation == int | None
+    assert signature.parameters["omitted_optional"].annotation == str | None
+    assert signature.parameters["omitted_optional"].default is None
 
     result = await wrapper(required_second="hello")
 

--- a/tests/test_update_github_issue_tool.py
+++ b/tests/test_update_github_issue_tool.py
@@ -62,6 +62,9 @@ def test_update_github_issue_is_registered_with_all_supported_fields():
         "body",
     } <= properties.keys()
     assert properties["state"]["enum"] == ["open", "closed"]
+    assert "Only repo and issue_number are required" in definition["description"]
+    assert "omit a field to leave it unchanged" in definition["description"]
+    assert "rejected, not applied" in definition["description"]
 
     registration = get_tool_registration("update_github_issue")
     assert registration is not None
@@ -256,6 +259,65 @@ async def test_handler_reuses_create_issue_vault_app_write_lane_and_surfaces_rea
     }
     update.assert_awaited_once()
     assert update.await_args.kwargs["token"] == "minted-installation-token"
+
+
+@pytest.mark.asyncio
+async def test_handler_assignee_only_update_leaves_title_body_and_labels_untouched():
+    read_back = _updated_issue(assignees=["new-owner"], labels=["existing-label"])
+
+    async def request(_client, method, path, **kwargs):
+        if method == "GET":
+            return read_back
+        return {}
+
+    candidates = [{
+        "key_name": None,
+        "token": "minted-installation-token",
+        "source": "project_binding:GITHUB_TOKEN",
+    }]
+    with patch(
+        f"{_H}._github_token_candidates",
+        new=AsyncMock(return_value=candidates),
+    ), patch(
+        f"{_C}._async_request",
+        new=AsyncMock(side_effect=request),
+    ) as github_request:
+        payload = json.loads(await _handle_update_github_issue(
+            repo="Illospace/illospace",
+            issue_number=369,
+            assignees_add=["new-owner"],
+        ))
+
+    assert payload["status"] == "applied"
+    assert payload["issue"]["title"] == "Updated title"
+    assert payload["issue"]["body"] == "Updated body"
+    assert [label["name"] for label in payload["issue"]["labels"]] == ["existing-label"]
+    assert [(call.args[1], call.args[2]) for call in github_request.await_args_list] == [
+        ("POST", "/repos/Illospace/illospace/issues/369/assignees"),
+        ("GET", "/repos/Illospace/illospace/issues/369"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("field_name", "value"), [
+    ("title", " preserve "),
+    ("body", "PRESERVE"),
+])
+async def test_handler_rejects_placeholder_text_without_writing(field_name, value):
+    with patch(f"{_H}._github_token_candidates", new=AsyncMock()) as candidates, patch(
+        f"{_H}.async_update_repo_issue",
+        new=AsyncMock(),
+    ) as update:
+        payload = json.loads(await _handle_update_github_issue(
+            repo="Illospace/illospace",
+            issue_number=369,
+            **{field_name: value},
+        ))
+
+    assert payload["status_code"] == 422
+    assert f"omit {field_name} to leave it unchanged" in payload["error"]
+    candidates.assert_not_awaited()
+    update.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #870

## What broke

The tool-wrapper generator forwarded **every** schema property into the handler
kwargs, so a field the caller never passed arrived as an explicit value. It also
annotated optional parameters with the bare schema type, so the agent-facing
contract read `title: str = None` — a `str`-typed, required-looking parameter on
an optional field.

An agent updating only assignees filled those required-looking fields with
placeholders (`title="preserve"`, `labels_set=[]`). `update_github_issue` applied
them literally: **six real issues lost their titles, bodies and labels**, and
recovery needed GitHub webhook history.

The JSON schema was never the bug — `required` was already `["repo", "issue_number"]`,
and the handler already treated `None` as "leave unchanged". The defect was one
level down, in `_make_async_tool_wrapper`.

## The fix

- **`predict_rlm_backend.py`** — unset optional params default to an internal
  sentinel that is filtered out before the handler is called, so *omitted stays
  omitted* for every tool in the catalog. Real schema defaults still pass through.
  Optional params are annotated `X | None`, and `__signature__` is repaired so the
  sentinel never leaks into introspection.
- **`handlers/github.py`** — placeholder `title`/`body` values are rejected with a
  422 that tells the caller to omit the field, *before* any token is minted.
- **`definitions/github.py`** — the description now states which fields are optional.

## How to judge this without reading the diff

This is a code-path fix with no UI. The evidence is the tests:

1. **The regression is proved, not asserted.** 4 of the new tests were run against
   unfixed `origin/main` in a throwaway worktree: they **fail** there and **pass**
   on this branch.
2. **The incident itself is pinned.** `test_handler_assignee_only_update_leaves_title_body_and_labels_untouched`
   asserts the exact ordered list of GitHub API calls — assignees `POST` then the
   read-back `GET`, and no `PATCH`. A future change that reintroduces the overwrite
   cannot pass it.
3. **Full fast suite green, run serially:** `5034 passed, 11 skipped` — the repo's CI
   command verbatim, no path argument, so `meetbot/tests` is included. Run twice
   (before and after the review fold-in), load average 2–4, no other workers live.

To exercise it by hand: call `update_github_issue` with only `repo`, `issue_number`
and `assignees_add`, then confirm the issue's title, body and labels are unchanged.
Calling it with `title="preserve"` should now return a 422 instead of writing.

## Review

Codex ran the thermo-nuclear maintainability rubric on this branch (cross-family:
Claude directed, Codex reviewed). Verdict **APPROVE_WITH_NOTES**, 1 finding, 9 files
read. The finding — omission policy living inside `exec`'d source via an injected
free name — **is folded in** as the second commit: the filter now sits in `_run` as
ordinary Python and the generated body is a direct call again. The suite was re-run
after the fold-in rather than carrying the earlier green forward.

## One judgement call worth your eye

The placeholder list rejects ten strings for `title`/`body`, including `"none"` and
`"n/a"`. A human genuinely wanting a body of `"n/a"` now gets a 422 telling them to
omit the field. I took that trade deliberately — this tool destroyed six real issues
— but it is a product call, not a technical one, so overrule it if you disagree.
