### PR TITLE
fix(alerts): make the provider-alert filing claim atomic

### DIFF
--- a/brain/platform/db/alembic/versions/0066_provider_alert_filing_claims.py
+++ b/brain/platform/db/alembic/versions/0066_provider_alert_filing_claims.py
@@ -1,0 +1,47 @@
+"""Reserve one canonical GitHub filing per provider-alert signature.
+
+Revision ID: 0066_provider_alert_filing_claims
+Revises: 0065_enable_automatic_reclamation
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0066_provider_alert_filing_claims"
+down_revision = "0065_enable_automatic_reclamation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The public baseline already materializes current models on fresh installs.
+    if sa.inspect(op.get_bind()).has_table("provider_alert_filing_claims"):
+        return
+    op.create_table(
+        "provider_alert_filing_claims",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=False).with_variant(sa.String(), "sqlite"),
+                  sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("service", sa.String(120), nullable=False),
+        sa.Column("subsystem", sa.String(120), nullable=False),
+        sa.Column("tracked_signature", sa.String(64), nullable=False),
+        sa.Column("repo", sa.String(255), nullable=False),
+        sa.Column("state", sa.String(20), server_default=sa.text("'pending'"), nullable=False),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("issue_number", sa.Integer(), nullable=True),
+        sa.Column("issue_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("org_id", "service", "subsystem", "tracked_signature",
+                            name="uq_provider_alert_filing_signature"),
+    )
+    op.create_index("ix_provider_alert_filing_pending", "provider_alert_filing_claims", ["state", "claimed_at"])
+
+
+def downgrade() -> None:
+    if not sa.inspect(op.get_bind()).has_table("provider_alert_filing_claims"):
+        return
+    op.drop_index("ix_provider_alert_filing_pending", table_name="provider_alert_filing_claims")
+    op.drop_table("provider_alert_filing_claims")

--- a/brain/platform/db/models/provider_alert.py
+++ b/brain/platform/db/models/provider_alert.py
@@ -14,10 +14,39 @@ from brain.platform.db.base import Base, TimestampMixin
 UUIDString = UUID(as_uuid=False).with_variant(String, "sqlite")
 
 __all__ = [
+    "ProviderAlertFilingClaim",
     "ProviderAlertLedger",
     "ProviderAlertOccurrence",
     "ProviderAlertSurge",
 ]
+
+
+class ProviderAlertFilingClaim(Base, TimestampMixin):
+    """Canonical GitHub filing and expiring owner for a tracked signature."""
+
+    __tablename__ = "provider_alert_filing_claims"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "service", "subsystem", "tracked_signature",
+            name="uq_provider_alert_filing_signature",
+        ),
+        Index("ix_provider_alert_filing_pending", "state", "claimed_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUIDString, ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False,
+    )
+    service: Mapped[str] = mapped_column(String(120), nullable=False)
+    subsystem: Mapped[str] = mapped_column(String(120), nullable=False)
+    tracked_signature: Mapped[str] = mapped_column(String(64), nullable=False)
+    repo: Mapped[str] = mapped_column(String(255), nullable=False)
+    state: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default=text("'pending'"),
+    )
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    issue_url: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class ProviderAlertLedger(Base, TimestampMixin):

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -202,6 +202,20 @@ GITHUB_TOOLS = [
                         "to deliver the created artifact back to a matching open request."
                     ),
                 },
+                "provider_alert": {
+                    "type": "object",
+                    "description": (
+                        "Optional deterministic provider-alert identity. Atomically reserves the initial "
+                        "filing or returns the canonical issue and appends occurrence evidence from body. "
+                        "If filing_pending is returned, retry with the same identity."
+                    ),
+                    "properties": {
+                        "service": {"type": "string", "minLength": 1, "maxLength": 120},
+                        "subsystem": {"type": "string", "minLength": 1, "maxLength": 120},
+                        "tracked_signature": {"type": "string", "minLength": 1, "maxLength": 64},
+                    },
+                    "required": ["service", "subsystem", "tracked_signature"],
+                },
                 "token_secret_key": {
                     "type": "string",
                     "description": "Optional Vault secret key holding a write-capable GitHub token for private repos.",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -56,6 +56,11 @@ from brain.systems.deploy_state_github import (
 )
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+from brain.systems.slack.provider_alert_filing import (
+    FilingIdentity,
+    FilingPendingError,
+    create_provider_alert_issue,
+)
 from brain.systems.vault import (
     VAULT_AGENT_ACCESS_AVAILABLE,
     async_get_secret,
@@ -657,6 +662,7 @@ async def _handle_create_github_issue(
     assignee_rationale: str | None = None,
     token_secret_key: str | None = None,
     origin_ref: str | None = None,
+    provider_alert: dict[str, Any] | None = None,
 ) -> str:
     """Open a REAL GitHub issue in the target repository.
 
@@ -683,6 +689,17 @@ async def _handle_create_github_issue(
     clean_assignee_rationale = _clean(assignee_rationale)
     effective_assignees = requested_assignees if clean_assignee_rationale else []
 
+    filing_identity = None
+    if provider_alert is not None:
+        if not isinstance(provider_alert, Mapping):
+            return json.dumps({"error": "provider_alert must be an object"})
+        try:
+            filing_identity = FilingIdentity.parse(
+                _clean(getattr(_agent_context, "org_id", None)), provider_alert,
+            )
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,
         token_secret_key=token_secret_key,
@@ -705,14 +722,15 @@ async def _handle_create_github_issue(
     auth_statuses = {401, 403, 404}
     for index, candidate in enumerate(write_candidates):
         try:
-            payload = await async_create_repo_issue(
-                repo_slug,
-                title=clean_title,
-                body=issue_body,
-                labels=_string_list(labels),
-                assignees=effective_assignees,
-                token=candidate["token"],
-            )
+            create_args = dict(title=clean_title, body=issue_body, labels=_string_list(labels),
+                               assignees=effective_assignees, token=candidate["token"])
+            if filing_identity is not None:
+                payload = await create_provider_alert_issue(
+                    filing_identity, repo_slug, create_issue=async_create_repo_issue, **create_args,
+                )
+                repo_slug = payload["repo"]
+            else:
+                payload = await async_create_repo_issue(repo_slug, **create_args)
         except GitHubConnectorError as exc:
             last_error = exc
             # Retry the next token only on auth/visibility failures. A 422 is a
@@ -726,6 +744,16 @@ async def _handle_create_github_issue(
                 "no_write_token": exc.status_code in auth_statuses,
                 "repo": repo_slug,
                 "token_key_name": candidate.get("key_name"),
+                **({"filing_pending": True, "retryable": True} if filing_identity else {}),
+            })
+        except FilingPendingError as exc:
+            return json.dumps({"error": str(exc), "filing_pending": True, "retryable": True})
+        except Exception as exc:
+            if filing_identity is None:
+                raise
+            return json.dumps({
+                "error": str(exc), "filing_pending": True, "retryable": True,
+                "instruction": "Retry the same provider_alert claim; do not create another issue or tracker record.",
             })
         payload["token_secret_key_used"] = bool(candidate.get("key_name"))
         payload["token_source"] = candidate["source"]

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -726,7 +726,8 @@ async def _handle_create_github_issue(
                                assignees=effective_assignees, token=candidate["token"])
             if filing_identity is not None:
                 payload = await create_provider_alert_issue(
-                    filing_identity, repo_slug, create_issue=async_create_repo_issue, **create_args,
+                    filing_identity, repo_slug, title=create_args["title"], body=create_args["body"],
+                    labels=create_args["labels"], assignees=create_args["assignees"], token=create_args["token"],
                 )
                 repo_slug = payload["repo"]
             else:

--- a/brain/systems/slack/channel_monitor_rendering.py
+++ b/brain/systems/slack/channel_monitor_rendering.py
@@ -141,6 +141,13 @@ def slack_channel_monitor_message(
                 f"- External id: {provider_alert.get('external_id')}",
                 f"- Tracked signature: {provider_alert.get('tracked_signature')}",
                 f"- Signature title: {provider_alert.get('signature_title')}",
+                "- For create_github_issue, pass provider_alert with the service, subsystem, and "
+                "tracked_signature above. This reserves the initial filing atomically. Include this "
+                "occurrence's evidence in body. Search is only for historical deduplication.",
+                "- If filing_pending is returned, retry the same identity; do not create a second "
+                "issue or tracker record. If reused is true, use the returned canonical issue and "
+                "its existing tracker record; occurrence evidence is already appended unless the "
+                "tool reports occurrence_evidence_appended=false.",
             ]
         )
         if provider_alert.get("is_new_error"):

--- a/brain/systems/slack/provider_alert_filing.py
+++ b/brain/systems/slack/provider_alert_filing.py
@@ -1,0 +1,252 @@
+"""Atomic ownership of the initial GitHub filing for a provider-alert signature.
+
+The unique row owns the side effect, following the material-post claim-column
+pattern. Acquisition commits before calling GitHub. A fenced row lock spans the
+remote operation and finalization, so an expired, still-running owner cannot
+race its successor. Recovery uses a durable issue-body marker and the repository
+issues endpoint (including closed issues), never the search index.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import logging
+from typing import Any, Awaitable, Callable, Mapping
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from brain.kernel.common.time import utcnow
+from brain.platform.db.models.provider_alert import ProviderAlertFilingClaim
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
+    async_add_repo_issue_comment,
+    async_list_repo_issues,
+)
+
+CLAIM_TTL_SECONDS = 60
+WAIT_ATTEMPTS = 60
+logger = logging.getLogger(__name__)
+
+
+class FilingPendingError(Exception):
+    """Retry the same claim; do not create another issue or tracker record."""
+
+
+@dataclass(frozen=True)
+class FilingIdentity:
+    org_id: str
+    service: str
+    subsystem: str
+    tracked_signature: str
+
+    @classmethod
+    def parse(cls, org_id: str | None, value: Mapping[str, Any]) -> FilingIdentity:
+        if not org_id:
+            raise ValueError("provider_alert requires an organization context")
+        fields = {}
+        for name, limit in (("service", 120), ("subsystem", 120), ("tracked_signature", 64)):
+            raw = value.get(name)
+            if not isinstance(raw, str) or not raw.strip() or len(raw.strip()) > limit:
+                raise ValueError(f"provider_alert requires {name} (1–{limit} characters)")
+            fields[name] = raw.strip()
+        return cls(org_id=org_id, **fields)
+
+    @property
+    def marker(self) -> str:
+        key = json.dumps([self.org_id, self.service, self.subsystem, self.tracked_signature])
+        return f"<!-- illo-provider-alert-filing:{hashlib.sha256(key.encode()).hexdigest()} -->"
+
+
+@dataclass(frozen=True)
+class FilingClaim:
+    id: int
+    repo: str
+    claimed_at: datetime | None
+    issue_number: int | None
+    issue_url: str | None
+    acquired: bool
+    reconcile: bool = False
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "issue": {"number": self.issue_number, "html_url": self.issue_url},
+            "filing_claim_id": self.id,
+            "filing_state": "filed",
+            "reused": True,
+        }
+
+
+def _snapshot(row: ProviderAlertFilingClaim, *, acquired: bool, reconcile: bool = False) -> FilingClaim:
+    return FilingClaim(row.id, row.repo, row.claimed_at, row.issue_number, row.issue_url, acquired, reconcile)
+
+
+async def acquire_filing_claim(identity: FilingIdentity, repo: str) -> FilingClaim:
+    """Insert the canonical key, then compare-and-set its expiring claim column."""
+    now = utcnow()
+    async with UnitOfWork() as uow:
+        session = uow.session
+        insert = sqlite_insert if session.get_bind().dialect.name == "sqlite" else postgresql_insert
+        key = dict(org_id=identity.org_id, service=identity.service,
+                   subsystem=identity.subsystem, tracked_signature=identity.tracked_signature)
+        await session.execute(
+            insert(ProviderAlertFilingClaim).values(**key, repo=repo)
+            .on_conflict_do_nothing(index_elements=list(key))
+        )
+        row = await session.scalar(select(ProviderAlertFilingClaim).filter_by(**key).with_for_update())
+        assert row is not None
+        if row.state == "filed":
+            return _snapshot(row, acquired=False)
+        if row.repo != repo:
+            raise ValueError(f"This provider-alert claim belongs to {row.repo}; retry with that repo")
+        reconcile = row.state == "creating"
+        # The SQL predicate also enforces arbitration in SQLite, whose FOR UPDATE
+        # is a no-op. PostgreSQL uses the same predicate plus its row lock.
+        won = await session.scalar(
+            update(ProviderAlertFilingClaim)
+            .where(
+                ProviderAlertFilingClaim.id == row.id,
+                ProviderAlertFilingClaim.state != "filed",
+                or_(ProviderAlertFilingClaim.claimed_at.is_(None),
+                    ProviderAlertFilingClaim.claimed_at <= now - timedelta(seconds=CLAIM_TTL_SECONDS)),
+            )
+            .values(claimed_at=now)
+            .returning(ProviderAlertFilingClaim.id)
+            .execution_options(synchronize_session=False)
+        )
+        await session.refresh(row)
+        return _snapshot(row, acquired=won is not None, reconcile=reconcile)
+
+
+def _owns(row: ProviderAlertFilingClaim, claim: FilingClaim) -> bool:
+    def aware(value: datetime | None) -> datetime | None:
+        return value.replace(tzinfo=timezone.utc) if value is not None and value.tzinfo is None else value
+    return (
+        claim.acquired
+        and claim.claimed_at is not None
+        and row.state != "filed"
+        and aware(row.claimed_at) == aware(claim.claimed_at)
+    )
+
+
+async def _prepare_create(claim: FilingClaim) -> None:
+    # Commit the uncertainty BEFORE the request. A crash or rollback after the
+    # request must leave a durable instruction to reconcile on the next attempt.
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is None or not _owns(row, claim):
+            raise FilingPendingError("Provider-alert filing ownership changed; retry the same claim")
+        row.state = "creating"
+        await uow.session.flush()
+
+
+async def _release_claim(claim: FilingClaim) -> None:
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is not None and _owns(row, claim):
+            row.claimed_at = None
+            await uow.session.flush()
+
+
+async def _find_filed_issue(repo: str, marker: str, token: str) -> dict[str, Any] | None:
+    cursor = None
+    while True:
+        page = await async_list_repo_issues(
+            repo, token=token, state="all", limit=100, cursor=cursor, body_limit=65536,
+        )
+        for issue in page["issues"]:
+            if marker in str(issue.get("body") or ""):
+                return {"repo": repo, "issue": issue}
+        cursor = page.get("next_page")
+        if not cursor:
+            return None
+
+
+async def _create_or_reconcile(
+    claim: FilingClaim, identity: FilingIdentity, create_issue: Callable[..., Awaitable[dict[str, Any]]],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    await _prepare_create(claim)
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            select(ProviderAlertFilingClaim).where(ProviderAlertFilingClaim.id == claim.id).with_for_update()
+        )
+        if row is None or not _owns(row, claim):
+            raise FilingPendingError("Provider-alert filing ownership changed; retry the same claim")
+        payload = await _find_filed_issue(claim.repo, identity.marker, kwargs["token"]) if claim.reconcile else None
+        reused = payload is not None
+        if payload is None:
+            payload = await create_issue(
+                claim.repo, **{**kwargs, "body": f"{identity.marker}\n\n{kwargs.get('body') or ''}"},
+            )
+        issue = payload.get("issue") or {}
+        number = issue.get("number")
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            raise ValueError("GitHub returned no issue number; retry the same provider-alert claim")
+        row.issue_number = number
+        row.issue_url = issue.get("html_url") or f"https://github.com/{claim.repo}/issues/{number}"
+        row.state = "filed"
+        row.claimed_at = None
+        await uow.session.flush()
+        payload.update(filing_claim_id=row.id, filing_state="filed", reused=reused)
+    return payload
+
+
+async def create_provider_alert_issue(
+    identity: FilingIdentity, repo: str, *,
+    create_issue: Callable[..., Awaitable[dict[str, Any]]], **kwargs: Any,
+) -> dict[str, Any]:
+    for _ in range(WAIT_ATTEMPTS):
+        claim = await acquire_filing_claim(identity, repo)
+        if claim.issue_number is not None:
+            payload = claim.payload()
+            break
+        if claim.acquired:
+            try:
+                payload = await _create_or_reconcile(claim, identity, create_issue, **kwargs)
+            except Exception as exc:
+                # A timed-out POST may still be running remotely. Keep the lease
+                # until expiry before attempting reconciliation in that case.
+                if isinstance(exc, GitHubConnectorError) and exc.status_code >= 500:
+                    raise
+                # Leave 'creating' intact. Release only our generation, and never
+                # hide the original error if even the release cannot be saved.
+                try:
+                    await _release_claim(claim)
+                except Exception:
+                    logger.exception("provider alert filing claim release failed")
+                raise
+            break
+        await _wait_for_filing()
+    else:
+        raise FilingPendingError("Provider-alert filing is in progress; retry the same claim")
+
+    if payload["reused"]:
+        evidence = kwargs.get("body") or kwargs["title"]
+        try:
+            await async_add_repo_issue_comment(
+                payload["repo"], payload["issue"]["number"],
+                body=f"Additional provider-alert occurrence:\n\n{evidence}", token=kwargs["token"],
+            )
+            payload["occurrence_evidence_appended"] = True
+        except Exception as exc:
+            # Filing is already durable. Report the evidence failure without
+            # allowing token fallback to repeat the initial create.
+            payload["occurrence_evidence_appended"] = False
+            payload["occurrence_evidence_error"] = str(exc)
+    return payload
+
+
+async def _wait_for_filing() -> None:
+    await asyncio.sleep(0.25)

--- a/brain/systems/slack/provider_alert_filing.py
+++ b/brain/systems/slack/provider_alert_filing.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import logging
-from typing import Any, Awaitable, Callable, Mapping
+from typing import Any, Mapping
 
 from sqlalchemy import or_, select, update
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
@@ -27,6 +27,7 @@ from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_add_repo_issue_comment,
+    async_create_repo_issue,
     async_list_repo_issues,
 )
 
@@ -174,8 +175,8 @@ async def _find_filed_issue(repo: str, marker: str, token: str) -> dict[str, Any
 
 
 async def _create_or_reconcile(
-    claim: FilingClaim, identity: FilingIdentity, create_issue: Callable[..., Awaitable[dict[str, Any]]],
-    **kwargs: Any,
+    claim: FilingClaim, identity: FilingIdentity, *,
+    title: str, body: str | None, labels: list[str], assignees: list[str], token: str,
 ) -> dict[str, Any]:
     await _prepare_create(claim)
     async with UnitOfWork() as uow:
@@ -184,11 +185,12 @@ async def _create_or_reconcile(
         )
         if row is None or not _owns(row, claim):
             raise FilingPendingError("Provider-alert filing ownership changed; retry the same claim")
-        payload = await _find_filed_issue(claim.repo, identity.marker, kwargs["token"]) if claim.reconcile else None
+        payload = await _find_filed_issue(claim.repo, identity.marker, token) if claim.reconcile else None
         reused = payload is not None
         if payload is None:
-            payload = await create_issue(
-                claim.repo, **{**kwargs, "body": f"{identity.marker}\n\n{kwargs.get('body') or ''}"},
+            payload = await async_create_repo_issue(
+                claim.repo, title=title, body=f"{identity.marker}\n\n{body or ''}",
+                labels=labels, assignees=assignees, token=token,
             )
         issue = payload.get("issue") or {}
         number = issue.get("number")
@@ -205,7 +207,7 @@ async def _create_or_reconcile(
 
 async def create_provider_alert_issue(
     identity: FilingIdentity, repo: str, *,
-    create_issue: Callable[..., Awaitable[dict[str, Any]]], **kwargs: Any,
+    title: str, body: str | None, labels: list[str], assignees: list[str], token: str,
 ) -> dict[str, Any]:
     for _ in range(WAIT_ATTEMPTS):
         claim = await acquire_filing_claim(identity, repo)
@@ -214,7 +216,9 @@ async def create_provider_alert_issue(
             break
         if claim.acquired:
             try:
-                payload = await _create_or_reconcile(claim, identity, create_issue, **kwargs)
+                payload = await _create_or_reconcile(
+                    claim, identity, title=title, body=body, labels=labels, assignees=assignees, token=token,
+                )
             except Exception as exc:
                 # A timed-out POST may still be running remotely. Keep the lease
                 # until expiry before attempting reconciliation in that case.
@@ -233,11 +237,11 @@ async def create_provider_alert_issue(
         raise FilingPendingError("Provider-alert filing is in progress; retry the same claim")
 
     if payload["reused"]:
-        evidence = kwargs.get("body") or kwargs["title"]
+        evidence = body or title
         try:
             await async_add_repo_issue_comment(
                 payload["repo"], payload["issue"]["number"],
-                body=f"Additional provider-alert occurrence:\n\n{evidence}", token=kwargs["token"],
+                body=f"Additional provider-alert occurrence:\n\n{evidence}", token=token,
             )
             payload["occurrence_evidence_appended"] = True
         except Exception as exc:

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -23,6 +23,8 @@ BROAD_DESTRUCTIVE_SQL_PATTERNS = (
     r"\bREASSIGN\s+OWNED\b",
 )
 REVIEWED_DESTRUCTIVE_MIGRATIONS = {
+    # Downgrade removes only the provider-alert filing claims introduced here.
+    "0066_provider_alert_filing_claims.py",
     "0003_schema_simplification.py",
     # Downgrade removes only the access table introduced by the same migration.
     "0005_project_profile_privacy.py",

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -80,6 +80,7 @@ EXPECTED_TABLES = {
     "project_narratives",
     "project_profile_access",
     "project_profiles",
+    "provider_alert_filing_claims",
     "provider_alert_ledger",
     "provider_alert_occurrences",
     "provider_alert_surges",

--- a/tests/test_provider_alert_filing.py
+++ b/tests/test_provider_alert_filing.py
@@ -116,7 +116,7 @@ async def test_four_messages_force_claim_conflict_and_share_one_ticket(filing_st
     monkeypatch.setattr(filing, "acquire_filing_claim", observe_claim)
     monkeypatch.setattr(filing, "_wait_for_filing", owner_done.wait)
     create_mock = AsyncMock(side_effect=create)
-    monkeypatch.setattr(github, "async_create_repo_issue", create_mock)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create_mock)
 
     async def run(index):
         result = await _file(identity, body=f"Message 1788716940.{index}, Rollbar #{2278 + index}")
@@ -156,14 +156,17 @@ async def test_dead_owner_before_create_is_replaced_after_expiry(filing_store, m
     assert not (await filing.acquire_filing_claim(IDENTITY, REPO)).acquired
     control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
     create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     result = await _file()
     assert result["issue"]["number"] == 2021
     assert result["filing_claim_id"] == dead.id
     create.assert_awaited_once()
     filing.async_list_repo_issues.assert_not_awaited()
     with pytest.raises(filing.FilingPendingError):
-        await filing._create_or_reconcile(dead, IDENTITY, create, token="test-token")
+        await filing._create_or_reconcile(
+            dead, IDENTITY, title="Generation failed", body="Occurrence evidence",
+            labels=[], assignees=[], token="test-token",
+        )
     create.assert_awaited_once()
 
 
@@ -181,7 +184,7 @@ async def test_create_survives_failed_finalization_and_reconciles(filing_store, 
         return {"repo": REPO, "issue": dict(ISSUE)}
 
     create_mock = AsyncMock(side_effect=create)
-    monkeypatch.setattr(github, "async_create_repo_issue", create_mock)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create_mock)
     if failure == "process_death":
         with pytest.raises(asyncio.CancelledError):
             await _file()
@@ -244,6 +247,7 @@ async def test_pending_claim_does_not_fall_through_to_unclaimed_create(filing_st
     monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
     create = AsyncMock()
     monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     result = await _file()
     assert result["filing_pending"] and result["retryable"]
     create.assert_not_awaited()
@@ -256,7 +260,7 @@ async def test_failed_reconciliation_never_creates_blindly(filing_store, monkeyp
     await filing._release_claim(claim)
     filing.async_list_repo_issues.side_effect = GitHubConnectorError(status_code=502, message="unavailable")
     create = AsyncMock()
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     result = await _file()
     assert result["status_code"] == 502
     create.assert_not_awaited()
@@ -266,7 +270,7 @@ async def test_failed_reconciliation_never_creates_blindly(filing_store, monkeyp
 async def test_timed_out_post_keeps_lease_and_reconciles_after_expiry(filing_store, monkeypatch):
     _, control = filing_store
     create = AsyncMock(side_effect=GitHubConnectorError(status_code=502, message="timed out"))
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     monkeypatch.setattr(filing, "WAIT_ATTEMPTS", 1)
     monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
     assert (await _file())["filing_pending"]
@@ -285,7 +289,7 @@ async def test_canonical_repo_cannot_be_changed_by_another_run(filing_store, mon
         await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
     await filing._release_claim(claim)
     create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     await _file()
     canonical = await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
     assert canonical.repo == REPO
@@ -301,7 +305,7 @@ async def test_missing_reconciliation_match_allows_retry_before_remote_create(fi
     await filing._prepare_create(claim)  # Crash immediately before the POST.
     control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
     create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     assert (await _file())["issue"]["number"] == 2021
     filing.async_list_repo_issues.assert_awaited_once()
     create.assert_awaited_once()
@@ -310,7 +314,7 @@ async def test_missing_reconciliation_match_allows_retry_before_remote_create(fi
 @pytest.mark.asyncio
 async def test_evidence_failure_preserves_canonical_filing(filing_store, monkeypatch):
     create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
-    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     await _file()
     filing.async_add_repo_issue_comment.side_effect = GitHubConnectorError(status_code=403, message="denied")
     result = await _file()
@@ -333,6 +337,7 @@ def test_provider_alert_argument_is_optional_and_validates_only_when_supplied():
 async def test_malformed_identity_cannot_create_an_unclaimed_issue(filing_store, monkeypatch):
     create = AsyncMock()
     monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "async_create_repo_issue", create)
     with bind_agent_context({"org_id": ORG}):
         result = json.loads(await github._handle_create_github_issue(
             repo=REPO, title="Failure", provider_alert={"service": "api"},

--- a/tests/test_provider_alert_filing.py
+++ b/tests/test_provider_alert_filing.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
+
+from brain.platform.db.models.provider_alert import (
+    ProviderAlertFilingClaim, ProviderAlertOccurrence, ProviderAlertSurge,
+)
+from brain.platform.provider_alerts import classify_provider_alert_ingest
+from brain.systems.cortex.project_context.github import GitHubConnectorError
+from brain.systems.runs.execution_context import bind_agent_context
+from brain.systems.runs.tool_catalog.handlers import github
+from brain.systems.slack import provider_alert_filing as filing
+from brain.systems.slack.provider_alert_surge import record_provider_alert_occurrence
+
+ORG = "4b5e2f59-4f88-4956-a660-4f544ccffbd7"
+REPO = "uwear-ai/uwear-backend"
+NOW = datetime(2026, 9, 6, 17, 49, tzinfo=timezone.utc)
+IDENTITY = filing.FilingIdentity(ORG, "uwear-api", "generation", "a" * 64)
+ISSUE = {"number": 2021, "html_url": f"https://github.com/{REPO}/issues/2021"}
+
+
+@pytest.fixture
+async def filing_store(tmp_path, monkeypatch):
+    """Real unique inserts and CAS writes, using independent SQLite sessions.
+
+    No server is needed. The production PostgreSQL row locks additionally prevent
+    lease takeover while an active owner is inside the remote side effect.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'filing.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        for model in (ProviderAlertFilingClaim, ProviderAlertOccurrence, ProviderAlertSurge):
+            await connection.execute(CreateTable(model.__table__))
+    control = {"now": NOW, "fail_commit": False}
+
+    class TestUnitOfWork:
+        async def __aenter__(self):
+            self.session = sessions()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            try:
+                if exc_type:
+                    await self.session.rollback()
+                elif control["fail_commit"]:
+                    control["fail_commit"] = False
+                    await self.session.rollback()
+                    raise RuntimeError("local finalization failed")
+                else:
+                    await self.session.commit()
+            finally:
+                await self.session.close()
+
+    monkeypatch.setattr(filing, "UnitOfWork", TestUnitOfWork)
+    monkeypatch.setattr(filing, "utcnow", lambda: control["now"])
+    monkeypatch.setattr(github, "_github_token_candidates", AsyncMock(return_value=[
+        {"token": "test-token", "source": "test", "key_name": None},
+    ]))
+    monkeypatch.setattr(filing, "async_add_repo_issue_comment", AsyncMock(return_value={}))
+    monkeypatch.setattr(filing, "async_list_repo_issues", AsyncMock(return_value={"issues": []}))
+    try:
+        yield sessions, control
+    finally:
+        await engine.dispose()
+
+
+async def _file(identity=IDENTITY, *, body="Occurrence evidence"):
+    with bind_agent_context({"user_id": "test-user", "org_id": identity.org_id}):
+        return json.loads(await github._handle_create_github_issue(
+            repo=REPO, title="Generation failed", body=body,
+            provider_alert={"service": identity.service, "subsystem": identity.subsystem,
+                            "tracked_signature": identity.tracked_signature},
+        ))
+
+
+@pytest.mark.asyncio
+async def test_four_messages_force_claim_conflict_and_share_one_ticket(filing_store, monkeypatch):
+    sessions, _ = filing_store
+    for index in range(4):
+        alert = classify_provider_alert_ingest(
+            f"<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/{2278 + index}|"
+            f"#{2278 + index} New error: TimeoutError: Garment description generation timed out>"
+        )
+        assert alert is not None
+        async with sessions.begin() as session:
+            await record_provider_alert_occurrence(
+                session, org_id=ORG, channel_id="C_ALERTS", message_ts=f"1788716940.{index}",
+                alert=alert, occurred_at=NOW,
+            )
+    identity = filing.FilingIdentity(ORG, alert.service, alert.subsystem, alert.signature)
+    all_contended, owner_done = asyncio.Event(), asyncio.Event()
+    acquired = filing.acquire_filing_claim
+    losers = set()
+
+    async def observe_claim(*args):
+        claim = await acquired(*args)
+        if not claim.acquired and claim.issue_number is None:
+            losers.add(asyncio.current_task())
+            if len(losers) == 3:
+                all_contended.set()
+        return claim
+
+    async def create(*args, **kwargs):
+        await all_contended.wait()
+        return {"repo": REPO, "issue": dict(ISSUE)}
+
+    monkeypatch.setattr(filing, "acquire_filing_claim", observe_claim)
+    monkeypatch.setattr(filing, "_wait_for_filing", owner_done.wait)
+    create_mock = AsyncMock(side_effect=create)
+    monkeypatch.setattr(github, "async_create_repo_issue", create_mock)
+
+    async def run(index):
+        result = await _file(identity, body=f"Message 1788716940.{index}, Rollbar #{2278 + index}")
+        if result.get("reused") is False:
+            owner_done.set()
+        return result
+
+    results = await asyncio.wait_for(asyncio.gather(*(run(i) for i in range(4))), timeout=10)
+    assert len(losers) == 3  # All three went through the losing DB-write path.
+    create_mock.assert_awaited_once()
+    assert identity.marker in create_mock.await_args.kwargs["body"]
+    assert {r["issue"]["number"] for r in results} == {2021}
+    assert {r["filing_claim_id"] for r in results} == {results[0]["filing_claim_id"]}
+    assert all(r["mutated_target_refs"] == [{"kind": "github_issue", "id": f"{REPO}#2021"}] for r in results)
+    # Only the initial owner may create the associated tracker record. The other
+    # three receive explicit reuse results and the same canonical external ref.
+    assert sum(not result["reused"] for result in results) == 1
+    assert filing.async_add_repo_issue_comment.await_count == 3
+    async with sessions() as session:
+        occurrences = (await session.scalars(select(ProviderAlertOccurrence))).all()
+        claims = (await session.scalars(select(ProviderAlertFilingClaim))).all()
+    assert len(occurrences) == 4
+    assert len({o.slack_message_ts for o in occurrences}) == 4
+    assert len({o.external_id for o in occurrences}) == 4
+    assert len({o.signature for o in occurrences}) == 1
+    assert len(claims) == 1
+    assert (claims[0].repo, claims[0].issue_number, claims[0].issue_url, claims[0].state) == (
+        REPO, 2021, ISSUE["html_url"], "filed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dead_owner_before_create_is_replaced_after_expiry(filing_store, monkeypatch):
+    _, control = filing_store
+    dead = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert dead.acquired
+    assert not (await filing.acquire_filing_claim(IDENTITY, REPO)).acquired
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["issue"]["number"] == 2021
+    assert result["filing_claim_id"] == dead.id
+    create.assert_awaited_once()
+    filing.async_list_repo_issues.assert_not_awaited()
+    with pytest.raises(filing.FilingPendingError):
+        await filing._create_or_reconcile(dead, IDENTITY, create, token="test-token")
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["commit", "process_death"])
+async def test_create_survives_failed_finalization_and_reconciles(filing_store, monkeypatch, failure):
+    sessions, control = filing_store
+    remote = []
+
+    async def create(*args, **kwargs):
+        remote.append({**ISSUE, "body": kwargs["body"], "state": "closed"})
+        if failure == "process_death":
+            raise asyncio.CancelledError()
+        control["fail_commit"] = True
+        return {"repo": REPO, "issue": dict(ISSUE)}
+
+    create_mock = AsyncMock(side_effect=create)
+    monkeypatch.setattr(github, "async_create_repo_issue", create_mock)
+    if failure == "process_death":
+        with pytest.raises(asyncio.CancelledError):
+            await _file()
+        control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    else:
+        assert (await _file())["filing_pending"] is True
+    async with sessions() as session:
+        row = await session.scalar(select(ProviderAlertFilingClaim))
+        assert row.state == "creating"
+        assert row.issue_number is None
+
+    # Force pagination, and ensure even a closed issue on a later page is found.
+    filing.async_list_repo_issues.side_effect = [
+        {"issues": [{"number": 900, "body": "unrelated"}], "next_page": "page-two"},
+        {"issues": remote},
+    ]
+    result = await _file(body="Retried occurrence")
+    assert result["reused"] is True
+    assert result["issue"]["number"] == 2021
+    create_mock.assert_awaited_once()
+    assert filing.async_list_repo_issues.await_args_list[1].kwargs["cursor"] == "page-two"
+    assert all(c.kwargs["state"] == "all" for c in filing.async_list_repo_issues.await_args_list)
+    async with sessions() as session:
+        row = await session.scalar(select(ProviderAlertFilingClaim))
+        assert row.state == "filed"
+        assert row.issue_url == ISSUE["html_url"]
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_cannot_release_or_prepare_successors_claim(filing_store):
+    _, control = filing_store
+    first = await filing.acquire_filing_claim(IDENTITY, REPO)
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    successor = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert successor.acquired
+    await filing._release_claim(first)
+    with pytest.raises(filing.FilingPendingError):
+        await filing._prepare_create(first)
+    current = await filing.acquire_filing_claim(IDENTITY, REPO)
+    assert not current.acquired
+    assert current.claimed_at == successor.claimed_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("org_id", "e54e4e0d-ac19-42dd-b356-9735ce68ae23"),
+    ("service", "other-service"), ("subsystem", "other-subsystem"), ("tracked_signature", "b" * 64),
+])
+async def test_filing_identity_is_scoped_by_all_four_fields(filing_store, field, value):
+    first = await filing.acquire_filing_claim(IDENTITY, REPO)
+    other = await filing.acquire_filing_claim(replace(IDENTITY, **{field: value}), REPO)
+    assert first.acquired and other.acquired
+    assert first.id != other.id
+
+
+@pytest.mark.asyncio
+async def test_pending_claim_does_not_fall_through_to_unclaimed_create(filing_store, monkeypatch):
+    await filing.acquire_filing_claim(IDENTITY, REPO)
+    monkeypatch.setattr(filing, "WAIT_ATTEMPTS", 1)
+    monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
+    create = AsyncMock()
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["filing_pending"] and result["retryable"]
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_reconciliation_never_creates_blindly(filing_store, monkeypatch):
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    await filing._prepare_create(claim)
+    await filing._release_claim(claim)
+    filing.async_list_repo_issues.side_effect = GitHubConnectorError(status_code=502, message="unavailable")
+    create = AsyncMock()
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    result = await _file()
+    assert result["status_code"] == 502
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_post_keeps_lease_and_reconciles_after_expiry(filing_store, monkeypatch):
+    _, control = filing_store
+    create = AsyncMock(side_effect=GitHubConnectorError(status_code=502, message="timed out"))
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    monkeypatch.setattr(filing, "WAIT_ATTEMPTS", 1)
+    monkeypatch.setattr(filing, "_wait_for_filing", AsyncMock())
+    assert (await _file())["filing_pending"]
+    assert (await _file())["filing_pending"]
+    create.assert_awaited_once()
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    filing.async_list_repo_issues.return_value = {"issues": [{**ISSUE, "body": IDENTITY.marker}]}
+    assert (await _file())["issue"]["number"] == 2021
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_repo_cannot_be_changed_by_another_run(filing_store, monkeypatch):
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    with pytest.raises(ValueError, match="belongs to"):
+        await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
+    await filing._release_claim(claim)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    await _file()
+    canonical = await filing.acquire_filing_claim(IDENTITY, "uwear-ai/other")
+    assert canonical.repo == REPO
+    assert canonical.issue_number == 2021
+    assert not canonical.acquired
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_reconciliation_match_allows_retry_before_remote_create(filing_store, monkeypatch):
+    _, control = filing_store
+    claim = await filing.acquire_filing_claim(IDENTITY, REPO)
+    await filing._prepare_create(claim)  # Crash immediately before the POST.
+    control["now"] += timedelta(seconds=filing.CLAIM_TTL_SECONDS)
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    assert (await _file())["issue"]["number"] == 2021
+    filing.async_list_repo_issues.assert_awaited_once()
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_evidence_failure_preserves_canonical_filing(filing_store, monkeypatch):
+    create = AsyncMock(return_value={"repo": REPO, "issue": dict(ISSUE)})
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    await _file()
+    filing.async_add_repo_issue_comment.side_effect = GitHubConnectorError(status_code=403, message="denied")
+    result = await _file()
+    assert result["reused"]
+    assert result["occurrence_evidence_appended"] is False
+    assert result["issue"]["number"] == 2021
+    create.assert_awaited_once()
+
+
+def test_provider_alert_argument_is_optional_and_validates_only_when_supplied():
+    from brain.systems.runs.tool_catalog.definitions.github import GITHUB_TOOLS
+    definition = next(t for t in GITHUB_TOOLS if t["name"] == "create_github_issue")
+    assert "provider_alert" in definition["input_schema"]["properties"]
+    assert definition["input_schema"]["required"] == ["repo", "title"]
+    with pytest.raises(ValueError, match="tracked_signature"):
+        filing.FilingIdentity.parse(ORG, {"service": "api", "subsystem": "jobs"})
+
+
+@pytest.mark.asyncio
+async def test_malformed_identity_cannot_create_an_unclaimed_issue(filing_store, monkeypatch):
+    create = AsyncMock()
+    monkeypatch.setattr(github, "async_create_repo_issue", create)
+    with bind_agent_context({"org_id": ORG}):
+        result = json.loads(await github._handle_create_github_issue(
+            repo=REPO, title="Failure", provider_alert={"service": "api"},
+        ))
+    assert "error" in result
+    create.assert_not_awaited()


### PR DESCRIPTION
> Part A of #892. **Stacked on #893** (Part B) — merge that first, or merge this train in one click.

## What went wrong

On 2026-09-06 at 17:49 UTC, four Rollbar messages for **one** production failure arrived in the monitored Slack `#alerts` lane sharing the exact tracked signature `207d7d2e…a5c1f`.

Three independent runs each completed a read-before-write duplicate search, each saw "no match", and each filed a **separate real GitHub issue** — `uwear-ai/uwear-backend#2021`, `#2022`, `#2023` — plus three tracker records (Domain 1: 6005, 6007, 6008).

The duplicate check was a **policy the model was asked to follow**, not a lock. The provider-alert ledger already held the right stable key, but nothing made it own the side effect.

## What this changes

A `provider_alert_filing_claims` row now owns the filing.

- The canonical key `(org_id, service, subsystem, tracked_signature)` is inserted with `on_conflict_do_nothing`, then its expiring claim column is taken by **compare-and-set**. Exactly one run can create the issue.
- The claim moves to `creating` and **commits before** the GitHub request. So a crash *after* the request leaves a durable instruction to reconcile rather than to file again.
- Recovery matches a hashed marker in the issue body through the repository issues endpoint, **including closed issues** — never the search index, which is what failed here.
- Concurrent runs reuse the canonical issue and append their occurrence as a comment.
- The claim **expires**, so an owner that dies before or after the create does not wedge the signature forever.

`create_github_issue`'s new `provider_alert` argument is **optional**. Omit it and behavior is exactly as today — deliberately, because #893 exists precisely because callers were once forced to synthesize values for fields they did not intend to touch.

## How to see it work

This is Illo, so the real gate is using it. After merge, the next time two alerts share a signature in `#alerts`:

1. Confirm **one** issue is filed, not three.
2. The later occurrences appear as **comments on that one issue**.
3. Domain 1 gains **one** tracker record for the signature.
4. The issue body carries an `<!-- illo-provider-alert-filing:… -->` marker — that is the recovery key; leave it in place while filing is unresolved.

## Verification

| | |
|---|---|
| suite | **5178 passed**, 0 failed, 11 skipped, 90 deselected |
| commit | `027a6f99` — the head of this PR |
| command | repo CI verbatim, no path argument, so `meetbot/tests` is included |
| wall clock | 94.22s, serial, load 3.34, no Codex worker live |
| alembic | one head — `0066_provider_alert_filing_claims` |
| new tests | 17 in `tests/test_provider_alert_filing.py`, covering the ticket's three acceptance cases |

The parent branch measures 5161, and 5161 + 17 = 5178 — the delta is reconciled, not assumed.

## Review — and an honest label

Codex authored this diff, and a second Codex pass ran the thermo-nuclear maintainability rubric (19 files read): **BLOCKING, 2 blockers + 3 notes**. Those two passes are the **same family**, so the rubric run does not independently check the author. The cross-family element is the Claude director review: pre-dispatch scan, reading the diff, re-running the gate outside the sandbox, reconciling the delta, and triaging the blockers.

**Blocker 2 is fixed in `027a6f99`.** The injected `create_issue` callback plus `**kwargs` hid the title/body/token the module actually requires, while reconciliation and commenting already called the connector directly. Explicit typed parameters now; no callback.

**Blocker 1 is deliberately NOT fixed here**, and it is the one thing worth your judgement:

> `handlers/github.py` now selects two error policies inside one token-fallback loop — ordinary creation re-raises unexpected exceptions, provider-alert filing converts them to retryable pending results.

The reviewer's fix is to split the plain-create and provider-alert adapters and extract the shared token loop. That restructures a handler which was **already over 1000 lines before this PR**, so folding it here would widen the blast radius well past this ticket and detach the verified 5178 from a much larger change. It belongs in its own pass.

Three NOTE-level findings are also left for later, recorded so they are not lost: `claimed_at` doubles as lease age *and* generation identity (an opaque token would separate them); the 60s lease versus the ~15s wait budget is undocumented; and the body-marker serialization is an implicit external contract that deserves a versioned codec.

## Scope

#892 stays open after this merges — it carries two defects, and #893 is the other one.
