### PR TITLE
fix(self-update): keep the controller heartbeat alive during blocking updates

### DIFF
--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -16,6 +16,8 @@ WORKSPACE_TOOLS_HEARTBEAT_FILE="${ILLO_WORKSPACE_TOOLS_HEARTBEAT_FILE:-/data/pri
 WORKSPACE_TOOLS_LOG_PATH="${ILLO_WORKSPACE_TOOLS_LOG_PATH:-/data/private/logs/illo-workspace-tools.log}"
 WORKER_DRAIN_TIMEOUT_FILE="${ILLO_SELF_UPDATE_WORKER_DRAIN_TIMEOUT_FILE:-/data/private/self-update/worker-drain-timeout.json}"
 POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
+HEARTBEAT_INTERVAL_SECONDS="${ILLO_SELF_UPDATE_HEARTBEAT_INTERVAL_SECONDS:-2}"
+HEARTBEAT_KEEPER_PID=""
 AUTO_UPDATE_ENABLED="${ILLO_AUTO_UPDATE_ENABLED:-1}"
 AUTO_UPDATE_POLL_SECONDS="${ILLO_AUTO_UPDATE_POLL_SECONDS:-300}"
 APP_UID="${ILLO_APP_UID:-10001}"
@@ -139,6 +141,80 @@ write_workspace_tools_heartbeat() {
   json_write "$WORKSPACE_TOOLS_HEARTBEAT_FILE" \
     --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     '{status: "ready", updated_at: $updated_at}'
+}
+
+stop_heartbeat_keeper() {
+  trap '' USR1
+  if [ -n "$HEARTBEAT_KEEPER_PID" ]; then
+    kill "$HEARTBEAT_KEEPER_PID" 2>/dev/null || true
+    wait "$HEARTBEAT_KEEPER_PID" 2>/dev/null || true
+    HEARTBEAT_KEEPER_PID=""
+  fi
+}
+
+refresh_controller_heartbeats() {
+  # Do not reenter json_write while its shared temporary file is in use.
+  trap '' USR1
+  write_heartbeat
+  write_runtime_services_heartbeat
+  write_workspace_tools_heartbeat
+  trap refresh_controller_heartbeats USR1
+}
+
+run_with_heartbeats() {
+  local controller_pid=$$ exit_code
+  trap stop_heartbeat_keeper EXIT
+  trap 'exit 143' TERM
+  trap 'exit 130' INT
+  # Only the controller writes: a stopped/wedged controller cannot renew health.
+  trap refresh_controller_heartbeats USR1
+  (
+    operation_pid=""
+    sleeper_pid=""
+    cleanup_operation() {
+      if [ -n "$operation_pid" ]; then
+        kill -- "-$operation_pid" 2>/dev/null || true
+        wait "$operation_pid" 2>/dev/null || true
+      fi
+      if [ -n "$sleeper_pid" ]; then
+        kill "$sleeper_pid" 2>/dev/null || true
+        wait "$sleeper_pid" 2>/dev/null || true
+      fi
+    }
+    trap cleanup_operation EXIT
+    trap 'exit 0' TERM INT
+    # BASHPID is unavailable in macOS's Bash 3.2.
+    HEARTBEAT_KEEPER_PID="${BASHPID:-$(exec sh -c 'echo "$PPID"')}"
+    # Give the operation and its descendants a group that cleanup can stop.
+    set -m
+    (set +m; "$@") &
+    operation_pid=$!
+    set +m
+    while kill -0 "$operation_pid" 2>/dev/null; do
+      kill -0 "$controller_pid" 2>/dev/null || exit 1
+      # Linux may retain a dead controller as a zombie until its parent reaps it.
+      if [ -r "/proc/$controller_pid/stat" ]; then
+        read -r controller_state < "/proc/$controller_pid/stat" || exit 1
+        controller_state="${controller_state##*) }"
+        case "$controller_state" in Z*|X*) exit 1 ;; esac
+      fi
+      kill -USR1 "$controller_pid" 2>/dev/null || exit 1
+      sleep "$HEARTBEAT_INTERVAL_SECONDS" &
+      sleeper_pid=$!
+      wait "$sleeper_pid"
+      sleeper_pid=""
+    done
+    if wait "$operation_pid"; then exit 0; else exit $?; fi
+  ) &
+  HEARTBEAT_KEEPER_PID=$!
+  # Bash dispatches traps promptly during builtin wait, unlike a foreground build.
+  while kill -0 "$HEARTBEAT_KEEPER_PID" 2>/dev/null; do
+    wait "$HEARTBEAT_KEEPER_PID" 2>/dev/null || true
+  done
+  # A signal can interrupt wait; read the completed operation's actual status.
+  if wait "$HEARTBEAT_KEEPER_PID"; then exit_code=0; else exit_code=$?; fi
+  stop_heartbeat_keeper
+  return "$exit_code"
 }
 
 process_request() {
@@ -349,7 +425,7 @@ main() {
     write_workspace_tools_heartbeat
     if [ -f "$REQUEST_FILE" ]; then
       set +e
-      process_request
+      run_with_heartbeats process_request
       exit_code=$?
       set -e
       if [ "$exit_code" -ne 0 ]; then
@@ -359,7 +435,7 @@ main() {
     fi
     if [ -f "$RUNTIME_SERVICES_REQUEST_FILE" ]; then
       set +e
-      process_runtime_services_request
+      run_with_heartbeats process_runtime_services_request
       exit_code=$?
       set -e
       if [ "$exit_code" -ne 0 ]; then
@@ -369,7 +445,7 @@ main() {
     fi
     if [ -f "$WORKSPACE_TOOLS_REQUEST_FILE" ]; then
       set +e
-      process_workspace_tools_request
+      run_with_heartbeats process_workspace_tools_request
       exit_code=$?
       set -e
       if [ "$exit_code" -ne 0 ]; then

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -18,6 +18,7 @@ WORKER_DRAIN_TIMEOUT_FILE="${ILLO_SELF_UPDATE_WORKER_DRAIN_TIMEOUT_FILE:-/data/p
 POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
 HEARTBEAT_INTERVAL_SECONDS="${ILLO_SELF_UPDATE_HEARTBEAT_INTERVAL_SECONDS:-2}"
 HEARTBEAT_KEEPER_PID=""
+HEARTBEAT_PREVIOUS_USR1_TRAP=""
 AUTO_UPDATE_ENABLED="${ILLO_AUTO_UPDATE_ENABLED:-1}"
 AUTO_UPDATE_POLL_SECONDS="${ILLO_AUTO_UPDATE_POLL_SECONDS:-300}"
 APP_UID="${ILLO_APP_UID:-10001}"
@@ -143,29 +144,45 @@ write_workspace_tools_heartbeat() {
     '{status: "ready", updated_at: $updated_at}'
 }
 
+write_controller_heartbeats() {
+  write_heartbeat
+  write_runtime_services_heartbeat
+  write_workspace_tools_heartbeat
+}
+
+install_controller_signal_handlers() {
+  trap stop_heartbeat_keeper EXIT
+  trap 'exit 143' TERM
+  trap 'exit 130' INT
+}
+
 stop_heartbeat_keeper() {
-  trap '' USR1
+  if [ -n "$HEARTBEAT_PREVIOUS_USR1_TRAP" ]; then
+    trap '' USR1
+  fi
   if [ -n "$HEARTBEAT_KEEPER_PID" ]; then
     kill "$HEARTBEAT_KEEPER_PID" 2>/dev/null || true
     wait "$HEARTBEAT_KEEPER_PID" 2>/dev/null || true
     HEARTBEAT_KEEPER_PID=""
+  fi
+  if [ -n "$HEARTBEAT_PREVIOUS_USR1_TRAP" ]; then
+    eval "$HEARTBEAT_PREVIOUS_USR1_TRAP"
+    HEARTBEAT_PREVIOUS_USR1_TRAP=""
   fi
 }
 
 refresh_controller_heartbeats() {
   # Do not reenter json_write while its shared temporary file is in use.
   trap '' USR1
-  write_heartbeat
-  write_runtime_services_heartbeat
-  write_workspace_tools_heartbeat
+  write_controller_heartbeats
   trap refresh_controller_heartbeats USR1
 }
 
 run_with_heartbeats() {
   local controller_pid=$$ exit_code
-  trap stop_heartbeat_keeper EXIT
-  trap 'exit 143' TERM
-  trap 'exit 130' INT
+  HEARTBEAT_PREVIOUS_USR1_TRAP="$(trap -p USR1)"
+  # An empty trap listing means the default disposition, not an ignored signal.
+  HEARTBEAT_PREVIOUS_USR1_TRAP="${HEARTBEAT_PREVIOUS_USR1_TRAP:-trap - USR1}"
   # Only the controller writes: a stopped/wedged controller cannot renew health.
   trap refresh_controller_heartbeats USR1
   (
@@ -414,15 +431,14 @@ main() {
   local exit_code now_epoch
 
   prepare_shared_paths
+  install_controller_signal_handlers
   write_status "idle" "Compose updater sidecar is ready." "" ""
   write_runtime_services_status "idle" "Runtime service host controller is ready." "" "" "" "[]"
   write_workspace_tools_status "idle" "Workspace tool host controller is ready." "" "" "" "" ""
   initialize_auto_update_poll "$(date +%s)"
 
   while true; do
-    write_heartbeat
-    write_runtime_services_heartbeat
-    write_workspace_tools_heartbeat
+    write_controller_heartbeats
     if [ -f "$REQUEST_FILE" ]; then
       set +e
       run_with_heartbeats process_request

--- a/deploy/scripts/self-update-healthcheck.sh
+++ b/deploy/scripts/self-update-healthcheck.sh
@@ -9,7 +9,8 @@ MAX_AGE_SECONDS="${ILLO_SELF_UPDATE_HEARTBEAT_MAX_AGE_SECONDS:-60}"
 updated_at="$(jq -r '.updated_at // empty' "$HEARTBEAT_FILE" 2>/dev/null)"
 [ -n "$updated_at" ] || exit 1
 
-heartbeat_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null)" || exit 1
+heartbeat_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null ||
+  date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$updated_at" +%s 2>/dev/null)" || exit 1
 now_epoch="$(date -u +%s)"
 
 [ $((now_epoch - heartbeat_epoch)) -le "$MAX_AGE_SECONDS" ]

--- a/tests/test_self_update_daemon.py
+++ b/tests/test_self_update_daemon.py
@@ -90,7 +90,7 @@ def _daemon_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
 
 def _run_daemon_function(env: dict[str, str], body: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", "-c", f'source "{DAEMON}"\n{body}'],
+        ["bash", "-c", f'source "{DAEMON}"\ninstall_controller_signal_handlers\n{body}'],
         cwd=ROOT,
         env=env,
         text=True,
@@ -179,6 +179,38 @@ def test_keeper_preserves_failed_operation_status_across_repeated_calls(tmp_path
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_operation_restores_signal_dispositions(tmp_path):
+    env, _paths = _heartbeat_env(tmp_path)
+    result = _run_daemon_function(
+        env,
+        '''
+        controller_traps=$(trap -p EXIT TERM INT)
+        operation() { sleep 0.15; return "$1"; }
+        for disposition in default ignored custom; do
+          case "$disposition" in
+            default) trap - USR1 ;;
+            ignored) trap '' USR1 ;;
+            custom) trap 'echo restored' USR1 ;;
+          esac
+          usr1_trap=$(trap -p USR1)
+          for expected_status in 0 7; do
+            set +e
+            run_with_heartbeats operation "$expected_status"
+            operation_status=$?
+            set -e
+            [ "$operation_status" -eq "$expected_status" ]
+            [ "$(trap -p USR1)" = "$usr1_trap" ]
+            [ "$(trap -p EXIT TERM INT)" = "$controller_traps" ]
+            stop_heartbeat_keeper
+            [ "$(trap -p USR1)" = "$usr1_trap" ]
+            [ "$(trap -p EXIT TERM INT)" = "$controller_traps" ]
+          done
+        done
+        ''',
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 @pytest.mark.parametrize("stop_signal", [signal.SIGTERM, signal.SIGINT, signal.SIGKILL, signal.SIGSTOP])
 def test_keeper_stops_when_controller_stops(tmp_path, stop_signal):
     env, paths = _heartbeat_env(tmp_path)
@@ -194,7 +226,7 @@ def test_keeper_stops_when_controller_stops(tmp_path, stop_signal):
     run_with_heartbeats blocking_build
     '''
     daemon = subprocess.Popen(
-        ["bash", "-c", f'source "{DAEMON}"\n{body}'],
+        ["bash", "-c", f'source "{DAEMON}"\ninstall_controller_signal_handlers\n{body}'],
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/tests/test_self_update_daemon.py
+++ b/tests/test_self_update_daemon.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import signal
 import subprocess
 import textwrap
+import time
 
 import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DAEMON = ROOT / "deploy" / "scripts" / "self-update-daemon.sh"
+HEALTHCHECK = ROOT / "deploy" / "scripts" / "self-update-healthcheck.sh"
 
 
 def _fake_git_tools(tmp_path: Path) -> Path:
@@ -92,7 +95,147 @@ def _run_daemon_function(env: dict[str, str], body: str) -> subprocess.Completed
         env=env,
         text=True,
         capture_output=True,
+        timeout=15,
     )
+
+
+def _heartbeat_env(tmp_path: Path) -> tuple[dict[str, str], list[Path]]:
+    env, *_ = _daemon_env(tmp_path)
+    paths = []
+    for controller in ("SELF_UPDATE", "RUNTIME_SERVICES", "WORKSPACE_TOOLS"):
+        path = tmp_path / f"{controller.lower()}-heartbeat.json"
+        env[f"ILLO_{controller}_HEARTBEAT_FILE"] = str(path)
+        paths.append(path)
+    env["ILLO_SELF_UPDATE_HEARTBEAT_MAX_AGE_SECONDS"] = "1"
+    env["ILLO_SELF_UPDATE_HEARTBEAT_INTERVAL_SECONDS"] = "0.05"
+    return env, paths
+
+
+def test_blocking_build_keeps_all_heartbeats_healthy_and_reaps_keeper(tmp_path):
+    env, paths = _heartbeat_env(tmp_path)
+    result = _run_daemon_function(
+        env,
+        f'''
+        blocking_build() {{
+          echo "$HEARTBEAT_KEEPER_PID" > "$HEARTBEAT_FILE.keeper"
+          for path in "$HEARTBEAT_FILE" "$RUNTIME_SERVICES_HEARTBEAT_FILE" "$WORKSPACE_TOOLS_HEARTBEAT_FILE"; do
+            for attempt in {{1..100}}; do
+              [ ! -f "$path" ] || break
+              sleep 0.01
+            done
+            cp "$path" "$path.before"
+          done
+          sleep 2.2
+          for path in "$HEARTBEAT_FILE" "$RUNTIME_SERVICES_HEARTBEAT_FILE" "$WORKSPACE_TOOLS_HEARTBEAT_FILE"; do
+            ILLO_SELF_UPDATE_HEARTBEAT_FILE="$path" bash "{HEALTHCHECK}" || return 1
+          done
+        }}
+        run_with_heartbeats blocking_build
+        [ -z "$HEARTBEAT_KEEPER_PID" ]
+        ! kill -0 "$(cat "$HEARTBEAT_FILE.keeper")" 2>/dev/null
+        ''',
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    for path in paths:
+        before = json.loads(Path(f"{path}.before").read_text())["updated_at"]
+        assert json.loads(path.read_text())["updated_at"] > before
+
+
+def test_heartbeats_expire_after_keeper_cleanup(tmp_path):
+    env, paths = _heartbeat_env(tmp_path)
+    result = _run_daemon_function(env, "run_with_heartbeats sleep 0.2")
+    assert result.returncode == 0, result.stdout + result.stderr
+    snapshots = [path.read_bytes() for path in paths]
+    time.sleep(2.1)
+
+    for path, snapshot in zip(paths, snapshots):
+        assert path.read_bytes() == snapshot
+        check = subprocess.run(
+            ["bash", str(HEALTHCHECK)],
+            env={**env, "ILLO_SELF_UPDATE_HEARTBEAT_FILE": str(path)},
+            capture_output=True,
+            timeout=5,
+        )
+        assert check.returncode != 0
+
+
+def test_keeper_preserves_failed_operation_status_across_repeated_calls(tmp_path):
+    env, _paths = _heartbeat_env(tmp_path)
+    result = _run_daemon_function(
+        env,
+        '''
+        fail_build() { sleep 0.15; return 7; }
+        for attempt in 1 2 3; do
+          set +e
+          run_with_heartbeats fail_build
+          result=$?
+          set -e
+          [ "$result" -eq 7 ]
+          [ -z "$HEARTBEAT_KEEPER_PID" ]
+        done
+        ''',
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("stop_signal", [signal.SIGTERM, signal.SIGINT, signal.SIGKILL, signal.SIGSTOP])
+def test_keeper_stops_when_controller_stops(tmp_path, stop_signal):
+    env, paths = _heartbeat_env(tmp_path)
+    pid_path = tmp_path / "keeper.pid"
+    build_pid_path = tmp_path / "build.pid"
+    body = f'''
+    blocking_build() {{
+      echo "$HEARTBEAT_KEEPER_PID" > "{pid_path}"
+      sleep 10 &
+      echo $! > "{build_pid_path}"
+      wait $!
+    }}
+    run_with_heartbeats blocking_build
+    '''
+    daemon = subprocess.Popen(
+        ["bash", "-c", f'source "{DAEMON}"\n{body}'],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not (pid_path.exists() and all(path.exists() for path in paths)):
+            assert time.monotonic() < deadline, "keeper did not start"
+            time.sleep(0.01)
+        keeper_pid = int(pid_path.read_text())
+        build_pid = int(build_pid_path.read_text())
+        daemon.send_signal(stop_signal)
+        if stop_signal == signal.SIGSTOP:
+            # The timer may still signal, but only the stopped controller writes.
+            time.sleep(0.1)
+            snapshots = [path.read_bytes() for path in paths]
+            time.sleep(0.2)
+            assert [path.read_bytes() for path in paths] == snapshots
+            daemon.kill()
+        daemon.wait(timeout=5)
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                os.kill(keeper_pid, 0)
+            except ProcessLookupError:
+                break
+            assert time.monotonic() < deadline, "keeper survived its controller"
+            time.sleep(0.02)
+        snapshots = [path.read_bytes() for path in paths]
+        time.sleep(0.1)
+        assert [path.read_bytes() for path in paths] == snapshots
+        with pytest.raises(ProcessLookupError):
+            os.kill(build_pid, 0)
+    finally:
+        # Also remove the simulated build after SIGKILL/SIGSTOP.
+        try:
+            os.killpg(daemon.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        daemon.wait(timeout=5)
 
 
 def test_auto_update_queues_once_when_origin_main_is_ahead(tmp_path):


### PR DESCRIPTION
## What was broken

`self-update-daemon.sh` wrote its three heartbeat files at the top of its loop, then called
`process_request` **synchronously**. That call builds images and drains workers for minutes.
`self-update-healthcheck.sh` rejects a heartbeat older than 60s, and `upgrade.sh:150` runs
`doctor.sh` before returning to the loop.

So a **successful** build and service swap was recorded as a failed update
(`ERROR: updater service health is unhealthy`), and the scheduled updater self-refresh at
`upgrade.sh:153` never ran. The controller looked healthy again only once it went idle.

## The fix

`run_with_heartbeats <fn>` now wraps each of the three blocking calls (self-update,
runtime-services, workspace-tools). It forks a keeper that runs the operation as its own
child and sends `SIGUSR1` to the controller on an interval; the controller's trap does the
writing.

**The controller stays the only writer.** That is the load-bearing choice: a stopped or
wedged controller cannot renew its own liveness, so a real hang still fails the health gate —
the ticket's "a stuck or dead controller is still detected". It also removes the
concurrent-writer question rather than coordinating two writers over `json_write`'s shared
temp path. The keeper is reaped on return and on `EXIT`/`TERM`/`INT`, and the operation's
exit status propagates unchanged.

The health check is **kept**, not weakened. `ILLO_SELF_UPDATE_HEARTBEAT_INTERVAL_SECONDS`
defaults to 2s against the 60s threshold.

`self-update-healthcheck.sh` parsed timestamps with GNU `date -u -d`, which exits 1 on BSD
`date` — the check then reported "unhealthy" for a parser failure rather than for heartbeat
age. A BSD `date -j -f` fallback was added, which also lets the tests exercise the real
healthcheck script instead of a stand-in.

## How to judge this without reading the diff

The behaviour is proven by tests rather than by eye, because the failure only appears on a
build longer than the health threshold:

- a 2.2s operation against a **1s** threshold keeps all three heartbeats passing
  `self-update-healthcheck.sh` mid-build, and the keeper is reaped afterwards;
- heartbeats **stop** once the keeper is gone, and the healthcheck then fails;
- the operation's exit status survives three repeated calls;
- the keeper stops when the controller takes `SIGTERM`, `SIGINT`, `SIGKILL` or **`SIGSTOP`** —
  `SIGSTOP` is the wedge case, and it is the one that proves the health gate still works.

## Verification

- Repo CI command verbatim, no path argument:
  `pytest -m "not requires_db and not requires_browser and not live_provider" -q`
  → **5130 passed, 11 skipped, 90 deselected in 116.54s**. Run serially at load 3.96 with no
  other worker live, so the number is not a contended one. `meetbot/tests` is included.
- `bash -n` clean on both scripts.
- Lanes selected by this diff are `backend` and `db` (`deploy/**`, `tests/**`); `frontend` is
  not selected.

## The review finding, now FIXED in `b01a5f86`

An independent Codex code-quality review of the first commit returned **BLOCKING** on one
maintainability point. It is fixed in the second commit on this branch:

> `deploy/scripts/self-update-daemon.sh:166` — the operation wrapper takes ownership of
> process-wide `EXIT`, `TERM` and `INT` handlers and leaves them installed after it returns;
> cleanup also leaves `USR1` ignored. Daemon signal policy therefore depends on whether an
> update has run.

What changed:

- `install_controller_signal_handlers` installs `EXIT`, `TERM` and `INT` **once**, from
  `main()` during startup. Signal policy no longer depends on whether an update has run.
- `run_with_heartbeats` now owns only the temporary `USR1` trap. It saves the previous
  disposition with `trap -p USR1` and `stop_heartbeat_keeper` restores it on every path,
  including the `EXIT` path. An empty listing is read as *default*, not as *ignored*.
- The three-heartbeat triple is now one `write_controller_heartbeats` helper, called from
  both the main loop and the `USR1` handler.
- The sourced-function tests call the installer directly, so they keep keeper cleanup.

One new test, `test_operation_restores_signal_dispositions`, proves it: for each of the three
`USR1` dispositions (default, ignored, custom) and for both a success and a failure exit, the
`USR1` listing and the `EXIT`/`TERM`/`INT` listings are byte-identical before and after the
operation, and identical again after a second `stop_heartbeat_keeper`.

A second, non-blocking finding notes that the keeper-PID assignment in the subshell exists
only for the tests. It is load-bearing for them as written, so it was deliberately left
alone — that is the remaining follow-up.

Full review: `state/evidence/889-thermo-review-20260904T2258.md` in `uwear-routines`.

## Gate status — the owed full suite has now been run

The section this replaces said the full backend fast suite was still owed against `b01a5f86`,
because the attempt wedged on a host at load 46–60. It was re-run on a quiet machine:

- Repo CI command **verbatim**, no path argument, against `b01a5f86` (the actual head):
  `pytest -m "not requires_db and not requires_browser and not live_provider" -q`
  → **5131 passed, 11 skipped, 90 deselected in 129.20s**, exit 0.
- Run **serially** in a throwaway detached worktree, load average **5.22** at start and 7.10 at
  the end, with no Codex worker live — so the number is not a contended one.
- No path argument, so `meetbot/tests` is included (`pytest.ini` sets
  `testpaths = tests meetbot/tests`, and naming a path would override both).
- `bash -n` clean on both scripts.

**The `5130` figure earlier in this body is superseded.** It was measured on `c4c03a91`. The
difference of exactly one is `test_operation_restores_signal_dispositions`, the test the second
commit adds — `tests/test_self_update_daemon.py` now collects 15.

Lanes this diff selects are `backend` and `db` (`deploy/**`, `tests/**`); `frontend` is not
selected. The `db` lane needs Postgres and was not run.

Closes #889

