### PR TITLE
fix(triage): make the assignment-provenance verdict reachable (#881 clause 3)

### DIFF
--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -20,6 +20,7 @@ GITHUB_TOOLS = [
                     "type": "string",
                     "enum": [
                         "get_repo",
+                        "get_issue",
                         "list_issues",
                         "list_pull_requests",
                         "get_pull_request",
@@ -31,7 +32,11 @@ GITHUB_TOOLS = [
                     ],
                     "default": "list_issues",
                     "description": (
-                        "Which GitHub source data to read. get_pull_request includes mergeability, CI "
+                        "Which GitHub source data to read. get_issue reads one issue by exact number and "
+                        "returns assignment_provenance: none means no assignee, unknown means provenance could "
+                        "not be determined, human means a human assignment, and automation_at_filing means the "
+                        "filing actor assigned it within seconds of creation, so it is not a human assignment. "
+                        "get_pull_request includes mergeability, CI "
                         "check runs, and combined status; pull_request_checks reads CI for a head SHA; "
                         "get_counts returns exact issue and PR counts for the requested state. get_file, "
                         "list_tree, and grep require ref; grep is literal rather than regular-expression search."
@@ -67,6 +72,11 @@ GITHUB_TOOLS = [
                     "type": "integer",
                     "minimum": 1,
                     "description": "Pull request number required by get_pull_request.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Issue number required by get_issue.",
                 },
                 "number": {
                     "type": "integer",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -21,6 +21,7 @@ from brain.systems.cortex.project_context.github import (
     async_add_repo_sub_issue,
     async_create_repo_issue,
     async_grep_repo,
+    async_get_issue,
     async_get_repo_issue_parent,
     async_get_issue_closure_info,
     async_get_pull_request_deploy_info,
@@ -345,6 +346,7 @@ async def _read_with_token(
     base: str | None,
     limit: int,
     token: str | None,
+    issue_number: int | None,
     pull_number: int | None,
     sha: str | None,
     cursor: str | None,
@@ -373,6 +375,13 @@ async def _read_with_token(
             include_pull_requests=bool(include_pull_requests),
             limit=_limit(limit),
             cursor=cursor,
+        )
+    if action in {"get_issue", "issue"}:
+        return await async_get_issue(
+            repo_slug,
+            int(issue_number or 0),
+            token=token,
+            include_assignment_provenance=True,
         )
     if action in {"list_pull_requests", "pull_requests", "prs"}:
         return await async_list_repo_pull_requests(
@@ -449,6 +458,7 @@ async def _handle_read_github_source(
     include_pull_requests: bool = False,
     head: str | None = None,
     base: str | None = None,
+    issue_number: int | None = None,
     pull_number: int | None = None,
     number: int | None = None,
     sha: str | None = None,
@@ -473,6 +483,8 @@ async def _handle_read_github_source(
         "get_repo",
         "list_issues",
         "issues",
+        "get_issue",
+        "issue",
         "list_pull_requests",
         "pull_requests",
         "prs",
@@ -492,10 +504,19 @@ async def _handle_read_github_source(
     if clean_action not in valid_actions:
         return json.dumps({
             "error": (
-                "read_github_source action must be get_repo, list_issues, list_pull_requests, "
+                "read_github_source action must be get_repo, get_issue, list_issues, list_pull_requests, "
                 "get_pull_request, pull_request_checks, get_counts, get_file, list_tree, or grep"
             )
         })
+    if clean_action in {"get_issue", "issue"}:
+        try:
+            clean_issue_number = int(issue_number or 0)
+        except (TypeError, ValueError):
+            clean_issue_number = 0
+        if clean_issue_number < 1:
+            return json.dumps({"error": "get_issue requires a positive issue_number"})
+    else:
+        clean_issue_number = None
     if clean_action in {"pull_request", "get_pull_request", "pr"}:
         try:
             clean_pull_number = int(number or pull_number or 0)
@@ -587,6 +608,7 @@ async def _handle_read_github_source(
                 base=base,
                 limit=limit,
                 token=candidate["token"],
+                issue_number=clean_issue_number,
                 pull_number=clean_pull_number,
                 sha=clean_sha,
                 cursor=_clean(cursor),

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -389,9 +389,13 @@ a human action. This never-merge rule is absolute for staging→main.
 Route by GitHub signal first, then by work class — area prose is the last
 resort, not the first.
 
-- **An explicit GitHub assignee always wins** — on issues AND PRs — over every
-  heuristic below. If you think the assignment is wrong, recommend a change —
-  never override it.
+- **An explicit human GitHub assignee always wins** — on issues AND PRs — over
+  every heuristic below. For issues, obtain `assignment_provenance` with the
+  `github` tool using `action="get_issue"`. A verdict of
+  `automation_at_filing` is Illo's earlier guess, not a human claim; re-derive
+  the assignee from the ownership rules exactly as if the issue were unassigned.
+  If you think a human assignment is wrong, recommend a change — never override
+  it.
 - **Unassigned PRs are owned by their GitHub author** when the author is a
   human. The team does not do peer review, so never assign a PR to a
   reviewer, a "review owner", or a "coordination owner", and never put
@@ -482,11 +486,14 @@ fix any that fail:
    closed — never listed as active work. Exception: an alert-linked ticket
    whose fix is only on staging or is not verified is NOT cleanup — keep it
    active per **Deploy State on Read**.
-2. **Owner gate:** every PR shows its GitHub assignee when set, else its human
+2. **Owner gate:** every PR shows its human GitHub assignee when set, else its human
    author, with an evidence-based next action (fix the named failing check /
    merge when green / close when obsolete) and no reviewer or coordination
-   owner attached. Every issue owner is the GitHub assignee, or the work-class
-   routing only if unassigned. No customer-generation issue is pre-assigned.
+   owner attached. Every issue owner is the human GitHub assignee, or the
+   work-class routing if unassigned. Read `assignment_provenance` with the
+   `github` tool using `action="get_issue"`; `automation_at_filing` is Illo's
+   earlier guess, not a human claim, so re-derive ownership exactly as if the
+   issue were unassigned. No customer-generation issue is pre-assigned.
 3. **Dedup gate:** no two items describe the same underlying problem under
    different issue numbers.
 4. **Deploy-state gate:** no expected-noise staging re-fire re-pings an owner

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -1725,3 +1725,45 @@ async def test_grep_pages_before_match_evidence_exceeds_the_tool_output_budget()
     assert 0 < payload["returned"] < 50
     assert payload["truncated"] is True
     assert payload["next_page"]
+
+
+@pytest.mark.asyncio
+async def test_get_issue_action_reads_one_issue_with_assignment_provenance_enabled():
+    payload = {
+        "repo": "uwear-ai/uwear-backend",
+        "issue": {"number": 1918, "assignment_provenance": "automation_at_filing"},
+    }
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_issue",
+        new=AsyncMock(return_value=payload),
+    ) as get_issue:
+        result = await _handle_read_github_source(
+            action="get_issue",
+            repo="https://github.com/uwear-ai/uwear-backend.git",
+            issue_number=1918,
+        )
+
+    body = json.loads(result)
+    assert body["issue"]["assignment_provenance"] == "automation_at_filing"
+    get_issue.assert_awaited_once()
+    assert get_issue.await_args.args == ("uwear-ai/uwear-backend", 1918)
+    # Provenance is the safety signal clause 3 of #881 depends on. A caller that
+    # has to know to ask for it will not ask, so get_issue always enables it.
+    assert get_issue.await_args.kwargs["include_assignment_provenance"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("issue_number", [None, 0, -3])
+async def test_get_issue_action_requires_a_positive_issue_number(issue_number):
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_issue",
+        new=AsyncMock(),
+    ) as get_issue:
+        result = await _handle_read_github_source(
+            action="get_issue",
+            repo="uwear-ai/uwear-backend",
+            issue_number=issue_number,
+        )
+
+    assert json.loads(result) == {"error": "get_issue requires a positive issue_number"}
+    get_issue.assert_not_awaited()

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -766,7 +766,12 @@ def test_read_github_source_schema_exposes_pinned_source_actions():
     definition = next(tool for tool in GITHUB_TOOLS if tool["name"] == "read_github_source")
     properties = definition["input_schema"]["properties"]
 
-    assert {"get_file", "list_tree", "grep"} <= set(properties["action"]["enum"])
+    assert {"get_issue", "get_file", "list_tree", "grep"} <= set(properties["action"]["enum"])
+    assert properties["issue_number"] == {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Issue number required by get_issue.",
+    }
     assert properties["ref"]["type"] == "string"
     assert properties["path"]["type"] == "string"
     assert properties["query"]["type"] == "string"


### PR DESCRIPTION
Stacked on `illo-qa/881-assignment-routing` (PR #882). **Merge #882 first.**

#881 stays open after this merges — clauses 1 and 2 belong to #882.

## What this fixes

PR #882 builds the clause-3 detector and tests it well: `_assignment_provenance()` returns `none` / `unknown` / `human` / `automation_at_filing`, `_issue_payload()` surfaces it, and `async_get_issue(..., include_assignment_provenance=True)` fetches the timeline that feeds it.

Nothing could reach it. Measured on that branch, three independent probes:

1. `async_get_issue` had **zero production callers** — its definition plus three call sites in `tests/test_project_context_github.py`. (Every other `async_get_issue*` match in the repo is the unrelated `async_get_issue_closure_info`.)
2. The agent-callable `github` source-reader tool had **no `get_issue` action** and **no `issue_number` property**.
3. `include_assignment_provenance` appeared **nowhere** under `brain/systems/runs/`.

So the only issue read an agent could perform was `action="list_issues"` → `async_list_repo_issues`, which builds each payload with no timeline. `assignment_provenance` was `"unknown"` on every read any agent could actually make, and the playbook that would honour it still said "An explicit GitHub assignee always wins".

## What changed

- `definitions/github.py` — `get_issue` added to the source-reader action enum, plus an `issue_number` property. The action description spells out what each of the four verdicts means.
- `handlers/github.py` — a `get_issue` branch that validates `issue_number` before any token lookup and calls `async_get_issue(..., include_assignment_provenance=True)`. Provenance is **always on** for this action: a caller that has to know to ask for the safety signal will not ask. `issue_number` is threaded exactly the way `pull_number` already is.
- `uwear-engineering-triage/SKILL.md` — both ownership rules (the routing rule at ~389 and the Owner gate at ~486) now say *human* assignee, name `action="get_issue"` as the way to read the verdict, and say that `automation_at_filing` is Illo's earlier guess, so ownership is re-derived exactly as if the issue were unassigned.

## How to check it

This is a tool-surface and playbook change, so the reviewable surface is behaviour, not pixels:

1. Ask Illo to read `uwear-ai/uwear-backend#1918` with the `github` tool, `action="get_issue"`. The payload should carry `assignment_provenance: "automation_at_filing"` — that ticket was assigned by `illo-bot[bot]` in the same second it was filed.
2. Ask it to read a ticket a human assigned. The verdict should be `"human"`.
3. Ask it to triage #1918's ownership. Under the amended rule it should route by the playbook (MCP work → `axel-havard`) instead of deferring to the auto-assignment — which is #881's acceptance clause 2.
4. `action="get_issue"` with no `issue_number` returns `get_issue requires a positive issue_number` rather than raising.

## Verification — read this honestly

**The full-suite gate could not be run cleanly, so this PR does not claim one.**

The targeted file passes: `tests/test_github_source_tool.py` → **46 passed** (run twice, 1.70s and 8.28s). That covers the new action, the `issue_number` guard, and the schema contract.

The repo CI command verbatim (no path argument, so `meetbot/tests` is included) was started at load 12.6 and never finished. Two things spoiled it: the machine reached **load 54**, and the Codex worker recovered from its stream-reconnect and launched a second copy of the same suite 51 seconds after mine. Two concurrent suites under that load is not evidence in either direction, so no green is quoted here.

No `frontend/**` file and no alembic revision is in this layer, so neither of those lanes is selected — the Python lane is the only one this diff triggers.

## Notes for the reviewer

- The Codex worker that wrote the production change died in stream-reconnect backoff before it could add tests or commit. The orchestrator reviewed the diff, wrote the four tests in `tests/test_github_source_tool.py`, and committed. Flagging it so the authorship is not a surprise.
- `_read_with_token` has exactly one caller, which passes the new keyword — checked, because a new required keyword-only argument would otherwise break it silently.

Closes nothing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
