### PR TITLE
fix(runtime): let the host-capacity alert escalate from warn to critical

### DIFF
--- a/brain/systems/host_capacity.py
+++ b/brain/systems/host_capacity.py
@@ -5,7 +5,7 @@ import logging
 import os
 import shutil
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypedDict
@@ -45,14 +45,65 @@ logger = logging.getLogger(__name__)
 HOST_CAPACITY_CHECK_TYPE = "host_capacity"
 HOST_CAPACITY_ALERT_KEY = "host_capacity_warn"
 HOST_CAPACITY_CRITICAL_ALERT_KEY = "host_capacity_critical"
-_CAPACITY_WARN_TRIGGER_KIND = FailureGuardTriggerKind(HOST_CAPACITY_ALERT_KEY)
-_CAPACITY_CRITICAL_TRIGGER_KIND = FailureGuardTriggerKind(
-    HOST_CAPACITY_CRITICAL_ALERT_KEY
+
+
+@dataclass(frozen=True, slots=True)
+class _CapacitySeverity:
+    status: str
+    alert_key: str
+    trigger_kind: FailureGuardTriggerKind
+    alert_title: str
+    error_severity: str
+    priority: int
+    threshold_percent: Callable[[StoragePolicyValues], int]
+
+
+_CAPACITY_SEVERITIES = (
+    _CapacitySeverity(
+        status="warn",
+        alert_key=HOST_CAPACITY_ALERT_KEY,
+        trigger_kind=FailureGuardTriggerKind(HOST_CAPACITY_ALERT_KEY),
+        alert_title="Host capacity warning",
+        error_severity="warning",
+        priority=1,
+        threshold_percent=lambda policy: policy.capacity_warn_percent,
+    ),
+    _CapacitySeverity(
+        status="critical",
+        alert_key=HOST_CAPACITY_CRITICAL_ALERT_KEY,
+        trigger_kind=FailureGuardTriggerKind(HOST_CAPACITY_CRITICAL_ALERT_KEY),
+        alert_title="Host capacity critical",
+        error_severity="critical",
+        priority=2,
+        threshold_percent=lambda policy: policy.capacity_critical_percent,
+    ),
 )
-_CAPACITY_ALERT_KEY_BY_TRIGGER_KIND = {
-    _CAPACITY_WARN_TRIGGER_KIND: HOST_CAPACITY_ALERT_KEY,
-    _CAPACITY_CRITICAL_TRIGGER_KIND: HOST_CAPACITY_CRITICAL_ALERT_KEY,
-}
+
+
+def _capacity_severity_for_kind(
+    trigger_kind: FailureGuardTriggerKind,
+) -> _CapacitySeverity:
+    severity = next(
+        (
+            severity
+            for severity in _CAPACITY_SEVERITIES
+            if severity.trigger_kind == trigger_kind
+        ),
+        None,
+    )
+    if severity is None:
+        raise ValueError(f"Unsupported host-capacity trigger: {trigger_kind}")
+    return severity
+
+
+def _capacity_priority(status: str) -> int:
+    if status == "ok":
+        return 0
+    return next(
+        severity.priority
+        for severity in _CAPACITY_SEVERITIES
+        if severity.status == status
+    )
 
 
 class HostCapacityDetails(TypedDict):
@@ -107,7 +158,10 @@ class _HostCapacityLatchStore:
         latches = await self.session.scalars(
             select(SchedulerAlertLatch).where(
                 SchedulerAlertLatch.alert_key.in_(
-                    _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.values()
+                    tuple(
+                        severity.alert_key
+                        for severity in _CAPACITY_SEVERITIES
+                    )
                 )
             )
         )
@@ -121,11 +175,9 @@ class _HostCapacityLatchStore:
         trigger_kind: FailureGuardTriggerKind,
         alerted_at: datetime,
     ) -> SchedulerAlertLatch:
-        alert_key = _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.get(trigger_kind)
-        if alert_key is None:
-            raise ValueError(f"Unsupported host-capacity trigger: {trigger_kind}")
+        severity = _capacity_severity_for_kind(trigger_kind)
         latch = SchedulerAlertLatch(
-            alert_key=alert_key,
+            alert_key=severity.alert_key,
             alerted_at=alerted_at,
         )
         self.session.add(latch)
@@ -198,8 +250,8 @@ def _capacity_status(
 
 def _thresholds(policy: StoragePolicyValues) -> dict[str, int]:
     return {
-        "warn_percent": policy.capacity_warn_percent,
-        "critical_percent": policy.capacity_critical_percent,
+        f"{severity.status}_percent": severity.threshold_percent(policy)
+        for severity in _CAPACITY_SEVERITIES
     }
 
 
@@ -240,20 +292,16 @@ async def record_host_capacity(
     )
 
     store = _HostCapacityLatchStore(session)
-    if status == "ok":
+    current_priority = _capacity_priority(status)
+    alert_keys_to_clear = tuple(
+        severity.alert_key
+        for severity in _CAPACITY_SEVERITIES
+        if severity.priority > current_priority
+    )
+    if alert_keys_to_clear:
         await session.execute(
             delete(SchedulerAlertLatch).where(
-                SchedulerAlertLatch.alert_key.in_(
-                    _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.values()
-                )
-            )
-        )
-    elif status == "warn":
-        # Falling below critical rearms only that edge; the warning latch stays.
-        await session.execute(
-            delete(SchedulerAlertLatch).where(
-                SchedulerAlertLatch.alert_key
-                == HOST_CAPACITY_CRITICAL_ALERT_KEY
+                SchedulerAlertLatch.alert_key.in_(alert_keys_to_clear)
             )
         )
 
@@ -261,29 +309,18 @@ async def record_host_capacity(
         f"{measurement.pct_used}% used on {measurement.mount}; "
         f"{measurement.bytes_free} bytes free."
     )
-    triggers = (
+    triggers = tuple(
         FailureGuardTriggerResult(
-            kind=_CAPACITY_WARN_TRIGGER_KIND,
-            # Warning stays active at critical so the downward crossing to warn
-            # cannot create a second warning edge.
-            active=status != "ok",
+            kind=severity.trigger_kind,
+            active=current_priority >= severity.priority,
             public_details={
                 "pct_used": measurement.pct_used,
                 **_thresholds(policy),
             },
-            alert_title="Host capacity warning",
+            alert_title=severity.alert_title,
             alert_summary=alert_summary,
-        ),
-        FailureGuardTriggerResult(
-            kind=_CAPACITY_CRITICAL_TRIGGER_KIND,
-            active=status == "critical",
-            public_details={
-                "pct_used": measurement.pct_used,
-                **_thresholds(policy),
-            },
-            alert_title="Host capacity critical",
-            alert_summary=alert_summary,
-        ),
+        )
+        for severity in _CAPACITY_SEVERITIES
     )
     guard = await async_evaluate_failure_edges(
         results=triggers,
@@ -295,44 +332,42 @@ async def record_host_capacity(
     )
 
     alert_sent = False
-    thresholds_by_kind = {
-        _CAPACITY_WARN_TRIGGER_KIND: ("warning", policy.capacity_warn_percent),
-        _CAPACITY_CRITICAL_TRIGGER_KIND: (
-            "critical",
-            policy.capacity_critical_percent,
-        ),
-    }
-    if deliver_alert is not None:
-        for edge in guard.crossed_edges:
-            severity, threshold_percent = thresholds_by_kind[edge.kind]
-            try:
-                await deliver_alert(
-                    policy=alert_policy or _default_alert_policy(),
-                    subject=FailureAlertSubject(
-                        identity_label="Mount",
-                        identity=measurement.mount,
-                        url_label="Illo",
-                        url=f"{public_app_base_url()}/api/system",
-                        link_label="open system state",
-                    ),
-                    presentation=FailureAlertPresentation(
-                        title=edge.alert_title,
-                        summary=edge.alert_summary,
-                    ),
-                    error_text=(
-                        f"Storage use crossed the active policy {severity} "
-                        f"threshold of {threshold_percent}%."
-                    ),
-                )
-            except Exception:  # noqa: BLE001 - retry the edge on the next tick
-                logger.exception("Host-capacity Slack delivery failed")
-            else:
-                await async_latch_failure_edges(
-                    replace(guard, edges=(edge,)),
-                    alerted_at=observed_at,
-                    store=store,
-                )
-                alert_sent = True
+    highest_edge = max(
+        guard.crossed_edges,
+        key=lambda edge: _capacity_severity_for_kind(edge.kind).priority,
+        default=None,
+    )
+    if deliver_alert is not None and highest_edge is not None:
+        severity = _capacity_severity_for_kind(highest_edge.kind)
+        try:
+            await deliver_alert(
+                policy=alert_policy or _default_alert_policy(),
+                subject=FailureAlertSubject(
+                    identity_label="Mount",
+                    identity=measurement.mount,
+                    url_label="Illo",
+                    url=f"{public_app_base_url()}/api/system",
+                    link_label="open system state",
+                ),
+                presentation=FailureAlertPresentation(
+                    title=highest_edge.alert_title,
+                    summary=highest_edge.alert_summary,
+                ),
+                error_text=(
+                    "Storage use crossed the active policy "
+                    f"{severity.error_severity} threshold of "
+                    f"{severity.threshold_percent(policy)}%."
+                ),
+            )
+        except Exception:  # noqa: BLE001 - retry the edge on the next tick
+            logger.exception("Host-capacity Slack delivery failed")
+        else:
+            await async_latch_failure_edges(
+                guard,
+                alerted_at=observed_at,
+                store=store,
+            )
+            alert_sent = True
 
     return {
         "id": entry.id,

--- a/brain/systems/host_capacity.py
+++ b/brain/systems/host_capacity.py
@@ -5,7 +5,7 @@ import logging
 import os
 import shutil
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypedDict
@@ -44,7 +44,15 @@ logger = logging.getLogger(__name__)
 
 HOST_CAPACITY_CHECK_TYPE = "host_capacity"
 HOST_CAPACITY_ALERT_KEY = "host_capacity_warn"
+HOST_CAPACITY_CRITICAL_ALERT_KEY = "host_capacity_critical"
 _CAPACITY_WARN_TRIGGER_KIND = FailureGuardTriggerKind(HOST_CAPACITY_ALERT_KEY)
+_CAPACITY_CRITICAL_TRIGGER_KIND = FailureGuardTriggerKind(
+    HOST_CAPACITY_CRITICAL_ALERT_KEY
+)
+_CAPACITY_ALERT_KEY_BY_TRIGGER_KIND = {
+    _CAPACITY_WARN_TRIGGER_KIND: HOST_CAPACITY_ALERT_KEY,
+    _CAPACITY_CRITICAL_TRIGGER_KIND: HOST_CAPACITY_CRITICAL_ALERT_KEY,
+}
 
 
 class HostCapacityDetails(TypedDict):
@@ -96,18 +104,28 @@ class _HostCapacityLatchStore:
     session: AsyncSession
 
     async def load_latches(self):
-        latch = await self.session.get(SchedulerAlertLatch, HOST_CAPACITY_ALERT_KEY)
-        return {_CAPACITY_WARN_TRIGGER_KIND: latch} if latch is not None else {}
+        latches = await self.session.scalars(
+            select(SchedulerAlertLatch).where(
+                SchedulerAlertLatch.alert_key.in_(
+                    _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.values()
+                )
+            )
+        )
+        return {
+            FailureGuardTriggerKind(latch.alert_key): latch
+            for latch in latches
+        }
 
     async def create_latch(
         self,
         trigger_kind: FailureGuardTriggerKind,
         alerted_at: datetime,
     ) -> SchedulerAlertLatch:
-        if trigger_kind != _CAPACITY_WARN_TRIGGER_KIND:
+        alert_key = _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.get(trigger_kind)
+        if alert_key is None:
             raise ValueError(f"Unsupported host-capacity trigger: {trigger_kind}")
         latch = SchedulerAlertLatch(
-            alert_key=HOST_CAPACITY_ALERT_KEY,
+            alert_key=alert_key,
             alerted_at=alerted_at,
         )
         self.session.add(latch)
@@ -225,29 +243,50 @@ async def record_host_capacity(
     if status == "ok":
         await session.execute(
             delete(SchedulerAlertLatch).where(
-                SchedulerAlertLatch.alert_key == HOST_CAPACITY_ALERT_KEY
+                SchedulerAlertLatch.alert_key.in_(
+                    _CAPACITY_ALERT_KEY_BY_TRIGGER_KIND.values()
+                )
+            )
+        )
+    elif status == "warn":
+        # Falling below critical rearms only that edge; the warning latch stays.
+        await session.execute(
+            delete(SchedulerAlertLatch).where(
+                SchedulerAlertLatch.alert_key
+                == HOST_CAPACITY_CRITICAL_ALERT_KEY
             )
         )
 
-    trigger = FailureGuardTriggerResult(
-        kind=_CAPACITY_WARN_TRIGGER_KIND,
-        active=status != "ok",
-        public_details={
-            "pct_used": measurement.pct_used,
-            **_thresholds(policy),
-        },
-        alert_title=(
-            "Host capacity critical"
-            if status == "critical"
-            else "Host capacity warning"
+    alert_summary = (
+        f"{measurement.pct_used}% used on {measurement.mount}; "
+        f"{measurement.bytes_free} bytes free."
+    )
+    triggers = (
+        FailureGuardTriggerResult(
+            kind=_CAPACITY_WARN_TRIGGER_KIND,
+            # Warning stays active at critical so the downward crossing to warn
+            # cannot create a second warning edge.
+            active=status != "ok",
+            public_details={
+                "pct_used": measurement.pct_used,
+                **_thresholds(policy),
+            },
+            alert_title="Host capacity warning",
+            alert_summary=alert_summary,
         ),
-        alert_summary=(
-            f"{measurement.pct_used}% used on {measurement.mount}; "
-            f"{measurement.bytes_free} bytes free."
+        FailureGuardTriggerResult(
+            kind=_CAPACITY_CRITICAL_TRIGGER_KIND,
+            active=status == "critical",
+            public_details={
+                "pct_used": measurement.pct_used,
+                **_thresholds(policy),
+            },
+            alert_title="Host capacity critical",
+            alert_summary=alert_summary,
         ),
     )
     guard = await async_evaluate_failure_edges(
-        results=(trigger,),
+        results=triggers,
         failure_signature=None,
         last_error=None,
         now=observed_at,
@@ -256,35 +295,44 @@ async def record_host_capacity(
     )
 
     alert_sent = False
-    if guard.crossed_edges and deliver_alert is not None:
-        try:
-            await deliver_alert(
-                policy=alert_policy or _default_alert_policy(),
-                subject=FailureAlertSubject(
-                    identity_label="Mount",
-                    identity=measurement.mount,
-                    url_label="Illo",
-                    url=f"{public_app_base_url()}/api/system",
-                    link_label="open system state",
-                ),
-                presentation=FailureAlertPresentation(
-                    title=trigger.alert_title,
-                    summary=trigger.alert_summary,
-                ),
-                error_text=(
-                    f"Storage use crossed the active policy warning threshold "
-                    f"of {policy.capacity_warn_percent}%."
-                ),
-            )
-        except Exception:  # noqa: BLE001 - leave the edge open for the next tick
-            logger.exception("Host-capacity Slack delivery failed")
-        else:
-            await async_latch_failure_edges(
-                guard,
-                alerted_at=observed_at,
-                store=store,
-            )
-            alert_sent = True
+    thresholds_by_kind = {
+        _CAPACITY_WARN_TRIGGER_KIND: ("warning", policy.capacity_warn_percent),
+        _CAPACITY_CRITICAL_TRIGGER_KIND: (
+            "critical",
+            policy.capacity_critical_percent,
+        ),
+    }
+    if deliver_alert is not None:
+        for edge in guard.crossed_edges:
+            severity, threshold_percent = thresholds_by_kind[edge.kind]
+            try:
+                await deliver_alert(
+                    policy=alert_policy or _default_alert_policy(),
+                    subject=FailureAlertSubject(
+                        identity_label="Mount",
+                        identity=measurement.mount,
+                        url_label="Illo",
+                        url=f"{public_app_base_url()}/api/system",
+                        link_label="open system state",
+                    ),
+                    presentation=FailureAlertPresentation(
+                        title=edge.alert_title,
+                        summary=edge.alert_summary,
+                    ),
+                    error_text=(
+                        f"Storage use crossed the active policy {severity} "
+                        f"threshold of {threshold_percent}%."
+                    ),
+                )
+            except Exception:  # noqa: BLE001 - retry the edge on the next tick
+                logger.exception("Host-capacity Slack delivery failed")
+            else:
+                await async_latch_failure_edges(
+                    replace(guard, edges=(edge,)),
+                    alerted_at=observed_at,
+                    store=store,
+                )
+                alert_sent = True
 
     return {
         "id": entry.id,
@@ -361,6 +409,7 @@ async def async_read_host_capacity(
 
 __all__ = [
     "HOST_CAPACITY_ALERT_KEY",
+    "HOST_CAPACITY_CRITICAL_ALERT_KEY",
     "HOST_CAPACITY_CHECK_TYPE",
     "HostDiskCapacity",
     "HostCapacityMeasurement",

--- a/tests/test_host_capacity.py
+++ b/tests/test_host_capacity.py
@@ -263,6 +263,48 @@ async def test_host_capacity_warn_to_critical_delivers_one_critical_alert(
     assert critical_latch is not None
 
 
+async def test_host_capacity_cold_critical_delivers_only_highest_severity_and_latches_both_edges(
+    session,
+    monkeypatch,
+):
+    _patch_capacity_sequence(monkeypatch, 95.0)
+    await _add_policy(session, warn=70, critical=90)
+    deliveries = []
+
+    async def fake_deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 10, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    latch_keys = set(
+        await session.scalars(
+            select(SchedulerAlertLatch.alert_key).where(
+                SchedulerAlertLatch.alert_key.in_(
+                    (
+                        HOST_CAPACITY_ALERT_KEY,
+                        HOST_CAPACITY_CRITICAL_ALERT_KEY,
+                    )
+                )
+            )
+        )
+    )
+    assert [item["presentation"].title for item in deliveries] == [
+        "Host capacity critical",
+    ]
+    assert deliveries[0]["error_text"] == (
+        "Storage use crossed the active policy critical threshold of 90%."
+    )
+    assert latch_keys == {
+        HOST_CAPACITY_ALERT_KEY,
+        HOST_CAPACITY_CRITICAL_ALERT_KEY,
+    }
+
+
 async def test_host_capacity_second_consecutive_critical_tick_does_not_alert(
     session,
     monkeypatch,
@@ -280,7 +322,6 @@ async def test_host_capacity_second_consecutive_critical_tick_does_not_alert(
         now=datetime(2026, 9, 1, 10, 0, tzinfo=timezone.utc),
         deliver_alert=fake_deliver,
     )
-    deliveries.clear()
 
     result = await record_host_capacity(
         session,
@@ -290,7 +331,9 @@ async def test_host_capacity_second_consecutive_critical_tick_does_not_alert(
     )
 
     assert result["alert_sent"] is False
-    assert deliveries == []
+    assert [item["presentation"].title for item in deliveries] == [
+        "Host capacity critical",
+    ]
 
 
 async def test_host_capacity_ok_clears_both_latches_and_rearms_warning(

--- a/tests/test_host_capacity.py
+++ b/tests/test_host_capacity.py
@@ -15,6 +15,7 @@ from brain.platform.db.models.scheduler import SchedulerAlertLatch
 from brain.platform.db.models.storage_policy import StoragePolicy
 from brain.systems.host_capacity import (
     HOST_CAPACITY_ALERT_KEY,
+    HOST_CAPACITY_CRITICAL_ALERT_KEY,
     HOST_CAPACITY_CHECK_TYPE,
     HostCapacityMeasurement,
     HostDiskCapacity,
@@ -70,6 +71,18 @@ async def _add_policy(session, *, warn: int, critical: int) -> None:
         )
     )
     await session.flush()
+
+
+def _patch_capacity_sequence(monkeypatch, *pct_used: float) -> None:
+    measurements = iter(pct_used)
+
+    async def fake_measure(_workspace_root):
+        return _measurement(pct_used=next(measurements))
+
+    monkeypatch.setattr(
+        "brain.systems.host_capacity.async_measure_host_capacity",
+        fake_measure,
+    )
 
 
 async def test_measure_host_capacity_inventories_largest_workspace_consumers(
@@ -212,6 +225,198 @@ async def test_host_capacity_warn_alert_latch_fires_exactly_once_across_two_over
     assert latch is not None
     assert latch.alerted_at == datetime(2026, 8, 9, 12, 0)
     assert row_count == 2
+
+
+async def test_host_capacity_warn_to_critical_delivers_one_critical_alert(
+    session,
+    monkeypatch,
+):
+    _patch_capacity_sequence(monkeypatch, 80.0, 95.0)
+    await _add_policy(session, warn=70, critical=90)
+    deliveries = []
+
+    async def fake_deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 10, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+    deliveries.clear()
+
+    result = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 11, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    critical_latch = await session.get(
+        SchedulerAlertLatch,
+        HOST_CAPACITY_CRITICAL_ALERT_KEY,
+    )
+    assert result["alert_sent"] is True
+    assert len(deliveries) == 1
+    assert deliveries[0]["presentation"].title == "Host capacity critical"
+    assert critical_latch is not None
+
+
+async def test_host_capacity_second_consecutive_critical_tick_does_not_alert(
+    session,
+    monkeypatch,
+):
+    _patch_capacity_sequence(monkeypatch, 95.0, 95.0)
+    await _add_policy(session, warn=70, critical=90)
+    deliveries = []
+
+    async def fake_deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 10, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+    deliveries.clear()
+
+    result = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 11, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    assert result["alert_sent"] is False
+    assert deliveries == []
+
+
+async def test_host_capacity_ok_clears_both_latches_and_rearms_warning(
+    session,
+    monkeypatch,
+):
+    _patch_capacity_sequence(monkeypatch, 80.0, 95.0, 60.0, 80.0)
+    await _add_policy(session, warn=70, critical=90)
+    deliveries = []
+
+    async def fake_deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    for hour in (10, 11):
+        await record_host_capacity(
+            session,
+            workspace_root="/srv/illo-workspace",
+            now=datetime(2026, 9, 1, hour, 0, tzinfo=timezone.utc),
+            deliver_alert=fake_deliver,
+        )
+
+    assert await session.get(SchedulerAlertLatch, HOST_CAPACITY_ALERT_KEY)
+    assert await session.get(
+        SchedulerAlertLatch,
+        HOST_CAPACITY_CRITICAL_ALERT_KEY,
+    )
+
+    ok_result = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    assert ok_result["alert_sent"] is False
+    assert await session.get(SchedulerAlertLatch, HOST_CAPACITY_ALERT_KEY) is None
+    assert (
+        await session.get(
+            SchedulerAlertLatch,
+            HOST_CAPACITY_CRITICAL_ALERT_KEY,
+        )
+        is None
+    )
+
+    warning_result = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 13, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    assert warning_result["alert_sent"] is True
+    assert [item["presentation"].title for item in deliveries] == [
+        "Host capacity warning",
+        "Host capacity critical",
+        "Host capacity warning",
+    ]
+
+
+async def test_host_capacity_critical_rearms_only_after_falling_to_warning(
+    session,
+    monkeypatch,
+):
+    _patch_capacity_sequence(monkeypatch, 80.0, 95.0, 95.0, 80.0, 95.0)
+    await _add_policy(session, warn=70, critical=90)
+    deliveries = []
+
+    async def fake_deliver(**kwargs):
+        deliveries.append(kwargs)
+
+    for hour in (10, 11):
+        await record_host_capacity(
+            session,
+            workspace_root="/srv/illo-workspace",
+            now=datetime(2026, 9, 1, hour, 0, tzinfo=timezone.utc),
+            deliver_alert=fake_deliver,
+        )
+    critical_latch = await session.get(
+        SchedulerAlertLatch,
+        HOST_CAPACITY_CRITICAL_ALERT_KEY,
+    )
+    assert critical_latch is not None
+
+    consecutive_critical = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+    assert consecutive_critical["alert_sent"] is False
+    assert (
+        await session.get(
+            SchedulerAlertLatch,
+            HOST_CAPACITY_CRITICAL_ALERT_KEY,
+        )
+    ).alerted_at == critical_latch.alerted_at
+
+    warning_result = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 13, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+    assert warning_result["alert_sent"] is False
+    assert await session.get(SchedulerAlertLatch, HOST_CAPACITY_ALERT_KEY)
+    assert (
+        await session.get(
+            SchedulerAlertLatch,
+            HOST_CAPACITY_CRITICAL_ALERT_KEY,
+        )
+        is None
+    )
+
+    critical_again = await record_host_capacity(
+        session,
+        workspace_root="/srv/illo-workspace",
+        now=datetime(2026, 9, 1, 14, 0, tzinfo=timezone.utc),
+        deliver_alert=fake_deliver,
+    )
+
+    assert critical_again["alert_sent"] is True
+    assert [item["presentation"].title for item in deliveries] == [
+        "Host capacity warning",
+        "Host capacity critical",
+        "Host capacity critical",
+    ]
 
 
 async def test_read_host_capacity_returns_live_disk_and_persisted_inventory(


### PR DESCRIPTION
Closes #875

## What was broken

`_capacity_status()` has returned three states — `ok` / `warn` / `critical` — since [#780](https://github.com/Illospace/illospace/issues/780) shipped the sensor. But both non-ok states shared **one** latch key, and the failure guard only fires on an unlatched edge (`brain/systems/failure_guard/core.py:439-441`):

```python
crossed = (new_edge_mode != "ignore" and result.active and latch is None)
```

So once the warning alerted, every later tick was silent — including the critical crossing, and including 100% full. The latch cleared only on a return to `ok`.

The alarm was loudest when the problem was smallest, and mute when the disk actually filled.

This is not hypothetical. It is why [#874](https://github.com/Illospace/illospace/issues/874) happened with no warning: the root filesystem hit 100%, postgres entered a crash-restart loop, and the API never started. Nobody was paged. A human found it by hand.

## What this does

Each severity gets its own latch, and everything about a severity comes from one ordered table:

```python
_CAPACITY_SEVERITIES = (
    _CapacitySeverity(status="warn",     alert_key=HOST_CAPACITY_ALERT_KEY,          priority=1, ...),
    _CapacitySeverity(status="critical", alert_key=HOST_CAPACITY_CRITICAL_ALERT_KEY, priority=2, ...),
)
```

Which latches to clear, which triggers are active, which edge wins, the alert title, the severity word and the threshold percent all derive from it. Both are priority comparisons against the current status, so a third severity would need no new branches.

**One alert per tick.** When a jump crosses both thresholds at once, only the highest is delivered — critical subsumes warning — but *both* edges are latched, so the warning cannot fire later on the way down.

## Behavior, as pinned by tests

| tick | status | alert delivered | latches after |
|---|---|---|---|
| cold start at 95% | critical | **1** — "Host capacity critical" | warn + critical |
| again at 95% | critical | none | warn + critical |
| 80% | warn | none | warn |
| 95% again | critical | **1** — "Host capacity critical" | warn + critical |
| 50% | ok | none | none |

`warn → critical` delivers exactly one critical alert. A sustained state never re-alerts.

## Verification — read this before merging

**The full suite did not run, and I will not claim it did.** The host sat at load ~50 for this entire run from unrelated work. The guardrail is load > 20 invalidates a suite result in either direction, so a green number produced there would have been decoration. I started the repo's CI command verbatim, gave it 45 minutes, and stopped it at ~10% of a core rather than report a number that proves nothing.

What did run, serially, on the final commit:

```
pytest -m "not requires_db and not requires_browser and not live_provider" -q \
  tests/test_host_capacity.py tests/test_scheduler.py \
  tests/test_scheduler_programs.py tests/test_tool_registry.py
→ 115 passed in 295.72s
```

Those four files are the complete set that references `host_capacity` anywhere in the repo, so this is the change's full blast radius — but it is a subset of CI, not CI.

The diff touches no `frontend/**` path, so that lane is not selected.

**This cannot be exercised on the live host until [#874](https://github.com/Illospace/illospace/issues/874) is fixed.** The scheduler container is in `Created` and never started, so the hourly `host_capacity` job is not running at all right now.

## Review pass

A Codex code-quality review of the first commit (`3e70efab`) returned **BLOCKING** on three points. All three are folded into `27519810`:

1. the ok→critical double alert (it independently recommended suppressing the warning);
2. the lifecycle smeared across four places;
3. `replace(guard, edges=(edge,))` synthesizing a partial aggregate to reach around `async_latch_failure_edges`.

## Production receipt — this defect is recorded, not just reasoned about

The hourly sensor ran at 15:07Z on 2026-09-01, 18 minutes before the API died, and wrote this:

```json
{"status": "critical", "pct_used": 95.9, "bytes_free": 0, "mount": "/workspaces",
 "alert_sent": false,
 "thresholds": {"warn_percent": 80, "critical_percent": 90}}
```

`status: critical`, **zero bytes free**, `alert_sent: false`. The warning latch was already held, so the critical crossing produced nothing — while postgres was minutes from a crash-loop that took the API down for 2.5 hours ([#874](https://github.com/Illospace/illospace/issues/874)). That is exactly the branch this PR changes.

## Correction to an earlier claim on #875

The issue body says the sensor's `top_consumers` "would have reported 100% used while listing consumers summing to a few GB — pointing away from the 1.1T that actually filled the disk." **That was wrong and I have withdrawn it.** I inferred it from the code rather than from what the sensor recorded; the real 15:07Z row named `ideas` at **572.8 GB**, the largest reclaimable object on the box.

What survives is narrower: `mount` is `/workspaces`, not `/`, so the sensor read 95.9% on its own volume while the root filesystem was at 100%. Pressure originating outside that volume is invisible to it. Still a separate change from this one, which is only about whether the alarm fires at all.

No migration: `SchedulerAlertLatch` is keyed by an `alert_key` string, so the new severity is a new row.
