### PR TITLE
fix(inbound): stop a preservation receipt claiming success when its own evidence says missing (#885)

### DIFF
--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -489,7 +489,6 @@ async def reconcile_inbound_triage_run(
         stored_failure_category
         or (await _run_failure_category(session, run_id) if status == RunStatus.FAILED else None),
     )
-    public_final_answer = final_answer if failure is None else None
     attribution = await summarize_inbound_run_attribution(session, run_id=run_id, status=status)
     evidence_contract = preservation_evidence_result(
         preservation_contract_from_run_metadata(metadata),
@@ -497,6 +496,9 @@ async def reconcile_inbound_triage_run(
         attribution=attribution,
     )
     evidence_missing = evidence_contract.get("status") == "missing"
+    public_final_answer = final_answer if failure is None else None
+    if evidence_missing:
+        public_final_answer = evidence_contract.get("reason") or PRESERVATION_MISSING_REASON
     terminal_status = STATUS_REVIEW_REQUIRED if evidence_missing else _receipt_terminal_status(status)
     outcome_status = "needs_action" if evidence_missing else status.value
     triage_terminal = _triage_terminal_payload(

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -17,7 +17,10 @@ from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundE
 from brain.platform.db.models.org import Org, User
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import service as inbound
-from brain.systems.inbound.preservation import PRESERVATION_MISSING_REASON
+from brain.systems.inbound.preservation import (
+    PRESERVATION_MISSING_REASON,
+    PRESERVATION_NON_DURABLE_REASON,
+)
 from brain.systems.runs.events import run_event
 from brain.systems.runs.failure_diagnostic import (
     RunFailureStage,
@@ -317,6 +320,11 @@ async def test_preservation_submission_without_durable_evidence_stays_actionable
     assert evidence["status"] == "missing"
     assert evidence["reason"] == PRESERVATION_MISSING_REASON
     assert "non_durable_target_refs" not in evidence
+    assert event.action_result["handling"]["final_answer"] == PRESERVATION_MISSING_REASON
+    assert (
+        event.action_result["handling"]["result"]["final_answer"]
+        == PRESERVATION_MISSING_REASON
+    )
     assert "did not produce durable storage evidence" in event.error
     assert receipt.status == "review_required"
     assert receipt.tool_use["status"] == "needs_action"
@@ -393,9 +401,14 @@ async def test_preservation_submission_with_github_comment_names_non_durable_evi
     assert evidence["status"] == "missing"
     assert evidence["mutated_target_refs"] == []
     assert evidence["non_durable_target_refs"] == [expected_ref]
-    assert evidence["reason"] != PRESERVATION_MISSING_REASON
+    assert evidence["reason"] == PRESERVATION_NON_DURABLE_REASON
     assert "non-durable surface" in evidence["reason"]
     assert "Illo-owned" in evidence["reason"]
+    assert event.action_result["handling"]["final_answer"] == PRESERVATION_NON_DURABLE_REASON
+    assert (
+        event.action_result["handling"]["result"]["final_answer"]
+        == PRESERVATION_NON_DURABLE_REASON
+    )
     assert receipt.status == "review_required"
     assert receipt.tool_use["evidence_contract"]["non_durable_target_refs"] == [expected_ref]
     assert receipt.tool_use["attribution"]["mutated_target_refs"] == [expected_ref]
@@ -454,6 +467,12 @@ async def test_preservation_submission_with_explicit_memory_evidence_reconciles_
     evidence = event.action_result["handling"]["evidence_contract"]
     assert evidence["status"] == "satisfied"
     assert "non_durable_target_refs" not in evidence
+    assert event.action_result["handling"]["final_answer"] == (
+        "Stored the playbook in reconstructive memory."
+    )
+    assert event.action_result["handling"]["result"]["final_answer"] == (
+        "Stored the playbook in reconstructive memory."
+    )
     assert {"kind": "memory_source", "id": "91", "source": "memory_ingest_source"} in evidence["mutated_target_refs"]
     assert receipt.status == "processed"
     assert "memory_source" in {ref["kind"] for ref in receipt.tool_use["attribution"]["mutated_target_refs"]}
@@ -598,11 +617,12 @@ async def test_get_result_lazily_reconciles_completed_submission_run(session):
         ingress_context={"surface": "test"},
     )
     handling = await _assert_queued_submission(session, result["ilo_outcome"])
-    run = await session.get(AgentRunRow, handling["run_id"])
-    assert run is not None
-    run.status = RunStatus.COMPLETED.value
-    run.completed_at = datetime.now(timezone.utc)
-    await session.flush()
+    await _finish_triage_run(
+        session,
+        handling,
+        status=RunStatus.COMPLETED,
+        final_answer="Reviewed the context; no preservation was requested.",
+    )
 
     from brain.app.api.routers.agent_mcp import _tool_get_result
 
@@ -613,6 +633,13 @@ async def test_get_result_lazily_reconciles_completed_submission_run(session):
     assert payload["handling_status"] == "completed"
     assert payload["run_status"] == "completed"
     assert payload["evidence_status"] == "not_required"
+    handling_result = payload["event"]["action_result"]["handling"]
+    assert handling_result["final_answer"] == (
+        "Reviewed the context; no preservation was requested."
+    )
+    assert handling_result["result"]["final_answer"] == (
+        "Reviewed the context; no preservation was requested."
+    )
 
 
 async def test_get_result_failed_preservation_reports_exception_class_states(session):


### PR DESCRIPTION
Closes #885

## What was wrong

A `preserve_knowledge` submission came back saying **"Preserved in the Production Workflow rollout handoff"** while the same receipt reported `evidence_status: missing` and `mutated_target_refs: []`. The only things it had touched were a timeline message and an idea — both non-durable.

The machine-readable half of the receipt was already correct. Only the prose lied, and the prose is what callers read: the Uwear routines are explicitly instructed to read `final_answer` rather than trust the status fields alone. So a caller was told its knowledge was safe when nothing durable had been written.

## The cause

`brain/systems/inbound/reconciliation.py` computed the published answer **before** the evidence contract existed, and suppressed it only when the run had failed:

```python
public_final_answer = final_answer if failure is None else None   # computed too early
...
evidence_contract = preservation_evidence_result(...)             # 2 lines later
evidence_missing = evidence_contract.get("status") == "missing"
```

`evidence_missing` then correctly flipped the terminal status to `review_required`, set the outcome to `needs_action`, and attached a `reason` — but the prose was never re-gated on it.

## The fix

Three net lines. Move the computation after the evidence contract, and publish the contract's own reason when evidence is missing.

- Non-durable refs only (the #885 case) → `PRESERVATION_NON_DURABLE_REASON`
- Nothing mutated → `PRESERVATION_MISSING_REASON`
- Evidence satisfied → the run's own answer, unchanged

No evidence, status, or attribution field changes behaviour. The model's original text is still in the run artifact; it is only no longer published as a success claim.

## How to check it (no code reading needed)

On staging, submit anything with `desired_outcome: preserve_knowledge` that will not write durable state — for example a message Illo answers by posting to the timeline only. Then read the receipt with `illo_get_result`:

1. `evidence_status` is `missing` and `mutated_target_refs` is `[]` — unchanged from today.
2. `final_answer` now says preservation produced no durable evidence, instead of claiming the knowledge was preserved. **This is the whole change.**
3. Repeat with a submission that does write durable memory: `evidence_status` is `satisfied` and `final_answer` is the run's own wording, untouched.

## Verification

- Repo CI command, verbatim: `pytest -m "not requires_db and not requires_browser and not live_provider"` → **5058 passed, 17 failed**.
- Those 17 failures are **pre-existing on `main`**. A clean throwaway worktree at `origin/main` (`8dff91eb`) with zero changes produced the byte-identical result — same 17 tests, same 5058 passed. They are all in `test_worker_swap_deploy.py` / `test_deploy_*` / `test_safe_deploy.py` / `test_launcher_uninstall_env_reset.py`, none of which this diff touches. **This branch adds no regression.**
- The 11 tests in `tests/test_inbound_preservation.py` all pass.
- Machine load was 4.27 during the run, so the numbers are not a contention artifact.
- Diff touches only `brain/**` and `tests/**`, so the frontend lane does not apply.

## Note for the reviewer

`main` is currently red with those 17 deploy/worker-swap failures. That is not this PR, and it is not filed — say the word and I will open a ticket for it.
