### PR TITLE
fix(alerts, github-tool): claim alert filing atomically, and stop an omitted update field meaning "destroy"

### DIFF
--- a/brain/platform/db/alembic/versions/0066_provider_alert_filing_claims.py
+++ b/brain/platform/db/alembic/versions/0066_provider_alert_filing_claims.py
@@ -1,0 +1,47 @@
+"""Reserve one canonical GitHub filing per provider-alert signature.
+
+Revision ID: 0066_provider_alert_filing_claims
+Revises: 0065_enable_automatic_reclamation
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0066_provider_alert_filing_claims"
+down_revision = "0065_enable_automatic_reclamation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The public baseline already materializes current models on fresh installs.
+    if sa.inspect(op.get_bind()).has_table("provider_alert_filing_claims"):
+        return
+    op.create_table(
+        "provider_alert_filing_claims",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=False).with_variant(sa.String(), "sqlite"),
+                  sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("service", sa.String(120), nullable=False),
+        sa.Column("subsystem", sa.String(120), nullable=False),
+        sa.Column("tracked_signature", sa.String(64), nullable=False),
+        sa.Column("repo", sa.String(255), nullable=False),
+        sa.Column("state", sa.String(20), server_default=sa.text("'pending'"), nullable=False),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("issue_number", sa.Integer(), nullable=True),
+        sa.Column("issue_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("org_id", "service", "subsystem", "tracked_signature",
+                            name="uq_provider_alert_filing_signature"),
+    )
+    op.create_index("ix_provider_alert_filing_pending", "provider_alert_filing_claims", ["state", "claimed_at"])
+
+
+def downgrade() -> None:
+    if not sa.inspect(op.get_bind()).has_table("provider_alert_filing_claims"):
+        return
+    op.drop_index("ix_provider_alert_filing_pending", table_name="provider_alert_filing_claims")
+    op.drop_table("provider_alert_filing_claims")

--- a/brain/platform/db/models/provider_alert.py
+++ b/brain/platform/db/models/provider_alert.py
@@ -14,10 +14,39 @@ from brain.platform.db.base import Base, TimestampMixin
 UUIDString = UUID(as_uuid=False).with_variant(String, "sqlite")
 
 __all__ = [
+    "ProviderAlertFilingClaim",
     "ProviderAlertLedger",
     "ProviderAlertOccurrence",
     "ProviderAlertSurge",
 ]
+
+
+class ProviderAlertFilingClaim(Base, TimestampMixin):
+    """Canonical GitHub filing and expiring owner for a tracked signature."""
+
+    __tablename__ = "provider_alert_filing_claims"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "service", "subsystem", "tracked_signature",
+            name="uq_provider_alert_filing_signature",
+        ),
+        Index("ix_provider_alert_filing_pending", "state", "claimed_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUIDString, ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False,
+    )
+    service: Mapped[str] = mapped_column(String(120), nullable=False)
+    subsystem: Mapped[str] = mapped_column(String(120), nullable=False)
+    tracked_signature: Mapped[str] = mapped_column(String(64), nullable=False)
+    repo: Mapped[str] = mapped_column(String(255), nullable=False)
+    state: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default=text("'pending'"),
+    )
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    issue_url: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class ProviderAlertLedger(Base, TimestampMixin):

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -269,7 +269,8 @@ GITHUB_TOOLS = [
             "as total success. This uses the same project-bound GitHub App write identity as issue "
             "creation; the resulting GitHub issues webhook keeps configured mirrored ticket records "
             "in sync. labels_set replaces every label and is mutually exclusive with labels_add and "
-            "labels_remove."
+            "labels_remove. Empty body or labels_set values are rejected; omit them to preserve "
+            "existing content. Use clear_body or clear_labels only for an intentional clear."
         ),
         "input_schema": {
             "type": "object",
@@ -307,8 +308,16 @@ GITHUB_TOOLS = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "Replace all issue labels with this exact list; [] clears every label. "
+                        "Replace all issue labels with this non-empty list. To clear all labels, "
+                        "omit labels_set and use clear_labels: true. "
                         "Do not combine with labels_add or labels_remove."
+                    ),
+                },
+                "clear_labels": {
+                    "type": "boolean",
+                    "description": (
+                        "Explicitly remove every issue label. Omit labels_set, labels_add and "
+                        "labels_remove when true. Omit this flag to preserve labels."
                     ),
                 },
                 "state": {
@@ -322,7 +331,14 @@ GITHUB_TOOLS = [
                 },
                 "body": {
                     "type": "string",
-                    "description": "Replacement Markdown body; an empty string clears the body.",
+                    "description": (
+                        "Non-empty replacement Markdown body. To clear the body, omit body and "
+                        "use clear_body: true."
+                    ),
+                },
+                "clear_body": {
+                    "type": "boolean",
+                    "description": "Explicitly clear the issue body. Omit body when true.",
                 },
                 "token_secret_key": {
                     "type": "string",

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -202,6 +202,20 @@ GITHUB_TOOLS = [
                         "to deliver the created artifact back to a matching open request."
                     ),
                 },
+                "provider_alert": {
+                    "type": "object",
+                    "description": (
+                        "Optional deterministic provider-alert identity. Atomically reserves the initial "
+                        "filing or returns the canonical issue and appends occurrence evidence from body. "
+                        "If filing_pending is returned, retry with the same identity."
+                    ),
+                    "properties": {
+                        "service": {"type": "string", "minLength": 1, "maxLength": 120},
+                        "subsystem": {"type": "string", "minLength": 1, "maxLength": 120},
+                        "tracked_signature": {"type": "string", "minLength": 1, "maxLength": 64},
+                    },
+                    "required": ["service", "subsystem", "tracked_signature"],
+                },
                 "token_secret_key": {
                     "type": "string",
                     "description": "Optional Vault secret key holding a write-capable GitHub token for private repos.",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -1047,6 +1047,8 @@ async def _handle_update_github_issue(
     title: str | None = None,
     body: str | None = None,
     token_secret_key: str | None = None,
+    clear_body: bool = False,
+    clear_labels: bool = False,
 ) -> str:
     """Update a real GitHub issue using the issue-create App write lane."""
 
@@ -1062,6 +1064,43 @@ async def _handle_update_github_issue(
     clean_labels_add = _string_list(labels_add)
     clean_labels_remove = _string_list(labels_remove)
     clean_labels_set = _string_list(labels_set) if labels_set is not None else None
+    for field_name, value in (("clear_body", clear_body), ("clear_labels", clear_labels)):
+        if not isinstance(value, bool):
+            return json.dumps({
+                "error": f"update_github_issue {field_name} must be a boolean",
+                "status_code": 422,
+            })
+    if clear_body and body is not None:
+        return json.dumps({
+            "error": "update_github_issue clear_body cannot be combined with body; omit body",
+            "status_code": 422,
+        })
+    if clear_labels and any(value is not None for value in (labels_set, labels_add, labels_remove)):
+        return json.dumps({
+            "error": (
+                "update_github_issue clear_labels cannot be combined with labels_set, "
+                "labels_add or labels_remove; omit those fields"
+            ),
+            "status_code": 422,
+        })
+    if body is not None and not str(body).strip():
+        return json.dumps({
+            "error": (
+                "update_github_issue body must be non-empty; omit body to leave it unchanged, "
+                "or omit body and use clear_body: true to clear it"
+            ),
+            "status_code": 422,
+        })
+    if clean_labels_set == []:
+        return json.dumps({
+            "error": (
+                "update_github_issue labels_set must be non-empty; omit labels_set to leave it "
+                "unchanged, or omit labels_set and use clear_labels: true to clear all labels"
+            ),
+            "status_code": 422,
+        })
+    if clear_labels:
+        clean_labels_set = []
     clean_state = _clean(state)
     if clean_state is not None:
         clean_state = clean_state.lower()
@@ -1085,7 +1124,7 @@ async def _handle_update_github_issue(
             "error": "update_github_issue title must be non-empty when provided",
             "status_code": 422,
         })
-    clean_body = str(body) if body is not None else None
+    clean_body = "" if clear_body else (str(body) if body is not None else None)
     if clean_labels_set is not None and (clean_labels_add or clean_labels_remove):
         return json.dumps({
             "error": "update_github_issue labels_set cannot be combined with labels_add or labels_remove",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -56,6 +56,11 @@ from brain.systems.deploy_state_github import (
 )
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+from brain.systems.slack.provider_alert_filing import (
+    FilingIdentity,
+    FilingPendingError,
+    create_provider_alert_issue,
+)
 from brain.systems.vault import (
     VAULT_AGENT_ACCESS_AVAILABLE,
     async_get_secret,
@@ -657,6 +662,7 @@ async def _handle_create_github_issue(
     assignee_rationale: str | None = None,
     token_secret_key: str | None = None,
     origin_ref: str | None = None,
+    provider_alert: dict[str, Any] | None = None,
 ) -> str:
     """Open a REAL GitHub issue in the target repository.
 
@@ -683,6 +689,17 @@ async def _handle_create_github_issue(
     clean_assignee_rationale = _clean(assignee_rationale)
     effective_assignees = requested_assignees if clean_assignee_rationale else []
 
+    filing_identity = None
+    if provider_alert is not None:
+        if not isinstance(provider_alert, Mapping):
+            return json.dumps({"error": "provider_alert must be an object"})
+        try:
+            filing_identity = FilingIdentity.parse(
+                _clean(getattr(_agent_context, "org_id", None)), provider_alert,
+            )
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,
         token_secret_key=token_secret_key,
@@ -705,14 +722,16 @@ async def _handle_create_github_issue(
     auth_statuses = {401, 403, 404}
     for index, candidate in enumerate(write_candidates):
         try:
-            payload = await async_create_repo_issue(
-                repo_slug,
-                title=clean_title,
-                body=issue_body,
-                labels=_string_list(labels),
-                assignees=effective_assignees,
-                token=candidate["token"],
-            )
+            create_args = dict(title=clean_title, body=issue_body, labels=_string_list(labels),
+                               assignees=effective_assignees, token=candidate["token"])
+            if filing_identity is not None:
+                payload = await create_provider_alert_issue(
+                    filing_identity, repo_slug, title=create_args["title"], body=create_args["body"],
+                    labels=create_args["labels"], assignees=create_args["assignees"], token=create_args["token"],
+                )
+                repo_slug = payload["repo"]
+            else:
+                payload = await async_create_repo_issue(repo_slug, **create_args)
         except GitHubConnectorError as exc:
             last_error = exc
             # Retry the next token only on auth/visibility failures. A 422 is a
@@ -726,6 +745,16 @@ async def _handle_create_github_issue(
                 "no_write_token": exc.status_code in auth_statuses,
                 "repo": repo_slug,
                 "token_key_name": candidate.get("key_name"),
+                **({"filing_pending": True, "retryable": True} if filing_identity else {}),
+            })
+        except FilingPendingError as exc:
+            return json.dumps({"error": str(exc), "filing_pending": True, "retryable": True})
+        except Exception as exc:
+            if filing_identity is None:
+                raise
+            return json.dumps({
+                "error": str(exc), "filing_pending": True, "retryable": True,
+                "instruction": "Retry the same provider_alert claim; do not create another issue or tracker record.",
             })
         payload["token_secret_key_used"] = bool(candidate.get("key_name"))
         payload["token_source"] = candidate["source"]

--- a/brain/systems/slack/channel_monitor_rendering.py
+++ b/brain/systems/slack/channel_monitor_rendering.py
@@ -141,6 +141,13 @@ def slack_channel_monitor_message(
                 f"- External id: {provider_alert.get('external_id')}",
                 f"- Tracked signature: {provider_alert.get('tracked_signature')}",
                 f"- Signature title: {provider_alert.get('signature_title')}",
+                "- For create_github_issue, pass provider_alert with the service, subsystem, and "
+                "tracked_signature above. This reserves the initial filing atomically. Include this "
+                "occurrence's evidence in body. Search is only for historical deduplication.",
+                "- If filing_pending is returned, retry the same identity; do not create a second "
+                "issue or tracker record. If reused is true, use the returned canonical issue and "
+                "its existing tracker record; occurrence evidence is already appended unless the "
+                "tool reports occurrence_evidence_appended=false.",
             ]
         )
         if provider_alert.get("is_new_error"):

--- a/brain/systems/slack/provider_alert_filing.py
+++ b/brain/systems/slack/provider_alert_filing.py
@@ -1,0 +1,256 @@
+"""Atomic ownership of the initial GitHub filing for a provider-alert signature.
+
+The unique row owns the side effect, following the material-post claim-column
+pattern. Acquisition commits before calling GitHub. A fenced row lock spans the
+remote operation and finalization, so an expired, still-running owner cannot
+race its successor. Recovery uses a durable issue-body marker and the repository
+issues endpoint (including closed issues), never the search index.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import logging
+from typing import Any, Mapping
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from brain.kernel.common.time import utcnow
+from brain.platform.db.models.provider_alert import ProviderAlertFilingClaim
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
+    async_add_repo_issue_comment,
+    async_create_repo_issue,
+    async_list_repo_issues,
+)
+
+CLAIM_TTL_SECONDS = 60
+WAIT_ATTEMPTS = 60
+logger = logging.getLogger(__name__)
+
+
+class FilingPendingError(Exception):
+    """Retry the same claim; do not create another issue or tracker record."""
+
+
+@dataclass(frozen=True)
+class FilingIdentity:
+    org_id: str
+    service: str
+    subsystem: str
+    tracked_signature: str
+
+    @classmethod
+    def parse(cls, org_id: str | None, value: Mapping[str, Any]) -> FilingIdentity:
+        if not org_id:
+            raise ValueError("provider_alert requires an organization context")
+        fields = {}
+        for name, limit in (("service", 120), ("subsystem", 120), ("tracked_signature", 64)):
+            raw = value.get(name)
+            if not isinstance(raw, str) or not raw.strip() or len(raw.strip()) > limit:
+                raise ValueError(f"provider_alert requires {name} (1–{limit} characters)")
+            fields[name] = raw.strip()
+        return cls(org_id=org_id, **fields)
+
+    @property
+    def marker(self) -> str:
+        key = json.dumps([self.org_id, self.service, self.subsystem, self.tracked_signature])
+        return f"<!-- illo-provider-alert-filing:{hashlib.sha256(key.encode()).hexdigest()} -->"
+
+
+@dataclass(frozen=True)
+class FilingClaim:
+    id: int
+    repo: str
+    claimed_at: datetime | None
+    issue_number: int | None
+    issue_url: str | None
+    acquired: bool
+    reconcile: bool = False
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "issue": {"number": self.issue_number, "html_url": self.issue_url},
+            "filing_claim_id": self.id,
+            "filing_state": "filed",
+            "reused": True,
+        }
+
+
+def _snapshot(row: ProviderAlertFilingClaim, *, acquired: bool, reconcile: bool = False) -> FilingClaim:
+    return FilingClaim(row.id, row.repo, row.claimed_at, row.issue_number, row.issue_url, acquired, reconcile)
+
+
+async def acquire_filing_claim(identity: FilingIdentity, repo: str) -> FilingClaim:
+    """Insert the canonical key, then compare-and-set its expiring claim column."""
+    now = utcnow()
+    async with UnitOfWork() as uow:
+        session = uow.session
+        insert = sqlite_insert if session.get_bind().dialect.name == "sqlite" else postgresql_insert
+        key = dict(org_id=identity.org_id, service=identity.service,
+                   subsystem=identity.subsystem, tracked_signature=identity.tracked_signature)
+        await session.execute(
+            insert(ProviderAlertFilingClaim).values(**key, repo=repo)
+            .on_conflict_do_nothing(index_elements=list(key))
+        )
+        row = await session.scalar(select(ProviderAlertFilingClaim).filter_by(**key).with_for_update())
+        assert row is not None
+        if row.state == "filed":
+            return _snapshot(row, acquired=False)
+        if row.repo != repo:
+            raise ValueError(f"This provider-alert claim belongs to {row.repo}; retry with that repo")
+        reconcile = row.state == "creating"
+        # The SQL predicate also enforces arbitration in SQLite, whose FOR UPDATE
+        # is a no-op. PostgreSQL uses the same predicate plus its row lock.
+        won = await session.scalar(
+            update(ProviderAlertFilingClaim)
+            .where(
+                ProviderAlertFilingClaim.id == row.id,
+                ProviderAlertFilingClaim.state != "filed",
+                or_(ProviderAlertFilingClaim.claimed_at.is_(None),
+                    ProviderAlertFilingClaim.claimed_at <= now - timedelta(seconds=CLAIM_TTL_SECONDS)),
+            )
+            .values(claimed_at=now)
+            .returning(ProviderAlertFilingClaim.id)
+            .execution_options(synchronize_session=False)
+        )
+        await session.refresh(row)
+        return _snapshot(row, acquired=won is not None, reconcile=reconcile)
+
+
+def _owns(row: ProviderAlertFilingClaim, claim: FilingClaim) -> bool:
+    def aware(value: datetime | None) -> datetime | None:
+        return value.replace(tzinfo=timezone.utc) if value is not None and value.tzinfo is None else value
+    return (
+        claim.acquired
+        and claim.claimed_at is not None
+        and row.state != "filed"
+        and aware(row.claimed_at) == aware(claim.claimed_at)
+    )
+
+
+async def _prepare_create(claim: FilingClaim) -> None:
+    # Commit the uncertainty BEFORE the request. A crash or rollback after the
+    # request must leave a durable instruction to reconcile on the next attempt.
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is None or not _owns(row, claim):
+            raise FilingPendingError("Provider-alert filing ownership changed; retry the same claim")
+        row.state = "creating"
+        await uow.session.flush()
+
+
+async def _release_claim(claim: FilingClaim) -> None:
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is not None and _owns(row, claim):
+            row.claimed_at = None
+            await uow.session.flush()
+
+
+async def _find_filed_issue(repo: str, marker: str, token: str) -> dict[str, Any] | None:
+    cursor = None
+    while True:
+        page = await async_list_repo_issues(
+            repo, token=token, state="all", limit=100, cursor=cursor, body_limit=65536,
+        )
+        for issue in page["issues"]:
+            if marker in str(issue.get("body") or ""):
+                return {"repo": repo, "issue": issue}
+        cursor = page.get("next_page")
+        if not cursor:
+            return None
+
+
+async def _create_or_reconcile(
+    claim: FilingClaim, identity: FilingIdentity, *,
+    title: str, body: str | None, labels: list[str], assignees: list[str], token: str,
+) -> dict[str, Any]:
+    await _prepare_create(claim)
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is None or not _owns(row, claim):
+            raise FilingPendingError("Provider-alert filing ownership changed; retry the same claim")
+        payload = await _find_filed_issue(claim.repo, identity.marker, token) if claim.reconcile else None
+        reused = payload is not None
+        if payload is None:
+            payload = await async_create_repo_issue(
+                claim.repo, title=title, body=f"{identity.marker}\n\n{body or ''}",
+                labels=labels, assignees=assignees, token=token,
+            )
+        issue = payload.get("issue") or {}
+        number = issue.get("number")
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            raise ValueError("GitHub returned no issue number; retry the same provider-alert claim")
+        row.issue_number = number
+        row.issue_url = issue.get("html_url") or f"https://github.com/{claim.repo}/issues/{number}"
+        row.state = "filed"
+        row.claimed_at = None
+        await uow.session.flush()
+        payload.update(filing_claim_id=row.id, filing_state="filed", reused=reused)
+    return payload
+
+
+async def create_provider_alert_issue(
+    identity: FilingIdentity, repo: str, *,
+    title: str, body: str | None, labels: list[str], assignees: list[str], token: str,
+) -> dict[str, Any]:
+    for _ in range(WAIT_ATTEMPTS):
+        claim = await acquire_filing_claim(identity, repo)
+        if claim.issue_number is not None:
+            payload = claim.payload()
+            break
+        if claim.acquired:
+            try:
+                payload = await _create_or_reconcile(
+                    claim, identity, title=title, body=body, labels=labels, assignees=assignees, token=token,
+                )
+            except Exception as exc:
+                # A timed-out POST may still be running remotely. Keep the lease
+                # until expiry before attempting reconciliation in that case.
+                if isinstance(exc, GitHubConnectorError) and exc.status_code >= 500:
+                    raise
+                # Leave 'creating' intact. Release only our generation, and never
+                # hide the original error if even the release cannot be saved.
+                try:
+                    await _release_claim(claim)
+                except Exception:
+                    logger.exception("provider alert filing claim release failed")
+                raise
+            break
+        await _wait_for_filing()
+    else:
+        raise FilingPendingError("Provider-alert filing is in progress; retry the same claim")
+
+    if payload["reused"]:
+        evidence = body or title
+        try:
+            await async_add_repo_issue_comment(
+                payload["repo"], payload["issue"]["number"],
+                body=f"Additional provider-alert occurrence:\n\n{evidence}", token=token,
+            )
+            payload["occurrence_evidence_appended"] = True
+        except Exception as exc:
+            # Filing is already durable. Report the evidence failure without
+            # allowing token fallback to repeat the initial create.
+            payload["occurrence_evidence_appended"] = False
+            payload["occurrence_evidence_error"] = str(exc)
+    return payload
+
+
+async def _wait_for_filing() -> None:
+    await asyncio.sleep(0.25)

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -23,6 +23,8 @@ BROAD_DESTRUCTIVE_SQL_PATTERNS = (
     r"\bREASSIGN\s+OWNED\b",
 )
 REVIEWED_DESTRUCTIVE_MIGRATIONS = {
+    # Downgrade removes only the provider-alert filing claims introduced here.
+    "0066_provider_alert_filing_claims.py",
     "0003_schema_simplification.py",
     # Downgrade removes only the access table introduced by the same migration.
     "0005_project_profile_privacy.py",

--- a/tests/test_github_issue_export_contract.py
+++ b/tests/test_github_issue_export_contract.py
@@ -1,0 +1,46 @@
+"""GitHub issue edits must stay optional on the actual provider surface."""
+
+from copy import deepcopy
+
+import pytest
+
+
+@pytest.mark.parametrize("role", ["coordinator", "worker"])
+@pytest.mark.parametrize("provider", ["openai", "anthropic"])
+def test_update_issue_required_fields_survive_provider_export(role, provider):
+    from brain.platform.integrations.transports.anthropic import AnthropicMessagesTransport
+    from brain.platform.integrations.transports.openai_responses import OpenAIResponsesTransport
+    from brain.systems.runs.direct_loop.request import build_api_request
+    from brain.systems.runs.tool_catalog.definitions.github import GITHUB_TOOLS
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+
+    name = "update_github_issue"
+    declared = deepcopy(next(tool for tool in GITHUB_TOOLS if tool["name"] == name)["input_schema"])
+    runtime_tools = COORDINATOR_TOOLS if role == "coordinator" else WORKER_TOOLS
+    runtime = next(tool for tool in runtime_tools if tool["name"] == name)
+    model = "gpt-5" if provider == "openai" else "claude-sonnet-4-5"
+    request = build_api_request(
+        model=model,
+        messages=[{"role": "user", "content": "File the alert and assign its owner."}],
+        max_tokens=1024,
+        system=None,
+        tools=runtime_tools,
+        reasoning_effort=None,
+        extra_headers=None,
+        provider_name=provider,
+        session_id="issue-export-contract",
+        persist_session=True,
+        cache_tools=True,
+        operation_type="agent_run",
+    )
+    transport = OpenAIResponsesTransport() if provider == "openai" else AnthropicMessagesTransport()
+    kwargs = transport.build_kwargs(request)
+    exported = next(tool for tool in kwargs["tools"] if tool["name"] == name)
+    exported_schema = exported["parameters" if provider == "openai" else "input_schema"]
+
+    assert declared["required"] == ["repo", "issue_number"]
+    assert get_tool_registration(name).schema == declared
+    assert runtime["input_schema"] == declared
+    assert exported_schema == declared
+    print(f"{provider}/{role} update_github_issue exported required: {exported_schema['required']}")

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -80,6 +80,7 @@ EXPECTED_TABLES = {
     "project_narratives",
     "project_profile_access",
     "project_profiles",
+    "provider_alert_filing_claims",
     "provider_alert_ledger",
     "provider_alert_occurrences",
     "provider_alert_surges",

--- a/tests/test_provider_alert_filing.py
+++ b/tests/test_provider_alert_filing.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
+
+from brain.platform.db.models.provider_alert import (
+    ProviderAlertFilingClaim, ProviderAlertOccurrence, ProviderAlertSurge,
+)
+from brain.platform.provider_alerts import classify_provider_alert_ingest
+from brain.systems.cortex.project_context.github import GitHubConnectorError
+from brain.systems.runs.execution_context import bind_agent_context
+from brain.systems.runs.tool_catalog.handlers import github
+from brain.systems.slack import provider_alert_filing as filing
+from brain.systems.slack.provider_alert_surge import record_provider_alert_occurrence
+
+ORG = "4b5e2f59-4f88-4956-a660-4f544ccffbd7"
+REPO = "uwear-ai/uwear-backend"
+NOW = datetime(2026, 9, 6, 17, 49, tzinfo=timezone.utc)
+IDENTITY = filing.FilingIdentity(ORG, "uwear-api", "generation", "a" * 64)
+ISSUE = {"number": 2021, "html_url": f"https://github.com/{REPO}/issues/2021"}
+
+
+@pytest.fixture
+async def filing_store(tmp_path, monkeypatch):
+    """Real unique inserts and CAS writes, using independent SQLite sessions.
+
+    No server is needed. The production PostgreSQL row locks additionally prevent
+    lease takeover while an active owner is inside the remote side effect.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'filing.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        for model in (ProviderAlertFilingClaim, ProviderAlertOccurrence, ProviderAlertSurge):
+            await connection.execute(CreateTable(model.__table__))
+    control = {"now": NOW, "fail_commit": False}
+
+    class TestUnitOfWork:
+        async def __aenter__(self):
+            self.session = sessions()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            try:
+                if exc_type:
+                    await self.session.rollback()
+                elif control["fail_commit"]:
+                    control["fail_commit"] = False
+                    await self.session.rollback()
+                    raise RuntimeError("local finalization failed")
+                else:
+                    await self.session.commit()
+            finally:
+                await self.session.close()
+
+    monkeypatch.setattr(filing, "UnitOfWork", TestUnitOfWork)
+    monkeypatch.setattr(filing, "utcnow", lambda: control["now"])
+    monkeypatch.setattr(github, "_github_token_candidates", AsyncMock(return_value=[
+        {"token": "test-token", "source": "test", "key_name": None},
+    ]))
+    monkeypatch.setattr(filing, "async_add_repo_issue_comment", AsyncMock(return_value={}))
+    monkeypatch.setattr(filing, "async_list_repo_issues", AsyncMock(return_value={"issues": []}))
+    try:
+        yield sessions, control
+    finally:
+        await engine.dispose()
+
+
+async def _file(identity=IDENTITY, *, body="Occurrence evidence"):
+    with bind_agent_context({"user_id": "test-user", "org_id": identity.org_id}):
+        return json.loads(await github._handle_create_github_issue(
+            repo=REPO, title="Generation failed", body=body,
+            provider_alert={"service": identity.service, "subsystem": identity.subsystem,
+                            "tracked_signature": identity.tracked_signature},
+        ))
+
+
+@pytest.mark.asyncio
+async def test_four_messages_force_claim_conflict_and_share_one_ticket(filing_store, monkeypatch):
+    sessions, _ = filing_store
+    for index in range(4):
+        alert = classify_provider_alert_ingest(
+            f"<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/{2278 + index}|"
+            f"#{2278 + index} New error: TimeoutError: Garment description generation timed out>"
+        )
+        assert alert is not None
+        async with sessions.begin() as session:
+            await record_provider_alert_occurrence(
+                session, org_id=ORG, channel_id="C_ALERTS", message_ts=f"1788716940.{index}",
+                alert=alert, occurred_at=NOW,
+            )
+    identity = filing.FilingIdentity(ORG, alert.service, alert.subsystem, alert.signature)
+    all_contended, owner_done = asyncio.Event(), asyncio.Event()
+    acquired = filing.acquire_filing_claim
+    losers = set()
+
+    async def observe_claim(*args):
+        claim = await acquired(*args)
+        if not claim.acquired and claim.issue_number is None:
+            losers.add(asyncio.current_task())
+            if len(losers) == 3:
+                all_contended.set()
+        return claim
+
+    async def create(*args, **kwargs):
+        await all_contended.wait()
+        return {"repo": REPO, "issue": dict(ISSUE)}
+
+    monkeypatch.setattr(filing, "acquire_filing_claim", observe_claim)
+    monkeypatch.setattr(filing, "_wait_for_filing", owner_done.wait)
+    create_mock = AsyncMock(side_effect=create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create_mock)
+
+    async def run(index):
+        result = await _file(identity, body=f"Message 1788716940.{index}, Rollbar #{2278 + index}")
+        if result.get("reused") is False:
+            owner_done.set()
+        return result
+
+    results = await asyncio.wait_for(asyncio.gather(*(run(i) for i in range(4))), timeout=10)
+    assert len(losers) == 3  # All three went through the losing DB-write path.
+    create_mock.assert_awaited_once()
+    assert identity.marker in create_mock.await_args.kwargs["body"]
+    assert {r["issue"]["number"] for r in results} == {2021}
+    assert {r["filing_claim_id"] for r in results} == {results[0]["filing_claim_id"]}
+    assert all(r["mutated_target_refs"] == [{"kind": "github_issue", "id": f"{REPO}#2021"}] for r in results)
+    # Only the initial owner may create the associated tracker record. The other
+    # three receive explicit reuse results and the same canonical external ref.
+    assert sum(not result["reused"] for result in results) == 1
+    assert filing.async_add_repo_issue_comment.await_count == 3
+    async with sessions() as session:
+        occurrences = (await session.scalars(select(ProviderAlertOccurrence))).all()
+        claims = (await session.scalars(select(ProviderAlertFilingClaim))).all()
+    assert len(occurrences) == 4
+    assert len({o.slack_message_ts for o in occurrences}) == 4
+    assert len({o.external_id for o in occurrences}) == 4
+    assert len({o.signature for o in occurrences}) == 1
+    assert len(claims) == 1
+    assert (claims[0].repo, claims[0].issue_number, claims[0].issue_url, claims[0].state) == (
+        REPO, 2021, ISSUE["html_url"], "filed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dead_owner_before_create_is_replaced_after_expiry(filing_store, monkeypatch):
+    _, control = filing_store
+    dead = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert dead.acquired
+    assert not (await filing.acquire_filing_claim(IDENTITY, REPO)).acquired
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["issue"]["number"] == 2021
+    assert result["filing_claim_id"] == dead.id
+    create.assert_awaited_once()
+    filing.async_list_repo_issues.assert_not_awaited()
+    with pytest.raises(filing.FilingPendingError):
+        await filing._create_or_reconcile(
+            dead, IDENTITY, title="Generation failed", body="Occurrence evidence",
+            labels=[], assignees=[], token="test-token",
+        )
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["commit", "process_death"])
+async def test_create_survives_failed_finalization_and_reconciles(filing_store, monkeypatch, failure):
+    sessions, control = filing_store
+    remote = []
+
+    async def create(*args, **kwargs):
+        remote.append({**ISSUE, "body": kwargs["body"], "state": "closed"})
+        if failure == "process_death":
+            raise asyncio.CancelledError()
+        control["fail_commit"] = True
+        return {"repo": REPO, "issue": dict(ISSUE)}
+
+    create_mock = AsyncMock(side_effect=create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create_mock)
+    if failure == "process_death":
+        with pytest.raises(asyncio.CancelledError):
+            await _file()
+        control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    else:
+        assert (await _file())["filing_pending"] is True
+    async with sessions() as session:
+        row = await session.scalar(select(ProviderAlertFilingClaim))
+        assert row.state == "creating"
+        assert row.issue_number is None
+
+    # Force pagination, and ensure even a closed issue on a later page is found.
+    filing.async_list_repo_issues.side_effect = [
+        {"issues": [{"number": 900, "body": "unrelated"}], "next_page": "page-two"},
+        {"issues": remote},
+    ]
+    result = await _file(body="Retried occurrence")
+    assert result["reused"] is True
+    assert result["issue"]["number"] == 2021
+    create_mock.assert_awaited_once()
+    assert filing.async_list_repo_issues.await_args_list[1].kwargs["cursor"] == "page-two"
+    assert all(c.kwargs["state"] == "all" for c in filing.async_list_repo_issues.await_args_list)
+    async with sessions() as session:
+        row = await session.scalar(select(ProviderAlertFilingClaim))
+        assert row.state == "filed"
+        assert row.issue_url == ISSUE["html_url"]
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_cannot_release_or_prepare_successors_claim(filing_store):
+    _, control = filing_store
+    first = await filing.acquire_filing_claim(IDENTITY, REPO)
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    successor = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert successor.acquired
+    await filing._release_claim(first)
+    with pytest.raises(filing.FilingPendingError):
+        await filing._prepare_create(first)
+    current = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert not current.acquired
+    assert current.claimed_at == successor.claimed_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("org_id", "e54e4e0d-ac19-42dd-b356-9735ce68ae23"),
+    ("service", "other-service"), ("subsystem", "other-subsystem"), ("tracked_signature", "b" * 64),
+])
+async def test_filing_identity_is_scoped_by_all_four_fields(filing_store, field, value):
+    first = await filing.acquire_filing_claim(IDENTITY, REPO)
+    other = await filing.acquire_filing_claim(replace(IDENTITY, **{field: value}), REPO)
+    assert first.acquired and other.acquired
+    assert first.id != other.id
+
+
+@pytest.mark.asyncio
+async def test_pending_claim_does_not_fall_through_to_unclaimed_create(filing_store, monkeypatch):
+    await filing.acquire_filing_claim(IDENTITY, REPO)
+    monkeypatch.setattr(filing, "WAIT_ATTEMPTS", 1)
+    monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
+    create = AsyncMock()
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["filing_pending"] and result["retryable"]
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_reconciliation_never_creates_blindly(filing_store, monkeypatch):
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    await filing._prepare_create(claim)
+    await filing._release_claim(claim)
+    filing.async_list_repo_issues.side_effect = GitHubConnectorError(status_code=502, message="unavailable")
+    create = AsyncMock()
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["status_code"] == 502
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_post_keeps_lease_and_reconciles_after_expiry(filing_store, monkeypatch):
+    _, control = filing_store
+    create = AsyncMock(side_effect=GitHubConnectorError(status_code=502, message="timed out"))
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "WAIT_ATTEMPTS", 1)
+    monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
+    assert (await _file())["filing_pending"]
+    assert (await _file())["filing_pending"]
+    create.assert_awaited_once()
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    filing.async_list_repo_issues.return_value = {"issues": [{**ISSUE, "body": IDENTITY.marker}]}
+    assert (await _file())["issue"]["number"] == 2021
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_repo_cannot_be_changed_by_another_run(filing_store, monkeypatch):
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    with pytest.raises(ValueError, match="belongs to"):
+        await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
+    await filing._release_claim(claim)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    await _file()
+    canonical = await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
+    assert canonical.repo == REPO
+    assert canonical.issue_number == 2021
+    assert not canonical.acquired
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_reconciliation_match_allows_retry_before_remote_create(filing_store, monkeypatch):
+    _, control = filing_store
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    await filing._prepare_create(claim)  # Crash immediately before the POST.
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    assert (await _file())["issue"]["number"] == 2021
+    filing.async_list_repo_issues.assert_awaited_once()
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_evidence_failure_preserves_canonical_filing(filing_store, monkeypatch):
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    await _file()
+    filing.async_add_repo_issue_comment.side_effect = GitHubConnectorError(status_code=403, message="denied")
+    result = await _file()
+    assert result["reused"]
+    assert result["occurrence_evidence_appended"] is False
+    assert result["issue"]["number"] == 2021
+    create.assert_awaited_once()
+
+
+def test_provider_alert_argument_is_optional_and_validates_only_when_supplied():
+    from brain.systems.runs.tool_catalog.definitions.github import GITHUB_TOOLS
+    definition = next(t for t in GITHUB_TOOLS if t["name"] == "create_github_issue")
+    assert "provider_alert" in definition["input_schema"]["properties"]
+    assert definition["input_schema"]["required"] == ["repo", "title"]
+    with pytest.raises(ValueError, match="tracked_signature"):
+        filing.FilingIdentity.parse(ORG, {"service": "api", "subsystem": "jobs"})
+
+
+@pytest.mark.asyncio
+async def test_malformed_identity_cannot_create_an_unclaimed_issue(filing_store, monkeypatch):
+    create = AsyncMock()
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
+    with bind_agent_context({"org_id": ORG}):
+        result = json.loads(await github._handle_create_github_issue(
+            repo=REPO, title="Failure", provider_alert={"service": "api"},
+        ))
+    assert "error" in result
+    create.assert_not_awaited()

--- a/tests/test_update_github_issue_tool.py
+++ b/tests/test_update_github_issue_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -11,7 +12,10 @@ from brain.systems.cortex.project_context.github import (
 )
 from brain.systems.runs.execution_context import bind_agent_context
 from brain.systems.runs.tool_catalog.definitions.github import GITHUB_TOOLS
-from brain.systems.runs.tool_catalog.handlers.github import _handle_update_github_issue
+from brain.systems.runs.tool_catalog.handlers.github import (
+    _handle_add_github_issue_comment,
+    _handle_update_github_issue,
+)
 
 
 _C = "brain.systems.cortex.project_context.github"
@@ -60,6 +64,8 @@ def test_update_github_issue_is_registered_with_all_supported_fields():
         "state",
         "title",
         "body",
+        "clear_body",
+        "clear_labels",
     } <= properties.keys()
     assert properties["state"]["enum"] == ["open", "closed"]
     assert "Only repo and issue_number are required" in definition["description"]
@@ -318,6 +324,152 @@ async def test_handler_rejects_placeholder_text_without_writing(field_name, valu
     assert f"omit {field_name} to leave it unchanged" in payload["error"]
     candidates.assert_not_awaited()
     update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fields", [
+    {"body": ""},
+    {"body": " \n\t"},
+    {"labels_set": []},
+    {"labels_set": [" "]},
+    {"labels_set": ""},
+    {"body": "", "labels_set": []},
+    {"clear_body": "true"},
+    {"clear_labels": 1},
+    {"clear_body": True, "body": "replacement"},
+    {"clear_body": True, "body": ""},
+    {"clear_labels": True, "labels_set": []},
+    {"clear_labels": True, "labels_add": ["bug"]},
+    {"clear_labels": True, "labels_remove": ["bug"]},
+])
+async def test_handler_rejects_ambiguous_clears_before_any_write(fields):
+    with patch(f"{_H}._github_token_candidates", new=AsyncMock()) as candidates, patch(
+        f"{_H}.async_update_repo_issue", new=AsyncMock(),
+    ) as update:
+        payload = json.loads(await _handle_update_github_issue(
+            repo="Illospace/illospace", issue_number=369,
+            assignees_add=["new-owner"], **fields,
+        ))
+
+    assert payload["status_code"] == 422
+    assert "omit" in payload["error"] or "must be a boolean" in payload["error"]
+    candidates.assert_not_awaited()
+    update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("fields", "changed", "delta"), [
+    ({"assignees_add": ["new-owner"]}, "assignees", [{"login": "new-owner", "id": 99}]),
+    ({"labels_add": ["triaged"]}, "labels", [{"name": "triaged", "color": "654321"}]),
+    ({"state": "open"}, "state", "open"),
+    ({"body": "New occurrence\n\nEvidence: alert 4"}, "comments", None),
+])
+async def test_enrichment_preserves_all_unrequested_issue_fields(fields, changed, delta):
+    # Model GitHub's mutations, so accidental PATCH defaults actually destroy the
+    # fixture and fail the assertion instead of being hidden by a static GET mock.
+    issue = _updated_issue(assignees=["existing-owner"], labels=["bug", "production"])
+    issue["body"] = "## Failure\n\n  Exact spacing.\n```\nstack trace\n```\n" * 50
+    before = deepcopy(issue)
+    comments = []
+
+    async def request(_client, method, path, **kwargs):
+        data = kwargs.get("json") or {}
+        if method == "GET":
+            return deepcopy(issue)
+        if path.endswith("/comments") and method == "POST":
+            comments.append(data["body"])
+            return {"id": 1234, "body": data["body"]}
+        if path.endswith("/assignees") and method == "POST":
+            issue["assignees"].extend({"login": login, "id": 99} for login in data["assignees"])
+        elif path.endswith("/labels") and method in {"POST", "PUT"}:
+            labels = [{"name": label, "color": "654321"} for label in data["labels"]]
+            if method == "PUT":
+                issue["labels"] = labels
+            else:
+                issue["labels"].extend(labels)
+        elif method == "PATCH":
+            issue.update(data)
+        else:
+            pytest.fail(f"Unexpected GitHub operation: {method} {path}")
+        return deepcopy(issue)
+
+    handler = _handle_add_github_issue_comment if changed == "comments" else _handle_update_github_issue
+    with patch(f"{_H}._github_token_candidates", new=AsyncMock(return_value=[{
+        "token": "installation-token", "source": "project_binding:GITHUB_TOKEN",
+    }])), patch(f"{_C}._async_request", new=AsyncMock(side_effect=request)):
+        payload = json.loads(await handler(repo="Illospace/illospace", issue_number=369, **fields))
+
+    expected = deepcopy(before)
+    if changed in {"assignees", "labels"}:
+        expected[changed].extend(delta)
+    elif changed == "state":
+        expected[changed] = delta
+    if changed == "comments":
+        assert comments == [fields["body"]]
+        assert payload["comment"]["id"] == 1234
+    else:
+        assert comments == []
+        assert payload["status"] == "applied"
+    assert issue == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("flag", "field", "value", "method", "suffix"), [
+    ("clear_body", "body", "", "PATCH", ""),
+    ("clear_labels", "labels_set", [], "PUT", "/labels"),
+])
+async def test_handler_explicit_clear_is_applied_and_verified(flag, field, value, method, suffix):
+    read_back = _updated_issue()
+    read_back["body" if field == "body" else "labels"] = value
+    with patch(f"{_H}._github_token_candidates", new=AsyncMock(return_value=[{
+        "token": "installation-token", "source": "project_binding:GITHUB_TOKEN",
+    }])), patch(f"{_C}._async_request", new=AsyncMock(side_effect=[{}, read_back])) as request:
+        payload = json.loads(await _handle_update_github_issue(
+            repo="Illospace/illospace", issue_number=369, **{flag: True},
+        ))
+
+    assert payload["ok"] is True
+    assert payload["applied"] == {field: value}
+    assert payload["fields"][field]["verified"] is True
+    assert request.await_args_list[0].args[1:] == (
+        method, f"/repos/Illospace/illospace/issues/369{suffix}",
+    )
+    assert request.await_args_list[0].kwargs["json"] == {
+        "body" if field == "body" else "labels": value,
+    }
+    assert request.await_args_list[1].args[1] == "GET"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("fields", "verified_field", "returned"), [
+    ({"title": "Requested title"}, "title", {"title": "Stale title"}),
+    ({"body": "Requested body\n"}, "body", {"body": "Requested body"}),
+    ({"body": "Full incident report"}, "body", {"body": "Filed by Illo"}),
+    ({"labels_set": ["triaged"]}, "labels_set", {"labels": [{"name": "triaged"}, {"name": "stale"}]}),
+    ({"labels_set": ["triaged"]}, "labels_set", {"labels": []}),
+    ({"clear_body": True}, "body", {"body": "Still present"}),
+    ({"clear_labels": True}, "labels_set", {"labels": [{"name": "stale"}]}),
+])
+async def test_handler_reports_partial_failure_when_replacement_is_not_confirmed(fields, verified_field, returned):
+    read_back = {**_updated_issue(assignees=["new-owner"]), **returned}
+
+    async def request(_client, method, _path, **_kwargs):
+        return read_back if method == "GET" else {}
+
+    with patch(f"{_H}._github_token_candidates", new=AsyncMock(return_value=[{
+        "token": "installation-token", "source": "project_binding:GITHUB_TOKEN",
+    }])), patch(f"{_C}._async_request", new=AsyncMock(side_effect=request)):
+        payload = json.loads(await _handle_update_github_issue(
+            repo="Illospace/illospace", issue_number=369,
+            assignees_add=["new-owner"], **fields,
+        ))
+
+    assert payload["ok"] is False
+    assert payload["partial"] is True
+    assert payload["status"] == "partial"
+    assert payload["applied"] == {"assignees_add": ["new-owner"]}
+    assert payload["failed"][verified_field]["verified"] is False
+    assert payload["failed"][verified_field]["status_code"] == 502
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #892.

**This PR changed shape after it was opened.** It originally carried only the
second of #892's two defects, and its stacked child #894 carried the first. #894
merged into this branch on 2026-09-07 at 15:16Z, so this single PR now carries
**both** halves and closes the issue on merge. The train is gone — there is one
click here, not two.

| commit | half | what it fixes |
|---|---|---|
| `ceb89e0e` | Part B | an omitted update field could mean "destroy" |
| `cfabf6ab` | Part A | the provider-alert filing claim was not atomic |

## Part A — three runs each filed their own issue for one alert

Four simultaneous Rollbar messages for one production failure shared the exact
tracked signature. Three independent runs each completed a read-before-write
duplicate search, each saw "no match", and each opened a real GitHub issue:
`uwear-ai/uwear-backend#2021`, `#2022`, `#2023`. Domain 1 gained three tracker
records for one fault.

The provider ledger already had the right stable key and did not own the side
effect. A search is not a lock.

This adds an atomic filing claim on `(org_id, service, subsystem,
tracked_signature)` — new table via migration `0066_provider_alert_filing_claims`,
logic in `brain/systems/slack/provider_alert_filing.py`. Exactly one run owns the
GitHub create. Others wait for the canonical issue and append occurrence evidence.
The claim is durable and leased, so a run that dies before or after the create
does not strand the alert and does not file twice.

`main` already carried a same-signature **admission** fence from #620. That fence
guards admission; the filing side effect happened later and unguarded, which is
why it did not stop this incident.

## Part B — an omitted update field could mean "destroy"

On 2026-09-06 an assignee-only enrichment call **cleared the body and labels** of
`uwear-ai/uwear-backend#2022`, and `#2023` was observed carrying only its
43-character provenance banner. Both were repaired by hand afterwards.

`_handle_update_github_issue` applied every non-`None` field independently, so the
values a caller synthesizes when it believes a field is mandatory both carried
destructive meaning: `body=""` replaced the body with nothing, and `labels_set=[]`
replaced every label with none.

Destruction is now unreachable by accident and still reachable on purpose:

- `body=""` and `labels_set=[]` are **rejected** with a 422 that names the alternative.
- Clearing is explicit: `clear_body: true`, `clear_labels: true`.
- Each flag refuses to be combined with the field it replaces, so there is one way
  to express each intent.

### The issue's other hypothesis was wrong, and this PR proves it

#892 says *"the live agent-facing tool schema currently presents every update field
as mandatory"*. **They are already optional.** Measured through both transports and
both tool sets, the exported schema carries `required: ["repo", "issue_number"]` —
identical to the checked-in definition. The two functions that do force every
property into `required` (`brain/systems/memory/truth_maintenance.py:915`,
`brain/systems/sessions/harvest_extraction.py:520`) serve memory structured outputs
and never receive the GitHub tool schema.

`tests/test_github_issue_export_contract.py` pins this so the hypothesis cannot come
back unmeasured.

## Why this closes #892

All seven of the issue's expected behaviors are covered, and all six of its
acceptance tests exist:

| # | expected behavior | where |
|---|---|---|
| 1–3 | atomic claim, single create owner, durable claim + lease expiry | Part A |
| 4 | search is not the lock | Part A |
| 5–6 | update fields optional end to end; no synthetic destructive defaults | Part B |
| 7 | read back the requested postcondition, report partial failure | already on `main` (`brain/systems/cortex/project_context/github.py:2683`) |

Acceptance tests, by name in `tests/test_provider_alert_filing.py`:
`test_four_messages_force_claim_conflict_and_share_one_ticket` (four concurrent
messages, one create), `test_dead_owner_before_create_is_replaced_after_expiry`
(crash before create, expired lease, exactly one create),
`test_create_survives_failed_finalization_and_reconciles` (create then local
finalization failure reconciles instead of re-creating). The update-path scenarios
are in `tests/test_update_github_issue_tool.py`, and the schema contract test is
`tests/test_github_issue_export_contract.py`.

## Verification

Repo CI command verbatim from `.github/workflows/brain-ci.yml`, no path argument so
`meetbot/tests` is included:

```
python3 -m pytest -m "not requires_db and not requires_browser and not live_provider" -q
```

Measured on this PR's head `cfabf6ab` — the exact commit you would merge:

| | this PR (`cfabf6ab`) | clean `origin/main` (`0fa3e0e6`) |
|---|---|---|
| passed | **5176** | 5130 |
| failed | 2 | **1** |
| collected | 5178 | 5131 |
| wall clock | 110.5s | 108.0s |

**The two reds are machine artifacts, not this diff — proven, not assumed.**
`tests/test_safe_deploy.py::test_worker_restart_policy_suspension_is_restored_when_a_deploy_is_interrupted[HUP-1-129]`
fails **identically on unmodified `origin/main`**, which is the baseline column
above. `tests/test_self_update_daemon.py::test_keeper_stops_when_controller_stops[2]`
failed here and not on the baseline; both pass in isolation on this same tree
(`7 passed in 1.23s`). Both tests exercise the deploy and
self-update daemons — neither touches alert filing or the GitHub tool surface this PR
changes.

To be precise about what that evidence does and does not establish: it shows these two
tests are **nondeterministic**, and it rules out this diff as the cause. It does not
establish *why* they flake. Load is the usual suspect here and was 4.4–5.3 throughout,
but this run did not isolate it, so treat the mechanism as unproven and the "not this
diff" conclusion as the claim that matters.

The +47 collected delta reconciles against the new tests: `test_provider_alert_filing.py`
(new, 13 tests), `test_github_issue_export_contract.py` (new), and the additions to
`test_update_github_issue_tool.py`.

`alembic heads` prints exactly one: `0066_provider_alert_filing_claims`. The diff
touches no `frontend/**` file, so that CI lane does not apply.

## How to judge it without reading the diff

Part B is a tool contract, so exercise it:

1. Call `update_github_issue` with only `repo`, `issue_number` and `assignees_add`.
   Title, body, labels and state must come back byte-for-byte unchanged.
2. Call it with `body: ""`. It must fail with a 422 telling you to omit `body` or use
   `clear_body`, and the issue must be untouched.
3. Call it with `clear_body: true` and no `body`. The body must actually clear — the
   escape hatch has to work, or this trades one bug for another.
4. Call it with both `clear_labels: true` and `labels_set: [...]`. It must refuse
   rather than pick one.

Part A needs a real concurrent alert to exercise by hand. The closest honest check is
the first test named above, which forces the claim conflict directly.

## Known follow-up, already filed

A code-quality pass on Part A returned one **BLOCKING** maintainability finding that
was deliberately **not** folded here, so this PR's verified gate stays attached to an
unchanged commit: `_handle_create_github_issue` now runs two error policies
interleaved in one token-fallback loop, branching on `filing_identity` in three
places. Filed as #895 rather than left inside a merged PR body.

Part B's review returned APPROVE_WITH_NOTES. Its one note is test organization only:
`tests/test_update_github_issue_tool.py:365` exercises comment preservation and
belongs in `tests/test_add_github_issue_comment_tool.py`. No shipped behavior.

Three NOTE-level findings on Part A stay recorded and unfixed: `claimed_at` doubling
as lease age and generation identity, the undocumented 60s lease against the ~15s wait
budget, and the body-marker serialization being an implicit external contract.

**Roles, stated plainly:** Codex authored both diffs, and a second Codex pass ran the
maintainability rubric — those two are same-family, so the rubric is not an
independent check of the author. The cross-family element is the Claude director
review: the stated cause was verified against `origin/main` before dispatch, the diffs
were read directly, the acceptance coverage above was probed with positive and
negative controls, and every gate number in this section was measured by the director,
not carried from a worker.


---

## Merge order and merge method (added 2026-09-09)

The "the train is gone" note above is about #894 and #892's two halves. It is not
the whole picture: **PR #896 is stacked on this branch** and is a second click,
for a different issue.

Merge this one with **"Create a merge commit"** or **"Rebase and merge"** — **not
"Squash and merge"** — then merge #896. Two independent reasons, both measured on
2026-09-09:

1. This PR **adds** 4 files, and #896's branch adds those same 4 plus one more.
   A squash rewrites this branch's history, so #896 would then land add/add
   conflicts on all four.
2. #896's body carries no linking keyword of its own; its link to its issue lives
   only in commit `cd2befb1`'s message, which a squash rewrites.

Gate re-run on #896's tip (`596e5cef`, tree `010dfd09`) on 2026-09-09: 5178
passed, 11 skipped, 0 failed; `alembic heads` prints exactly one.
